### PR TITLE
[Backport stable/8.2] Build quickly with maven

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,14 @@
 Zeebe is a multi-module maven project. To **quickly** build all components,
 run the command: `mvn clean install -Dquickly` in the root folder.
 
-> NOTE: All Java modules in Zeebe are built and tested with JDK 17. Most modules use language level
+> [!NOTE]
+> All Java modules in Zeebe are built and tested with JDK 17. Most modules use language level
 > 17, exceptions are: zeebe-bpmn-model, zeebe-client-java, zeebe-gateway-protocol,
 > zeebe-gateway-protocol-impl, zeebe-protocol and zeebe-protocol-jackson which use language level 8
 >
-> NOTE: The Go client and zbctl are built and tested with Go 1.15
+> The Go client and zbctl are built and tested with Go 1.15
 >
-> NOTE: The Java and the Go modules are built and tested with Docker 20.10.5 [with IPv6 support](https://docs.docker.com/config/daemon/ipv6/).
+> The Java and the Go modules are built and tested with Docker 20.10.5 [with IPv6 support](https://docs.docker.com/config/daemon/ipv6/).
 
 For contributions to Zeebe, building quickly is typically sufficient.
 However, users of Zeebe are recommended to build the full distribution.
@@ -73,11 +74,13 @@ This is a small overview of the contents of the different modules:
 
 Tests can be executed via maven (`mvn verify`) or in your preferred IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
 
-> Note: If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it
-
 > [!TIP]
 > To execute the tests quickly, run `mvn verify -Dquickly -DskipTests=false`.
 > The tests will be skipped when using `-Dquickly` without `-DskipTests=false`.
+
+#### Test Troubleshooting
+
+- If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it.
 
 ### Build profiling
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ This is a small overview of the contents of the different modules:
 
 ### Test Execution
 
-Tests can be executed via maven (`mvn verify`) or in your prefered IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
+Tests can be executed via maven (`mvn verify`) or in your preferred IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
 
 > Note: If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@
 
 ## Build Zeebe from source
 
-Zeebe is a multi-module maven project. To build all components,
-run the command: `mvn clean install -DskipTests` in the root folder.
+Zeebe is a multi-module maven project. To **quickly** build all components,
+run the command: `mvn clean install -Dquickly` in the root folder.
 
 > NOTE: All Java modules in Zeebe are built and tested with JDK 17. Most modules use language level
 > 17, exceptions are: zeebe-bpmn-model, zeebe-client-java, zeebe-gateway-protocol,
@@ -26,6 +26,11 @@ run the command: `mvn clean install -DskipTests` in the root folder.
 >
 > NOTE: The Java and the Go modules are built and tested with Docker 20.10.5 [with IPv6 support](https://docs.docker.com/config/daemon/ipv6/).
 
+For contributions to Zeebe, building quickly is typically sufficient.
+However, users of Zeebe are recommended to build the full distribution.
+
+To fully build the Zeebe distribution, run the command: `mvn clean install -DskipTests` in the root folder.
+This is slightly slower than building quickly, but ensures the distribution is assembled completely.
 The resulting Zeebe distribution can be found in the folder `dist/target`, i.e.
 
 ```
@@ -33,7 +38,7 @@ dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.tar.gz
 dist/target/camunda-zeebe-X.Y.Z-SNAPSHOT.zip
 ```
 
-The distribution can be containerized with Docker (i.e. build a Docker image) by running:
+This distribution can be containerized with Docker (i.e. build a Docker image) by running:
 
 ```
 docker build \
@@ -69,6 +74,10 @@ This is a small overview of the contents of the different modules:
 Tests can be executed via maven (`mvn verify`) or in your preferred IDE. The Zeebe Team uses mostly [Intellij IDEA](https://www.jetbrains.com/idea/), where we also [provide settings for](https://github.com/camunda/zeebe/tree/main/.idea).
 
 > Note: If you encounter issues (like `java.lang.UnsatisfiedLinkError: failed to load the required native library`) while running the test StandaloneGatewaySecurityTest.shouldStartWithTlsEnabled take a look at https://github.com/camunda/zeebe/issues/10488 to resolve it
+
+> [!TIP]
+> To execute the tests quickly, run `mvn verify -Dquickly -DskipTests=false`.
+> The tests will be skipped when using `-Dquickly` without `-DskipTests=false`.
 
 ### Build profiling
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -168,12 +168,14 @@
 
     <!--
       you can use the following to disable some or all goals:
+        - quickly will skip all non-essential goals, like checks, tests, and assembly
         - skipTests will skip all tests
         - skipITs will skip integration tests
         - skipUTs will skip unit tests
         - skipChecks will non-test checks, such as licensing, checkstyle, backwards compat, etc.
       -->
-    <skipTests>false</skipTests>
+    <quickly>false</quickly>
+    <skipTests>${quickly}</skipTests>
     <skipUTs>${skipTests}</skipUTs>
     <skipITs>${skipTests}</skipITs>
     <jacoco.skip>${skipUTs}</jacoco.skip>
@@ -185,7 +187,7 @@
       that way, you can use skipChecks, but you can also still use checkstyle.skip if you only want
       to disable checkstyle
       -->
-    <skipChecks>false</skipChecks>
+    <skipChecks>${quickly}</skipChecks>
     <checkstyle.skip>${skipChecks}</checkstyle.skip>
     <revapi.skip>${skipChecks}</revapi.skip>
     <license.skip>${skipChecks}</license.skip>
@@ -194,6 +196,9 @@
     <sort.skip>${skipChecks}</sort.skip>
     <spotless.apply.skip>${skipChecks}</spotless.apply.skip>
     <spotless.checks.skip>${skipChecks}</spotless.checks.skip>
+
+    <!-- disable other non-essential goals -->
+    <assembly.skipAssembly>${quickly}</assembly.skipAssembly>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
# Description
Backport of #15336 to `stable/8.2`.

Resolved a small conflict in CONTRIBUTING because 8.1 is still on JDK 17. Applied automatically thanks to [git rerere](https://git-scm.com/book/en/v2/Git-Tools-Rerere). ❤️ 
