### PR TITLE
Complete native user tasks

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessorCo
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.timer.DueDateTimerChecker;
+import io.camunda.zeebe.engine.processing.usertask.UserTaskEventProcessors;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -174,6 +175,9 @@ public final class EngineProcessors {
         processingState,
         scheduledTaskStateFactory,
         interPartitionCommandSender);
+
+    UserTaskEventProcessors.addUserTaskProcessors(
+        typedRecordProcessors, processingState, bpmnBehaviors, writers);
 
     return typedRecordProcessors;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -156,6 +157,16 @@ public final class EventHandle {
         jobRecord.getElementInstanceKey(),
         jobRecord.getElementIdBuffer(),
         jobRecord.getVariablesBuffer());
+  }
+
+  public void triggeringProcessEvent(final UserTaskRecord userTaskRecord) {
+    triggeringProcessEvent(
+        userTaskRecord.getProcessDefinitionKey(),
+        userTaskRecord.getProcessInstanceKey(),
+        userTaskRecord.getTenantId(),
+        userTaskRecord.getElementInstanceKey(),
+        userTaskRecord.getElementIdBuffer(),
+        userTaskRecord.getVariablesBuffer());
   }
 
   private boolean isElementActivated(final ExecutableFlowElement catchEvent) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public class UserTaskCommandPreconditionChecker {
+
+  private static final String NO_USER_TASK_FOUND_MESSAGE =
+      "Expected to %s user task with key '%d', but no such user task was found";
+  private static final String INVALID_USER_TASK_STATE_MESSAGE =
+      "Expected to %s user task with key '%d', but it is in state '%s'";
+
+  private final List<LifecycleState> validLifecycleStates;
+  private final String intent;
+
+  private final UserTaskState userTaskState;
+
+  public UserTaskCommandPreconditionChecker(
+      final List<LifecycleState> validLifecycleStates,
+      final String intent,
+      final UserTaskState userTaskState) {
+    this.validLifecycleStates = validLifecycleStates;
+    this.intent = intent;
+    this.userTaskState = userTaskState;
+  }
+
+  protected Either<Tuple<RejectionType, String>, Void> check(
+      final TypedRecord<UserTaskRecord> command) {
+    final long userTaskKey = command.getKey();
+    final UserTaskRecord persistedRecord =
+        userTaskState.getUserTask(userTaskKey, command.getAuthorizations());
+
+    if (persistedRecord == null) {
+      return Either.left(
+          Tuple.of(
+              RejectionType.NOT_FOUND,
+              String.format(NO_USER_TASK_FOUND_MESSAGE, intent, userTaskKey)));
+    }
+
+    final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
+
+    if (validLifecycleStates.contains(lifecycleState)) {
+      return Either.right(null);
+    }
+
+    return Either.left(
+        Tuple.of(
+            RejectionType.INVALID_STATE,
+            String.format(INVALID_USER_TASK_STATE_MESSAGE, intent, userTaskKey, lifecycleState)));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
@@ -19,25 +19,20 @@ import io.camunda.zeebe.engine.state.immutable.UserTaskState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
-import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
 
 public final class UserTaskCompleteProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
-  private static final String NO_USER_TASK_FOUND_MESSAGE =
-      "Expected to %s user task with key '%d', but no such user task was found";
-  private static final String INVALID_USER_TASK_STATE_MESSAGE =
-      "Expected to %s user task with key '%d', but it is in state '%s'";
   private final UserTaskState userTaskState;
   private final ElementInstanceState elementInstanceState;
   private final EventHandle eventHandle;
   private final StateWriter stateWriter;
   private final TypedCommandWriter commandWriter;
   private final TypedRejectionWriter rejectionWriter;
+  private final UserTaskCommandPreconditionChecker preconditionChecker;
 
   public UserTaskCompleteProcessor(
       final ProcessingState state, final EventHandle eventHandle, final Writers writers) {
@@ -47,11 +42,15 @@ public final class UserTaskCompleteProcessor implements TypedRecordProcessor<Use
     stateWriter = writers.state();
     commandWriter = writers.command();
     rejectionWriter = writers.rejection();
+    preconditionChecker =
+        new UserTaskCommandPreconditionChecker(
+            List.of(LifecycleState.CREATED), "complete", userTaskState);
   }
 
   @Override
   public void processRecord(final TypedRecord<UserTaskRecord> userTaskRecord) {
-    checkTaskState(userTaskRecord)
+    preconditionChecker
+        .check(userTaskRecord)
         .ifRightOrLeft(
             ok -> {
               final long userTaskKey = userTaskRecord.getKey();
@@ -89,33 +88,5 @@ public final class UserTaskCompleteProcessor implements TypedRecordProcessor<Use
             userTaskElementInstance.getValue());
       }
     }
-  }
-
-  private Either<Tuple<RejectionType, String>, Void> checkTaskState(
-      final TypedRecord<UserTaskRecord> userTaskRecord) {
-    final long userTaskKey = userTaskRecord.getKey();
-    final UserTaskRecord persistedRecord =
-        userTaskState.getUserTask(userTaskKey, userTaskRecord.getAuthorizations());
-    if (persistedRecord == null) {
-      return Either.left(
-          Tuple.of(
-              RejectionType.NOT_FOUND,
-              String.format(NO_USER_TASK_FOUND_MESSAGE, UserTaskIntent.COMPLETE, userTaskKey)));
-    }
-
-    final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
-
-    if (lifecycleState == LifecycleState.CREATED) {
-      return Either.right(null);
-    }
-
-    return Either.left(
-        Tuple.of(
-            RejectionType.INVALID_STATE,
-            String.format(
-                INVALID_USER_TASK_STATE_MESSAGE,
-                UserTaskIntent.COMPLETE,
-                userTaskKey,
-                lifecycleState)));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.collection.Tuple;
+
+public final class UserTaskCompleteProcessor implements CommandProcessor<UserTaskRecord> {
+
+  private static final String NO_USER_TASK_FOUND_MESSAGE =
+      "Expected to %s user task with key '%d', but no such user task was found";
+  private static final String INVALID_USER_TASK_STATE_MESSAGE =
+      "Expected to %s user task with key '%d', but it is in state '%s'";
+  private final UserTaskState userTaskState;
+  private final ElementInstanceState elementInstanceState;
+  private final EventHandle eventHandle;
+
+  public UserTaskCompleteProcessor(final ProcessingState state, final EventHandle eventHandle) {
+    userTaskState = state.getUserTaskState();
+    elementInstanceState = state.getElementInstanceState();
+    this.eventHandle = eventHandle;
+  }
+
+  @Override
+  public boolean onCommand(
+      final TypedRecord<UserTaskRecord> command,
+      final CommandControl<UserTaskRecord> commandControl) {
+    final long userTaskKey = command.getKey();
+    checkTaskState(userTaskKey)
+        .ifRightOrLeft(
+            ok -> acceptCommand(command, commandControl),
+            violation -> commandControl.reject(violation.getLeft(), violation.getRight()));
+    return true;
+  }
+
+  @Override
+  public void afterAccept(
+      final TypedCommandWriter commandWriter,
+      final StateWriter stateWriter,
+      final long key,
+      final Intent intent,
+      final UserTaskRecord value) {
+
+    // mark the user task as completed
+    stateWriter.appendFollowUpEvent(key, UserTaskIntent.COMPLETED, value);
+
+    // complete the user task element
+    final var userTaskElementInstanceKey = value.getElementInstanceKey();
+
+    final ElementInstance userTaskElementInstance =
+        elementInstanceState.getInstance(userTaskElementInstanceKey);
+
+    if (userTaskElementInstance != null) {
+      final long scopeKey = userTaskElementInstance.getValue().getFlowScopeKey();
+      final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
+
+      if (scopeInstance != null && scopeInstance.isActive()) {
+        eventHandle.triggeringProcessEvent(value);
+        commandWriter.appendFollowUpCommand(
+            userTaskElementInstanceKey,
+            ProcessInstanceIntent.COMPLETE_ELEMENT,
+            userTaskElementInstance.getValue());
+      }
+    }
+  }
+
+  private Either<Tuple<RejectionType, String>, Void> checkTaskState(final long userTaskKey) {
+    final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
+    if (lifecycleState == LifecycleState.CREATED) {
+      return Either.right(null);
+    }
+
+    if (lifecycleState == LifecycleState.NOT_FOUND) {
+      return Either.left(
+          Tuple.of(
+              RejectionType.NOT_FOUND,
+              String.format(NO_USER_TASK_FOUND_MESSAGE, UserTaskIntent.COMPLETE, userTaskKey)));
+    }
+
+    return Either.left(
+        Tuple.of(
+            RejectionType.INVALID_STATE,
+            String.format(
+                INVALID_USER_TASK_STATE_MESSAGE,
+                UserTaskIntent.COMPLETE,
+                userTaskKey,
+                lifecycleState)));
+  }
+
+  private void acceptCommand(
+      final TypedRecord<UserTaskRecord> command,
+      final CommandControl<UserTaskRecord> commandControl) {
+
+    final long userTaskKey = command.getKey();
+
+    final UserTaskRecord userTask =
+        userTaskState.getUserTask(userTaskKey, command.getAuthorizations());
+    if (userTask == null) {
+      commandControl.reject(
+          RejectionType.NOT_FOUND,
+          String.format(NO_USER_TASK_FOUND_MESSAGE, UserTaskIntent.COMPLETE, userTaskKey));
+      return;
+    }
+
+    userTask.setVariables(command.getValue().getVariablesBuffer());
+
+    commandControl.accept(UserTaskIntent.COMPLETING, userTask);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskEventProcessors.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskEventProcessors {
+
+  public static void addUserTaskProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final MutableProcessingState processingState,
+      final BpmnBehaviors bpmnBehaviors,
+      final Writers writers) {
+
+    final var keyGenerator = processingState.getKeyGenerator();
+
+    final EventHandle eventHandle =
+        new EventHandle(
+            keyGenerator,
+            processingState.getEventScopeInstanceState(),
+            writers,
+            processingState.getProcessState(),
+            bpmnBehaviors.eventTriggerBehavior(),
+            bpmnBehaviors.stateBehavior());
+
+    typedRecordProcessors.onCommand(
+        ValueType.USER_TASK,
+        UserTaskIntent.COMPLETE,
+        new UserTaskCompleteProcessor(processingState, eventHandle));
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskEventProcessors.java
@@ -37,6 +37,6 @@ public final class UserTaskEventProcessors {
     typedRecordProcessors.onCommand(
         ValueType.USER_TASK,
         UserTaskIntent.COMPLETE,
-        new UserTaskCompleteProcessor(processingState, eventHandle));
+        new UserTaskCompleteProcessor(processingState, eventHandle, writers));
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -308,6 +308,8 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.CREATED, new UserTaskCreatedApplier(state));
     register(UserTaskIntent.CANCELING, new UserTaskCancelingApplier(state));
     register(UserTaskIntent.CANCELED, new UserTaskCanceledApplier(state));
+    register(UserTaskIntent.COMPLETING, new UserTaskCompletingApplier(state));
+    register(UserTaskIntent.COMPLETED, new UserTaskCompletedApplier(state));
   }
 
   private void registerCommandDistributionAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskCompletedApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskCompletedApplier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.delete(key);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletingApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletingApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskCompletingApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskCompletingApplier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    userTaskState.updateUserTaskLifecycleState(key, LifecycleState.COMPLETING);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -118,29 +117,6 @@ public final class NativeUserTaskTest {
             .getFirst();
 
     Assertions.assertThat(userTask.getValue()).hasTenantId(tenantId);
-  }
-
-  @Test
-  public void shouldNotCreateJob() {
-    // given
-    ENGINE.deployment().withXmlResource(process()).deploy();
-
-    // when
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-
-    // then
-    assertThat(
-            RecordingExporter.processInstanceRecords().withProcessInstanceKey(processInstanceKey))
-        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
-        .containsSequence(
-            tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATING),
-            tuple(BpmnElementType.USER_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATED));
-
-    assertThat(
-            RecordingExporter.jobRecords(JobIntent.CREATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .count())
-        .isEqualTo(0L);
   }
 
   @Test
@@ -297,7 +273,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithCandidateGroups() {
+  public void shouldCreateUserTaskWithCandidateGroups() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeCandidateGroups("alice,bob"))).deploy();
 
@@ -314,7 +290,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithEvaluatedCandidateGroupsExpression() {
+  public void shouldCreateUserTaskWithEvaluatedCandidateGroupsExpression() {
     // given
     ENGINE
         .deployment()
@@ -339,7 +315,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithCandidateUsers() {
+  public void shouldCreateUserTaskWithCandidateUsers() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeCandidateUsers("jack,rose"))).deploy();
 
@@ -356,7 +332,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithEvaluatedCandidateUsersExpression() {
+  public void shouldCreateUserTaskWithEvaluatedCandidateUsersExpression() {
     // given
     ENGINE
         .deployment()
@@ -381,7 +357,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithDueDate() {
+  public void shouldCreateUserTaskWithDueDate() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeDueDate(DUE_DATE))).deploy();
 
@@ -398,7 +374,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithEvaluatedDueDateExpression() {
+  public void shouldCreateUserTaskWithEvaluatedDueDateExpression() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeDueDateExpression("dueDate"))).deploy();
 
@@ -420,7 +396,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobAndIgnoreEmptyDueDate() {
+  public void shouldCreateUserTaskAndIgnoreEmptyDueDate() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeDueDate(""))).deploy();
 
@@ -437,7 +413,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobAndIgnoreEmptyEvaluatedDueDateExpression() {
+  public void shouldCreateUserTaskAndIgnoreEmptyEvaluatedDueDateExpression() {
     // given
     ENGINE
         .deployment()
@@ -462,7 +438,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobAndIgnoreNullEvaluatedDueDateExpression() {
+  public void shouldCreateUserTaskAndIgnoreNullEvaluatedDueDateExpression() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeDueDateExpression("=null"))).deploy();
 
@@ -479,7 +455,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithFollowUpDate() {
+  public void shouldCreateUserTaskWithFollowUpDate() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeFollowUpDate(FOLLOW_UP_DATE))).deploy();
 
@@ -496,7 +472,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobWithEvaluatedFollowUpDateExpression() {
+  public void shouldCreateUserTaskWithEvaluatedFollowUpDateExpression() {
     // given
     ENGINE
         .deployment()
@@ -521,7 +497,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobAndIgnoreEmptyFollowUpDate() {
+  public void shouldCreateUserTaskAndIgnoreEmptyFollowUpDate() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeFollowUpDate(""))).deploy();
 
@@ -538,7 +514,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobAndIgnoreEmptyEvaluatedFollowUpDateExpression() {
+  public void shouldCreateUserTaskAndIgnoreEmptyEvaluatedFollowUpDateExpression() {
     // given
     ENGINE
         .deployment()
@@ -563,7 +539,7 @@ public final class NativeUserTaskTest {
   }
 
   @Test
-  public void shouldCreateJobAndIgnoreNullEvaluatedFollowUpDateExpression() {
+  public void shouldCreateUserTaskAndIgnoreNullEvaluatedFollowUpDateExpression() {
     // given
     ENGINE
         .deployment()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class CompleteUserTaskTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance process() {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .userTask("task")
+        .zeebeUserTask()
+        .endEvent()
+        .done();
+  }
+
+  @Test
+  public void shouldEmitCompletingEventForUserTask() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE.userTask().withKey(userTaskKey).complete();
+
+    // then
+    final UserTaskRecordValue recordValue = completedRecord.getValue();
+
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.COMPLETING);
+
+    Assertions.assertThat(recordValue)
+        .hasUserTaskKey(userTaskKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldRejectCompletionIfUserTaskNotFound() {
+    // given
+    final int key = 123;
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE.userTask().withKey(key).expectRejection().complete();
+
+    // then
+    Assertions.assertThat(completedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldCompleteUserTaskWithVariables() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).withVariables("{'foo':'bar'}").complete();
+
+    // then
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.COMPLETING);
+    assertThat(completedRecord.getValue().getVariables()).containsExactly(entry("foo", "bar"));
+  }
+
+  @Test
+  public void shouldCompleteUserTaskWithNilVariables() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withVariables(new UnsafeBuffer(MsgPackHelper.NIL))
+            .complete();
+
+    // then
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.COMPLETING);
+    assertThat(completedRecord.getValue().getVariables()).isEmpty();
+  }
+
+  @Test
+  public void shouldCompleteUserTaskWithZeroLengthVariables() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withVariables(new UnsafeBuffer(new byte[0]))
+            .complete();
+
+    // then
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.COMPLETING);
+    assertThat(completedRecord.getValue().getVariables()).isEmpty();
+  }
+
+  @Test
+  public void shouldThrowExceptionOnCompletionIfVariablesAreInvalid() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final byte[] invalidVariables = new byte[] {1}; // positive fixnum, i.e. no object
+
+    // when
+    final Throwable throwable =
+        catchThrowable(
+            () ->
+                ENGINE
+                    .userTask()
+                    .ofInstance(processInstanceKey)
+                    .withVariables(new UnsafeBuffer(invalidVariables))
+                    .expectRejection()
+                    .complete());
+
+    // then
+    assertThat(throwable).isInstanceOf(RuntimeException.class);
+    assertThat(throwable.getMessage()).contains("Property 'variables' is invalid");
+    assertThat(throwable.getMessage())
+        .contains("Expected document to be a root level object, but was 'INTEGER'");
+  }
+
+  @Test
+  public void shouldRejectCompletionIfUserTaskIsCompleted() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).expectRejection().complete();
+
+    // then
+    Assertions.assertThat(completedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldCompleteUserTaskForCustomTenant() {
+    // given
+    final String tenantId = "acme";
+    ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAuthorizedTenantIds(tenantId)
+            .complete();
+
+    // then
+    final UserTaskRecordValue recordValue = completedRecord.getValue();
+
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.COMPLETING);
+
+    Assertions.assertThat(recordValue).hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldRejectCompletionIfTenantIsUnauthorized() {
+    // given
+    final String tenantId = "acme";
+    final String falseTenantId = "foo";
+    ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAuthorizedTenantIds(falseTenantId)
+            .expectRejection()
+            .complete();
+
+    // then
+    Assertions.assertThat(completedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/UserTaskOutputMappingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/UserTaskOutputMappingTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.variable.mapping;
+
+import static io.camunda.zeebe.engine.processing.variable.mapping.VariableValue.variable;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ZeebeVariablesMappingBuilder;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public final class UserTaskOutputMappingTest {
+
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Parameter(0)
+  public String userTaskVariables;
+
+  @Parameter(1)
+  public Consumer<UserTaskBuilder> mappings;
+
+  @Parameter(2)
+  public List<VariableValue> expectedActivityVariables;
+
+  @Parameter(3)
+  public List<VariableValue> expectedScopeVariables;
+
+  @Parameters(name = "from {0} to activity: {2} and scope: {3}")
+  public static Object[][] parameters() {
+    return new Object[][] {
+      // create variable
+      {"{'x': 1}", mapping(b -> {}), activityVariables(), scopeVariables(variable("x", "1"))},
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeOutputExpression("x", "x")),
+        activityVariables(variable("x", "1")),
+        scopeVariables(variable("x", "1"))
+      },
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeOutputExpression("x", "y")),
+        activityVariables(variable("x", "1")),
+        scopeVariables(variable("y", "1"))
+      },
+      {
+        "{'x': 1, 'y': 2}",
+        mapping(b -> b.zeebeOutputExpression("y", "z")),
+        activityVariables(variable("x", "1"), variable("y", "2")),
+        scopeVariables(variable("z", "2"))
+      },
+      {
+        "{'x': {'y': 2}}",
+        mapping(b -> {}),
+        activityVariables(),
+        scopeVariables(variable("x", "{\"y\":2}"))
+      },
+      {
+        "{'x': {'y': 2}}",
+        mapping(b -> b.zeebeOutputExpression("x", "y")),
+        activityVariables(variable("x", "{\"y\":2}")),
+        scopeVariables(variable("y", "{\"y\":2}"))
+      },
+      {
+        "{'x': {'y': 2}}",
+        mapping(b -> b.zeebeOutputExpression("x.y", "y")),
+        activityVariables(variable("x", "{\"y\":2}")),
+        scopeVariables(variable("y", "2"))
+      },
+      {
+        "{'x': 1, 'y': 2}",
+        mapping(b -> b.zeebeOutputExpression("x", "z.x").zeebeOutputExpression("y", "z.y")),
+        activityVariables(variable("x", "1"), variable("y", "2")),
+        scopeVariables(variable("z", "{\"x\":1,\"y\":2}"))
+      },
+      // update variable
+      {"{'i': 1}", mapping(b -> {}), activityVariables(), scopeVariables(variable("i", "1"))},
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeOutputExpression("x", "i")),
+        activityVariables(variable("x", "1")),
+        scopeVariables(variable("i", "1"))
+      },
+      // combine input and output mapping
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeInputExpression("i", "y").zeebeOutputExpression("y", "z")),
+        activityVariables(variable("x", "1"), variable("y", "0")),
+        scopeVariables(variable("z", "0"))
+      },
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeInputExpression("i", "x").zeebeOutputExpression("x", "y")),
+        activityVariables(variable("x", "0"), variable("x", "1")),
+        scopeVariables(variable("y", "1"))
+      },
+      {
+        "{'x': 1, 'y': 2}",
+        mapping(
+            b ->
+                b.zeebeInputExpression("i", "x")
+                    .zeebeInputExpression("i", "y")
+                    .zeebeOutputExpression("y", "z")),
+        activityVariables(
+            variable("x", "0"), variable("y", "0"), variable("x", "1"), variable("y", "2")),
+        scopeVariables(variable("z", "2"))
+      },
+      {
+        "{'x': 1}",
+        mapping(b -> b.zeebeInputExpression("i", "y")),
+        activityVariables(variable("y", "0")),
+        scopeVariables(variable("x", "1"))
+      },
+      {
+        "{'z': 1, 'j': 1}",
+        mapping(b -> b.zeebeInputExpression("i", "z")),
+        activityVariables(variable("z", "0")),
+        scopeVariables(variable("j", "1"))
+      },
+    };
+  }
+
+  @Test
+  public void shouldApplyOutputMappings() {
+    // given
+    ENGINE_RULE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .userTask("task", builder -> mappings.accept(builder))
+                .zeebeUserTask()
+                .endEvent()
+                .done())
+        .deploy()
+        .getValue()
+        .getProcessesMetadata()
+        .get(0)
+        .getProcessDefinitionKey();
+
+    // when
+    final long processInstanceKey =
+        ENGINE_RULE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("i", 0).create();
+
+    ENGINE_RULE
+        .userTask()
+        .ofInstance(processInstanceKey)
+        .withVariables(MsgPackUtil.asMsgPack(userTaskVariables))
+        .complete();
+
+    // then
+    final long elementInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("task")
+            .getFirst()
+            .getKey();
+
+    final Record<VariableRecordValue> initialVariable =
+        RecordingExporter.variableRecords(VariableIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName("i")
+            .getFirst();
+
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .skipUntil(r -> r.getPosition() > initialVariable.getPosition())
+                .withScopeKey(elementInstanceKey)
+                .limit(expectedActivityVariables.size()))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .hasSize(expectedActivityVariables.size())
+        .containsAll(expectedActivityVariables);
+
+    assertThat(
+            RecordingExporter.variableRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .skipUntil(r -> r.getPosition() > initialVariable.getPosition())
+                .withScopeKey(processInstanceKey)
+                .limit(expectedScopeVariables.size()))
+        .extracting(Record::getValue)
+        .extracting(v -> variable(v.getName(), v.getValue()))
+        .hasSize(expectedScopeVariables.size())
+        .containsAll(expectedScopeVariables);
+  }
+
+  private static Consumer<ZeebeVariablesMappingBuilder<UserTaskBuilder>> mapping(
+      final Consumer<ZeebeVariablesMappingBuilder<UserTaskBuilder>> mappingBuilder) {
+    return mappingBuilder;
+  }
+
+  private static List<VariableValue> activityVariables(final VariableValue... variables) {
+    return Arrays.asList(variables);
+  }
+
+  private static List<VariableValue> scopeVariables(final VariableValue... variables) {
+    return Arrays.asList(variables);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
 import io.camunda.zeebe.engine.util.client.ResourceDeletionClient;
 import io.camunda.zeebe.engine.util.client.SignalClient;
+import io.camunda.zeebe.engine.util.client.UserTaskClient;
 import io.camunda.zeebe.engine.util.client.VariableClient;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
@@ -300,6 +301,10 @@ public final class EngineRule extends ExternalResource {
 
   public SignalClient signal() {
     return new SignalClient(environmentRule);
+  }
+
+  public UserTaskClient userTask() {
+    return new UserTaskClient(environmentRule);
   }
 
   public Record<JobRecordValue> createJob(final String type, final String processId) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
+import java.util.function.Function;
+
+public final class UserTaskClient {
+  private static final long DEFAULT_KEY = -1L;
+
+  private static final Function<Long, Record<UserTaskRecordValue>> SUCCESS_SUPPLIER =
+      (position) ->
+          RecordingExporter.userTaskRecords().withSourceRecordPosition(position).getFirst();
+
+  private static final Function<Long, Record<UserTaskRecordValue>> REJECTION_SUPPLIER =
+      (position) ->
+          RecordingExporter.userTaskRecords()
+              .onlyCommandRejections()
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final UserTaskRecord userTaskRecord;
+  private final CommandWriter writer;
+  private long processInstanceKey;
+  private long userTaskKey = DEFAULT_KEY;
+  private List<String> authorizedTenantIds = List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+  private Function<Long, Record<UserTaskRecordValue>> expectation = SUCCESS_SUPPLIER;
+
+  public UserTaskClient(final CommandWriter writer) {
+    this.writer = writer;
+    userTaskRecord = new UserTaskRecord();
+  }
+
+  public UserTaskClient ofInstance(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+    return this;
+  }
+
+  public UserTaskClient withKey(final long userTaskKey) {
+    this.userTaskKey = userTaskKey;
+    return this;
+  }
+
+  public UserTaskClient withAuthorizedTenantIds(final String... tenantIds) {
+    authorizedTenantIds = List.of(tenantIds);
+    return this;
+  }
+
+  public UserTaskClient expectRejection() {
+    expectation = REJECTION_SUPPLIER;
+    return this;
+  }
+
+  private long findUserTaskKey() {
+    if (userTaskKey == DEFAULT_KEY) {
+      final Record<UserTaskRecordValue> userTask =
+          RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+              .withProcessInstanceKey(processInstanceKey)
+              .getFirst();
+
+      return userTask.getKey();
+    }
+
+    return userTaskKey;
+  }
+
+  public Record<UserTaskRecordValue> complete() {
+    final long userTaskKey = findUserTaskKey();
+    final long position =
+        writer.writeCommand(
+            userTaskKey,
+            UserTaskIntent.COMPLETE,
+            userTaskRecord,
+            authorizedTenantIds.toArray(new String[0]));
+    return expectation.apply(position);
+  }
+}


### PR DESCRIPTION
## Description

Support the completion of native user tasks in the broker.

## Related issues

closes #15450

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
