### PR TITLE
Added compensation event type

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
@@ -27,6 +27,8 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
 
   boolean isSignal();
 
+  boolean isCompensation();
+
   default boolean isNone() {
     return !isTimer() && !isMessage() && !isError() && !isLink() && !isEscalation() && !isSignal();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEvent.java
@@ -30,7 +30,13 @@ public interface ExecutableCatchEvent extends ExecutableFlowElement {
   boolean isCompensation();
 
   default boolean isNone() {
-    return !isTimer() && !isMessage() && !isError() && !isLink() && !isEscalation() && !isSignal();
+    return !isTimer()
+        && !isMessage()
+        && !isError()
+        && !isLink()
+        && !isEscalation()
+        && !isSignal()
+        && !isCompensation();
   }
 
   ExecutableMessage getMessage();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
@@ -32,6 +32,8 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   private boolean isLink;
 
+  private boolean isCompensation;
+
   public ExecutableCatchEventElement(final String id) {
     super(id);
   }
@@ -64,6 +66,11 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   @Override
   public boolean isSignal() {
     return signal != null;
+  }
+
+  @Override
+  public boolean isCompensation() {
+    return isCompensation;
   }
 
   @Override
@@ -110,6 +117,10 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   public void setSignal(final ExecutableSignal signal) {
     this.signal = signal;
+  }
+
+  public void setCompensation(final boolean isCompensation) {
+    this.isCompensation = isCompensation;
   }
 
   public void setLink(final boolean isLink) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableReceiveTask.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableReceiveTask.java
@@ -55,6 +55,11 @@ public class ExecutableReceiveTask extends ExecutableActivity implements Executa
   }
 
   @Override
+  public boolean isCompensation() {
+    return false;
+  }
+
+  @Override
   public ExecutableMessage getMessage() {
     return message;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BoundaryEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/BoundaryEventTransformer.java
@@ -36,6 +36,8 @@ public final class BoundaryEventTransformer implements ModelElementTransformer<B
       element.setEventType(BpmnEventType.ERROR);
     } else if (element.isEscalation()) {
       element.setEventType(BpmnEventType.ESCALATION);
+    } else if (element.isCompensation()) {
+      element.setEventType(BpmnEventType.COMPENSATION);
     }
 
     element.setInterrupting(event.cancelActivity());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CatchEventTransformer.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelE
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
 import io.camunda.zeebe.engine.processing.timer.CronTimer;
 import io.camunda.zeebe.model.bpmn.instance.CatchEvent;
+import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
@@ -65,9 +66,8 @@ public final class CatchEventTransformer implements ModelElementTransformer<Catc
       transformMessageEventDefinition(
           context, executableElement, (MessageEventDefinition) eventDefinition);
 
-    } else if (eventDefinition instanceof TimerEventDefinition) {
+    } else if (eventDefinition instanceof final TimerEventDefinition timerDefinition) {
       final var expressionLanguage = context.getExpressionLanguage();
-      final var timerDefinition = (TimerEventDefinition) eventDefinition;
       transformTimerEventDefinition(expressionLanguage, executableElement, timerDefinition);
 
     } else if (eventDefinition instanceof ErrorEventDefinition) {
@@ -82,6 +82,8 @@ public final class CatchEventTransformer implements ModelElementTransformer<Catc
     } else if (eventDefinition instanceof SignalEventDefinition) {
       transformSignalEventDefinition(
           context, executableElement, (SignalEventDefinition) eventDefinition);
+    } else if (eventDefinition instanceof CompensateEventDefinition) {
+      transformCompensationEventDefinition(executableElement);
     }
   }
 
@@ -209,5 +211,12 @@ public final class CatchEventTransformer implements ModelElementTransformer<Catc
     final ExecutableSignal executableSignal = context.getSignal(signal.getId());
     executableElement.setSignal(executableSignal);
     executableElement.setEventType(BpmnEventType.SIGNAL);
+  }
+
+  private void transformCompensationEventDefinition(
+      final ExecutableCatchEventElement executableElement) {
+
+    executableElement.setCompensation(true);
+    executableElement.setEventType(BpmnEventType.COMPENSATION);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/EndEventTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.model.transformer;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.ModelElementTransformer;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.TransformContext;
+import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EndEvent;
 import io.camunda.zeebe.model.bpmn.instance.ErrorEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
@@ -68,6 +69,8 @@ public final class EndEventTransformer implements ModelElementTransformer<EndEve
     } else if (eventDefinition instanceof SignalEventDefinition) {
       transformSignalEventDefinition(
           context, executableElement, (SignalEventDefinition) eventDefinition);
+    } else if (eventDefinition instanceof CompensateEventDefinition) {
+      transformCompensationEventDefinition(executableElement);
     }
   }
 
@@ -111,5 +114,9 @@ public final class EndEventTransformer implements ModelElementTransformer<EndEve
     final var executableSignal = context.getSignal(signal.getId());
     executableElement.setSignal(executableSignal);
     executableElement.setEventType(BpmnEventType.SIGNAL);
+  }
+
+  private void transformCompensationEventDefinition(final ExecutableEndEvent executableElement) {
+    executableElement.setEventType(BpmnEventType.COMPENSATION);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/StartEventTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/StartEventTransformer.java
@@ -49,6 +49,8 @@ public final class StartEventTransformer implements ModelElementTransformer<Star
       startEvent.setEventType(BpmnEventType.ESCALATION);
     } else if (startEvent.isSignal()) {
       startEvent.setEventType(BpmnEventType.SIGNAL);
+    } else if (startEvent.isCompensation()) {
+      startEvent.setEventType(BpmnEventType.COMPENSATION);
     }
 
     if (element.getScope() instanceof FlowNode) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnEventTypeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnEventTypeTest.java
@@ -407,17 +407,6 @@ public class BpmnEventTypeTest {
                       end -> end.compensateEventDefinition().compensateEventDefinitionDone())
                   .done();
             }
-          },
-          new BpmnEventTypeScenario(
-              "Compensation Start Event", BpmnElementType.START_EVENT, BpmnEventType.COMPENSATION) {
-            @Override
-            BpmnModelInstance modelInstance() {
-              return Bpmn.createExecutableProcess(processId())
-                  .startEvent(elementId())
-                  .compensation()
-                  .endEvent()
-                  .done();
-            }
           });
 
   @Rule

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnEventTypeTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/BpmnEventTypeTest.java
@@ -380,6 +380,44 @@ public class BpmnEventTypeTest {
                   .endEvent(elementId(), e -> e.escalation(escalationCode()))
                   .done();
             }
+          },
+          new BpmnEventTypeScenario(
+              "Compensation Intermediate Throw Event",
+              BpmnElementType.INTERMEDIATE_THROW_EVENT,
+              BpmnEventType.COMPENSATION) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .intermediateThrowEvent(
+                      elementId(),
+                      t -> t.compensateEventDefinition().compensateEventDefinitionDone())
+                  .endEvent()
+                  .done();
+            }
+          },
+          new BpmnEventTypeScenario(
+              "Compensation End Event", BpmnElementType.END_EVENT, BpmnEventType.COMPENSATION) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent()
+                  .endEvent(
+                      elementId(),
+                      end -> end.compensateEventDefinition().compensateEventDefinitionDone())
+                  .done();
+            }
+          },
+          new BpmnEventTypeScenario(
+              "Compensation Start Event", BpmnElementType.START_EVENT, BpmnEventType.COMPENSATION) {
+            @Override
+            BpmnModelInstance modelInstance() {
+              return Bpmn.createExecutableProcess(processId())
+                  .startEvent(elementId())
+                  .compensation()
+                  .endEvent()
+                  .done();
+            }
           });
 
   @Rule

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnEventType.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/BpmnEventType.java
@@ -32,7 +32,8 @@ public enum BpmnEventType {
   NONE("none"),
   SIGNAL("signal"),
   TERMINATE("terminate"),
-  TIMER("timer");
+  TIMER("timer"),
+  COMPENSATION("compensation");
 
   private final String eventTypeName;
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

With this PR a new Compensation event type is added. When a process with compensation is deployed, events with  `bpmnEventType` are written

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14944 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
