### PR TITLE
Iterate over execution latency buckets

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -27,6 +27,7 @@ public class ExecutionLatencyMetrics {
           .help("The life time of an job")
           .labelNames("partition")
           .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
+          .buckets(0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0, 45.0)
           .register();
   private static final Histogram JOB_ACTIVATION_TIME =
       Histogram.build()

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -18,9 +18,8 @@ public class ExecutionLatencyMetrics {
           .name("process_instance_execution_time")
           .help("The execution time of processing a complete process instance")
           .labelNames("partition")
-          .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
+          .buckets(0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0, 45.0, 60.0)
           .register();
-
   private static final Histogram JOB_LIFE_TIME =
       Histogram.build()
           .namespace("zeebe")
@@ -29,7 +28,6 @@ public class ExecutionLatencyMetrics {
           .labelNames("partition")
           .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
           .register();
-
   private static final Histogram JOB_ACTIVATION_TIME =
       Histogram.build()
           .namespace("zeebe")
@@ -38,7 +36,6 @@ public class ExecutionLatencyMetrics {
           .labelNames("partition")
           .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
           .register();
-
   private static final Gauge CURRENT_ACTIVE_INSTANCE =
       Gauge.build()
           .namespace("zeebe")

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -34,7 +34,7 @@ public class ExecutionLatencyMetrics {
           .name("job_activation_time")
           .help("The time until an job was activated")
           .labelNames("partition")
-          .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
+          .buckets(0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0)
           .register();
   private static final Gauge CURRENT_ACTIVE_INSTANCE =
       Gauge.build()

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -46,7 +46,7 @@ public class ExecutionLatencyMetrics {
           .help(
               "A current estimation of active instances (jobs or process instances). This can only be an estimation, since long lived instances are excluded from this.")
           .labelNames("partition", "type")
-          .create();
+          .register();
 
   public void observeProcessInstanceExecutionTime(
       final int partitionId, final long creationTimeMs, final long completionTimeMs) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -37,12 +37,12 @@ public class ExecutionLatencyMetrics {
           .labelNames("partition")
           .buckets(0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 10.0, 15.0, 30.0)
           .register();
-  private static final Gauge CURRENT_ACTIVE_INSTANCE =
+  private static final Gauge CURRENT_CACHED_INSTANCE =
       Gauge.build()
           .namespace("zeebe")
-          .name("estimated_current_active_instances")
+          .name("execution_latency_current_cached_instances")
           .help(
-              "A current estimation of active instances (jobs or process instances). This can only be an estimation, since long lived instances are excluded from this.")
+              "The current cached instances for counting their execution latency. If only short-lived instances are handled this can be seen or observed as the current active instance count.")
           .labelNames("partition", "type")
           .register();
 
@@ -68,11 +68,11 @@ public class ExecutionLatencyMetrics {
   }
 
   public void setCurrentJobsCount(final int partitionId, final int count) {
-    CURRENT_ACTIVE_INSTANCE.labels(Integer.toString(partitionId), "jobs").set(count);
+    CURRENT_CACHED_INSTANCE.labels(Integer.toString(partitionId), "jobs").set(count);
   }
 
   public void setCurrentProcessInstanceCount(final int partitionId, final int count) {
-    CURRENT_ACTIVE_INSTANCE.labels(Integer.toString(partitionId), "processInstances").set(count);
+    CURRENT_CACHED_INSTANCE.labels(Integer.toString(partitionId), "processInstances").set(count);
   }
 
   public Histogram getJobLifeTime() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/ExecutionLatencyMetrics.java
@@ -17,6 +17,7 @@ public class ExecutionLatencyMetrics {
           .name("process_instance_execution_time")
           .help("The execution time of processing a complete process instance")
           .labelNames("partition")
+          .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
           .register();
 
   private static final Histogram JOB_LIFE_TIME =
@@ -25,6 +26,7 @@ public class ExecutionLatencyMetrics {
           .name("job_life_time")
           .help("The life time of an job")
           .labelNames("partition")
+          .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
           .register();
 
   private static final Histogram JOB_ACTIVATION_TIME =
@@ -33,6 +35,7 @@ public class ExecutionLatencyMetrics {
           .name("job_activation_time")
           .help("The time until an job was activated")
           .labelNames("partition")
+          .buckets(0.10f, 0.2, 0.4, 0.8, 1.6, 3.2, 6.4, 12.8, 25.6, 51.2)
           .register();
 
   public void observeProcessInstanceExecutionTime(

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -217,16 +217,4 @@ public class MetricsExporter implements Exporter {
     final var recordValue = (ProcessInstanceRecordValue) record.getValue();
     return BpmnElementType.PROCESS == recordValue.getBpmnElementType();
   }
-
-  public static class MetricsExporterConfiguration {
-    private String maxExecutionTimeToTrack = TIME_TO_LIVE.toString();
-
-    public String getMaxExecutionTimeToTrack() {
-      return maxExecutionTimeToTrack;
-    }
-
-    public void setMaxExecutionTimeToTrack(final String maxExecutionTimeToTrack) {
-      this.maxExecutionTimeToTrack = maxExecutionTimeToTrack;
-    }
-  }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -29,7 +29,23 @@ import org.agrona.collections.Long2LongHashMap;
 
 public class MetricsExporter implements Exporter {
 
-  public static final Duration TIME_TO_LIVE = Duration.ofSeconds(10);
+  /**
+   * Defines the time after instances or jobs are getting removed from the cache/map.
+   *
+   * <p>Using large TTL or increasing the current needs to be done with care. Right now we assume
+   * that we can create at max ~150 PI per partition per second.
+   *
+   * <p>This means: 150 * TIME_TO_LIVE = max_cache_size max_cache_size * 4 (cache counts) * 8 (long)
+   * * 8 (long) = estimated_max_used_spaced_per_partition (roughly)
+   * estimated_max_used_spaced_per_partition * partitions = max_used_spaced_per_broker When using a
+   * TTL of 60 seconds this means: max_cache_size = 9000 (entries)
+   * estimated_max_used_spaced_per_partition = 2.304.000 (bytes) = 2.3 MB
+   *
+   * <p>The estimated_max_used_spaced_per_partition is slightly a little more, since the TreeMap
+   * might consume more memory than the Long2LongHashMap.
+   */
+  public static final Duration TIME_TO_LIVE = Duration.ofSeconds(60);
+
   private final ExecutionLatencyMetrics executionLatencyMetrics;
   private final Long2LongHashMap jobKeyToCreationTimeMap;
   private final Long2LongHashMap processInstanceKeyToCreationTimeMap;

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -138,6 +138,8 @@ public class MetricsExporter implements Exporter {
       executionLatencyMetrics.observeProcessInstanceExecutionTime(
           partitionId, creationTime, record.getTimestamp());
     }
+    executionLatencyMetrics.setCurrentProcessInstanceCount(
+        partitionId, processInstanceKeyToCreationTimeMap.size());
   }
 
   private void storeProcessInstanceCreation(final long creationTime, final long recordKey) {
@@ -155,6 +157,7 @@ public class MetricsExporter implements Exporter {
       final var creationTime = jobKeyToCreationTimeMap.remove(recordKey);
       executionLatencyMetrics.observeJobLifeTime(partitionId, creationTime, record.getTimestamp());
     }
+    executionLatencyMetrics.setCurrentJobsCount(partitionId, jobKeyToCreationTimeMap.size());
   }
 
   private void handleJobBatchRecord(final Record<?> record, final int partitionId) {
@@ -213,5 +216,17 @@ public class MetricsExporter implements Exporter {
   private static boolean isProcessInstanceRecord(final Record<?> record) {
     final var recordValue = (ProcessInstanceRecordValue) record.getValue();
     return BpmnElementType.PROCESS == recordValue.getBpmnElementType();
+  }
+
+  public static class MetricsExporterConfiguration {
+    private String maxExecutionTimeToTrack = TIME_TO_LIVE.toString();
+
+    public String getMaxExecutionTimeToTrack() {
+      return maxExecutionTimeToTrack;
+    }
+
+    public void setMaxExecutionTimeToTrack(final String maxExecutionTimeToTrack) {
+      this.maxExecutionTimeToTrack = maxExecutionTimeToTrack;
+    }
   }
 }


### PR DESCRIPTION
## Description

Execution latencies need to be a bit more broad-ranging to better cover more use cases. They depend on users/workers, which means it might be slower than our usual latency.

* The recommendation from the Prometheus book is to use not more than 10 buckets. 
* Furthermore, it also doesn't make much sense to have much larger buckets, if we talking about long-running instances this exporter should likely not be used (or is not useful). Other tools would help here like Optimize.


I realized that we have an artificial timeout at ~10 seconds https://github.com/camunda/zeebe/blob/main/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java#L32 but not sure what the impact would have. We might buffer more, for longer time and cause OOMs.

I did a benchmark and calculation whether this is actually a problem and came to the conclusion it shouldn't be a big issue. Let me know what you think.

Calcuation:

The calculation I did was based on a benchmark where I tried to max out the PI/job creations 

![instances-general](https://github.com/camunda/zeebe/assets/2758593/ed861e8b-a8fd-49be-a427-2f72cacc34f5)
![instances-general-throughput](https://github.com/camunda/zeebe/assets/2758593/a8cb1e86-e4dc-403e-84d9-31a96eac2c4b)

We can see that we can reach maximum ~120 PI per second on one partition. I rounded this to 150 in my calculation.

![instances-general-throughput-p1](https://github.com/camunda/zeebe/assets/2758593/63b66ddd-498f-4295-a39a-6f2f8bd30f9c)

```
   * <p>This means: 150 * TIME_TO_LIVE = max_cache_size max_cache_size * 4 (cache counts) * 8 (long)
   * * 8 (long) = estimated_max_used_spaced_per_partition (roughly)
   * estimated_max_used_spaced_per_partition * partitions = max_used_spaced_per_broker When using a
   * TTL of 60 seconds this means: max_cache_size = 9000 (entries)
   * estimated_max_used_spaced_per_partition = 2.304.000 (bytes) = 2.3 MB
   *
   * <p>The estimated_max_used_spaced_per_partition is slightly a little more, since the TreeMap
   * might consume more memory than the Long2LongHashMap.
```

I think it is ok to go with the 60s, if we see issues we can also disable the exporter in clusters. 

Ideally, as follow up we might want to think about making this configuration better configurable from the outside, but I didn't want to go too far here in this PR. (In general I think this makes sense).

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/14333

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
