### PR TITLE
feat(topology): verify checksum of persisted topology

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -65,7 +65,8 @@ public final class ClusterTopologyManagerService extends Actor implements Topolo
 
     final MemberId localMemberId = memberShipService.getLocalMember().id();
     topologyFile = dataRootDirectory.resolve(TOPOLOGY_FILE_NAME);
-    persistedClusterTopology = new PersistedClusterTopology(topologyFile, new ProtoBufSerializer());
+    persistedClusterTopology =
+        PersistedClusterTopology.ofFile(topologyFile, new ProtoBufSerializer());
     clusterTopologyManager =
         new ClusterTopologyManagerImpl(this, localMemberId, persistedClusterTopology);
     clusterTopologyGossiper =

--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -134,7 +134,7 @@ final class PersistedClusterTopology {
     return checksum.getValue();
   }
 
-  private static final class UnexpectedVersion extends RuntimeException {
+  public static final class UnexpectedVersion extends RuntimeException {
     private UnexpectedVersion(final Path topologyFile, final byte version) {
       super(
           "Topology file %s had version '%s', but expected version '%s'"
@@ -142,7 +142,7 @@ final class PersistedClusterTopology {
     }
   }
 
-  private static final class MissingHeader extends RuntimeException {
+  public static final class MissingHeader extends RuntimeException {
     private MissingHeader(final Path topologyFile, final Object fileSize) {
       super(
           "Topology file %s is too small to contain the expected header: %s bytes"
@@ -150,7 +150,7 @@ final class PersistedClusterTopology {
     }
   }
 
-  private static final class ChecksumMismatch extends RuntimeException {
+  public static final class ChecksumMismatch extends RuntimeException {
     private ChecksumMismatch(
         final Path topologyFile, final long expectedChecksum, final long actualChecksum) {
       super(

--- a/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/PersistedClusterTopology.java
@@ -24,11 +24,10 @@ import java.util.zip.CRC32C;
  * fixed-size header containing a version and a checksum, followed by the serialized topology.
  */
 final class PersistedClusterTopology {
+  // Header is a single byte for the version, followed by a long for the checksum.
+  public static final int HEADER_LENGTH = Byte.BYTES + Long.BYTES;
   // Constant version, to be incremented if the format changes.
   private static final byte VERSION = 1;
-
-  // Header is a single byte for the version, followed by a long for the checksum.
-  private static final int HEADER_LENGTH = Byte.BYTES + Long.BYTES;
   private final Path topologyFile;
   private final ClusterTopologySerializer serializer;
   private ClusterTopology clusterTopology;

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
@@ -135,7 +135,7 @@ public interface TopologyInitializer {
     public ActorFuture<ClusterTopology> initialize() {
       try {
         final var persistedTopology =
-            new PersistedClusterTopology(topologyFile, serializer).getTopology();
+            PersistedClusterTopology.ofFile(topologyFile, serializer).getTopology();
         if (!persistedTopology.isUninitialized()) {
           LOGGER.debug(
               "Initialized cluster topology '{}' from file '{}'", persistedTopology, topologyFile);

--- a/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/TopologyInitializer.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
  *     topology from the coordinator via gossip. See {@link GossipInitializer}.
  */
 public interface TopologyInitializer {
+  Logger LOG = LoggerFactory.getLogger(TopologyInitializer.class);
 
   /**
    * Initializes the cluster topology.
@@ -102,6 +103,7 @@ public interface TopologyInitializer {
           .onComplete(
               (topology, error) -> {
                 if (error != null && exception.isAssignableFrom(error.getClass())) {
+                  LOG.warn("Recovering from {} by falling back to {}", error, recovery);
                   recovery.initialize().onComplete(chainedInitialize);
                 } else if (error != null) {
                   chainedInitialize.completeExceptionally(error);

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ClusterTopologySerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ClusterTopologySerializer.java
@@ -18,5 +18,6 @@ public interface ClusterTopologySerializer {
 
   byte[] encode(ClusterTopology clusterTopology);
 
-  ClusterTopology decodeClusterTopology(byte[] encodedClusterTopology);
+  ClusterTopology decodeClusterTopology(
+      byte[] encodedClusterTopology, final int offset, final int length);
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOp
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import io.camunda.zeebe.util.Either;
+import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -85,9 +86,12 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
   }
 
   @Override
-  public ClusterTopology decodeClusterTopology(final byte[] encodedClusterTopology) {
+  public ClusterTopology decodeClusterTopology(
+      final byte[] encodedClusterTopology, final int offset, final int length) {
     try {
-      final var topology = Topology.ClusterTopology.parseFrom(encodedClusterTopology);
+      final var topology =
+          Topology.ClusterTopology.parseFrom(
+              ByteBuffer.wrap(encodedClusterTopology, offset, length));
       return decodeClusterTopology(topology);
 
     } catch (final InvalidProtocolBufferException e) {

--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -57,7 +57,7 @@ final class ClusterTopologyManagerTest {
   @BeforeEach
   void init() {
     persistedClusterTopology =
-        new PersistedClusterTopology(tempDir.resolve("topology.temp"), serializer);
+        PersistedClusterTopology.ofFile(tempDir.resolve("topology.temp"), serializer);
   }
 
   private ActorFuture<ClusterTopologyManagerImpl> startTopologyManager(

--- a/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyRandomizedPropertyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyRandomizedPropertyTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
+import io.camunda.zeebe.topology.state.ClusterChangePlan;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.CompletedChange;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.util.ReflectUtil;
+import java.io.IOException;
+import java.nio.file.Files;
+import net.jqwik.api.Arbitraries;
+import net.jqwik.api.Arbitrary;
+import net.jqwik.api.Combinators;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.Provide;
+import net.jqwik.api.domains.Domain;
+import net.jqwik.api.domains.DomainContext;
+import net.jqwik.api.domains.DomainContextBase;
+
+final class PersistedClusterTopologyRandomizedPropertyTest {
+
+  @Property(tries = 100)
+  @Domain(ClusterTopologyDomain.class)
+  @Domain(DomainContext.Global.class)
+  void shouldUpdatePersistedFile(
+      @ForAll final ClusterTopology initialTopology, @ForAll final ClusterTopology updatedTopology)
+      throws IOException {
+    // given
+    final var tmp = Files.createTempDirectory("topology");
+    final var topologyFile = tmp.resolve("topology.meta");
+    final var serializer = new ProtoBufSerializer();
+    final var persistedClusterTopology = PersistedClusterTopology.ofFile(topologyFile, serializer);
+
+    // when
+    persistedClusterTopology.update(initialTopology);
+    persistedClusterTopology.update(updatedTopology);
+
+    // then
+    assertEquals(updatedTopology, persistedClusterTopology.getTopology());
+    assertEquals(
+        updatedTopology, PersistedClusterTopology.ofFile(topologyFile, serializer).getTopology());
+  }
+
+  /**
+   * Contains all arbitraries needed to generate a {@link ClusterTopology}. The topology is not
+   * semantically correct (e.g. contains operations for members that don't exist) but all fields
+   * should have valid values.
+   */
+  static final class ClusterTopologyDomain extends DomainContextBase {
+
+    @Provide
+    Arbitrary<ClusterTopology> clusterTopologies() {
+      // Combine arbitraries (instead of just using `Arbitraries.forType(ClusterTopology.class)`
+      // here so that we have control over the version. Version must be greater than 0 for
+      // `ClusterTopology#isUninitialized` to return false.
+      final var arbitraryVersion = Arbitraries.integers().greaterOrEqual(0);
+      final var arbitraryMembers =
+          Arbitraries.maps(memberIds(), Arbitraries.forType(MemberState.class).enableRecursion());
+      final var arbitraryCompletedChange =
+          Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
+      final var arbitraryChangePlan =
+          Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
+      return Combinators.combine(
+              arbitraryVersion, arbitraryMembers, arbitraryCompletedChange, arbitraryChangePlan)
+          .as(ClusterTopology::new);
+    }
+
+    @Provide
+    Arbitrary<TopologyChangeOperation> topologyChangeOperations() {
+      // jqwik does not support sealed classes yet, so we have to use reflection to get all possible
+      // types. See https://github.com/jqwik-team/jqwik/issues/523
+      return Arbitraries.of(
+              ReflectUtil.implementationsOfSealedInterface(TopologyChangeOperation.class).toList())
+          .flatMap(Arbitraries::forType);
+    }
+
+    @Provide
+    Arbitrary<MemberId> memberIds() {
+      return Arbitraries.integers().greaterOrEqual(0).map(id -> MemberId.from(id.toString()));
+    }
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
@@ -41,7 +41,7 @@ final class PersistedClusterTopologyTest {
     final var tmp = Files.createTempDirectory("topology");
     final var topologyFile = tmp.resolve("topology.meta");
     final var serializer = new ProtoBufSerializer();
-    final var persistedClusterTopology = new PersistedClusterTopology(topologyFile, serializer);
+    final var persistedClusterTopology = PersistedClusterTopology.ofFile(topologyFile, serializer);
 
     // when
     persistedClusterTopology.update(initialTopology);
@@ -50,7 +50,7 @@ final class PersistedClusterTopologyTest {
     // then
     assertEquals(updatedTopology, persistedClusterTopology.getTopology());
     assertEquals(
-        updatedTopology, new PersistedClusterTopology(topologyFile, serializer).getTopology());
+        updatedTopology, PersistedClusterTopology.ofFile(topologyFile, serializer).getTopology());
   }
 
   /**

--- a/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
@@ -9,6 +9,9 @@ package io.camunda.zeebe.topology;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.camunda.zeebe.topology.PersistedClusterTopology.ChecksumMismatch;
+import io.camunda.zeebe.topology.PersistedClusterTopology.MissingHeader;
+import io.camunda.zeebe.topology.PersistedClusterTopology.UnexpectedVersion;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import java.io.IOException;
@@ -32,7 +35,7 @@ final class PersistedClusterTopologyTest {
 
     // then
     Assertions.assertThatCode(() -> PersistedClusterTopology.ofFile(topologyFile, serializer))
-        .hasMessageContaining("checksum");
+        .isInstanceOf(ChecksumMismatch.class);
   }
 
   @Test
@@ -49,7 +52,7 @@ final class PersistedClusterTopologyTest {
 
     // then
     Assertions.assertThatCode(() -> PersistedClusterTopology.ofFile(topologyFile, serializer))
-        .hasMessageContaining("version");
+        .isInstanceOf(UnexpectedVersion.class);
   }
 
   @Test
@@ -64,7 +67,7 @@ final class PersistedClusterTopologyTest {
 
     // then
     Assertions.assertThatCode(() -> PersistedClusterTopology.ofFile(topologyFile, serializer))
-        .hasMessageContaining("too small");
+        .isInstanceOf(MissingHeader.class);
   }
 
   @Test
@@ -80,6 +83,6 @@ final class PersistedClusterTopologyTest {
 
     // then
     Assertions.assertThatCode(() -> PersistedClusterTopology.ofFile(topologyFile, serializer))
-        .hasMessageContaining("header");
+        .isInstanceOf(MissingHeader.class);
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
@@ -50,7 +50,7 @@ final class PersistedClusterTopologyTest {
     // then
     assertEquals(updatedTopology, persistedClusterTopology.getTopology());
     assertEquals(
-        updatedTopology, serializer.decodeClusterTopology(Files.readAllBytes(topologyFile)));
+        updatedTopology, new PersistedClusterTopology(topologyFile, serializer).getTopology());
   }
 
   /**

--- a/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyTest.java
@@ -9,53 +9,15 @@ package io.camunda.zeebe.topology;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
-import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
-import io.camunda.zeebe.topology.state.CompletedChange;
-import io.camunda.zeebe.topology.state.MemberState;
-import io.camunda.zeebe.topology.state.TopologyChangeOperation;
-import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
-import net.jqwik.api.Arbitraries;
-import net.jqwik.api.Arbitrary;
-import net.jqwik.api.Combinators;
-import net.jqwik.api.ForAll;
-import net.jqwik.api.Property;
-import net.jqwik.api.Provide;
-import net.jqwik.api.domains.Domain;
-import net.jqwik.api.domains.DomainContext;
-import net.jqwik.api.domains.DomainContextBase;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class PersistedClusterTopologyTest {
-
-  @Property(tries = 100)
-  @Domain(ClusterTopologyDomain.class)
-  @Domain(DomainContext.Global.class)
-  void shouldUpdatePersistedFile(
-      @ForAll final ClusterTopology initialTopology, @ForAll final ClusterTopology updatedTopology)
-      throws IOException {
-    // given
-    final var tmp = Files.createTempDirectory("topology");
-    final var topologyFile = tmp.resolve("topology.meta");
-    final var serializer = new ProtoBufSerializer();
-    final var persistedClusterTopology = PersistedClusterTopology.ofFile(topologyFile, serializer);
-
-    // when
-    persistedClusterTopology.update(initialTopology);
-    persistedClusterTopology.update(updatedTopology);
-
-    // then
-    assertEquals(updatedTopology, persistedClusterTopology.getTopology());
-    assertEquals(
-        updatedTopology, PersistedClusterTopology.ofFile(topologyFile, serializer).getTopology());
-  }
-
   @Test
   void shouldDetectFileWithMoreDataThanExpected() throws IOException {
     // given
@@ -119,44 +81,5 @@ final class PersistedClusterTopologyTest {
     // then
     Assertions.assertThatCode(() -> PersistedClusterTopology.ofFile(topologyFile, serializer))
         .hasMessageContaining("header");
-  }
-
-  /**
-   * Contains all arbitraries needed to generate a {@link ClusterTopology}. The topology is not
-   * semantically correct (e.g. contains operations for members that don't exist) but all fields
-   * should have valid values.
-   */
-  static final class ClusterTopologyDomain extends DomainContextBase {
-
-    @Provide
-    Arbitrary<ClusterTopology> clusterTopologies() {
-      // Combine arbitraries (instead of just using `Arbitraries.forType(ClusterTopology.class)`
-      // here so that we have control over the version. Version must be greater than 0 for
-      // `ClusterTopology#isUninitialized` to return false.
-      final var arbitraryVersion = Arbitraries.integers().greaterOrEqual(0);
-      final var arbitraryMembers =
-          Arbitraries.maps(memberIds(), Arbitraries.forType(MemberState.class).enableRecursion());
-      final var arbitraryCompletedChange =
-          Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
-      final var arbitraryChangePlan =
-          Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
-      return Combinators.combine(
-              arbitraryVersion, arbitraryMembers, arbitraryCompletedChange, arbitraryChangePlan)
-          .as(ClusterTopology::new);
-    }
-
-    @Provide
-    Arbitrary<TopologyChangeOperation> topologyChangeOperations() {
-      // jqwik does not support sealed classes yet, so we have to use reflection to get all possible
-      // types. See https://github.com/jqwik-team/jqwik/issues/523
-      return Arbitraries.of(
-              ReflectUtil.implementationsOfSealedInterface(TopologyChangeOperation.class).toList())
-          .flatMap(Arbitraries::forType);
-    }
-
-    @Provide
-    Arbitrary<MemberId> memberIds() {
-      return Arbitraries.integers().greaterOrEqual(0).map(id -> MemberId.from(id.toString()));
-    }
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/TopologyInitializerTest.java
@@ -60,7 +60,8 @@ final class TopologyInitializerTest {
   @BeforeEach
   void init() {
     topologyFile = rootDir.resolve("topology.temp");
-    persistedClusterTopology = new PersistedClusterTopology(topologyFile, new ProtoBufSerializer());
+    persistedClusterTopology =
+        PersistedClusterTopology.ofFile(topologyFile, new ProtoBufSerializer());
   }
 
   @Test

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -60,8 +60,9 @@ final class ProtoBufSerializerTest {
     final var initialClusterTopology = topologyWithTwoMembers();
 
     // when
+    final var encoded = protoBufSerializer.encode(initialClusterTopology);
     final var decodedClusterTopology =
-        protoBufSerializer.decodeClusterTopology(protoBufSerializer.encode(initialClusterTopology));
+        protoBufSerializer.decodeClusterTopology(encoded, 0, encoded.length);
 
     // then
     assertThat(decodedClusterTopology)


### PR DESCRIPTION
This adds a small header to the persisted topology file (.topology.meta in the data folder) that contains a version, which is just hardcoded to 1, and a CRC32 checksum of the rest of the file. This is to protect from silent corruption of the topology file which we already observed when the protobuf deserializer simply accepted broken files.

When a corrupted file is detected on non-coordinator members (so all members except 0), we try to recover by syncing with any other member.
If the coordinator starts with a corrupted file, it will fail to start. This is a precaution because we treat the coordinator as the source of truth.
More details in the commit messages.

Closes #15292 