### PR TITLE
Reject process instance migration if mappings refer to non existent element

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -178,7 +178,7 @@ public class ProcessInstanceMigrationMigrateProcessor
       responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, e.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }
-    if (error instanceof final IncorrectMappingException e) {
+    if (error instanceof final ElementTypeChangedException e) {
       rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, e.getMessage());
       responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, e.getMessage());
       return ProcessingError.EXPECTED_ERROR;
@@ -253,7 +253,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     final BpmnElementType targetElementType =
         processDefinition.getProcess().getElementById(targetElementId).getElementType();
     if (elementInstanceRecord.getBpmnElementType() != targetElementType) {
-      throw new IncorrectMappingException(
+      throw new ElementTypeChangedException(
           elementInstanceRecord.getProcessInstanceKey(),
           elementInstanceRecord.getElementId(),
           elementInstanceRecord.getBpmnElementType(),
@@ -367,8 +367,8 @@ public class ProcessInstanceMigrationMigrateProcessor
    * mapping instructions of the command refer to a source and a target element with different
    * element type, or different event type.
    */
-  private static final class IncorrectMappingException extends RuntimeException {
-    IncorrectMappingException(
+  private static final class ElementTypeChangedException extends RuntimeException {
+    ElementTypeChangedException(
         final long processInstanceKey,
         final String elementId,
         final BpmnElementType bpmnElementType,
@@ -380,7 +380,7 @@ public class ProcessInstanceMigrationMigrateProcessor
               Expected to migrate process instance '%s' \
               but active element with id '%s' and type '%s' is mapped to \
               an element with id '%s' and different type '%s'. \
-              Active elements must be mapped to the same type.""",
+              Elements must be mapped to elements of the same type.""",
               processInstanceKey,
               elementId,
               bpmnElementType,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -148,17 +148,18 @@ public class ProcessInstanceMigrationMigrateProcessor
 
     final DeployedProcess sourceProcessDefinition =
         processState.getProcessByKeyAndTenant(
-            targetProcessDefinitionKey, processInstance.getValue().getTenantId());
+            processInstance.getValue().getProcessDefinitionKey(),
+            processInstance.getValue().getTenantId());
     mappingInstructions.forEach(
         instruction -> {
-          final String targetElementId = instruction.getTargetElementId();
-          if (processDefinition.getProcess().getElementById(targetElementId) == null) {
-            throw new NonExistingElementException(processInstanceKey, targetElementId, "target");
-          }
-
           final String sourceElementId = instruction.getSourceElementId();
           if (sourceProcessDefinition.getProcess().getElementById(sourceElementId) == null) {
             throw new NonExistingElementException(processInstanceKey, sourceElementId, "source");
+          }
+
+          final String targetElementId = instruction.getTargetElementId();
+          if (processDefinition.getProcess().getElementById(targetElementId) == null) {
+            throw new NonExistingElementException(processInstanceKey, targetElementId, "target");
           }
         });
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15461 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
