### PR TITLE
Migrate task instances with recreated event subscriptions

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -91,7 +91,8 @@ public final class BpmnProcessors {
         typedRecordProcessors, processingState, writers, bpmnBehaviors, processEngineMetrics);
     addProcessInstanceModificationStreamProcessors(
         typedRecordProcessors, processingState, writers, bpmnBehaviors);
-    addProcessInstanceMigrationStreamProcessors(typedRecordProcessors, processingState, writers);
+    addProcessInstanceMigrationStreamProcessors(
+        typedRecordProcessors, processingState, writers, bpmnBehaviors);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
 
     return bpmnStreamProcessor;
@@ -227,7 +228,8 @@ public final class BpmnProcessors {
   private static void addProcessInstanceMigrationStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
-      final Writers writers) {
+      final Writers writers,
+      final BpmnBehaviors bpmnBehaviors) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         ProcessInstanceMigrationIntent.MIGRATE,
@@ -236,7 +238,8 @@ public final class BpmnProcessors {
             processingState.getElementInstanceState(),
             processingState.getProcessState(),
             processingState.getJobState(),
-            processingState.getVariableState()));
+            processingState.getVariableState(),
+            bpmnBehaviors));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventSubscriptionBehavior.java
@@ -49,7 +49,11 @@ public final class BpmnEventSubscriptionBehavior {
   }
 
   public void unsubscribeFromEvents(final BpmnElementContext context) {
-    catchEventBehavior.unsubscribeFromEvents(context.getElementInstanceKey());
+    unsubscribeFromEvents(context.getElementInstanceKey());
+  }
+
+  public void unsubscribeFromEvents(final long elementInstanceKey) {
+    catchEventBehavior.unsubscribeFromEvents(elementInstanceKey);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -223,11 +223,11 @@ public class ProcessInstanceMigrationMigrateProcessor
                         .setBpmnProcessId(processDefinition.getBpmnProcessId())
                         .setTenantId(elementInstance.getValue().getTenantId())));
 
-    final ExecutableCatchEventSupplier targetElement =
+    final var targetElement =
         processDefinition
             .getProcess()
             .getElementById(targetElementId, ExecutableCatchEventSupplier.class);
-    final BpmnElementContextImpl bpmnElementContext = new BpmnElementContextImpl();
+    final var bpmnElementContext = new BpmnElementContextImpl();
     bpmnElementContext.init(
         elementInstance.getKey(), elementInstance.getValue(), elementInstance.getState());
     eventSubscriptionBehavior.subscribeToEvents(targetElement, bpmnElementContext);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -7,6 +7,10 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContextImpl;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
@@ -61,16 +65,19 @@ public class ProcessInstanceMigrationMigrateProcessor
   private final ProcessState processState;
   private final JobState jobState;
   private final VariableState variableState;
+  private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
 
   public ProcessInstanceMigrationMigrateProcessor(
       final Writers writers,
       final ElementInstanceState elementInstanceState,
       final ProcessState processState,
       final JobState jobState,
-      final VariableState variableState) {
+      final VariableState variableState,
+      final BpmnBehaviors bpmnBehaviors) {
     stateWriter = writers.state();
     responseWriter = writers.response();
     rejectionWriter = writers.rejection();
+    eventSubscriptionBehavior = bpmnBehaviors.eventSubscriptionBehavior();
     this.elementInstanceState = elementInstanceState;
     this.processState = processState;
     this.jobState = jobState;
@@ -177,6 +184,8 @@ public class ProcessInstanceMigrationMigrateProcessor
           elementInstanceRecord.getProcessInstanceKey(), elementInstanceRecord.getElementId());
     }
 
+    eventSubscriptionBehavior.unsubscribeFromEvents(elementInstance.getKey());
+
     stateWriter.appendFollowUpEvent(
         elementInstance.getKey(),
         ProcessInstanceIntent.ELEMENT_MIGRATED,
@@ -213,6 +222,15 @@ public class ProcessInstanceMigrationMigrateProcessor
                         .setProcessDefinitionKey(processDefinition.getKey())
                         .setBpmnProcessId(processDefinition.getBpmnProcessId())
                         .setTenantId(elementInstance.getValue().getTenantId())));
+
+    final ExecutableCatchEventSupplier targetElement =
+        processDefinition
+            .getProcess()
+            .getElementById(targetElementId, ExecutableCatchEventSupplier.class);
+    final BpmnElementContextImpl bpmnElementContext = new BpmnElementContextImpl();
+    bpmnElementContext.init(
+        elementInstance.getKey(), elementInstance.getValue(), elementInstance.getState());
+    eventSubscriptionBehavior.subscribeToEvents(targetElement, bpmnElementContext);
   }
 
   /**

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceEventSubscriptionsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceEventSubscriptionsTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -142,13 +143,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
 
     final long processDefinitionKey =
         extractProcessDefinitionKeyByProcessId(deployment, processId1);
-    assertThat(
-            RecordingExporter.timerRecords(TimerIntent.CREATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withProcessDefinitionKey(processDefinitionKey)
-                .getFirst()
-                .getValue())
-        .hasTargetElementId("boundaryEvent");
+
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
 
     // when
     ENGINE
@@ -343,13 +342,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
 
     final long processDefinitionKey =
         extractProcessDefinitionKeyByProcessId(deployment, processId1);
-    assertThat(
-            RecordingExporter.timerRecords(TimerIntent.CREATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withProcessDefinitionKey(processDefinitionKey)
-                .getFirst()
-                .getValue())
-        .hasTargetElementId("eventSubProcessStart");
+
+    RecordingExporter.timerRecords(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .await();
 
     // when
     ENGINE
@@ -468,6 +465,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
 
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
     // when
     ENGINE
         .processInstance()
@@ -532,6 +534,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
 
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
     // when
     ENGINE
         .processInstance()
@@ -585,6 +592,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
         extractProcessDefinitionKeyByProcessId(deployment, processId2);
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
 
     // when
     ENGINE
@@ -645,6 +657,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
         extractProcessDefinitionKeyByProcessId(deployment, processId2);
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
 
     // when
     ENGINE
@@ -711,6 +728,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
 
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
     // when
     ENGINE
         .processInstance()
@@ -761,6 +783,11 @@ public class MigrateProcessInstanceEventSubscriptionsTest {
         extractProcessDefinitionKeyByProcessId(deployment, processId2);
 
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
 
     // when
     ENGINE

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceEventSubscriptionsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceEventSubscriptionsTest.java
@@ -1,0 +1,900 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateProcessInstanceEventSubscriptionsTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldUnsubscribeMessageBoundaryEventForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundaryEvent",
+                        e ->
+                            e.message(
+                                m ->
+                                    m.name("message")
+                                        .zeebeCorrelationKeyExpression("\"correlationKey\"")))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName("message")
+        .withCorrelationKey("correlationKey")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .withCorrelationKey("correlationKey")
+                .findAny())
+        .isPresent();
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to delete process message subscription for process instance")
+        .hasBpmnProcessId(processId1)
+        .hasElementId("boundaryEvent")
+        .hasCorrelationKey("correlationKey");
+  }
+
+  @Test
+  public void shouldUnsubscribeTimerBoundaryEventForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .boundaryEvent("boundaryEvent", e -> e.timerWithDuration("PT1M"))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    final long processDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId1);
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .getFirst()
+                .getValue())
+        .hasTargetElementId("boundaryEvent");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to cancel timer for process instance")
+        .hasTargetElementId("boundaryEvent");
+  }
+
+  @Test
+  public void shouldUnsubscribeSignalBoundaryEventForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .boundaryEvent("boundaryEvent", e -> e.signal("signal"))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    final long processDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId1);
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withBpmnProcessId(processId1)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withSignalName("signal")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .withSignalName("signal")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to delete signal subscription for process instance")
+        .hasBpmnProcessId(processId1)
+        .hasProcessDefinitionKey(processDefinitionKey);
+  }
+
+  @Test
+  public void shouldUnsubscribeMessageEventSubProcessForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .eventSubProcess(
+                        "eventSubProcess",
+                        sub ->
+                            sub.startEvent(
+                                    "eventSubProcessStart",
+                                    s ->
+                                        s.message(
+                                            m ->
+                                                m.name("message")
+                                                    .zeebeCorrelationKeyExpression(
+                                                        "\"correlationKey\"")))
+                                .endEvent())
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName("message")
+        .withCorrelationKey("correlationKey")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .withCorrelationKey("correlationKey")
+                .findAny())
+        .isPresent();
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Expected to delete event subprocess message subscription for process instance")
+        .hasBpmnProcessId(processId1)
+        .hasElementId("eventSubProcessStart")
+        .hasCorrelationKey("correlationKey");
+  }
+
+  @Test
+  public void shouldUnsubscribeTimerEventSubProcessForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .eventSubProcess(
+                        "eventSubProcess",
+                        sub ->
+                            sub.startEvent(
+                                "eventSubProcessStart", s -> s.timerWithDuration("PT1M")))
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    final long processDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId1);
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .getFirst()
+                .getValue())
+        .hasTargetElementId("eventSubProcessStart");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to cancel event subprocess timer start event for process instance")
+        .hasTargetElementId("eventSubProcessStart");
+  }
+
+  @Test
+  public void shouldUnsubscribeSignalEventSubProcessForProcessInstance() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .eventSubProcess(
+                        "eventSubProcess",
+                        sub -> sub.startEvent("eventSubProcessStart", s -> s.signal("signal")))
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    final long processDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId1);
+    RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+        .withBpmnProcessId(processId1)
+        .withProcessDefinitionKey(processDefinitionKey)
+        .withSignalName("signal")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.DELETED)
+                .withSignalName("signal")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to delete event subprocess signal subscription for process instance")
+        .hasBpmnProcessId(processId1)
+        .hasProcessDefinitionKey(processDefinitionKey);
+  }
+
+  @Test
+  public void shouldSubscribeMessageBoundaryEventForTargetProcessDefinition() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .boundaryEvent(
+                        "boundaryEvent",
+                        e ->
+                            e.message(
+                                m ->
+                                    m.name("message")
+                                        .zeebeCorrelationKeyExpression("\"correlationKey\"")))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .withCorrelationKey("correlationKey")
+                .findAny())
+        .isPresent();
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Expected to create process message subscription for target process definition")
+        .hasBpmnProcessId(processId2)
+        .hasElementId("boundaryEvent")
+        .hasCorrelationKey("correlationKey");
+  }
+
+  @Test
+  public void shouldSubscribeTimerBoundaryEventForTargetProcessDefinition() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .boundaryEvent("boundaryEvent", e -> e.timerWithDuration("PT1M"))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    final long processDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to create timer for target process definition")
+        .hasTargetElementId("boundaryEvent");
+  }
+
+  @Test
+  public void shouldSubscribeSignalBoundaryEventForTargetProcessDefinition() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .boundaryEvent("boundaryEvent", e -> e.signal("signal"))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+                .withSignalName("signal")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to create signal subscription for target process definition")
+        .hasBpmnProcessId(processId2)
+        .hasProcessDefinitionKey(otherProcessDefinitionKey);
+  }
+
+  @Test
+  public void shouldSubscribeMessageEventSubProcessForTargetProcessDefinition() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .eventSubProcess(
+                        "eventSubProcess",
+                        sub ->
+                            sub.startEvent(
+                                    "eventSubProcessStart",
+                                    s ->
+                                        s.message(
+                                            m ->
+                                                m.name("message")
+                                                    .zeebeCorrelationKeyExpression(
+                                                        "\"correlationKey\"")))
+                                .endEvent())
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .withCorrelationKey("correlationKey")
+                .findAny())
+        .isPresent();
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Expected to create event subprocess process message subscription for target process definition")
+        .hasBpmnProcessId(processId2)
+        .hasElementId("eventSubProcessStart")
+        .hasCorrelationKey("correlationKey");
+  }
+
+  @Test
+  public void shouldSubscribeTimerEventSubProcessForTargetProcessDefinition() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .eventSubProcess(
+                        "eventSubProcess",
+                        sub ->
+                            sub.startEvent(
+                                "eventSubProcessStart", s -> s.timerWithDuration("PT1M")))
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long processDefinitionKey2 =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(processDefinitionKey2)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withProcessDefinitionKey(processDefinitionKey2)
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to create event subprocess timer for target process definition")
+        .hasTargetElementId("eventSubProcessStart");
+  }
+
+  @Test
+  public void shouldSubscribeSignalEventSubProcessForTargetProcessDefinition() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .eventSubProcess(
+                        "eventSubProcess",
+                        sub -> sub.startEvent("eventSubProcessStart", s -> s.signal("signal")))
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long processDefinitionKey2 =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(processDefinitionKey2)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.signalSubscriptionRecords(SignalSubscriptionIntent.CREATED)
+                .withSignalName("signal")
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Expected to create event subprocess signal subscription for target process definition")
+        .hasBpmnProcessId(processId2)
+        .hasProcessDefinitionKey(processDefinitionKey2);
+  }
+
+  @Test
+  public void shouldRecreateMessageSubscription() {
+    // given
+    final String processId1 = helper.getBpmnProcessId();
+    final String processId2 = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId1)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundaryEvent",
+                        e ->
+                            e.message(
+                                m ->
+                                    m.name("message")
+                                        .zeebeCorrelationKeyExpression("\"correlationKey\"")))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId2)
+                    .startEvent()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .boundaryEvent(
+                        "boundaryEvent2",
+                        e ->
+                            e.message(
+                                m ->
+                                    m.name("message2")
+                                        .zeebeCorrelationKeyExpression("\"correlationKey2\"")))
+                    .userTask()
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long otherProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, processId2);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId1).create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName("message")
+        .withCorrelationKey("correlationKey")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(otherProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .withCorrelationKey("correlationKey")
+                .findAny())
+        .isPresent();
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.DELETED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message")
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to delete process message subscription for process instance")
+        .hasBpmnProcessId(processId1)
+        .hasElementId("boundaryEvent")
+        .hasCorrelationKey("correlationKey");
+
+    assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message2")
+                .withCorrelationKey("correlationKey2")
+                .findAny())
+        .isPresent();
+
+    assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("message2")
+                .getFirst()
+                .getValue())
+        .describedAs(
+            "Expected to create process message subscription for target process definition")
+        .hasBpmnProcessId(processId2)
+        .hasElementId("boundaryEvent2")
+        .hasCorrelationKey("correlationKey2");
+  }
+
+  private static long extractProcessDefinitionKeyByProcessId(
+      final Record<DeploymentRecordValue> deployment, final String processId) {
+    return deployment.getValue().getProcessesMetadata().stream()
+        .filter(p -> p.getBpmnProcessId().equals(processId))
+        .findAny()
+        .orElseThrow()
+        .getProcessDefinitionKey();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

### Following cases are handled for event subscriptions while migrating a process instance.

There are three subscriptions that needs to be handled:
- message
- timer
- signal

There are two cases where we can migrate process instances with event
subscriptions:
- boundary events
- event subprocesses

There are two scenarios to handle:
- Unsubscribing events from process instance
- Subscribing events in the target process definition

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15407 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
