### PR TITLE
Add some more context to the logs

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -166,9 +166,11 @@ final class PartitionTransitionProcess {
 
     if (stepsToPrepare.isEmpty()) {
       LOG.info(
-          "Preparing transition from {} on term {} completed",
+          MSG_PREPARE_TRANSITION_COMPLETED,
           context.getCurrentRole(),
-          context.getCurrentTerm());
+          context.getCurrentTerm(),
+          newRole,
+          newTerm);
       future.complete(null);
 
       return;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -28,9 +28,14 @@ import org.slf4j.Logger;
 
 final class PartitionTransitionProcess {
 
+  public static final String MSG_PREPARE_TRANSITION =
+      "Prepare transition from [role: {}, term: {}] -> [role: {}, term: {}]";
+  public static final String MSG_PREPARE_TRANSITION_STEP =
+      MSG_PREPARE_TRANSITION + " - preparing {}";
+  public static final String MSG_PREPARE_TRANSITION_COMPLETED =
+      MSG_PREPARE_TRANSITION + " completed";
   private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private static final long STEP_TIMEOUT_MS = Duration.ofSeconds(60).toMillis();
-
   private PartitionTransitionStep currentStep;
   private final List<PartitionTransitionStep> pendingSteps;
   private final Deque<PartitionTransitionStep> stepsToPrepare = new ArrayDeque<>();
@@ -111,10 +116,11 @@ final class PartitionTransitionProcess {
 
   ActorFuture<Void> prepare(final long newTerm, final Role newRole) {
     LOG.info(
-        "Prepare transition from {} on term {} to {}",
+        MSG_PREPARE_TRANSITION,
         context.getCurrentRole(),
         context.getCurrentTerm(),
-        newRole);
+        newRole,
+        newTerm);
     final ActorFuture<Void> prepareFuture = concurrencyControl.createFuture();
 
     if (stepsToPrepare.isEmpty()) {
@@ -133,10 +139,11 @@ final class PartitionTransitionProcess {
           final var nextPrepareStep = stepsToPrepare.pop();
 
           LOG.info(
-              "Prepare transition from {} on term {} to {} - preparing {}",
+              MSG_PREPARE_TRANSITION_STEP,
               context.getCurrentRole(),
               context.getCurrentTerm(),
               newRole,
+              newTerm,
               nextPrepareStep.getName());
 
           nextPrepareStep

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -29,7 +29,7 @@ import org.slf4j.Logger;
 final class PartitionTransitionProcess {
 
   public static final String MSG_PREPARE_TRANSITION =
-      "Prepare transition from [role: {}, term: {}] -> [role: {}, term: {}]";
+      "Prepare transition from {}[term: {}] -> {}[term: {}]";
   public static final String MSG_PREPARE_TRANSITION_STEP =
       MSG_PREPARE_TRANSITION + " - preparing {}";
   public static final String MSG_PREPARE_TRANSITION_COMPLETED =


### PR DESCRIPTION

## Description

Raised here https://github.com/camunda/zeebe/issues/14329#issuecomment-1831868910

To be honest I run into this issue several times now, so I wanted to clean this a bit up.

This PR adds some more context to the transition logs.
Previously we were missing the newTerm, which led to confusion reading the logs all the time

<!-- Please explain the changes you made here. -->

Let me know what you think:


Logs look now like this:

```
15:37:12.183 [Broker-1] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 2 requested.
15:37:12.183 [Broker-1] [ZeebePartition-1] [zb-actors-0] DEBUG io.camunda.zeebe.broker.system - Partition role transitioning from FOLLOWER to CANDIDATE in term 2
15:37:12.183 [Broker-1] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from [role: FOLLOWER, term: 1] -> [role: FOLLOWER, term: 2]
15:37:12.183 [Broker-1] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from [role: FOLLOWER, term: 1] -> [role: FOLLOWER, term: 2] - preparing Admin API
15:37:12.183 [Broker-1] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from [role: FOLLOWER, term: 1] -> [role: FOLLOWER, term: 2] - preparing BackupApiRequestHandler
15:37:12.183 [Broker-1] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from [role: FOLLOWER, term: 1] -> [role: FOLLOWER, term: 2] - preparing ExporterDirector
15:37:12.183 [Broker-1] [StreamProcessor-1] [zb-actors-0] DEBUG io.camunda.zeebe.logstreams - Paused replay for partition 1
15:37:12.183 [Broker-1] [Exporter-1] [zb-fs-workers-0] DEBUG io.camunda.zeebe.scheduler.ActorTask - Discard job io.camunda.zeebe.broker.exporter.stream.ExporterDirector$$Lambda/0x00007f8cb09a0d18 QUEUED from fastLane of Actor Exporter-1.
15:37:12.183 [Broker-1] [Exporter-1] [zb-fs-workers-0] DEBUG io.camunda.zeebe.broker.exporter - Closed exporter director 'Exporter-1'.
15:37:12.183 [Broker-1] [ZeebePartition-1] [zb-actors-0] INFO  io.camunda.zeebe.broker.system - Prepare transition from [role: FOLLOWER, term: 1] -> [role: FOLLOWER, term: 2] - preparing SnapshotDirector
```

Previously:

```
13:36:22.451 [Broker-1] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Transition to FOLLOWER on term 3 requested.
13:36:22.451 [Broker-1] [ZeebePartition-1] [zb-actors-1] DEBUG io.camunda.zeebe.broker.system - Partition role transitioning from FOLLOWER to CANDIDATE in term 3
13:36:22.451 [Broker-1] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Prepare transition from FOLLOWER on term 2 to FOLLOWER
13:36:22.451 [Broker-1] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Prepare transition from FOLLOWER on term 2 to FOLLOWER - preparing Admin API
13:36:22.451 [Broker-1] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Prepare transition from FOLLOWER on term 2 to FOLLOWER - preparing BackupApiRequestHandler
13:36:22.451 [Broker-1] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Prepare transition from FOLLOWER on term 2 to FOLLOWER - preparing ExporterDirector
13:36:22.451 [Broker-1] [StreamProcessor-1] [zb-actors-1] DEBUG io.camunda.zeebe.logstreams - Paused replay for partition 1
13:36:22.451 [Broker-1] [Exporter-1] [zb-fs-workers-1] DEBUG io.camunda.zeebe.broker.exporter - Closed exporter director 'Exporter-1'.
13:36:22.451 [Broker-1] [raft-server-1] [raft-server-1-1] DEBUG io.atomix.raft.roles.CandidateRole - RaftServer{raft-partition-partition-1}{role=CANDIDATE} - Received successful vote from DefaultRaftMember{id=2, type=ACTIVE, updated=2023-11-29T12:36:04.116Z}
13:36:22.451 [Broker-1] [ZeebePartition-1] [zb-actors-1] INFO  io.camunda.zeebe.broker.system - Prepare transition from FOLLOWER on term 2 to FOLLOWER - preparing SnapshotDirector

```