### PR TITLE
Reject unsupported migration

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -22,16 +22,24 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue.ProcessInstanceMigrationMappingInstructionValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayDeque;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ProcessInstanceMigrationMigrateProcessor
     implements TypedRecordProcessor<ProcessInstanceMigrationRecord> {
+
+  private static final EnumSet<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
+      EnumSet.of(BpmnElementType.PROCESS, BpmnElementType.SERVICE_TASK);
+  private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
+      EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to migrate process instance but no process instance found with key '%d'";
@@ -104,6 +112,21 @@ public class ProcessInstanceMigrationMigrateProcessor
         processInstanceKey, ProcessInstanceMigrationIntent.MIGRATED, value, command);
   }
 
+  @Override
+  public ProcessingError tryHandleError(
+      final TypedRecord<ProcessInstanceMigrationRecord> command, final Throwable error) {
+    if (error instanceof final UnsupportedElementMigrationException e) {
+      final String reason =
+          "Expected to migrate process instance '%s' but it contains an active element that is unsupported: %s"
+              .formatted(command.getKey(), e.getMessage());
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, reason);
+      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, reason);
+      return ProcessingError.EXPECTED_ERROR;
+    }
+
+    return ProcessingError.UNEXPECTED_ERROR;
+  }
+
   private Map<String, String> mapElementIds(
       final List<ProcessInstanceMigrationMappingInstructionValue> mappingInstructions,
       final ElementInstance processInstance,
@@ -126,14 +149,19 @@ public class ProcessInstanceMigrationMigrateProcessor
       final DeployedProcess processDefinition,
       final Map<String, String> sourceElementIdToTargetElementId) {
 
+    final var elementInstanceRecord = elementInstance.getValue();
+    if (UNSUPPORTED_ELEMENT_TYPES.contains(elementInstanceRecord.getBpmnElementType())) {
+      throw new UnsupportedElementMigrationException(
+          elementInstanceRecord.getElementId(), elementInstanceRecord.getBpmnElementType());
+    }
+
     final String targetElementId =
-        sourceElementIdToTargetElementId.get(elementInstance.getValue().getElementId());
+        sourceElementIdToTargetElementId.get(elementInstanceRecord.getElementId());
 
     stateWriter.appendFollowUpEvent(
         elementInstance.getKey(),
         ProcessInstanceIntent.ELEMENT_MIGRATED,
-        elementInstance
-            .getValue()
+        elementInstanceRecord
             .setProcessDefinitionKey(processDefinition.getKey())
             .setBpmnProcessId(processDefinition.getBpmnProcessId())
             .setVersion(processDefinition.getVersion())
@@ -150,6 +178,17 @@ public class ProcessInstanceMigrationMigrateProcessor
                 .setBpmnProcessId(processDefinition.getBpmnProcessId())
                 .setElementId(targetElementId));
       }
+    }
+  }
+
+  /**
+   * Exception that can be thrown during the migration of a process instance, in case the engine
+   * attempts to migrate an element which is not supported at this time.
+   */
+  private static final class UnsupportedElementMigrationException extends RuntimeException {
+    UnsupportedElementMigrationException(
+        final String elementId, final BpmnElementType bpmnElementType) {
+      super("%s. The migration of a %s is not supported.".formatted(elementId, bpmnElementType));
     }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -100,7 +100,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     final var elementInstances = new ArrayDeque<>(List.of(processInstance));
     while (!elementInstances.isEmpty()) {
       final var elementInstance = elementInstances.poll();
-      migrateElementInstance(elementInstance, processDefinition, mappedElementIds);
+      tryMigrateElementInstance(elementInstance, processDefinition, mappedElementIds);
       final List<ElementInstance> children =
           elementInstanceState.getChildren(elementInstance.getKey());
       elementInstances.addAll(children);
@@ -144,7 +144,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     return mappedElementIds;
   }
 
-  private void migrateElementInstance(
+  private void tryMigrateElementInstance(
       final ElementInstance elementInstance,
       final DeployedProcess processDefinition,
       final Map<String, String> sourceElementIdToTargetElementId) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -92,8 +92,9 @@ public class ProcessInstanceMigrationMigrateProcessor
     final var elementInstances = new ArrayDeque<>(List.of(processInstance));
     while (!elementInstances.isEmpty()) {
       final var elementInstance = elementInstances.poll();
+      migrateElementInstance(elementInstance, processDefinition, mappedElementIds);
       final List<ElementInstance> children =
-          migrateElementInstance(elementInstance, processDefinition, mappedElementIds);
+          elementInstanceState.getChildren(elementInstance.getKey());
       elementInstances.addAll(children);
     }
 
@@ -120,7 +121,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     return mappedElementIds;
   }
 
-  private List<ElementInstance> migrateElementInstance(
+  private void migrateElementInstance(
       final ElementInstance elementInstance,
       final DeployedProcess processDefinition,
       final Map<String, String> sourceElementIdToTargetElementId) {
@@ -150,7 +151,5 @@ public class ProcessInstanceMigrationMigrateProcessor
                 .setElementId(targetElementId));
       }
     }
-
-    return elementInstanceState.getChildren(elementInstance.getKey());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceModificationModifyProcessor.java
@@ -47,7 +47,7 @@ import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -125,16 +125,15 @@ public final class ProcessInstanceModificationModifyProcessor
       Expected to modify instance of process '%s' but it contains one or more activate instructions \
       with an ancestor scope key that is not an ancestor of the element to activate:%s""";
 
-  private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
-      Set.of(
+  private static final EnumSet<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
+      EnumSet.of(
           BpmnElementType.UNSPECIFIED,
           BpmnElementType.START_EVENT,
           BpmnElementType.SEQUENCE_FLOW,
           BpmnElementType.BOUNDARY_EVENT);
-  private static final Set<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
-      Arrays.stream(BpmnElementType.values())
-          .filter(elementType -> !UNSUPPORTED_ELEMENT_TYPES.contains(elementType))
-          .collect(Collectors.toSet());
+  private static final EnumSet<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
+      EnumSet.complementOf(UNSUPPORTED_ELEMENT_TYPES);
+
   private static final Either<Rejection, Object> VALID = Either.right(null);
 
   private final StateWriter stateWriter;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
@@ -1,0 +1,642 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateProcessInstanceUnsupportedElementsTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String SOURCE_PROCESS = "process_source";
+  private static final String TARGET_PROCESS = "process_target";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldRejectMigrationForActiveUserTask() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .userTask("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .userTask("A")
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "USER_TASK"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveSubProcess() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .subProcess(
+                        "sub", s -> s.embeddedSubProcess().startEvent().userTask("A").endEvent())
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .subProcess(
+                        "sub",
+                        s ->
+                            s.embeddedSubProcess()
+                                .startEvent()
+                                .userTask("A")
+                                .userTask("B")
+                                .endEvent())
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "sub", "SUB_PROCESS"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveMessageIntermediateCatchEvent() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .intermediateCatchEvent(
+                        "A",
+                        e -> e.message(m -> m.name("msg").zeebeCorrelationKeyExpression("key")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .intermediateCatchEvent(
+                        "A",
+                        e -> e.message(m -> m.name("msg").zeebeCorrelationKeyExpression("key")))
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(SOURCE_PROCESS)
+            .withVariable("key", helper.getCorrelationValue())
+            .create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "INTERMEDIATE_CATCH_EVENT"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveReceiveTask() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .receiveTask(
+                        "A",
+                        e -> e.message(m -> m.name("msg").zeebeCorrelationKeyExpression("key")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .receiveTask(
+                        "A",
+                        e -> e.message(m -> m.name("msg").zeebeCorrelationKeyExpression("key")))
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(SOURCE_PROCESS)
+            .withVariable("key", helper.getCorrelationValue())
+            .create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "RECEIVE_TASK"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveCallActivity() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .callActivity("A", c -> c.zeebeProcessId("CHILD_PROCESS"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .callActivity("A", c -> c.zeebeProcessId("CHILD_PROCESS"))
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess("CHILD_PROCESS")
+                    .startEvent()
+                    .userTask("C")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withParentProcessInstanceKey(processInstanceKey)
+        .withElementId("CHILD_PROCESS")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "CALL_ACTIVITY"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveExclusiveGateway() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .exclusiveGateway("A")
+                    .conditionExpression("missing_function_causing_incident()")
+                    .endEvent()
+                    .moveToLastExclusiveGateway()
+                    .defaultFlow()
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .exclusiveGateway("A")
+                    .conditionExpression("missing_function_causing_incident()")
+                    .endEvent()
+                    .moveToLastExclusiveGateway()
+                    .defaultFlow()
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "EXCLUSIVE_GATEWAY"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveInclusiveGateway() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .inclusiveGateway("A")
+                    .conditionExpression("missing_function_causing_incident()")
+                    .endEvent()
+                    .moveToLastInclusiveGateway()
+                    .defaultFlow()
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .inclusiveGateway("A")
+                    .conditionExpression("missing_function_causing_incident()")
+                    .endEvent()
+                    .moveToLastInclusiveGateway()
+                    .defaultFlow()
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "INCLUSIVE_GATEWAY"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveEventBasedSubProcess() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .eventSubProcess(
+                        "SUB",
+                        s ->
+                            s.startEvent()
+                                .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+                                .userTask("A")
+                                .endEvent())
+                    .startEvent()
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .eventSubProcess(
+                        "SUB",
+                        s ->
+                            s.startEvent()
+                                .message(m -> m.name("msg").zeebeCorrelationKeyExpression("key"))
+                                .userTask("A")
+                                .endEvent())
+                    .startEvent()
+                    .userTask("B")
+                    .userTask("C")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(SOURCE_PROCESS)
+            .withVariable("key", helper.getCorrelationValue())
+            .create();
+
+    ENGINE.message().withName("msg").withCorrelationKey(helper.getCorrelationValue()).publish();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "SUB", "EVENT_SUB_PROCESS"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveMultiInstance() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .userTask(
+                        "A",
+                        u ->
+                            u.multiInstance()
+                                .zeebeInputCollectionExpression("[1,2]")
+                                .zeebeInputElement("input"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .userTask(
+                        "A",
+                        u ->
+                            u.multiInstance()
+                                .zeebeInputCollectionExpression("[1,2]")
+                                .zeebeInputElement("input"))
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "MULTI_INSTANCE_BODY"));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveBusinessRuleTask() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(SOURCE_PROCESS)
+                    .startEvent()
+                    .businessRuleTask(
+                        "A", b -> b.zeebeCalledDecisionId("decision").zeebeResultVariable("result"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(TARGET_PROCESS)
+                    .startEvent()
+                    .businessRuleTask(
+                        "A", b -> b.zeebeCalledDecisionId("decision").zeebeResultVariable("result"))
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .expectRejection()
+            .migrate();
+
+    // then
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but it contains an active \
+                element that is unsupported: %s. The migration of a %s is not supported""",
+                processInstanceKey, "A", "BUSINESS_RULE_TASK"));
+  }
+
+  private static long extractTargetProcessDefinitionKey(
+      final Record<DeploymentRecordValue> deployment) {
+    return deployment.getValue().getProcessesMetadata().stream()
+        .filter(p -> p.getBpmnProcessId().equals(TARGET_PROCESS))
+        .findAny()
+        .orElseThrow()
+        .getProcessDefinitionKey();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Rejects the migration command when the process instance has an active element that is currently unsupported.

At this time, only `PROCESS` and `SERVICE_TASK` elements are supported. Active elements of any other type result in a rejected migration.

> [!NOTE]
> This pull request's large number of lines is due to a large set of example test cases. Most have a similar structure, so I looked into extracting it, but it didn't help the readability. I hope the examples can be easily read through.

> [!NOTE]
> While working on this, I wanted to reject all unsupported scenarios rather than just all unsupported elements. So I also tried to work on #15405 and #15406. However, those issues contain a lot of hidden complexity. For now, I've scoped these out of this pull request's related issue. We may want to consider implementing #15407 instead of the extracted issues.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15123

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
