### PR TITLE
Test new FEEL dependency for escaping characters

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/JobInputMappingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/JobInputMappingTest.java
@@ -66,6 +66,26 @@ public final class JobInputMappingTest {
         mapping(b -> b.zeebeInputExpression("x.y", "y")),
         "{'x': {'y': 2}, 'y': 2}"
       },
+      {
+        "{}",
+        mapping(b -> b.zeebeInputExpression("\"Hello\\nWorld\"", "input")),
+        "{\"input\": \"Hello\\nWorld\"}"
+      },
+      {
+        "{}",
+        mapping(b -> b.zeebeInputExpression("\"Hello\\rWorld\"", "input")),
+        "{\"input\": \"Hello\\rWorld\"}"
+      },
+      {
+        "{}",
+        mapping(b -> b.zeebeInputExpression("\"Hello\\tWorld\"", "input")),
+        "{\"input\": \"Hello\\tWorld\"}"
+      },
+      {
+        "{}",
+        mapping(b -> b.zeebeInputExpression("\"Hello\\'World\"", "input")),
+        "{\"input\": \"Hello\\'World\"}"
+      },
     };
   }
 

--- a/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/ExpressionLanguageTest.java
@@ -216,4 +216,13 @@ public class ExpressionLanguageTest {
             tuple("NO_VARIABLE_FOUND", "No variable found with name 'x'"),
             tuple("ASSERT_FAILURE", "The condition is not fulfilled"));
   }
+
+  @Test
+  public void shouldNotEscapeSpecialCharactersInString() {
+    final var expression = expressionLanguage.parseExpression("Hello\nWorld");
+    final var evaluationResult = expressionLanguage.evaluateExpression(expression, EMPTY_CONTEXT);
+
+    assertThat(evaluationResult).isNotNull();
+    assertThat(evaluationResult.getString()).isEqualTo("Hello\nWorld");
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR add some test cases to ensure the new behaviour of FEEL engine related to the escaping of characters

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15445 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
