### PR TITLE
test(qa): wait until previous operaration is completed before scaling

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleUpBrokersTest.java
@@ -171,7 +171,11 @@ final class ScaleUpBrokersTest {
 
     // Add new broker to the cluster without moving partitions
     final var newBroker = createNewBroker(newClusterSize, newBrokerId, Optional.of(dataDirectory));
-    ClusterActuator.of(cluster.availableGateway()).addBroker(newBrokerId);
+    final var brokerAdded = ClusterActuator.of(cluster.availableGateway()).addBroker(newBrokerId);
+    Awaitility.await()
+        .timeout(Duration.ofMinutes(2))
+        .untilAsserted(
+            () -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(brokerAdded));
 
     // when
     newBroker.stop();


### PR DESCRIPTION
## Description

The test was flaky because the add broker operation is not completed before scale request.

## Related issues

closes #15355

