### PR TITLE
style(github): added ref for existing customer's support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,6 @@
+<!-- For existing Camunda Customers,
+please also use our [Support Channels](https://camunda.com/services/support/) to get priority assistance -->
+
 ---
 
 name: Bug report


### PR DESCRIPTION
## Description

Added a comment to direct Camunda's existing customers to use our customer support since some bugs has already know workaround. 
This will also help Zeebe teams prioritise bugs coming from the support team with detailed analysis 

