### PR TITLE
feat: add scope parameter to zeebe client oauth credentials

### DIFF
--- a/clients/go/pkg/zbc/oauthCredentialsProvider.go
+++ b/clients/go/pkg/zbc/oauthCredentialsProvider.go
@@ -38,6 +38,9 @@ const OAuthClientSecretEnvVar = "ZEEBE_CLIENT_SECRET"
 // #nosec 101
 const OAuthTokenAudienceEnvVar = "ZEEBE_TOKEN_AUDIENCE"
 
+// #nosec 101
+const OAuthTokenScopeEnvVar = "ZEEBE_TOKEN_SCOPE"
+
 //nolint:revive
 const OAuthAuthorizationUrlEnvVar = "ZEEBE_AUTHORIZATION_SERVER_URL"
 const OAuthRequestTimeoutEnvVar = "ZEEBE_AUTH_REQUEST_TIMEOUT"
@@ -69,6 +72,8 @@ type OAuthProviderConfig struct {
 	ClientSecret string
 	// The audience to which the access token will be sent. Can be overridden with the environment variable 'ZEEBE_TOKEN_AUDIENCE'.
 	Audience string
+	// The scope(s) to be included in the access token. Can be overridden with the environment variable 'ZEEBE_TOKEN_SCOPE'.
+	Scope string
 	// The URL for the authorization server from which the access token will be requested. Can be overridden with
 	// the environment variable 'ZEEBE_AUTHORIZATION_SERVER_URL'.
 	AuthorizationServerURL string
@@ -128,6 +133,7 @@ func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentials
 		TokenConfig: &clientcredentials.Config{
 			ClientID:       config.ClientID,
 			ClientSecret:   config.ClientSecret,
+			Scopes:         []string{config.Scope},
 			EndpointParams: map[string][]string{"audience": {config.Audience}},
 			TokenURL:       config.AuthorizationServerURL,
 			AuthStyle:      oauth2.AuthStyleInParams,
@@ -210,6 +216,9 @@ func applyCredentialEnvOverrides(config *OAuthProviderConfig) error {
 	}
 	if envAudience := env.get(OAuthTokenAudienceEnvVar); envAudience != "" {
 		config.Audience = envAudience
+	}
+	if envScope := env.get(OAuthTokenScopeEnvVar); envScope != "" {
+		config.Scope = envScope
 	}
 	if envAuthzServerURL := env.get(OAuthAuthorizationUrlEnvVar); envAuthzServerURL != "" {
 		config.AuthorizationServerURL = envAuthzServerURL

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -123,6 +123,10 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
     payload.put("client_secret", builder.getClientSecret());
     payload.put("audience", builder.getAudience());
     payload.put("grant_type", "client_credentials");
+    final String scope = builder.getScope();
+    if (scope != null) {
+      payload.put("scope", scope);
+    }
 
     return payload.entrySet().stream()
         .map(e -> encode(e.getKey()) + "=" + encode(e.getValue()))

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProviderBuilder.java
@@ -28,6 +28,7 @@ public final class OAuthCredentialsProviderBuilder {
   public static final String OAUTH_ENV_CLIENT_ID = "ZEEBE_CLIENT_ID";
   public static final String OAUTH_ENV_CLIENT_SECRET = "ZEEBE_CLIENT_SECRET";
   public static final String OAUTH_ENV_TOKEN_AUDIENCE = "ZEEBE_TOKEN_AUDIENCE";
+  public static final String OAUTH_ENV_TOKEN_SCOPE = "ZEEBE_TOKEN_SCOPE";
   public static final String OAUTH_ENV_AUTHORIZATION_SERVER = "ZEEBE_AUTHORIZATION_SERVER_URL";
   public static final String OAUTH_ENV_CACHE_PATH = "ZEEBE_CLIENT_CONFIG_PATH";
   public static final String OAUTH_ENV_CONNECT_TIMEOUT = "ZEEBE_AUTH_CONNECT_TIMEOUT";
@@ -39,6 +40,7 @@ public final class OAuthCredentialsProviderBuilder {
   private String clientId;
   private String clientSecret;
   private String audience;
+  private String scope;
   private String authorizationServerUrl;
   private URL authorizationServer;
   private String credentialsCachePath;
@@ -72,7 +74,7 @@ public final class OAuthCredentialsProviderBuilder {
     return clientSecret;
   }
 
-  /** The resource for which the the access token should be valid. */
+  /** The resource for which the access token should be valid. */
   public OAuthCredentialsProviderBuilder audience(final String audience) {
     this.audience = audience;
     return this;
@@ -83,6 +85,19 @@ public final class OAuthCredentialsProviderBuilder {
    */
   String getAudience() {
     return audience;
+  }
+
+  /** The scopes of the access token. */
+  public OAuthCredentialsProviderBuilder scope(final String scope) {
+    this.scope = scope;
+    return this;
+  }
+
+  /**
+   * @see OAuthCredentialsProviderBuilder#scope(String)
+   */
+  String getScope() {
+    return scope;
   }
 
   /** The authorization server's URL, from which the access token will be requested. */
@@ -162,6 +177,7 @@ public final class OAuthCredentialsProviderBuilder {
     final String envClientId = Environment.system().get(OAUTH_ENV_CLIENT_ID);
     final String envClientSecret = Environment.system().get(OAUTH_ENV_CLIENT_SECRET);
     final String envAudience = Environment.system().get(OAUTH_ENV_TOKEN_AUDIENCE);
+    final String envScope = Environment.system().get(OAUTH_ENV_TOKEN_SCOPE);
     final String envAuthorizationUrl = Environment.system().get(OAUTH_ENV_AUTHORIZATION_SERVER);
     final String envCachePath = Environment.system().get(OAUTH_ENV_CACHE_PATH);
     final String envReadTimeout = Environment.system().get(OAUTH_ENV_READ_TIMEOUT);
@@ -177,6 +193,10 @@ public final class OAuthCredentialsProviderBuilder {
 
     if (envAudience != null) {
       audience = envAudience;
+    }
+
+    if (envScope != null) {
+      scope = envScope;
     }
 
     if (envAuthorizationUrl != null) {


### PR DESCRIPTION
## Description

Adds a new `scope` parameter to OAuth2 credentials request to support authorization via Microsoft Entra ID. The scopes can be set via a new environment variable `ZEEBE_CLIENT_SCOPE`

## Related issues

Relates to #15391

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
