### PR TITLE
test(qa): use any gateway for sending scale request even if it is not ready

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -40,7 +40,7 @@ final class Utils {
   }
 
   static PostOperationResponse scale(final TestCluster cluster, final int newClusterSize) {
-    final var actuator = ClusterActuator.of(cluster.availableGateway());
+    final var actuator = ClusterActuator.of(cluster.anyGateway());
     final var newBrokerSet = IntStream.range(0, newClusterSize).boxed().toList();
 
     // when


### PR DESCRIPTION
## Description

During the test, we are shutting down brokers. As a result there might be temporary period where there are no leaders for any partition. Gateway can be marked as " not READY" during this period since there are no leaders. `cluster.availableGateway()` only returns ready gateways. The test doesn't require a ready gateway, any gateway that can send the request to broker 0 is enough.

## Related issues

closes #15351 

