### PR TITLE
[Backport release-8.4.0-alpha2] fix(raft): resend configuration to members that lost their configuration

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -104,6 +104,11 @@ import org.slf4j.MDC;
  */
 public class RaftContext implements AutoCloseable, HealthMonitorable {
 
+  /**
+   * Configuration index returned when no configuration is available, i.e. configuration is null .
+   */
+  private static final long NO_CONFIGURATION_INDEX = -1L;
+
   protected final String name;
   protected final ThreadContext threadContext;
   protected final ClusterMembershipService membershipService;
@@ -1265,7 +1270,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    */
   public long getCurrentConfigurationIndex() {
     final var configuration = cluster.getConfiguration();
-    return configuration != null ? configuration.index() : -1L;
+    return configuration != null ? configuration.index() : NO_CONFIGURATION_INDEX;
   }
 
   public boolean isRunning() {

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -1260,6 +1260,14 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     return currentSnapshot != null ? currentSnapshot.getIndex() : 0L;
   }
 
+  /**
+   * @return the current configuration index or -1 if there is no configuration yet.
+   */
+  public long getCurrentConfigurationIndex() {
+    final var configuration = cluster.getConfiguration();
+    return configuration != null ? configuration.index() : -1L;
+  }
+
   public boolean isRunning() {
     return started;
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendResponse.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendResponse.java
@@ -113,15 +113,15 @@ public class AppendResponse extends AbstractRaftResponse {
 
   @Override
   public boolean equals(final Object object) {
-    if (object instanceof final AppendResponse response) {
-      return response.status == status
-          && response.term == term
-          && response.succeeded == succeeded
-          && response.lastLogIndex == lastLogIndex
-          && response.lastSnapshotIndex == lastSnapshotIndex
-          && response.configurationIndex == configurationIndex;
+    if (!(object instanceof final AppendResponse response)) {
+      return false;
     }
-    return false;
+    return response.status == status
+        && response.term == term
+        && response.succeeded == succeeded
+        && response.lastLogIndex == lastLogIndex
+        && response.lastSnapshotIndex == lastSnapshotIndex
+        && response.configurationIndex == configurationIndex;
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -769,6 +769,7 @@ public class PassiveRole extends InactiveRole {
                 .withSucceeded(succeeded)
                 .withLastLogIndex(lastLogIndex)
                 .withLastSnapshotIndex(raft.getCurrentSnapshotIndex())
+                .withConfigurationIndex(raft.getCurrentConfigurationIndex())
                 .build()));
     return succeeded;
   }


### PR DESCRIPTION
# Description
Backport of #15444 to `release-8.4.0-alpha2`.

relates to #15381
original author: @oleschoenburg