### PR TITLE
Do not delete jobs from backoff cf

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -243,7 +243,8 @@ public final class DbJobState implements JobState, MutableJobState {
           final var jobKey = key.second().inner();
           final var backoff = key.first().getValue();
           final var job = jobsColumnFamily.get(jobKey);
-          if (job == null || job.getRecord().getRetryBackoff() != backoff) {
+          if (job == null || job.getRecord().getRecurringTime() != backoff) {
+            LOG.debug("Deleting orphaned job with key {}", key);
             backoffColumnFamily.deleteExisting(key);
           }
           return true;

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.db.impl.DbForeignKey;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
 import io.camunda.zeebe.engine.state.instance.JobRecordValue;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -87,6 +88,26 @@ public class JobBackoffCleanupMigrationTest {
 
     // then
     assertThat(backoffColumnFamily.exists(backoffJobKey)).isFalse();
+  }
+
+  // regression test of https://github.com/camunda/zeebe/issues/14329
+  @Test
+  public void shouldNotCleanUpFailedJobs() {
+    // given
+    final MutableJobState jobState = processingState.getJobState();
+    final JobRecord record = new JobRecord();
+    record.setType("test");
+    jobState.create(jobKey.getValue(), record);
+    record.setRetries(3);
+    record.setRetryBackoff(1000);
+    record.setRecurringTime(System.currentTimeMillis() + 1000);
+    jobState.fail(jobKey.getValue(), record);
+
+    // when
+    jobBackoffCleanupMigration.runMigration(processingState);
+
+    // then
+    assertThat(backoffColumnFamily.isEmpty()).isFalse();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -60,34 +61,21 @@ public class JobBackoffCleanupMigrationTest {
     jobKey.wrapLong(1);
   }
 
+  // regression test of https://github.com/camunda/zeebe/issues/14329
   @Test
-  public void afterCleanupValidTimeoutIsStillPresent() {
+  public void shoulCleanOrphanBackoffEntries() {
     // given
-    final int deadline = 123;
-    jobsColumnFamily.upsert(jobKey, createJobRecordValue(deadline));
-    backoffKey.wrapLong(deadline);
-    backoffColumnFamily.upsert(backoffJobKey, DbNil.INSTANCE);
-
-    // when
-    jobBackoffCleanupMigration.runMigration(processingState);
-
-    // then
-    assertThat(backoffColumnFamily.exists(backoffJobKey)).isTrue();
-  }
-
-  @Test
-  public void afterCleanupOrphanedBackoffIsDeleted() {
-    // given
-    jobsColumnFamily.upsert(jobKey, new JobRecordValue());
-    backoffKey.wrapLong(123);
-    backoffColumnFamily.upsert(backoffJobKey, DbNil.INSTANCE);
+    final MutableJobState jobState = processingState.getJobState();
+    final JobRecord record = createJobRecord(1000);
+    jobState.create(jobKey.getValue(), record);
+    jobState.fail(jobKey.getValue(), record);
     jobsColumnFamily.deleteExisting(jobKey);
 
     // when
     jobBackoffCleanupMigration.runMigration(processingState);
 
     // then
-    assertThat(backoffColumnFamily.exists(backoffJobKey)).isFalse();
+    assertThat(backoffColumnFamily.isEmpty()).isTrue();
   }
 
   // regression test of https://github.com/camunda/zeebe/issues/14329
@@ -95,12 +83,8 @@ public class JobBackoffCleanupMigrationTest {
   public void shouldNotCleanUpFailedJobs() {
     // given
     final MutableJobState jobState = processingState.getJobState();
-    final JobRecord record = new JobRecord();
-    record.setType("test");
+    final JobRecord record = createJobRecord(1000);
     jobState.create(jobKey.getValue(), record);
-    record.setRetries(3);
-    record.setRetryBackoff(1000);
-    record.setRecurringTime(System.currentTimeMillis() + 1000);
     jobState.fail(jobKey.getValue(), record);
 
     // when
@@ -110,30 +94,38 @@ public class JobBackoffCleanupMigrationTest {
     assertThat(backoffColumnFamily.isEmpty()).isFalse();
   }
 
+  // regression test of https://github.com/camunda/zeebe/issues/14329
   @Test
-  public void afterCleanupTimeoutWithNonMatchingRetryBackoffIsDeleted() {
+  public void shoulCleanDuplicatedBackoffEntries() {
     // given
-    final int firstRetryBackoff = 123;
-    final int secondRetryBackoff = 456;
-    jobsColumnFamily.upsert(jobKey, createJobRecordValue(secondRetryBackoff));
-    backoffKey.wrapLong(firstRetryBackoff);
-    backoffColumnFamily.upsert(backoffJobKey, DbNil.INSTANCE);
-    backoffKey.wrapLong(secondRetryBackoff);
-    backoffColumnFamily.upsert(backoffJobKey, DbNil.INSTANCE);
+    final MutableJobState jobState = processingState.getJobState();
+    final JobRecord record = createJobRecord(1000);
+    jobState.create(jobKey.getValue(), record);
+    jobState.fail(jobKey.getValue(), record);
+
+    // second fail will cause duplicate entry and orphan the first backoff
+    record.setRecurringTime(System.currentTimeMillis() + 1001);
+    jobState.fail(jobKey.getValue(), record);
 
     // when
     jobBackoffCleanupMigration.runMigration(processingState);
 
     // then
-    backoffKey.wrapLong(firstRetryBackoff);
-    assertThat(backoffColumnFamily.exists(backoffJobKey)).isFalse();
-    backoffKey.wrapLong(secondRetryBackoff);
-    assertThat(backoffColumnFamily.exists(backoffJobKey)).isTrue();
+    assertThat(backoffColumnFamily.isEmpty()).isFalse();
+    final var keys = new ArrayList<DbCompositeKey<DbLong, DbForeignKey<DbLong>>>();
+    backoffColumnFamily.forEach((k, v) -> keys.add(k));
+    assertThat(keys).hasSize(1);
+    assertThat(keys)
+        .extracting(DbCompositeKey::second)
+        .extracting(DbForeignKey::inner)
+        .contains(jobKey);
   }
 
-  private static JobRecordValue createJobRecordValue(final long retryBackoff) {
-    final JobRecordValue jobRecordValue = new JobRecordValue();
-    jobRecordValue.setRecordWithoutVariables(new JobRecord().setRetryBackoff(retryBackoff));
-    return jobRecordValue;
+  private static JobRecord createJobRecord(final long retryBackoff) {
+    return new JobRecord()
+        .setType("test")
+        .setRetries(3)
+        .setRetryBackoff(retryBackoff)
+        .setRecurringTime(System.currentTimeMillis() + retryBackoff);
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/StateMigrationTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/StateMigrationTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.netty.util.NetUtil;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+import org.springframework.util.unit.DataSize;
+
+public class StateMigrationTest {
+
+  private static final DataSize ATOMIX_SEGMENT_SIZE = DataSize.ofMegabytes(2);
+  private static final Duration SNAPSHOT_PERIOD = Duration.ofMinutes(5);
+  private final ClusteringRule clusteringRule =
+      new ClusteringRule(
+          1,
+          3,
+          3,
+          cfg -> {
+            cfg.getData().setSnapshotPeriod(SNAPSHOT_PERIOD);
+            cfg.getData().setLogSegmentSize(ATOMIX_SEGMENT_SIZE);
+            cfg.getData().setLogIndexDensity(1);
+            cfg.getNetwork().setMaxMessageSize(ATOMIX_SEGMENT_SIZE);
+          });
+  private final GrpcClientRule clientRule =
+      new GrpcClientRule(
+          config ->
+              config
+                  .gatewayAddress(NetUtil.toSocketAddressString(clusteringRule.getGatewayAddress()))
+                  .defaultRequestTimeout(Duration.ofMinutes(1))
+                  .usePlaintext());
+
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(clusteringRule).around(clientRule);
+
+  // regression test for https://github.com/camunda/zeebe/issues/14329
+  @Test
+  public void shouldMakeJobActivatableAfterMigrationAndBackoff() {
+    // given
+    final String jobType = "test";
+    clientRule.createSingleJob(jobType);
+
+    final var activateResponse =
+        clientRule
+            .getClient()
+            .newActivateJobsCommand()
+            .jobType(jobType)
+            .maxJobsToActivate(1)
+            .send()
+            .join();
+    final var jobKey = activateResponse.getJobs().get(0).getKey();
+
+    final Duration backoffTimeout = Duration.ofDays(1);
+    clientRule
+        .getClient()
+        .newFailCommand(jobKey)
+        .retries(1)
+        .retryBackoff(backoffTimeout)
+        .send()
+        .join();
+
+    // when
+    // we restart the leader - and expect another node takes over
+    // new leader has to run migration first before starting processing
+    clusteringRule.restartBroker(clusteringRule.getLeaderForPartition(1).getNodeId());
+    // increasing time so after job backoff timeout job should be marked activatable again
+    clusteringRule.getClock().addTime(backoffTimeout.plus(backoffTimeout));
+
+    // then
+    Awaitility.await()
+        .until(
+            () ->
+                clientRule
+                    .getClient()
+                    .newActivateJobsCommand()
+                    .jobType(jobType)
+                    .maxJobsToActivate(1)
+                    .send()
+                    .join(),
+            r -> !activateResponse.getJobs().isEmpty());
+  }
+}


### PR DESCRIPTION
## Description

This PR makes sure that during migration, which happens on each partition transition, we do not delete jobs from backoff CF if they are still existing, or have a correct recurring time set.

Previously we checked the wrong property which was always not the same as in the state, this caused us to delete jobs from the backoff column family. This means jobs were stuck in the failed state forever.


> [!Note]
> This fixes the issue in general that we no longer delete jobs from the backoff CF
> BUT we still need to somehow recover jobs from the FAILED state, as 
> this BUG existed for a while already we need to do some migration logic to restore them.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/zeebe/issues/14329

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
