### PR TITLE
[Backport stable/8.3] refactor(benchmarks): allow setting explicit worker timeout

### DIFF
--- a/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/Worker.java
@@ -105,12 +105,16 @@ public class Worker extends App {
 
   private ZeebeClient createZeebeClient() {
     final WorkerCfg workerCfg = appCfg.getWorker();
+    final var timeout =
+        appCfg.getWorker().getTimeout() != Duration.ZERO
+            ? appCfg.getWorker().getTimeout()
+            : workerCfg.getCompletionDelay().multipliedBy(6);
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder()
             .gatewayAddress(appCfg.getBrokerUrl())
             .numJobWorkerExecutionThreads(workerCfg.getThreads())
             .defaultJobWorkerName(workerCfg.getWorkerName())
-            .defaultJobTimeout(workerCfg.getCompletionDelay().multipliedBy(6))
+            .defaultJobTimeout(timeout)
             .defaultJobWorkerMaxJobsActive(workerCfg.getCapacity())
             .defaultJobPollInterval(workerCfg.getPollingDelay())
             .withProperties(System.getProperties())

--- a/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
+++ b/benchmarks/project/src/main/java/io/camunda/zeebe/config/WorkerCfg.java
@@ -28,6 +28,7 @@ public class WorkerCfg {
   private boolean completeJobsAsync;
   private String payloadPath;
   private boolean isStreamEnabled;
+  private Duration timeout;
 
   public String getJobType() {
     return jobType;
@@ -99,5 +100,13 @@ public class WorkerCfg {
 
   public void setStreamEnabled(final boolean isStreamEnabled) {
     this.isStreamEnabled = isStreamEnabled;
+  }
+
+  public Duration getTimeout() {
+    return timeout;
+  }
+
+  public void setTimeout(final Duration timeout) {
+    this.timeout = timeout;
   }
 }

--- a/benchmarks/project/src/main/resources/application.conf
+++ b/benchmarks/project/src/main/resources/application.conf
@@ -27,5 +27,8 @@ app {
     completeJobsAsync = false
     payloadPath = "bpmn/big_payload.json"
     streamEnabled = true
+    # if 0, timeout defaults to completionDelay * 6
+    timeout = 0
+    # timeout = 1800ms
   }
 }


### PR DESCRIPTION
# Description
Backport of #15511 to `stable/8.3`.

relates to 
original author: @npepinpe