### PR TITLE
refactor(benchmarks): allow setting explicit worker timeout

### DIFF
--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -105,12 +105,16 @@ public class Worker extends App {
 
   private ZeebeClient createZeebeClient() {
     final WorkerCfg workerCfg = appCfg.getWorker();
+    final var timeout =
+        appCfg.getWorker().getTimeout() != Duration.ZERO
+            ? appCfg.getWorker().getTimeout()
+            : workerCfg.getCompletionDelay().multipliedBy(6);
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder()
             .gatewayAddress(appCfg.getBrokerUrl())
             .numJobWorkerExecutionThreads(workerCfg.getThreads())
             .defaultJobWorkerName(workerCfg.getWorkerName())
-            .defaultJobTimeout(workerCfg.getCompletionDelay().multipliedBy(6))
+            .defaultJobTimeout(timeout)
             .defaultJobWorkerMaxJobsActive(workerCfg.getCapacity())
             .defaultJobPollInterval(workerCfg.getPollingDelay())
             .withProperties(System.getProperties())

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
@@ -28,6 +28,7 @@ public class WorkerCfg {
   private boolean completeJobsAsync;
   private String payloadPath;
   private boolean isStreamEnabled;
+  private Duration timeout;
 
   public String getJobType() {
     return jobType;
@@ -99,5 +100,13 @@ public class WorkerCfg {
 
   public void setStreamEnabled(final boolean isStreamEnabled) {
     this.isStreamEnabled = isStreamEnabled;
+  }
+
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(final Duration timeout) {
+    this.timeout = timeout;
   }
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -27,5 +27,8 @@ app {
     completeJobsAsync = false
     payloadPath = "bpmn/big_payload.json"
     streamEnabled = true
+    # if 0, timeout defaults to completionDelay * 6
+    timeout = 0
+    # timeout = 1800ms
   }
 }


### PR DESCRIPTION
## Description

Allows setting an explicit job timeout with the worker. This enables experiments where you want a worker with a slower completion delay (e.g. to test job worker back pressure) but that still gets aggregated along with the other streams. If the timeout is 0 (since HOCON does not support null or optional values), then it falls back to the previous behavior of setting it to 6 times the completion delay.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
