### PR TITLE
fix(raft): update role metrics when closing or transitioning to inactive

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -845,6 +845,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private RaftRole createRole(final Role role) {
     switch (role) {
       case INACTIVE:
+        raftRoleMetrics.becomingInactive();
         return new InactiveRole(this);
       case PASSIVE:
         return new PassiveRole(this);
@@ -907,6 +908,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   @Override
   public void close() {
+    raftRoleMetrics.becomingInactive();
     started = false;
     // Unregister protocol listeners.
     unregisterHandlers(protocol);

--- a/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
@@ -67,6 +67,10 @@ public class RaftRoleMetrics extends RaftMetrics {
     electionLatency = ELECTION_LATENCY.labels(partitionGroupName, partition);
   }
 
+  public void becomingInactive() {
+    role.set(0);
+  }
+
   public void becomingFollower() {
     role.set(1);
   }


### PR DESCRIPTION
## Description

Sometimes in Grafana we see two leaders for the same partition. This is because when the current leader is transitioned to inactive (or shutdown) the metrics is not updated. So it stays as the leader in the dashboard. This PR updates the metrics when transitioning to inactive or shutting down. 

Grafana panels already can show the inactive role if the metric is set. No need to update it.



