### PR TITLE
fix(topology): updating the topology file should truncate previous data

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -40,6 +40,7 @@ final class PersistedClusterTopology {
         serializedTopology,
         StandardOpenOption.CREATE,
         StandardOpenOption.WRITE,
+        StandardOpenOption.TRUNCATE_EXISTING,
         StandardOpenOption.DSYNC);
 
     this.clusterTopology = clusterTopology;

--- a/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.topology.state.ClusterChangePlan;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.CompletedChange;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.util.ReflectUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.domains.Domain;
+import net.jqwik.api.domains.DomainContext;
+import net.jqwik.api.domains.DomainContextBase;
+
+final class PersistedClusterTopologyTest {
+
+  @Property(tries = 100)
+  @Domain(ClusterTopologyDomain.class)
+  @Domain(DomainContext.Global.class)
+  void shouldUpdatePersistedFile(
+      @ForAll final ClusterTopology initialTopology, @ForAll final ClusterTopology updatedTopology)
+      throws IOException {
+    // given
+    final var tmp = Files.createTempDirectory("topology");
+    final var topologyFile = tmp.resolve("topology.meta");
+    final var serializer = new ProtoBufSerializer();
+    final var persistedClusterTopology = new PersistedClusterTopology(topologyFile, serializer);
+
+    // when
+    persistedClusterTopology.update(initialTopology);
+    persistedClusterTopology.update(updatedTopology);
+
+    // then
+    assertEquals(updatedTopology, persistedClusterTopology.getTopology());
+    assertEquals(
+        updatedTopology, serializer.decodeClusterTopology(Files.readAllBytes(topologyFile)));
+  }
+
+  /**
+   * Contains all arbitraries needed to generate a {@link ClusterTopology}. The topology is not
+   * semantically correct (e.g. contains operations for members that don't exist) but all fields
+   * should have valid values.
+   */
+  static final class ClusterTopologyDomain extends DomainContextBase {
+
+    @Provide
+    Arbitrary<ClusterTopology> clusterTopologies() {
+      // Combine arbitraries (instead of just using `Arbitraries.forType(ClusterTopology.class)`
+      // here so that we have control over the version. Version must be greater than 0 for
+      // `ClusterTopology#isUninitialized` to return false.
+      final var arbitraryVersion = Arbitraries.integers().greaterOrEqual(0);
+      final var arbitraryMembers =
+          Arbitraries.maps(memberIds(), Arbitraries.forType(MemberState.class).enableRecursion());
+      final var arbitraryCompletedChange =
+          Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
+      final var arbitraryChangePlan =
+          Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
+      return Combinators.combine(
+              arbitraryVersion, arbitraryMembers, arbitraryCompletedChange, arbitraryChangePlan)
+          .as(ClusterTopology::new);
+    }
+
+    @Provide
+    Arbitrary<TopologyChangeOperation> topologyChangeOperations() {
+      // jqwik does not support sealed classes yet, so we have to use reflection to get all possible
+      // types. See https://github.com/jqwik-team/jqwik/issues/523
+      return Arbitraries.of(
+              ReflectUtil.implementationsOfSealedInterface(TopologyChangeOperation.class).toList())
+          .flatMap(Arbitraries::forType);
+    }
+
+    @Provide
+    Arbitrary<MemberId> memberIds() {
+      return Arbitraries.integers().greaterOrEqual(0).map(id -> MemberId.from(id.toString()));
+    }
+  }
+}

--- a/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/ReflectUtil.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.util;
 
 import java.lang.reflect.InvocationTargetException;
+import java.util.stream.Stream;
 
 public final class ReflectUtil {
 
@@ -25,5 +26,23 @@ public final class ReflectUtil {
               "Failed to instantiate class %s with the default constructor", clazz.getName()),
           e);
     }
+  }
+
+  /**
+   * Returns a stream of all non-interface classes that are a subtypes of the given sealed class.
+   */
+  public static <T> Stream<Class<T>> implementationsOfSealedInterface(final Class<T> clazz) {
+    if (!clazz.isSealed()) {
+      throw new IllegalArgumentException(String.format("Class %s is not sealed", clazz.getName()));
+    }
+    return Stream.of(clazz.getPermittedSubclasses())
+        .flatMap(
+            c -> {
+              if (c.isSealed()) {
+                return implementationsOfSealedInterface((Class<T>) c);
+              } else {
+                return Stream.of((Class<T>) c);
+              }
+            });
   }
 }


### PR DESCRIPTION
While chaos testing, we saw on multiple occasions that the `.topology.meta` file contained corrupted content. The cause for this was that while updating the file, we didn't truncate previous data. Depending on previous and updated data, we'd get nonsense data or (at best) an exception during deserialization.

I added the `TRUNCATE_EXISTING` option to truncate the file in b9e09c4b02a0db7125d6c494e5c8cbc4cca49187. To test this reliably (not every update corrupted the file in such a way that it was easily detectable), I've added a simple property test that generates more or less valid `ClusterTopology`s, writes the first one, updates and then checks if the file content is as expected. Without adding the `TRUNCATE_EXISTING` flag, this test fails quickly.
