### PR TITLE
Automate supported process instance migration scenarios as E2E tests

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/MigrateProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/MigrateProcessInstanceTest.java
@@ -67,7 +67,7 @@ public class MigrateProcessInstanceTest {
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
                 .serviceTask("B", a -> a.zeebeJobType("B"))
-                .endEvent()
+                .endEvent("end")
                 .done());
 
     // when
@@ -131,6 +131,18 @@ public class MigrateProcessInstanceTest {
             "Expect that the type did not change even though it's different in the target process."
                 + " Re-evaluation of the job type expression is not enabled for this migration")
         .hasType("A");
+
+    CLIENT_RULE.getClient().newCompleteCommand(jobKey).send().join();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withRecordKey(serviceTaskKey)
+        .await();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementId("end")
+                .findAny())
+        .describedAs("Expect that end event is activated")
+        .isPresent();
   }
 
   @Test
@@ -234,7 +246,6 @@ public class MigrateProcessInstanceTest {
         .hasType("A");
 
     CLIENT_RULE.getClient().newCompleteCommand(jobKey).send().join();
-
     RecordingExporter.jobRecords(JobIntent.COMPLETED).withRecordKey(jobKey).await();
 
     Assertions.assertThat(
@@ -278,7 +289,7 @@ public class MigrateProcessInstanceTest {
             Bpmn.createExecutableProcess(targetProcessId)
                 .startEvent()
                 .serviceTask("B", a -> a.zeebeJobType("B"))
-                .endEvent()
+                .endEvent("end")
                 .done());
 
     // when
@@ -342,5 +353,17 @@ public class MigrateProcessInstanceTest {
             "Expect that the type did not change even though it's different in the target process."
                 + " Re-evaluation of the job type expression is not enabled for this migration")
         .hasType("A");
+
+    CLIENT_RULE.getClient().newCompleteCommand(jobKey).send().join();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+        .withRecordKey(serviceTaskKey)
+        .await();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementId("end")
+                .findAny())
+        .describedAs("Expect that end event is activated")
+        .isPresent();
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/MigrateProcessInstanceTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/MigrateProcessInstanceTest.java
@@ -1,0 +1,346 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class MigrateProcessInstanceTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateProcessInstanceWithToASmallDifferenceProcessDefinition() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final long definitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .endEvent()
+                .done());
+    final long processInstanceKey = CLIENT_RULE.createProcessInstance(definitionKey);
+
+    final long serviceTaskKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst()
+            .getKey();
+
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("A")
+            .getFirst()
+            .getKey();
+
+    // deploy a new version of the process
+    final long targetProcessDefinitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("B", a -> a.zeebeJobType("B"))
+                .endEvent()
+                .done());
+
+    // when
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newMigrateProcessInstanceCommand(processInstanceKey)
+            .migrationPlan(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "B")
+            .send();
+
+    // then
+    assertThatNoException()
+        .describedAs("Expect that migration command is not rejected")
+        .isThrownBy(command::join);
+
+    final var migratedProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue();
+
+    final var migratedTaskA =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+            .withRecordKey(serviceTaskKey)
+            .getFirst()
+            .getValue();
+
+    final var migratedJobA =
+        RecordingExporter.jobRecords(JobIntent.MIGRATED)
+            .withRecordKey(jobKey)
+            .getFirst()
+            .getValue();
+
+    assertThat(migratedProcessInstance)
+        .describedAs("Expect that process definition key changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id stayed the same")
+        .hasBpmnProcessId(processId)
+        .hasElementId(processId)
+        .describedAs("Expect that version number did not change")
+        .hasVersion(2);
+
+    assertThat(migratedTaskA)
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(processId)
+        .hasVersion(2)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("B");
+
+    assertThat(migratedJobA)
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(processId)
+        .hasProcessDefinitionVersion(2)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("B")
+        .describedAs(
+            "Expect that the type did not change even though it's different in the target process."
+                + " Re-evaluation of the job type expression is not enabled for this migration")
+        .hasType("A");
+  }
+
+  @Test
+  public void shouldMigrateProcessInstanceWithToALargeDifferenceProcessDefinition() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final long definitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .endEvent()
+                .done());
+    final long processInstanceKey = CLIENT_RULE.createProcessInstance(definitionKey);
+
+    final long serviceTaskKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst()
+            .getKey();
+
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("A")
+            .getFirst()
+            .getKey();
+
+    // deploy a new version of the process
+    final long targetProcessDefinitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .userTask("U")
+                .serviceTask("B", a -> a.zeebeJobType("B"))
+                .subProcess("sub", s -> s.embeddedSubProcess().startEvent().endEvent())
+                .endEvent()
+                .done());
+
+    // when
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newMigrateProcessInstanceCommand(processInstanceKey)
+            .migrationPlan(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "B")
+            .send();
+
+    // then
+    assertThatNoException()
+        .describedAs("Expect that migration command is not rejected")
+        .isThrownBy(command::join);
+
+    final var migratedProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue();
+
+    final var migratedTaskA =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+            .withRecordKey(serviceTaskKey)
+            .getFirst()
+            .getValue();
+
+    final var migratedJobA =
+        RecordingExporter.jobRecords(JobIntent.MIGRATED)
+            .withRecordKey(jobKey)
+            .getFirst()
+            .getValue();
+
+    assertThat(migratedProcessInstance)
+        .describedAs("Expect that process definition key changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id stayed the same")
+        .hasBpmnProcessId(processId)
+        .hasElementId(processId)
+        .describedAs("Expect that version number did not change")
+        .hasVersion(2);
+
+    assertThat(migratedTaskA)
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(processId)
+        .hasVersion(2)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("B");
+
+    assertThat(migratedJobA)
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(processId)
+        .hasProcessDefinitionVersion(2)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("B")
+        .describedAs(
+            "Expect that the type did not change even though it's different in the target process."
+                + " Re-evaluation of the job type expression is not enabled for this migration")
+        .hasType("A");
+
+    CLIENT_RULE.getClient().newCompleteCommand(jobKey).send().join();
+
+    RecordingExporter.jobRecords(JobIntent.COMPLETED).withRecordKey(jobKey).await();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withElementId("sub")
+                .findAny())
+        .describedAs("Expect that sub process is activated")
+        .isPresent();
+  }
+
+  @Test
+  public void shouldMigrateProcessInstanceToACompletelyNewProcessDefinition() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final long definitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .serviceTask("A", a -> a.zeebeJobType("A"))
+                .endEvent()
+                .done());
+    final long processInstanceKey = CLIENT_RULE.createProcessInstance(definitionKey);
+
+    final long serviceTaskKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst()
+            .getKey();
+
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType("A")
+            .getFirst()
+            .getKey();
+
+    final String targetProcessId = helper.getBpmnProcessId() + "1";
+    final long targetProcessDefinitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess(targetProcessId)
+                .startEvent()
+                .serviceTask("B", a -> a.zeebeJobType("B"))
+                .endEvent()
+                .done());
+
+    // when
+    final var command =
+        CLIENT_RULE
+            .getClient()
+            .newMigrateProcessInstanceCommand(processInstanceKey)
+            .migrationPlan(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "B")
+            .send();
+
+    // then
+    assertThatNoException()
+        .describedAs("Expect that migration command is not rejected")
+        .isThrownBy(command::join);
+
+    final var migratedProcessInstance =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getValue();
+
+    final var migratedTaskA =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+            .withRecordKey(serviceTaskKey)
+            .getFirst()
+            .getValue();
+
+    final var migratedJobA =
+        RecordingExporter.jobRecords(JobIntent.MIGRATED)
+            .withRecordKey(jobKey)
+            .getFirst()
+            .getValue();
+
+    assertThat(migratedProcessInstance)
+        .describedAs("Expect that process definition key changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId(targetProcessId)
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+
+    assertThat(migratedTaskA)
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasVersion(1)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("B");
+
+    assertThat(migratedJobA)
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasProcessDefinitionVersion(1)
+        .describedAs("Expect that element id changed due to mapping")
+        .hasElementId("B")
+        .describedAs(
+            "Expect that the type did not change even though it's different in the target process."
+                + " Re-evaluation of the job type expression is not enabled for this migration")
+        .hasType("A");
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Three different tests are implemented:
1) Being able to migrate to a process with a small difference (new version)
2) Being able to migrate to a process with large differences (new version)
3) Being able to migrate to a different process altogether

For the case 2, please note that we migrated the services to a service task followed by a subprocess and asserted that the subprocess flow is taken.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15131 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
