### PR TITLE
Profile the maven build

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -9,4 +9,10 @@
     <artifactId>incremental-module-builder</artifactId>
     <version>0.2.0</version>
   </extension>
+
+  <extension>
+    <groupId>fr.jcgay.maven</groupId>
+    <artifactId>maven-profiler</artifactId>
+    <version>3.2</version>
+  </extension>
 </extensions>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,12 @@ Tests can be executed via maven (`mvn verify`) or in your prefered IDE. The Zeeb
 
 > Note: If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it
 
+### Build profiling
+
+The development team continues to push for a performant build.
+To investigate where the time is spent, you can run your maven command with the `-Dprofile` option.
+This will generate a profiler report in the `target` folder.
+
 ## Report issues or contact developers
 
 Zeebe uses GitHub issues to organize the development process. If you want to

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -33,7 +33,7 @@
     <checkstyle.config.location>.checkstyle.xml</checkstyle.config.location>
     <spotbugs.include>spotbugs/spotbugs-include.xml</spotbugs.include>
     <spotbugs.exclude>spotbugs/spotbugs-exclude.xml</spotbugs.exclude>
-    <maven-profiler-report-directory>${project.build.directory}</maven-profiler-report-directory>
+    <maven-profiler-report-directory>${project.build.directory}/profiler</maven-profiler-report-directory>
 
     <!-- EXTERNAL LIBS -->
     <version.agrona>1.20.0</version.agrona>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -33,6 +33,7 @@
     <checkstyle.config.location>.checkstyle.xml</checkstyle.config.location>
     <spotbugs.include>spotbugs/spotbugs-include.xml</spotbugs.include>
     <spotbugs.exclude>spotbugs/spotbugs-exclude.xml</spotbugs.exclude>
+    <maven-profiler-report-directory>${project.build.directory}</maven-profiler-report-directory>
 
     <!-- EXTERNAL LIBS -->
     <version.agrona>1.20.0</version.agrona>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This adds a maven extension to profile the maven build. It is disabled by default, and can be enabled easily using `-Dprofile`. The reports are placed in the target folder, so they are ignored by git and cleaned up by maven.

I've documented usage in the contributing guide.

See: https://github.com/jcgay/maven-profiler

## Related issues

<!-- Which issues are closed by this PR or are related -->

No related issue, this was today's slacktime effort

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
