### PR TITLE
Reject migration for unmapped active elements

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -202,7 +202,7 @@ public class ProcessInstanceMigrationMigrateProcessor
           String.format(
               """
               Expected to migrate process instance '%s' \
-              but it contains an active element that is unsupported: %s. \
+              but active element with id '%s' has an unsupported type. \
               The migration of a %s is not supported.""",
               processInstanceKey, elementId, bpmnElementType));
     }
@@ -218,7 +218,7 @@ public class ProcessInstanceMigrationMigrateProcessor
           String.format(
               """
               Expected to migrate process instance '%s' \
-              but no mapping instruction defined for active element '%s'. \
+              but no mapping instruction defined for active element with id '%s'. \
               Elements cannot be migrated without a mapping.""",
               processInstanceKey, elementId));
     }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
@@ -140,7 +140,7 @@ public class MigrateProcessInstanceRejectionTest {
             String.format(
                 """
                 Expected to migrate process instance '%d' \
-                but no mapping instruction defined for active element 'A'. \
+                but no mapping instruction defined for active element with id 'A'. \
                 Elements cannot be migrated without a mapping.""",
                 processInstanceKey))
         .hasKey(processInstanceKey);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
@@ -11,8 +11,10 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
@@ -91,5 +93,65 @@ public class MigrateProcessInstanceRejectionTest {
                 "Expected to migrate process instance to process definition but no process definition found with key '%d'",
                 unknownKey))
         .hasKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldRejectCommandWhenActiveElementIsNotMapped() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process")
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("task"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process2")
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("task"))
+                    .userTask("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    final long targetProcessDefinitionKey =
+        extractTargetProcessDefinitionKey(deployment, "process2");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            String.format(
+                """
+                Expected to migrate process instance '%d' \
+                but no mapping instruction defined for active element 'A'. \
+                Elements cannot be migrated without a mapping.""",
+                processInstanceKey))
+        .hasKey(processInstanceKey);
+  }
+
+  private static long extractTargetProcessDefinitionKey(
+      final Record<DeploymentRecordValue> deployment, final String bpmnProcessId) {
+    return deployment.getValue().getProcessesMetadata().stream()
+        .filter(p -> p.getBpmnProcessId().equals(bpmnProcessId))
+        .findAny()
+        .orElseThrow()
+        .getProcessDefinitionKey();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
@@ -81,8 +81,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "USER_TASK"));
   }
 
@@ -140,8 +140,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "sub", "SUB_PROCESS"));
   }
 
@@ -200,8 +200,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "INTERMEDIATE_CATCH_EVENT"));
   }
 
@@ -260,8 +260,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "RECEIVE_TASK"));
   }
 
@@ -318,8 +318,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "CALL_ACTIVITY"));
   }
 
@@ -378,8 +378,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "EXCLUSIVE_GATEWAY"));
   }
 
@@ -438,8 +438,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "INCLUSIVE_GATEWAY"));
   }
 
@@ -514,8 +514,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "EVENT_BASED_GATEWAY"));
   }
 
@@ -586,8 +586,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "SUB", "EVENT_SUB_PROCESS"));
   }
 
@@ -648,8 +648,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "MULTI_INSTANCE_BODY"));
   }
 
@@ -702,8 +702,8 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-                Expected to migrate process instance '%s' but it contains an active \
-                element that is unsupported: %s. The migration of a %s is not supported""",
+                Expected to migrate process instance '%s' but active element with id '%s' \
+                has an unsupported type. The migration of a %s is not supported""",
                 processInstanceKey, "A", "BUSINESS_RULE_TASK"));
   }
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

> [!WARNING]
> This pull request is based on top of #15408. It should be merged before this pull request.

This rejects migrations when an active element is not mapped in the mapping instructions.

The engine cannot decide for the user how to migrate active elements. Mappings must be provided. In the future, we can add the ability to automatically map all elements that keep the same element id.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15124

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
