### PR TITLE
refactor: change dockerfile uid and gid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -151,19 +151,19 @@ VOLUME /tmp
 VOLUME ${ZB_HOME}/data
 VOLUME ${ZB_HOME}/logs
 
-RUN groupadd -g 1000 zeebe && \
-    adduser -u 1000 zeebe --system --ingroup zeebe && \
+RUN groupadd --gid 1001 camunda && \
+    adduser --system --gid 1001 --uid 1001 --home ${ZB_HOME} camunda && \
     chmod g=u /etc/passwd && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
     # helps to avoid potential permission issues due to default volume ownership.
     mkdir ${ZB_HOME}/data && \
     mkdir ${ZB_HOME}/logs && \
-    chown -R 1000:0 ${ZB_HOME} && \
+    chown -R 1001:0 ${ZB_HOME} && \
     chmod -R 0775 ${ZB_HOME}
 
-COPY --link --chown=1000:0 docker/utils/startup.sh /usr/local/bin/startup.sh
-COPY --from=dist --chown=1000:0 /zeebe/camunda-zeebe ${ZB_HOME}
+COPY --link --chown=1001:0 docker/utils/startup.sh /usr/local/bin/startup.sh
+COPY --from=dist --chown=1001:0 /zeebe/camunda-zeebe ${ZB_HOME}
 
-USER zeebe:zeebe
+USER 1001:1001
 
 ENTRYPOINT ["tini", "--", "/usr/local/bin/startup.sh"]

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/NonDefaultContainerSetupTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/NonDefaultContainerSetupTest.java
@@ -34,7 +34,7 @@ public class NonDefaultContainerSetupTest {
     return Stream.of(
         /* Tests running with the default unprivileged user. */
         Arguments.arguments(
-            Named.of("user[zeebe]", (Consumer<CreateContainerCmd>) cmd -> cmd.withUser("zeebe"))),
+            Named.of("user[1001]", (Consumer<CreateContainerCmd>) cmd -> cmd.withUser("1001"))),
         /*
          * Runs with a random uid and guid of 0 as common for Openshift.
          * While this cannot guarantee OpenShift compatibility, it's a common compatibility issue.

--- a/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -342,10 +342,14 @@ final class RollingUpdateTest {
         // ensure we have an exporter present to test sharing exporter state across nodes
         .withEnv("ZEEBE_BROKER_EXECUTIONMETRICSEXPORTERENABLED", "true")
         .withEnv("ZEEBE_LOG_LEVEL", "DEBUG")
-        // user needs to be set to allow a smooth update from zeebe 8.2 to 8.3
-        // as the default user changed to `zeebe` with 8.3 and was `root` with 8.2
-        // TODO remove after 8.3 release
-        .withCreateContainerCmdModifier(createContainerCmd -> createContainerCmd.withUser("zeebe"));
+        // user - needs to be set to `1001` to allow a smooth update from zeebe 8.3 to 8.4,
+        // as the default user changed to `1001` with 8.4 and was `1000` with 8.3
+        // group - needs to be set to `0` as the data volume in 8.3 is owned by 1000:0
+        // thus zeebe 8.4 needs to run with group `0` to be able to create new files in
+        // the root of the data volume (in particular it creates a new `.topology.meta` file)
+        // TODO remove after 8.4 release
+        .withCreateContainerCmdModifier(
+            createContainerCmd -> createContainerCmd.withUser("1001:0"));
     broker.setDockerImageName(PREVIOUS_VERSION.asCanonicalNameString());
   }
 }


### PR DESCRIPTION
## Description

Using a non-numeric user and group ID in Dockerfile makes it harder to configure in K8s since it's not possible to detect if it's a root or non-root.

So we need to make that change to remove explicit config related to the user and group ID. 

**Please note that:**
- This change should be part of 8.4 and not part of 8.3.x release.
- This could be marked as a potential breaking change (it doesn't affect the app itself but the operational side like K8s).

## Related issues

Related to: https://github.com/camunda/distribution/issues/122


## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] Camunda Controller (K8s Operator) has already been informed of the change.

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
