### PR TITLE
[Backport stable/8.3] fix(raft): update role metrics when closing or transitioning to inactive

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -853,6 +853,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
   private RaftRole createRole(final Role role) {
     switch (role) {
       case INACTIVE:
+        raftRoleMetrics.becomingInactive();
         return new InactiveRole(this);
       case PASSIVE:
         return new PassiveRole(this);
@@ -915,6 +916,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
 
   @Override
   public void close() {
+    raftRoleMetrics.becomingInactive();
     started = false;
     // Unregister protocol listeners.
     unregisterHandlers(protocol);

--- a/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/metrics/RaftRoleMetrics.java
@@ -67,6 +67,10 @@ public class RaftRoleMetrics extends RaftMetrics {
     electionLatency = ELECTION_LATENCY.labels(partitionGroupName, partition);
   }
 
+  public void becomingInactive() {
+    role.set(0);
+  }
+
   public void becomingFollower() {
     role.set(1);
   }


### PR DESCRIPTION
# Description
Backport of #15413 to `stable/8.3`.

relates to 
original author: @deepthidevaki