### PR TITLE
fix(raft): complete bootstrap when partition leaves before becoming READY

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -536,6 +536,12 @@ public interface RaftServer {
     }
   }
 
+  class CancelledBootstrapException extends RuntimeException {
+    public CancelledBootstrapException(final String message) {
+      super(message);
+    }
+  }
+
   /**
    * Raft server state types.
    *

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -257,7 +257,7 @@ public class DefaultRaftServer implements RaftServer {
     }
   }
 
-  private class StartedStateListener implements Consumer<State> {
+  private final class StartedStateListener implements Consumer<State> {
 
     private final RaftServer raftServer;
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -302,7 +302,7 @@ final class LeaderAppender {
   /** Connects to the member and sends a configure request. */
   private void sendConfigureRequest(
       final RaftMemberContext member, final ConfigureRequest request) {
-    log.debug("Configuring {}", member.getMember().memberId());
+    log.debug("Configuring {} : {}", member.getMember().memberId(), request);
 
     // Start the configure to the member.
     member.startConfigure();


### PR DESCRIPTION
## Description

`PartitionManager` can only shutdown the partition when the future for current ongoing startup step is completed either successfully or exceptionally. When the `RaftBootstrapStep` has started and the partition leave at the same time, bootstrap future could never complete because the server never becomes ready. This prevented partition leave from completing if it was interrupted due to restart. 

To fix this, we now complete the raft bootstrap future exceptionally when the raft server left the replication group.

## Related issues

closes #15343 

