### PR TITLE
Handle job worker back pressure/yield as an expected case

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/Loggers.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/Loggers.java
@@ -24,11 +24,7 @@ public final class Loggers {
 
   public static final Logger EXPORTER_LOGGER =
       LoggerFactory.getLogger("io.camunda.zeebe.broker.exporter");
-  public static final Logger DELETION_SERVICE =
-      LoggerFactory.getLogger("io.camunda.zeebe.broker.logstreams.delete");
   public static final Logger RAFT = LoggerFactory.getLogger("io.camunda.zeebe.broker.raft");
-  public static final Logger JOB_STREAM =
-      LoggerFactory.getLogger("io.camunda.zeebe.broker.jobStream");
 
   public static Logger getExporterLogger(final String exporterId) {
     final String loggerName = String.format("io.camunda.zeebe.broker.exporter.%s", exporterId);

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/JobStreamMetrics.java
@@ -8,31 +8,40 @@
 package io.camunda.zeebe.broker.jobstream;
 
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 
 public class JobStreamMetrics implements RemoteStreamMetrics {
-  private static final String NAMESPACE = "zeebe";
+  private static final String NAMESPACE = "zeebe_broker";
 
   private static final Gauge STREAM_COUNT =
       Gauge.build()
           .namespace(NAMESPACE)
-          .name("broker_open_job_stream_count")
+          .name("open_job_stream_count")
           .help("Number of open job streams in broker")
           .register();
 
   private static final Counter PUSH_SUCCESS_COUNT =
       Counter.build()
           .namespace(NAMESPACE)
-          .name("broker_jobs_pushed_count")
+          .name("jobs_pushed_count")
           .help("Total number of jobs pushed to all streams")
           .register();
 
   private static final Counter PUSH_FAILED_COUNT =
       Counter.build()
           .namespace(NAMESPACE)
-          .name("broker_jobs_push_fail_count")
+          .name("jobs_push_fail_count")
           .help("Total number of failures when pushing jobs to the streams")
+          .register();
+
+  private static final Counter PUSH_TRY_FAILED_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("jobs_push_fail_try_count")
+          .help("Total number of failed attempts when pushing jobs to the streams, grouped by code")
+          .labelNames("code")
           .register();
 
   @Override
@@ -53,5 +62,10 @@ public class JobStreamMetrics implements RemoteStreamMetrics {
   @Override
   public void pushFailed() {
     PUSH_FAILED_COUNT.inc();
+  }
+
+  @Override
+  public void pushTryFailed(final ErrorCode code) {
+    PUSH_TRY_FAILED_COUNT.labels(code.name()).inc();
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.jobstream;
 
-import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
@@ -21,6 +20,7 @@ import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.time.Duration;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A {@link RemoteStreamErrorHandler} for {@link ActivatedJob} payloads, which will write any
@@ -36,9 +36,8 @@ import org.slf4j.Logger;
  * until it times out.
  */
 final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<ActivatedJob> {
-  private static final Logger LOGGER = Loggers.JOB_STREAM;
+  private static final Logger LOGGER = LoggerFactory.getLogger(RemoteStreamErrorHandler.class);
   private static final Logger NO_WRITER_LOGGER = new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
-  private static final Logger NO_ACTION_LOGGER = new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
   private static final Logger FAILED_WRITER_LOGGER =
       new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
 
@@ -89,7 +88,7 @@ final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<Acti
       FAILED_WRITER_LOGGER.warn(
           """
           Failed to handle failed job push {} on partition {}. Write to logstream failed with {};
-          job will remain activated until it times out. """,
+          job will remain activated until it times out.""",
           job.jobKey(),
           partitionId,
           writeResult.getLeft());

--- a/broker/src/main/java/io/camunda/zeebe/broker/jobstream/YieldingJobStreamErrorHandler.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/jobstream/YieldingJobStreamErrorHandler.java
@@ -7,20 +7,20 @@
  */
 package io.camunda.zeebe.broker.jobstream;
 
-import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-public class YieldingJobStreamErrorHandler implements JobStreamErrorHandler {
+public final class YieldingJobStreamErrorHandler implements JobStreamErrorHandler {
 
-  private static final Logger LOG = Loggers.JOB_STREAM;
+  private static final Logger LOG = LoggerFactory.getLogger(YieldingJobStreamErrorHandler.class);
 
   @Override
   public void handleError(
       final ActivatedJob job, final Throwable error, final TaskResultBuilder resultBuilder) {
-    LOG.warn("Failed to push job {}. Yielding...", job.jobKey(), error);
+    LOG.trace("Failed to push job {}. Yielding...", job.jobKey(), error);
     resultBuilder.appendCommandRecord(job.jobKey(), JobIntent.YIELD, job.jobRecord());
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/stream/JobClientStreamMetrics.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.gateway.impl.stream;
 
 import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
@@ -46,6 +47,13 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
           .help("Count of pushed payloads, tagged by result status (success, failure)")
           .labelNames("status")
           .register();
+  private static final Counter PUSH_TRY_FAILED_COUNT =
+      Counter.build()
+          .namespace(NAMESPACE)
+          .name("push_fail_try")
+          .help("Total number of failed attempts when pushing jobs to the clients, grouped by code")
+          .labelNames("code")
+          .register();
 
   private final Counter.Child pushSuccessCount;
   private final Counter.Child pushFailureCount;
@@ -83,5 +91,10 @@ final class JobClientStreamMetrics implements ClientStreamMetrics {
   @Override
   public void pushFailed() {
     pushFailureCount.inc();
+  }
+
+  @Override
+  public void pushTryFailed(final ErrorCode code) {
+    PUSH_TRY_FAILED_COUNT.labels(code.name()).inc();
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamMetrics.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/ClientStreamMetrics.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+
 public interface ClientStreamMetrics {
   /** Invoked whenever the count of known servers in the registry changes */
   default void serverCount(final int count) {}
@@ -29,6 +31,14 @@ public interface ClientStreamMetrics {
 
   /** Invoked if pushing a payload to a stream failed */
   default void pushFailed() {}
+
+  /**
+   * Invoked when a push failed for a given client, regardless of whether it ultimately succeeded
+   * with another.
+   *
+   * @param code the error code for the given attempt
+   */
+  default void pushTryFailed(final ErrorCode code) {}
 
   static ClientStreamMetrics noop() {
     return new ClientStreamMetrics() {};

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamMetrics.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/RemoteStreamMetrics.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.transport.stream.api;
 
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+
 public interface RemoteStreamMetrics {
 
   /** Invoked after a stream is successfully added to the registry */
@@ -20,6 +22,13 @@ public interface RemoteStreamMetrics {
 
   /** Invoked if pushing a payload to a stream failed */
   default void pushFailed() {}
+
+  /**
+   * Invoked when a push failed, once per remote attempt
+   *
+   * @param code the error code for the given attempt
+   */
+  default void pushTryFailed(final ErrorCode code) {}
 
   static RemoteStreamMetrics noop() {
     return new RemoteStreamMetrics() {};

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/api/StreamResponseException.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/api/StreamResponseException.java
@@ -10,20 +10,24 @@ package io.camunda.zeebe.transport.stream.api;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
+import java.util.ArrayList;
+import java.util.List;
 
 /** An exception returned */
 public class StreamResponseException extends UnrecoverableException {
 
   private final ErrorCode code;
   private final String message;
+  private final List<ErrorDetail> details;
 
   public StreamResponseException(final ErrorResponse response) {
     super(
-        "Remote stream server error: [code=%s, message='%s']"
-            .formatted(response.code(), response.message()));
+        "Remote stream server error: [code=%s, message='%s', details=%s]"
+            .formatted(response.code(), response.message(), response.details()));
 
     code = response.code();
     message = response.message();
+    details = new ArrayList<>(response.details());
   }
 
   public ErrorCode code() {
@@ -32,5 +36,15 @@ public class StreamResponseException extends UnrecoverableException {
 
   public String message() {
     return message;
+  }
+
+  public List<ErrorDetail> details() {
+    return details;
+  }
+
+  public interface ErrorDetail {
+    ErrorCode code();
+
+    String message();
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandler.java
@@ -10,10 +10,6 @@ package io.camunda.zeebe.transport.stream.impl;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
-import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
-import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
-import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamResponse;
@@ -56,20 +52,11 @@ final class ClientStreamApiHandler {
     }
 
     final var errorResponse =
-        new ErrorResponse().code(mapErrorToCode(error)).message(error.getMessage());
+        new ErrorResponse().code(ErrorResponse.mapErrorToCode(error)).message(error.getMessage());
     for (final var detail : error.getSuppressed()) {
-      errorResponse.addDetail(mapErrorToCode(detail), detail.getMessage());
+      errorResponse.addDetail(ErrorResponse.mapErrorToCode(detail), detail.getMessage());
     }
 
     response.complete(errorResponse);
-  }
-
-  private ErrorCode mapErrorToCode(final Throwable error) {
-    return switch (error) {
-      case final ClientStreamBlockedException ignored -> ErrorCode.BLOCKED;
-      case final NoSuchStreamException ignored -> ErrorCode.NOT_FOUND;
-      case final StreamExhaustedException ignored -> ErrorCode.EXHAUSTED;
-      default -> ErrorCode.INTERNAL;
-    };
   }
 }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamImpl.java
@@ -8,8 +8,6 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.util.buffer.BufferWriter;
@@ -24,14 +22,6 @@ record ClientStreamImpl<M extends BufferWriter>(
     M metadata,
     ClientStreamConsumer clientStreamConsumer)
     implements ClientStream<M> {
-
-  ActorFuture<Void> push(final DirectBuffer payload) {
-    try {
-      return clientStreamConsumer.push(payload);
-    } catch (final Exception e) {
-      return CompletableActorFuture.completedExceptionally(e);
-    }
-  }
 
   @Override
   public Set<MemberId> liveConnections() {

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -23,11 +23,11 @@ import org.slf4j.LoggerFactory;
 
 final class ClientStreamManager<M extends BufferWriter> {
   private static final Logger LOG = LoggerFactory.getLogger(ClientStreamManager.class);
+  private final Set<MemberId> servers = new HashSet<>();
   private final ClientStreamRegistry<M> registry;
   private final ClientStreamRequestManager<M> requestManager;
   private final ClientStreamMetrics metrics;
-  private final Set<MemberId> servers = new HashSet<>();
-  private final ClientStreamPusher streamPusher = new ClientStreamPusher();
+  private final ClientStreamPusher streamPusher;
 
   ClientStreamManager(
       final ClientStreamRegistry<M> registry,
@@ -36,6 +36,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     this.registry = registry;
     this.requestManager = requestManager;
     this.metrics = metrics;
+    streamPusher = new ClientStreamPusher(metrics);
   }
 
   /**

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManager.java
@@ -27,6 +27,7 @@ final class ClientStreamManager<M extends BufferWriter> {
   private final ClientStreamRequestManager<M> requestManager;
   private final ClientStreamMetrics metrics;
   private final Set<MemberId> servers = new HashSet<>();
+  private final ClientStreamPusher streamPusher = new ClientStreamPusher();
 
   ClientStreamManager(
       final ClientStreamRegistry<M> registry,
@@ -73,7 +74,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     final var serverStream = registry.removeClient(streamId);
     serverStream.ifPresent(
         stream -> {
-          LOG.debug("Removing aggregated stream [{}]", stream.getStreamId());
+          LOG.debug("Removing aggregated stream [{}]", stream.streamId());
           stream.close();
           requestManager.remove(stream, servers);
         });
@@ -102,7 +103,7 @@ final class ClientStreamManager<M extends BufferWriter> {
     clientStream.ifPresentOrElse(
         stream -> {
           try {
-            stream.push(payload, responseFuture);
+            streamPusher.push(stream, payload, responseFuture);
           } catch (final Exception e) {
             responseFuture.completeExceptionally(e);
           }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusher.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
+import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
+import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.UUID;
+import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Handles forwarding pushed payloads to aggregated client streams. It will try each underlying
+ * stream once until either one succeeds or it exhausts all of them.
+ */
+final class ClientStreamPusher {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ClientStreamPusher.class);
+  private static final Logger PUSH_ERROR_LOGGER =
+      new ThrottledLogger(LOGGER, Duration.ofSeconds(1));
+
+  /**
+   * Pushes the given payload downstream to any of the stream's clients. On success, will complete
+   * the given future with null.
+   *
+   * <p>May complete exceptionally with:
+   *
+   * <ul>
+   *   <li>{@link StreamExhaustedException} if all clients failed
+   *   <li>{@link NoSuchStreamException} if all clients were removed since the push was received but
+   *       before it was forwarded
+   * </ul>
+   *
+   * @param stream the stream to push to
+   * @param payload the payload to push
+   * @param future the future to complete on success or failure
+   */
+  void push(
+      final AggregatedClientStream<?> stream,
+      final DirectBuffer payload,
+      final ActorFuture<Void> future) {
+    final var streams = stream.clientStreams().values();
+    if (streams.isEmpty()) {
+      future.completeExceptionally(
+          new NoSuchStreamException(
+              "Cannot forward remote payload as there is no known client streams for aggregated stream %s"
+                  .formatted(stream.logicalId())));
+      return;
+    }
+
+    final LinkedList<ClientStreamImpl<?>> targets = new LinkedList<>(streams);
+    Collections.shuffle(targets);
+
+    tryPush(stream.streamId(), targets, payload, future);
+  }
+
+  private void tryPush(
+      final UUID streamId,
+      final Queue<ClientStreamImpl<?>> targets,
+      final DirectBuffer buffer,
+      final ActorFuture<Void> future) {
+    final var clientStream = targets.poll();
+    if (clientStream == null) {
+      failOnStreamExhausted(future);
+      return;
+    }
+
+    LOGGER.trace("Pushing data from stream [{}] to client [{}]", streamId, clientStream.streamId());
+    push(clientStream, buffer)
+        .onComplete(
+            (ok, pushFailed) -> {
+              if (pushFailed == null) {
+                future.complete(null);
+                return;
+              }
+
+              logFailedPush(pushFailed, clientStream);
+              tryPush(streamId, targets, buffer, future);
+            });
+  }
+
+  private ActorFuture<Void> push(final ClientStreamImpl<?> stream, final DirectBuffer payload) {
+    try {
+      return stream.clientStreamConsumer().push(payload);
+    } catch (final Exception e) {
+      return CompletableActorFuture.completedExceptionally(e);
+    }
+  }
+
+  private void failOnStreamExhausted(final ActorFuture<Void> future) {
+    final StreamExhaustedException error =
+        new StreamExhaustedException(
+            "Failed to push data to all available clients. No more clients left to retry.");
+    future.completeExceptionally(error);
+  }
+
+  private void logFailedPush(final Throwable pushFailed, final ClientStreamImpl<?> clientStream) {
+    if (pushFailed instanceof ClientStreamBlockedException) {
+      LOGGER.trace(
+          "Failed to push data to client [{}], stream is blocked", clientStream.streamId());
+    } else {
+      PUSH_ERROR_LOGGER.warn(
+          "Failed to push data to client [{}], retrying with next client.",
+          clientStream.streamId(),
+          pushFailed);
+    }
+  }
+}

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistration.java
@@ -39,7 +39,7 @@ final class ClientStreamRegistration<M extends BufferWriter> {
   }
 
   UUID streamId() {
-    return stream.getStreamId();
+    return stream.streamId();
   }
 
   LogicalId<? extends BufferWriter> logicalId() {
@@ -94,7 +94,7 @@ final class ClientStreamRegistration<M extends BufferWriter> {
     }
 
     state = target;
-    LOGGER.trace("{} remote client stream {} on server {}", target, stream.getStreamId(), serverId);
+    LOGGER.trace("{} remote client stream {} on server {}", target, stream.streamId(), serverId);
     return true;
   }
 
@@ -102,7 +102,7 @@ final class ClientStreamRegistration<M extends BufferWriter> {
     LOGGER.trace(
         "Skip {} transition of stream {} on {} as its state is {}",
         target,
-        stream.getStreamId(),
+        stream.streamId(),
         serverId,
         state);
   }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRegistry.java
@@ -79,7 +79,7 @@ final class ClientStreamRegistry<M extends BufferWriter> {
       metrics.clientCount(clientStreams.size());
 
       if (serverStream.isEmpty()) {
-        serverStreams.remove(serverStream.getStreamId());
+        serverStreams.remove(serverStream.streamId());
         serverStreamIds.remove(serverStream.logicalId());
         metrics.aggregatedStreamCount(serverStreams.size());
 

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/ClientStreamRequestManager.java
@@ -132,7 +132,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       return;
     }
 
-    final var registration = streamsPerHost.get(stream.getStreamId());
+    final var registration = streamsPerHost.get(stream.streamId());
     if (registration != null) {
       remove(registration);
     }
@@ -236,7 +236,7 @@ final class ClientStreamRequestManager<M extends BufferWriter> {
       final AggregatedClientStream<M> stream, final MemberId serverId) {
     final var streamsPerHost = registrations.computeIfAbsent(serverId, ignored -> new HashMap<>());
     return streamsPerHost.computeIfAbsent(
-        stream.getStreamId(), streamId -> new ClientStreamRegistration<>(stream, serverId));
+        stream.streamId(), streamId -> new ClientStreamRegistration<>(stream, serverId));
   }
 
   private void sendAddRequest(

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamImpl.java
@@ -111,13 +111,13 @@ public final class RemoteStreamImpl<M, P extends BufferWriter> implements Remote
       }
 
       final var client = iterator.next();
-      LOGGER.debug(
+      LOGGER.trace(
           "Failed to push payload (size = {}), retrying with next stream", payload.getLength());
       streamer.pushAsync(payload, (error, data) -> retry(error, data, iterator), client.id());
     }
 
     private void onConsumersExhausted(final Throwable throwable, final P payload) {
-      LOGGER.debug(
+      LOGGER.trace(
           "Failed to push payload (size = {}), no more streams to retry", payload.getLength());
       errorHandler.handleError(throwable, payload);
     }

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusher.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
 import io.camunda.zeebe.transport.stream.api.StreamResponseException;
 import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
-import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamResponse;
@@ -66,13 +65,9 @@ final class RemoteStreamPusher<P extends BufferWriter> {
         return;
       }
 
-      if (error instanceof final StreamResponseException e
-          && (e.code() == ErrorCode.INVALID || e.code() == ErrorCode.MALFORMED)) {
-        pushErrorLogger.error(
-            "Failed to push (size = {}) to stream {}, request could not be parsed",
-            payload.getLength(),
-            streamId,
-            e);
+      if (error instanceof final StreamResponseException e) {
+        logResponseError(streamId, payload, e);
+        e.details().forEach(d -> metrics.pushTryFailed(d.code()));
       } else {
         pushWarnLogger.warn(
             "Failed to push (size = {}) to stream {}", payload.getLength(), streamId, error);
@@ -81,6 +76,24 @@ final class RemoteStreamPusher<P extends BufferWriter> {
       metrics.pushFailed();
       errorHandler.handleError(error, payload);
     };
+  }
+
+  private void logResponseError(
+      final StreamId streamId, final P payload, final StreamResponseException e) {
+    switch (e.code()) {
+      case INVALID, MALFORMED -> pushErrorLogger.error(
+          "Failed to push (size = {}) to stream {}, request could not be parsed",
+          payload.getLength(),
+          streamId,
+          e);
+      case EXHAUSTED -> LOG.trace(
+          "Failed to push (size = {}) to stream {} after trying all clients",
+          payload.getLength(),
+          streamId,
+          e);
+      default -> pushWarnLogger.warn(
+          "Failed to push (size = {}) to stream {}", payload.getLength(), streamId, e);
+    }
   }
 
   private void push(

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.transport.stream.impl.messages;
 
+import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
+import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
+import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
 import io.camunda.zeebe.transport.stream.api.StreamResponseException;
 import io.camunda.zeebe.transport.stream.api.StreamResponseException.ErrorDetail;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponseDecoder.DetailsDecoder;
@@ -153,6 +156,15 @@ public final class ErrorResponse implements StreamResponse {
 
   public StreamResponseException asException() {
     return new StacklessException(this);
+  }
+
+  public static ErrorCode mapErrorToCode(final Throwable error) {
+    return switch (error) {
+      case final ClientStreamBlockedException ignored -> ErrorCode.BLOCKED;
+      case final NoSuchStreamException ignored -> ErrorCode.NOT_FOUND;
+      case final StreamExhaustedException ignored -> ErrorCode.EXHAUSTED;
+      default -> ErrorCode.INTERNAL;
+    };
   }
 
   private record ErrorDetailImpl(ErrorCode code, DirectBuffer messageBuffer)

--- a/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
+++ b/transport/src/main/java/io/camunda/zeebe/transport/stream/impl/messages/ErrorResponse.java
@@ -8,8 +8,13 @@
 package io.camunda.zeebe.transport.stream.impl.messages;
 
 import io.camunda.zeebe.transport.stream.api.StreamResponseException;
+import io.camunda.zeebe.transport.stream.api.StreamResponseException.ErrorDetail;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponseDecoder.DetailsDecoder;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponseEncoder.DetailsEncoder;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
@@ -22,6 +27,7 @@ public final class ErrorResponse implements StreamResponse {
   private final ErrorResponseEncoder messageEncoder = new ErrorResponseEncoder();
   private final ErrorResponseDecoder messageDecoder = new ErrorResponseDecoder();
 
+  private final List<ErrorDetailImpl> details = new ArrayList<>();
   private final DirectBuffer message = new UnsafeBuffer();
   private ErrorCode code;
 
@@ -30,12 +36,31 @@ public final class ErrorResponse implements StreamResponse {
     messageDecoder.wrapAndApplyHeader(buffer, offset, headerDecoder);
     code = messageDecoder.code();
     messageDecoder.wrapMessage(message);
+
+    details.clear();
+    for (final DetailsDecoder decoder : messageDecoder.details()) {
+      final var messageBuffer = new UnsafeBuffer();
+      final var detail = new ErrorDetailImpl(decoder.code(), messageBuffer);
+      decoder.wrapMessage(messageBuffer);
+      details.add(detail);
+    }
   }
 
   @Override
   public int getLength() {
+    final var detailsLength =
+        details.stream()
+            .mapToInt(
+                e ->
+                    DetailsEncoder.sbeBlockLength()
+                        + DetailsEncoder.messageHeaderLength()
+                        + e.messageBuffer.capacity())
+            .sum();
+
     return headerEncoder.encodedLength()
         + messageEncoder.sbeBlockLength()
+        + DetailsEncoder.sbeHeaderSize()
+        + detailsLength
         + ErrorResponseEncoder.messageHeaderLength()
         + message.capacity();
   }
@@ -46,6 +71,13 @@ public final class ErrorResponse implements StreamResponse {
         .wrapAndApplyHeader(buffer, offset, headerEncoder)
         .code(code)
         .putMessage(message, 0, message.capacity());
+    final var detailsEncoder = messageEncoder.detailsCount(details.size());
+    details.forEach(
+        detail ->
+            detailsEncoder
+                .next()
+                .code(detail.code())
+                .putMessage(detail.messageBuffer(), 0, detail.messageBuffer().capacity()));
   }
 
   @Override
@@ -78,6 +110,16 @@ public final class ErrorResponse implements StreamResponse {
     return message.capacity() > 0 ? BufferUtil.bufferAsString(message) : "";
   }
 
+  public ErrorResponse addDetail(final ErrorCode code, final String message) {
+    details.add(
+        new ErrorDetailImpl(code, new UnsafeBuffer(message.getBytes(StandardCharsets.UTF_8))));
+    return this;
+  }
+
+  public List<? extends ErrorDetail> details() {
+    return details;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(message, code);
@@ -99,16 +141,38 @@ public final class ErrorResponse implements StreamResponse {
 
   @Override
   public String toString() {
-    return "ErrorResponse{" + "message=" + message() + ", code=" + code + '}';
+    return "ErrorResponse{"
+        + "message="
+        + message()
+        + ", code="
+        + code
+        + ", details="
+        + details
+        + '}';
   }
 
   public StreamResponseException asException() {
     return new StacklessException(this);
   }
 
+  private record ErrorDetailImpl(ErrorCode code, DirectBuffer messageBuffer)
+      implements ErrorDetail {
+
+    @Override
+    public String message() {
+      final var length = messageBuffer.capacity();
+      return length == 0 ? "" : messageBuffer.getStringWithoutLengthUtf8(0, length);
+    }
+
+    @Override
+    public String toString() {
+      return "ErrorDetailImpl{" + "code=" + code + ", message=" + message() + "}";
+    }
+  }
+
   private static final class StacklessException extends StreamResponseException {
 
-    public StacklessException(final ErrorResponse response) {
+    private StacklessException(final ErrorResponse response) {
       super(response);
     }
 

--- a/transport/src/main/resources/stream-protocol.xml
+++ b/transport/src/main/resources/stream-protocol.xml
@@ -21,7 +21,7 @@
 
     <enum name="errorCode" encodingType="uint8" semanticType="String"
       description="The unique identifier of an error">
-      <validValue name="INTERNAL_ERROR">0</validValue>
+      <validValue name="INTERNAL">0</validValue>
       <validValue name="NOT_FOUND">1</validValue>
       <validValue name="INVALID">2</validValue>
       <validValue name="MALFORMED">3</validValue>
@@ -61,6 +61,10 @@
 
   <sbe:message name="ErrorResponse" id="406" description="Returned whenever a request fails">
     <field name="code" id="1" type="errorCode" description="The specific error code" />
-    <data name="message" id="2" type="varDataEncoding" />
+    <group name="details" id="2" description="Additional details for aggregated errors">
+      <field name="code" id="3" type="errorCode" description="Detail error code" />
+      <data name="message" id="4" type="varDataEncoding" description="Detail error message" />
+    </group>
+    <data name="message" id="5" type="varDataEncoding" description="The error message"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/AggregatedClientStreamTest.java
@@ -10,16 +10,9 @@ package io.camunda.zeebe.transport.stream.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
-import io.camunda.zeebe.transport.stream.api.ClientStreamId;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.jupiter.api.Test;
 
@@ -30,60 +23,17 @@ class AggregatedClientStreamTest {
   private final UnsafeBuffer streamType = new UnsafeBuffer(BufferUtil.wrapString("foo"));
   private final TestSerializableData metadata = new TestSerializableData(1234);
   private final TestClientStreamMetrics metrics = new TestClientStreamMetrics();
-  final AggregatedClientStream<TestSerializableData> stream =
+  private final AggregatedClientStream<TestSerializableData> stream =
       new AggregatedClientStream<>(
           UUID.randomUUID(), new LogicalId<>(streamType, metadata), metrics);
-
-  @Test
-  void shouldRetryWithAllAvailableClientsIfPushFailed() {
-    // given
-    final List<ClientStreamId> executedClients = new ArrayList<>();
-    final List<ClientStreamId> expected =
-        List.of(
-            addFailingClient(executedClients::add),
-            addFailingClient(executedClients::add),
-            addFailingClient(executedClients::add));
-
-    // when
-    final TestActorFuture<Void> future = new TestActorFuture<>();
-    stream.push(null, future);
-
-    // then
-    assertThat(future).failsWithin(Duration.ofMillis(100));
-    assertThat(executedClients).containsExactlyInAnyOrderElementsOf(expected);
-  }
-
-  @Test
-  void shouldSucceedWhenOneClientSucceeds() {
-    // given
-    addFailingClient(s -> {});
-    addFailingClient(s -> {});
-
-    final AtomicBoolean pushSucceeded = new AtomicBoolean(false);
-    final ClientStreamIdImpl streamId = getNextStreamId();
-    addClient(
-        streamId,
-        p -> {
-          pushSucceeded.set(true);
-          return CompletableActorFuture.completed(null);
-        });
-
-    // when
-    final TestActorFuture<Void> future = new TestActorFuture<>();
-    stream.push(null, future);
-
-    // then
-    assertThat(future).succeedsWithin(Duration.ofMillis(100));
-    assertThat(pushSucceeded.get()).isTrue();
-  }
 
   @Test
   void shouldReportStreamCountOnAdd() {
     // given
 
     // when
-    addClient(getNextStreamId(), CLIENT_STREAM_CONSUMER);
-    addClient(getNextStreamId(), CLIENT_STREAM_CONSUMER);
+    addClient(getNextStreamId());
+    addClient(getNextStreamId());
 
     // then
     assertThat(metrics.getAggregatedClientCountObservations()).containsExactly(1, 2);
@@ -104,21 +54,16 @@ class AggregatedClientStreamTest {
   }
 
   private ClientStreamIdImpl getNextStreamId() {
-    return new ClientStreamIdImpl(stream.getStreamId(), stream.nextLocalId());
+    return new ClientStreamIdImpl(stream.streamId(), stream.nextLocalId());
   }
 
-  private ClientStreamId addFailingClient(final Consumer<ClientStreamId> consumer) {
-    final ClientStreamIdImpl streamId = getNextStreamId();
-    addClient(
-        streamId,
-        p -> {
-          consumer.accept(streamId);
-          throw new RuntimeException("Failed");
-        });
-    return streamId;
-  }
-
-  private void addClient(final ClientStreamIdImpl streamId, final ClientStreamConsumer consumer) {
-    stream.addClient(new ClientStreamImpl<>(streamId, stream, streamType, metadata, consumer));
+  private void addClient(final ClientStreamIdImpl streamId) {
+    stream.addClient(
+        new ClientStreamImpl<>(
+            streamId,
+            stream,
+            streamType,
+            metadata,
+            AggregatedClientStreamTest.CLIENT_STREAM_CONSUMER));
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandlerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamApiHandlerTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
 import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
+import io.camunda.zeebe.transport.stream.api.StreamResponseException.ErrorDetail;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
@@ -51,12 +52,37 @@ final class ClientStreamApiHandlerTest {
         .returns(testCase.code(), ErrorResponse::code);
   }
 
+  @ParameterizedTest
+  @MethodSource("provideExceptionToErrorMap")
+  void shouldMapSuppressedAsErrorDetails(final ExceptionErrorCase testCase) {
+    // given
+    final var apiHandler = new ClientStreamApiHandler(clientStreamManager, Runnable::run);
+    final var request = new PushStreamRequest();
+    final var payloadPushed = ArgumentCaptor.forClass(CompletableActorFuture.class);
+    final var error = new RuntimeException("failure");
+    //noinspection unchecked
+    doNothing().when(clientStreamManager).onPayloadReceived(eq(request), payloadPushed.capture());
+    error.addSuppressed(testCase.exception());
+
+    // when
+    final var response = apiHandler.handlePushRequest(request);
+    payloadPushed.getValue().completeExceptionally(error);
+
+    // then
+    assertThat(response)
+        .succeedsWithin(Duration.ZERO)
+        .asInstanceOf(InstanceOfAssertFactories.type(ErrorResponse.class))
+        .extracting(ErrorResponse::details, InstanceOfAssertFactories.list(ErrorDetail.class))
+        .map(ErrorDetail::code)
+        .containsExactly(testCase.code());
+  }
+
   private static Stream<ExceptionErrorCase> provideExceptionToErrorMap() {
     return Stream.of(
         new ExceptionErrorCase(new StreamExhaustedException("failed"), ErrorCode.EXHAUSTED),
         new ExceptionErrorCase(new ClientStreamBlockedException("failed"), ErrorCode.BLOCKED),
         new ExceptionErrorCase(new NoSuchStreamException("failed"), ErrorCode.NOT_FOUND),
-        new ExceptionErrorCase(new RuntimeException("failed"), ErrorCode.INTERNAL_ERROR));
+        new ExceptionErrorCase(new RuntimeException("failed"), ErrorCode.INTERNAL));
   }
 
   private record ExceptionErrorCase(Throwable exception, ErrorCode code)

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamManagerTest.java
@@ -104,8 +104,7 @@ class ClientStreamManagerTest {
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
     // then
-    assertThat(stream1.serverStream().getStreamId())
-        .isEqualTo(stream2.serverStream().getStreamId());
+    assertThat(stream1.serverStream().streamId()).isEqualTo(stream2.serverStream().streamId());
   }
 
   @Test
@@ -117,8 +116,7 @@ class ClientStreamManagerTest {
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
     // then
-    assertThat(stream1.serverStream().getStreamId())
-        .isNotEqualTo(stream2.serverStream().getStreamId());
+    assertThat(stream1.serverStream().streamId()).isNotEqualTo(stream2.serverStream().streamId());
   }
 
   @Test
@@ -132,8 +130,7 @@ class ClientStreamManagerTest {
     final var stream2 = registry.getClient(uuid2).orElseThrow();
 
     // then
-    assertThat(stream1.serverStream().getStreamId())
-        .isNotEqualTo(stream2.serverStream().getStreamId());
+    assertThat(stream1.serverStream().streamId()).isNotEqualTo(stream2.serverStream().streamId());
   }
 
   @Test
@@ -328,7 +325,7 @@ class ClientStreamManagerTest {
   }
 
   private UUID getServerStreamId(final ClientStreamId clientStreamId) {
-    return registry.getClient(clientStreamId).orElseThrow().serverStream().getStreamId();
+    return registry.getClient(clientStreamId).orElseThrow().serverStream().streamId();
   }
 
   private record TestMetadata(int data) implements BufferWriter {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusherTest.java
@@ -11,10 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamBlockedException;
 import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
 import io.camunda.zeebe.transport.stream.api.ClientStreamId;
 import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
 import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -22,9 +24,14 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.agrona.LangUtil;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class ClientStreamPusherTest {
   private final UnsafeBuffer streamType = new UnsafeBuffer(BufferUtil.wrapString("foo"));
@@ -34,7 +41,7 @@ final class ClientStreamPusherTest {
   private final AggregatedClientStream<TestSerializableData> stream =
       new AggregatedClientStream<>(
           UUID.randomUUID(), new LogicalId<>(streamType, metadata), metrics);
-  private final ClientStreamPusher streamPusher = new ClientStreamPusher();
+  private final ClientStreamPusher streamPusher = new ClientStreamPusher(metrics);
 
   @Test
   void shouldRetryWithAllAvailableClientsIfPushFailed() {
@@ -125,6 +132,20 @@ final class ClientStreamPusherTest {
         .containsExactlyInAnyOrderElementsOf(expected);
   }
 
+  @ParameterizedTest
+  @MethodSource("provideExceptionToErrorMap")
+  void shouldTrackFailedPushTry(final ExceptionErrorCase testCase) {
+    // given
+    addFailingClient(ignored -> {}, testCase.exception);
+
+    // when
+    final TestActorFuture<Void> future = new TestActorFuture<>();
+    streamPusher.push(stream, null, future);
+
+    // then
+    assertThat(metrics.getFailedPushTry(testCase.code)).isOne();
+  }
+
   private ClientStreamIdImpl getNextStreamId() {
     return new ClientStreamIdImpl(stream.streamId(), stream.nextLocalId());
   }
@@ -134,18 +155,41 @@ final class ClientStreamPusherTest {
   }
 
   private ClientStreamId addFailingClient(
-      final Consumer<ClientStreamId> consumer, final RuntimeException failure) {
+      final Consumer<ClientStreamId> consumer, final Throwable failure) {
     final ClientStreamIdImpl streamId = getNextStreamId();
     addClient(
         streamId,
         p -> {
           consumer.accept(streamId);
-          throw failure;
+          LangUtil.rethrowUnchecked(failure);
+          return null; // unreachable
         });
     return streamId;
   }
 
   private void addClient(final ClientStreamIdImpl streamId, final ClientStreamConsumer consumer) {
     stream.addClient(new ClientStreamImpl<>(streamId, stream, streamType, metadata, consumer));
+  }
+
+  private static Stream<ExceptionErrorCase> provideExceptionToErrorMap() {
+    return Stream.of(
+        new ExceptionErrorCase(new StreamExhaustedException("failed"), ErrorCode.EXHAUSTED),
+        new ExceptionErrorCase(new ClientStreamBlockedException("failed"), ErrorCode.BLOCKED),
+        new ExceptionErrorCase(new NoSuchStreamException("failed"), ErrorCode.NOT_FOUND),
+        new ExceptionErrorCase(new RuntimeException("failed"), ErrorCode.INTERNAL));
+  }
+
+  private record ExceptionErrorCase(Throwable exception, ErrorCode code)
+      implements Named<ExceptionErrorCase> {
+
+    @Override
+    public String getName() {
+      return "%s -> %s".formatted(exception.getClass().getSimpleName(), code.name());
+    }
+
+    @Override
+    public ExceptionErrorCase getPayload() {
+      return this;
+    }
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/ClientStreamPusherTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.transport.stream.api.ClientStreamConsumer;
+import io.camunda.zeebe.transport.stream.api.ClientStreamId;
+import io.camunda.zeebe.transport.stream.api.NoSuchStreamException;
+import io.camunda.zeebe.transport.stream.api.StreamExhaustedException;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class ClientStreamPusherTest {
+  private final UnsafeBuffer streamType = new UnsafeBuffer(BufferUtil.wrapString("foo"));
+  private final TestSerializableData metadata = new TestSerializableData(1234);
+  private final TestClientStreamMetrics metrics = new TestClientStreamMetrics();
+
+  private final AggregatedClientStream<TestSerializableData> stream =
+      new AggregatedClientStream<>(
+          UUID.randomUUID(), new LogicalId<>(streamType, metadata), metrics);
+  private final ClientStreamPusher streamPusher = new ClientStreamPusher();
+
+  @Test
+  void shouldRetryWithAllAvailableClientsIfPushFailed() {
+    // given
+    final List<ClientStreamId> executedClients = new ArrayList<>();
+    final List<ClientStreamId> expected =
+        List.of(
+            addFailingClient(executedClients::add),
+            addFailingClient(executedClients::add),
+            addFailingClient(executedClients::add));
+
+    // when
+    final TestActorFuture<Void> future = new TestActorFuture<>();
+    streamPusher.push(stream, null, future);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableThat()
+        .havingCause()
+        .isInstanceOf(StreamExhaustedException.class);
+    assertThat(executedClients).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @Test
+  void shouldFailIfOnNoClients() {
+    // given
+    final TestActorFuture<Void> future = new TestActorFuture<>();
+
+    // when
+    streamPusher.push(stream, null, future);
+
+    // then
+    assertThat(future)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableThat()
+        .havingCause()
+        .isInstanceOf(NoSuchStreamException.class);
+  }
+
+  @Test
+  void shouldSucceedWhenOneClientSucceeds() {
+    // given
+    addFailingClient(s -> {});
+    addFailingClient(s -> {});
+
+    final AtomicBoolean pushSucceeded = new AtomicBoolean(false);
+    final ClientStreamIdImpl streamId = getNextStreamId();
+    addClient(
+        streamId,
+        p -> {
+          pushSucceeded.set(true);
+          return CompletableActorFuture.completed(null);
+        });
+
+    // when
+    final TestActorFuture<Void> future = new TestActorFuture<>();
+    streamPusher.push(stream, null, future);
+
+    // then
+    assertThat(future).succeedsWithin(Duration.ofMillis(100));
+    assertThat(pushSucceeded.get()).isTrue();
+  }
+
+  private ClientStreamIdImpl getNextStreamId() {
+    return new ClientStreamIdImpl(stream.streamId(), stream.nextLocalId());
+  }
+
+  private ClientStreamId addFailingClient(final Consumer<ClientStreamId> consumer) {
+    final ClientStreamIdImpl streamId = getNextStreamId();
+    addClient(
+        streamId,
+        p -> {
+          consumer.accept(streamId);
+          throw new RuntimeException("Failed");
+        });
+    return streamId;
+  }
+
+  private void addClient(final ClientStreamIdImpl streamId, final ClientStreamConsumer consumer) {
+    stream.addClient(new ClientStreamImpl<>(streamId, stream, streamType, metadata, consumer));
+  }
+}

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/RemoteStreamPusherTest.java
@@ -12,9 +12,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.transport.stream.api.RemoteStreamErrorHandler;
-import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
+import io.camunda.zeebe.transport.stream.api.StreamResponseException;
 import io.camunda.zeebe.transport.stream.impl.AggregatedRemoteStream.StreamId;
 import io.camunda.zeebe.transport.stream.impl.RemoteStreamPusher.Transport;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorResponse;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamRequest;
 import io.camunda.zeebe.transport.stream.impl.messages.PushStreamResponse;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -26,13 +28,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import org.agrona.MutableDirectBuffer;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.EnumSource.Mode;
 
 final class RemoteStreamPusherTest {
   private final StreamId streamId = new StreamId(UUID.randomUUID(), MemberId.anonymous());
   private final TestTransport transport = new TestTransport();
   private final Executor executor = Runnable::run;
+  private final TestRemoteStreamMetrics metrics = new TestRemoteStreamMetrics();
   private final RemoteStreamPusher<Payload> pusher =
-      new RemoteStreamPusher<>(transport, executor, RemoteStreamMetrics.noop());
+      new RemoteStreamPusher<>(transport, executor, metrics);
 
   @Test
   void shouldPushPayload() {
@@ -50,6 +56,7 @@ final class RemoteStreamPusherTest {
     assertThat(sentRequest.request.streamId()).isEqualTo(streamId.streamId());
     assertThat(sentRequest.request.payloadWriter()).isEqualTo(payload);
     assertThat(sentRequest.receiver).isEqualTo(streamId.receiver());
+    assertThat(metrics.getPushSucceeded()).isOne();
   }
 
   @Test
@@ -64,6 +71,7 @@ final class RemoteStreamPusherTest {
     pusher.pushAsync(payload, errorHandler, streamId);
 
     // then
+    assertThat(metrics.getPushFailed()).isOne();
     assertThat(errorHandler.errors)
         .hasSize(1)
         .first()
@@ -83,6 +91,7 @@ final class RemoteStreamPusherTest {
     pusher.pushAsync(payload, errorHandler, streamId);
 
     // then
+    assertThat(metrics.getPushFailed()).isOne();
     assertThat(errorHandler.errors)
         .hasSize(1)
         .first()
@@ -108,6 +117,27 @@ final class RemoteStreamPusherTest {
     // when - then
     assertThatCode(() -> pusher.pushAsync(payload, null, streamId))
         .isInstanceOf(NullPointerException.class);
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = ErrorCode.class,
+      mode = Mode.EXCLUDE,
+      names = {"SBE_UNKNOWN", "NULL_VAL"})
+  void shouldTrackFailedPushTries(final ErrorCode detailCode) {
+    // given
+    final var payload = new Payload(1);
+    final var errorHandler = new TestErrorHandler();
+    final var errorResponse =
+        new ErrorResponse().code(ErrorCode.INTERNAL).message("foo").addDetail(detailCode, "bar");
+    final var failure = new StreamResponseException(errorResponse);
+    transport.response = CompletableFuture.failedFuture(failure);
+
+    // when
+    pusher.pushAsync(payload, errorHandler, streamId);
+
+    // then
+    assertThat(metrics.getFailedPushTry(detailCode)).isOne();
   }
 
   private record Payload(int version) implements BufferWriter {

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestClientStreamMetrics.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestClientStreamMetrics.java
@@ -8,12 +8,16 @@
 package io.camunda.zeebe.transport.stream.impl;
 
 import io.camunda.zeebe.transport.stream.api.ClientStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
 import java.util.ArrayList;
+import java.util.EnumMap;
 import java.util.List;
+import java.util.Map;
 
 final class TestClientStreamMetrics implements ClientStreamMetrics {
 
   private final List<Integer> aggregatedClientCountObservations = new ArrayList<>();
+  private final Map<ErrorCode, Integer> failedPushTries = new EnumMap<>(ErrorCode.class);
 
   private int serverCount;
   private int clientCount;
@@ -51,6 +55,11 @@ final class TestClientStreamMetrics implements ClientStreamMetrics {
     pushFailed++;
   }
 
+  @Override
+  public void pushTryFailed(final ErrorCode code) {
+    failedPushTries.compute(code, (ignored, value) -> value == null ? 1 : value + 1);
+  }
+
   public int getServerCount() {
     return serverCount;
   }
@@ -73,5 +82,9 @@ final class TestClientStreamMetrics implements ClientStreamMetrics {
 
   public int getPushFailed() {
     return pushFailed;
+  }
+
+  public int getFailedPushTry(final ErrorCode code) {
+    return failedPushTries.getOrDefault(code, 0);
   }
 }

--- a/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestRemoteStreamMetrics.java
+++ b/transport/src/test/java/io/camunda/zeebe/transport/stream/impl/TestRemoteStreamMetrics.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.transport.stream.impl;
+
+import io.camunda.zeebe.transport.stream.api.RemoteStreamMetrics;
+import io.camunda.zeebe.transport.stream.impl.messages.ErrorCode;
+import java.util.EnumMap;
+import java.util.Map;
+
+final class TestRemoteStreamMetrics implements RemoteStreamMetrics {
+
+  private int streamCount;
+  private int pushSucceeded;
+  private int pushFailed;
+  private final Map<ErrorCode, Integer> failedPushTries = new EnumMap<>(ErrorCode.class);
+
+  @Override
+  public void addStream() {
+    streamCount++;
+  }
+
+  @Override
+  public void removeStream() {
+    streamCount--;
+  }
+
+  @Override
+  public void pushSucceeded() {
+    pushSucceeded++;
+  }
+
+  @Override
+  public void pushFailed() {
+    pushFailed++;
+  }
+
+  @Override
+  public void pushTryFailed(final ErrorCode code) {
+    failedPushTries.compute(code, (ignored, value) -> value == null ? 1 : value + 1);
+  }
+
+  public int getStreamCount() {
+    return streamCount;
+  }
+
+  public int getPushSucceeded() {
+    return pushSucceeded;
+  }
+
+  public int getPushFailed() {
+    return pushFailed;
+  }
+
+  public int getFailedPushTry(final ErrorCode code) {
+    return failedPushTries.getOrDefault(code, 0);
+  }
+}


### PR DESCRIPTION
## Description

This PR downgrades job worker back pressure, which is observed as job yielding on the broker side, from an error state to an expected state. This means downgrading logs to trace level in most cases, and instead relying on metrics to track if we're blocked too often. Trace logging can then be turned on on-demand to narrow down issues.

Additionally, I took the opportunity to refactor the gateway push-to-client logic out of the `AggregatedClientStream` and `ClientStreamImpl` classes into its own class, `ClientStreamPusher`. These classes are now just data classes.

When back pressure occurs, the previous state was the following:

| Node type | Image |
| --------- | ----- |
| Gateway | ![image](https://github.com/camunda/zeebe/assets/43373/42e45e95-6450-430d-b800-eacac299995a) |
| Broker | ![image](https://github.com/camunda/zeebe/assets/43373/3d62181b-fd04-4d93-afcc-a2b6c6bcb2a5) |

It now looks like this without trace logging:

| Node type | Image |
| --------- | ----- |
| Gateway | ![image](https://github.com/camunda/zeebe/assets/43373/4049f382-a009-41b1-afb9-fc99bbda5d2e) |
| Broker | ![image](https://github.com/camunda/zeebe/assets/43373/73d80908-7826-4667-a428-7a27ddc375ba) |

And with trace logging enabled:

| Node type | Image |
| --------- | ----- |
| Gateway | ![image](https://github.com/camunda/zeebe/assets/43373/624712f3-21f7-4ac0-bbc9-621b758d9084) |
| Broker | ![image](https://github.com/camunda/zeebe/assets/43373/6318956f-7eb0-4f7c-9910-b0960a6155bb) |

> [!Note]
> I did not throttle the trace logging. My reasoning is if you're tracing something, you actually want to see everything, not just some of it.

And a quick preview of the new metric visualization:

> [!Note] 
> I will add the new metric visualization in a separate PR since Grafana changes tend to be quite big and difficult to review.

![image](https://github.com/camunda/zeebe/assets/43373/c0289c06-0527-4cc5-b0c3-50c649d6d194)

And here we can see when only one worker is slower than the others in the same deployment:

![image](https://github.com/camunda/zeebe/assets/43373/7228acab-3682-495d-ab76-7edcefa79899)

So we see that one gateway reports some blocked errors, but the other push metrics are "successful". This could help diagnose issues with specific stream, as you can then look at that gateway's actuator/trace logs to narrow things down.

## Related issues

closes #15455

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
