### PR TITLE
Special characters in static inputs should not be escaped

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -97,11 +97,6 @@
 
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
-import org.apache.commons.text.StringEscapeUtils;
 
 /**
  * Transform variable mappings into an expression.
@@ -155,9 +154,7 @@ public final class VariableMappingTransformer {
         final String expression;
 
         if (sourceExpression instanceof StaticExpression) {
-          expression =
-              String.format(
-                  "\"%s\"", StringEscapeUtils.escapeJava(sourceExpression.getExpression()));
+          expression = String.format("\"%s\"", sourceExpression.getExpression());
         } else {
           expression = sourceExpression.getExpression();
         }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ActivityTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ActivityTest.java
@@ -78,7 +78,7 @@ public final class ActivityTest {
                       .zeebeInput("https://github.com/{{orgId}}/{{repoId}}", "urlStatic")
                       .zeebeInputExpression(
                           "\"https://github.com/{{orgId}}/{{repoId}}\"", "urlExpression")
-                      .zeebeInput("My Name is \"Zeebe\", nice to meet you", "quotesStatic")
+                      .zeebeInput("My Name is &#34;Zeebe&#34;, nice to meet you", "quotesStatic")
                       .zeebeInputExpression(
                           "\"My Name is \\\"Zeebe\\\", nice to meet you\"", "quotesExpression"))
           .endEvent()
@@ -143,7 +143,7 @@ public final class ActivityTest {
             entry("nullExpression", "\"null\""),
             entry("urlStatic", "\"https://github.com/{{orgId}}/{{repoId}}\""),
             entry("urlExpression", "\"https://github.com/{{orgId}}/{{repoId}}\""),
-            entry("quotesStatic", "\"My Name is \\\\\\\"Zeebe\\\\\\\", nice to meet you\""),
+            entry("quotesStatic", "\"My Name is &#34;Zeebe&#34;, nice to meet you\""),
             entry("quotesExpression", "\"My Name is \\\\\\\"Zeebe\\\\\\\", nice to meet you\""));
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -97,6 +97,27 @@ public final class VariableMappingTransformerTest {
         .isEqualTo(ResultType.OBJECT);
   }
 
+  @Test
+  public void shouldNotEscapeCharactersInStaticExpression() {
+    // when
+    final var expression =
+        transformer.transformInputMappings(
+            List.of(
+                mapping("Hello\tWorld", "tab"),
+                mapping("Hello\nWorld", "newline"),
+                mapping("Hello\rWorld", "carriageReturn"),
+                mapping("My Name is &#34;Zeebe&#34;, nice to meet you", "encodedQuotes")),
+            expressionLanguage);
+
+    // then
+    assertThat(expression.isValid())
+        .describedAs("Expected valid expression: %s", expression.getFailureMessage())
+        .isTrue();
+    assertThat(expression.getExpression())
+        .isEqualTo(
+            "{tab:\"Hello\tWorld\",newline:\"Hello\nWorld\",carriageReturn:\"Hello\rWorld\",encodedQuotes:\"My Name is &#34;Zeebe&#34;, nice to meet you\"}");
+  }
+
   private static ZeebeMapping mapping(final String source, final String target) {
     return new ZeebeMapping() {
       @Override


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This PR fix the behaviour of static expression in Zeebe, ~~Using the built-in `translateEscapes()` API allow Zeebe to not escape special characters also in a Static Inputs~~ by removing all the escaping function 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15447 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
