### PR TITLE
feat(topology): include completed and pending changes in GET response

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.management.cluster.PartitionState;
 import io.camunda.zeebe.management.cluster.PartitionStateCode;
-import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.TopologyChange;
 import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
 import io.camunda.zeebe.management.cluster.TopologyChangeCompletedInner;
@@ -303,8 +303,8 @@ public class ClusterEndpoint {
     return ResponseEntity.status(errorCode).body(error);
   }
 
-  private static PostOperationResponse mapResponseType(final TopologyChangeResponse response) {
-    return new PostOperationResponse()
+  private static PlannedOperationsResponse mapResponseType(final TopologyChangeResponse response) {
+    return new PlannedOperationsResponse()
         .changeId(response.changeId())
         .currentTopology(mapBrokerStates(response.currentTopology()))
         .expectedTopology(mapBrokerStates(response.expectedTopology()))

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -391,25 +391,19 @@ public class ClusterEndpoint {
   private static GetTopologyResponse mapClusterTopology(final ClusterTopology topology) {
     final var response = new GetTopologyResponse();
     final List<BrokerState> brokers = mapBrokerStates(topology.members());
-    final TopologyChange change;
 
-    if (topology.pendingChanges().isPresent()) {
-      change = mapOngoingChange(topology.pendingChanges().get());
-    } else if (topology.lastChange().isPresent()) {
-      change = mapCompletedChange(topology.lastChange().get());
-    } else {
-      change = new TopologyChange();
-    }
-
-    response.version(topology.version()).brokers(brokers).change(change);
+    response.version(topology.version()).brokers(brokers);
+    topology.lastChange().ifPresent(change -> response.lastChange(mapCompletedChange(change)));
+    topology.pendingChanges().ifPresent(change -> response.pendingChange(mapOngoingChange(change)));
 
     return response;
   }
 
-  private static TopologyChange mapCompletedChange(final CompletedChange completedChange) {
-    return new TopologyChange()
+  private static io.camunda.zeebe.management.cluster.CompletedChange mapCompletedChange(
+      final CompletedChange completedChange) {
+    return new io.camunda.zeebe.management.cluster.CompletedChange()
         .id(completedChange.id())
-        .status(mapChangeStatus(completedChange.status()))
+        .status(mapCompletedChangeStatus(completedChange.status()))
         .startedAt(mapInstantToDateTime(completedChange.startedAt()))
         .completedAt(mapInstantToDateTime(completedChange.completedAt()));
   }
@@ -420,6 +414,16 @@ public class ClusterEndpoint {
         .status(mapChangeStatus(clusterChangePlan.status()))
         .pending(mapOperations(clusterChangePlan.pendingOperations()))
         .completed(mapCompletedOperations(clusterChangePlan.completedOperations()));
+  }
+
+  private static io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum
+      mapCompletedChangeStatus(final Status status) {
+    return switch (status) {
+      case COMPLETED -> io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum.COMPLETED;
+      case FAILED -> io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum.FAILED;
+      case CANCELLED -> io.camunda.zeebe.management.cluster.CompletedChange.StatusEnum.CANCELLED;
+      case IN_PROGRESS -> throw new IllegalStateException("Completed change cannot be in progress");
+    };
   }
 
   private static StatusEnum mapChangeStatus(final Status status) {

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -245,8 +245,32 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/BrokerState"
-        change:
-            $ref: "#/components/schemas/TopologyChange"
+        lastChange:
+          $ref: "#/components/schemas/CompletedChange"
+        pendingChange:
+          $ref: "#/components/schemas/TopologyChange"
+
+    CompletedChange:
+      type: object
+      properties:
+        id:
+          $ref: "#/components/schemas/ChangeId"
+        status:
+          type: string
+          enum:
+            - COMPLETED
+            - FAILED
+            - CANCELLED
+        startedAt:
+          type: string
+          format: date-time
+          description: The time when the topology change was started
+          example: "2020-01-01T00:00:00Z"
+        completedAt:
+          type: string
+          format: date-time
+          description: The time when the topology change was completed
+          example: "2020-01-01T00:00:00Z"
 
     TopologyChange:
       type: object

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -240,10 +240,7 @@ components:
       type: object
       properties:
         version:
-          type: integer
-          format: int64
-          description: The version of the topology
-          example: 1
+          $ref: "#/components/schemas/TopologyVersion"
         brokers:
           type: array
           items:
@@ -375,6 +372,13 @@ components:
         - JOINING
         - ACTIVE
         - LEAVING
+
+    TopologyVersion:
+      title: TopologyVersion
+      description: The version of the topology
+      type: integer
+      format: int64
+      example: 1
 
     ChangeId:
       title: ChangeId

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -167,21 +167,21 @@ components:
       content:
         application.json:
           schema:
-            $ref: "#/components/schemas/PostOperationResponse"
+            $ref: "#/components/schemas/PlannedOperationsResponse"
 
     ScaleBrokersResponse:
       description: Request to reconfigure brokers is accepted.
       content:
         application.json:
           schema:
-            $ref: "#/components/schemas/PostOperationResponse"
+            $ref: "#/components/schemas/PlannedOperationsResponse"
 
     RemoveBrokerResponse:
       description: Request to remove broker is accepted.
       content:
         application.json:
           schema:
-            $ref: "#/components/schemas/PostOperationResponse"
+            $ref: "#/components/schemas/PlannedOperationsResponse"
 
     GetTopologyResponse:
       description: response body for getting current topology
@@ -208,8 +208,8 @@ components:
       items:
         $ref: "#/components/schemas/BrokerId"
 
-    PostOperationResponse:
-      title: PostOperationResponse
+    PlannedOperationsResponse:
+      title: PlannedOperationsResponse
       description: Returns the current topology, planned changes and the expected final topology
                    when the planned changes have completed.
       type: object
@@ -222,7 +222,8 @@ components:
           items:
             $ref: "#/components/schemas/BrokerState"
         plannedChanges:
-          description: A sequence operations for processing to the request.
+          description: A sequence of operations that will be performed to transform the current
+                       topology into the expected topology.
           type: array
           items:
             $ref: "#/components/schemas/Operation"

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/CancelChangeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/CancelChangeTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.clustering.dynamic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
+import io.camunda.zeebe.management.cluster.CompletedChange;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -46,8 +46,9 @@ final class CancelChangeTest {
     final var cancelResponse = actuator.cancelChange(addResponse.getChangeId());
 
     // then
-    assertThat(cancelResponse.getChange().getStatus()).isEqualTo(StatusEnum.CANCELLED);
-    assertThat(cancelResponse.getChange().getId()).isEqualTo(addResponse.getChangeId());
+    assertThat(cancelResponse.getLastChange().getStatus())
+        .isEqualTo(CompletedChange.StatusEnum.CANCELLED);
+    assertThat(cancelResponse.getLastChange().getId()).isEqualTo(addResponse.getChangeId());
     assertThat(cancelResponse.getBrokers())
         .describedAs("Topology is not changed")
         .isEqualTo(initialTopology.getBrokers());

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionJoinTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.clustering.dynamic;
 
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
 
-import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
@@ -84,13 +84,13 @@ final class PartitionJoinTest {
         .awaitCompleteTopology();
   }
 
-  PostOperationResponse runOperation(final TestCluster cluster, final Operation operation) {
+  PlannedOperationsResponse runOperation(final TestCluster cluster, final Operation operation) {
     final var actuator = ClusterActuator.of(cluster.availableGateway());
     return actuator.joinPartition(
         operation.brokerId(), operation.partitionId(), operation.priority());
   }
 
-  PostOperationResponse revertOperation(final TestCluster cluster, final Operation operation) {
+  PlannedOperationsResponse revertOperation(final TestCluster cluster, final Operation operation) {
     final var actuator = ClusterActuator.of(cluster.availableGateway());
     return actuator.leavePartition(operation.brokerId(), operation.partitionId());
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/PartitionLeaveTest.java
@@ -9,7 +9,7 @@ package io.camunda.zeebe.it.clustering.dynamic;
 
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
 
-import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
@@ -63,12 +63,12 @@ final class PartitionLeaveTest {
     }
   }
 
-  PostOperationResponse runOperation(final TestCluster cluster, final Operation operation) {
+  PlannedOperationsResponse runOperation(final TestCluster cluster, final Operation operation) {
     final var actuator = ClusterActuator.of(cluster.availableGateway());
     return actuator.leavePartition(operation.brokerId(), operation.partitionId());
   }
 
-  private PostOperationResponse revertOperation(
+  private PlannedOperationsResponse revertOperation(
       final TestCluster cluster, final Operation operation) {
     final var actuator = ClusterActuator.of(cluster.availableGateway());
     return actuator.joinPartition(operation.brokerId(), operation.partitionId(), 1);

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/Utils.java
@@ -11,7 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -39,7 +39,7 @@ final class Utils {
         .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
   }
 
-  static PostOperationResponse scale(final TestCluster cluster, final int newClusterSize) {
+  static PlannedOperationsResponse scale(final TestCluster cluster, final int newClusterSize) {
     final var actuator = ClusterActuator.of(cluster.anyGateway());
     final var newBrokerSet = IntStream.range(0, newClusterSize).boxed().toList();
 
@@ -49,7 +49,7 @@ final class Utils {
     return response;
   }
 
-  static void assertChangeIsPlanned(final PostOperationResponse response) {
+  static void assertChangeIsPlanned(final PlannedOperationsResponse response) {
     assertThat(response.getPlannedChanges()).isNotEmpty();
     assertThat(response.getExpectedTopology())
         .usingRecursiveComparison()

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -19,7 +19,7 @@ import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.management.cluster.GetTopologyResponse;
-import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.zeebe.containers.ZeebeNode;
@@ -81,7 +81,7 @@ public interface ClusterActuator {
   @RequestLine("POST /brokers/{brokerId}/partitions/{partitionId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   @Body("%7B\"priority\": \"{priority}\"%7D")
-  PostOperationResponse joinPartition(
+  PlannedOperationsResponse joinPartition(
       @Param final int brokerId, @Param final int partitionId, @Param final int priority);
 
   /**
@@ -91,7 +91,7 @@ public interface ClusterActuator {
    */
   @RequestLine("DELETE /brokers/{brokerId}/partitions/{partitionId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PostOperationResponse leavePartition(@Param final int brokerId, @Param final int partitionId);
+  PlannedOperationsResponse leavePartition(@Param final int brokerId, @Param final int partitionId);
 
   /**
    * Queries the current cluster topology
@@ -110,7 +110,7 @@ public interface ClusterActuator {
    */
   @RequestLine("POST /brokers")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PostOperationResponse scaleBrokers(@RequestBody List<Integer> ids);
+  PlannedOperationsResponse scaleBrokers(@RequestBody List<Integer> ids);
 
   /**
    * Scales the given brokers up or down and reassigns partitions to the new brokers.
@@ -120,7 +120,7 @@ public interface ClusterActuator {
    */
   @RequestLine("POST /brokers?dryRun={dryRun}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PostOperationResponse scaleBrokers(@RequestBody List<Integer> ids, @Param boolean dryRun);
+  PlannedOperationsResponse scaleBrokers(@RequestBody List<Integer> ids, @Param boolean dryRun);
 
   /**
    * Request that the broker is added to the cluster.
@@ -129,7 +129,7 @@ public interface ClusterActuator {
    */
   @RequestLine("POST /brokers/{brokerId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PostOperationResponse addBroker(@Param final int brokerId);
+  PlannedOperationsResponse addBroker(@Param final int brokerId);
 
   /**
    * Request that the broker is removed from the cluster
@@ -138,7 +138,7 @@ public interface ClusterActuator {
    */
   @RequestLine("DELETE /brokers/{brokerId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PostOperationResponse removeBroker(@Param final int brokerId);
+  PlannedOperationsResponse removeBroker(@Param final int brokerId);
 
   @RequestLine("DELETE /changes/{changeId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
@@ -147,7 +147,7 @@ public interface ClusterActuator {
   // invalid parameter types
   @RequestLine("POST /brokers")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PostOperationResponse scaleBrokersInvalidType(@RequestBody List<String> ids);
+  PlannedOperationsResponse scaleBrokersInvalidType(@RequestBody List<String> ids);
 
   /**
    * Request that the broker is added to the cluster.
@@ -156,5 +156,5 @@ public interface ClusterActuator {
    */
   @RequestLine("POST /brokers/{brokerId}")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
-  PostOperationResponse addBrokerInvalidType(@Param final String brokerId);
+  PlannedOperationsResponse addBrokerInvalidType(@Param final String brokerId);
 }

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
@@ -8,8 +8,9 @@
 package io.camunda.zeebe.qa.util.topology;
 
 import io.camunda.zeebe.management.cluster.BrokerStateCode;
+import io.camunda.zeebe.management.cluster.CompletedChange;
 import io.camunda.zeebe.management.cluster.PartitionStateCode;
-import io.camunda.zeebe.management.cluster.PostOperationResponse;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
@@ -40,7 +41,7 @@ public final class ClusterActuatorAssert
     return this;
   }
 
-  public ClusterActuatorAssert hasAppliedChanges(final PostOperationResponse response) {
+  public ClusterActuatorAssert hasAppliedChanges(final PlannedOperationsResponse response) {
     final var expectedTopology = response.getExpectedTopology();
     final var currentTopology = actual.getTopology().getBrokers();
     Assertions.assertThat(currentTopology)
@@ -50,11 +51,12 @@ public final class ClusterActuatorAssert
     return this;
   }
 
-  public ClusterActuatorAssert hasCompletedChanges(final PostOperationResponse response) {
-    final var currentChange = actual.getTopology().getChange();
+  public ClusterActuatorAssert hasCompletedChanges(final PlannedOperationsResponse response) {
+    final var currentChange = actual.getTopology().getLastChange();
     Assertions.assertThat(currentChange).isNotNull();
     Assertions.assertThat(currentChange.getId()).isEqualTo(response.getChangeId());
-    Assertions.assertThat(currentChange.getStatus()).isEqualTo(StatusEnum.COMPLETED);
+    Assertions.assertThat(currentChange.getStatus())
+        .isEqualTo(CompletedChange.StatusEnum.COMPLETED);
     return this;
   }
 

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/topology/ClusterActuatorAssert.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.management.cluster.BrokerStateCode;
 import io.camunda.zeebe.management.cluster.CompletedChange;
 import io.camunda.zeebe.management.cluster.PartitionStateCode;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
-import io.camunda.zeebe.management.cluster.TopologyChange.StatusEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import java.time.OffsetDateTime;
@@ -92,9 +91,8 @@ public final class ClusterActuatorAssert
   }
 
   public ClusterActuatorAssert doesNotHavePendingChanges() {
-    final var currentChange = actual.getTopology().getChange();
-    Assertions.assertThat(currentChange).isNotNull();
-    Assertions.assertThat(currentChange.getStatus()).isEqualTo(StatusEnum.COMPLETED);
+    final var currentChange = actual.getTopology().getPendingChange();
+    Assertions.assertThat(currentChange).isNull();
     return this;
   }
 


### PR DESCRIPTION
Adds some missing data to the GET response so that querying the current topology includes both currently pending as well as the last completed change. 

I also included a minor cleanup of the OpenAPI spec.

closes #15293 