### PR TITLE
fix(raft): resend configuration to members that lost their configuration

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -104,6 +104,11 @@ import org.slf4j.MDC;
  */
 public class RaftContext implements AutoCloseable, HealthMonitorable {
 
+  /**
+   * Configuration index returned when no configuration is available, i.e. configuration is null .
+   */
+  private static final long NO_CONFIGURATION_INDEX = -1L;
+
   protected final String name;
   protected final ThreadContext threadContext;
   protected final ClusterMembershipService membershipService;
@@ -1265,7 +1270,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    */
   public long getCurrentConfigurationIndex() {
     final var configuration = cluster.getConfiguration();
-    return configuration != null ? configuration.index() : -1L;
+    return configuration != null ? configuration.index() : NO_CONFIGURATION_INDEX;
   }
 
   public boolean isRunning() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1260,6 +1260,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return currentSnapshot != null ? currentSnapshot.getIndex() : 0L;
   }
 
+  /**
+   * @return the current configuration index or -1 if there is no configuration yet.
+   */
+  public long getCurrentConfigurationIndex() {
+    final var configuration = cluster.getConfiguration();
+    return configuration != null ? configuration.index() : -1L;
+  }
+
   public boolean isRunning() {
     return started;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendResponse.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendResponse.java
@@ -113,15 +113,15 @@ public class AppendResponse extends AbstractRaftResponse {
 
   @Override
   public boolean equals(final Object object) {
-    if (object instanceof final AppendResponse response) {
-      return response.status == status
-          && response.term == term
-          && response.succeeded == succeeded
-          && response.lastLogIndex == lastLogIndex
-          && response.lastSnapshotIndex == lastSnapshotIndex
-          && response.configurationIndex == configurationIndex;
+    if (!(object instanceof final AppendResponse response)) {
+      return false;
     }
-    return false;
+    return response.status == status
+        && response.term == term
+        && response.succeeded == succeeded
+        && response.lastLogIndex == lastLogIndex
+        && response.lastSnapshotIndex == lastSnapshotIndex
+        && response.configurationIndex == configurationIndex;
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -769,6 +769,7 @@ public class PassiveRole extends InactiveRole {
                 .withSucceeded(succeeded)
                 .withLastLogIndex(lastLogIndex)
                 .withLastSnapshotIndex(raft.getCurrentSnapshotIndex())
+                .withConfigurationIndex(raft.getCurrentConfigurationIndex())
                 .build()));
     return succeeded;
   }


### PR DESCRIPTION
Leaders track the configuration index of all members in the replication group so that it can send a configuration update to outdated members. Previously, the leader only updated the configuration index when receiving a successful configuration response. In cases where a leader initially accepted the current configuration but then loses it again, for example because of dataloss or because it never managed to commit the configuration, the leaders view of the members configuration index remained outdated: The leader thought member B had configuration index X but actually the member has no configuration at all. This could only be resolved by restarting the leader or when creating a new configuration.

As a fix, the append response now contains the configuration index. The leader updates the configuration index when it receives an append response. This allows followers to signal to the leader that they have no configuration at all or and outdated one. Before the leader tries to send the next append request, it will first send a configuration request and bring the follower up to date.

On the follower side, we now reject append requests if there is not current configuration. The append response has configuration index -1, guaranteeing that the leader will send a configure request next.

### Backwards compatibility

Adding a new field to the `AppendResponse` is safe, we have done it before: https://github.com/camunda/zeebe/pull/14063#discussion_r1311219403

Followers from the previous version do not send a configuration index. A leader from the new version will then read a 0 (default value for longs). To prevent that the follower from the previous version is then stuck in a configuration loop, we treat configuration index 0 as a special case and _don't_ update the configuration index. Effectively, we fall back to the old behavior where the configuration index is only updated when a configuration response is sent. This fallback is safe for us because we want to fix a _join_ bug where it's guaranteed that the configuration index is not 0.

Closes #15381