### PR TITLE
Calculate the right versions

### DIFF
--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -32,8 +32,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: git fetch --tags
       - run: |
+          latest_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr | head -n1)
           latest_major_minor=$(echo $latest_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
+          previous_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "${latest_major_minor}" | sort -Vr | head -n1)
           previous_major_minor=$(echo $previous_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
+          previous_previous_major_minor_patch=$(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "${latest_major_minor}" | grep -v "${previous_major_minor}" | sort -Vr | head -n1)
           previous_previous_major_minor=$(echo $previous_previous_major_minor_patch | sed -E -e 's/\.[0-9]+$//')
 
           if [ ! -z $latest_major_minor ] && [ ! -z $previous_major_minor ] && [ ! -z $previous_previous_major_minor ]; then


### PR DESCRIPTION
## Description

Bring back the version calculation, which was broken without the patch versions.

For me it was easier to bring the part back, and not refactor it too much.

https://github.com/camunda/zeebe/commit/7039bf942fe31b9029ec23ada53a18f85b093355#diff-6a936ccc311a8f5af0da4203c51fec756b63a03f1a9b7dbd9c7e1b7b80531c1d
<!-- Please explain the changes you made here. -->
