### PR TITLE
deps(renovate): exclude SNAPSHOT dependencies

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -51,6 +51,14 @@
     {
       "matchPackagePrefixes": ["org.jacoco"],
       "allowedVersions": "!/0.8.9/"
+    },
+    {
+      "matchManagers": [
+        "maven"
+      ],
+      "groupName" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
+      "matchPackagePatterns": [".*"],
+      "allowedVersions": "!/-SNAPSHOT$/"
     }
   ],
   "dockerfile": {


### PR DESCRIPTION
## Description

Otherwise for pre-release versions like `*-alpha2`, renovate will suggest updates to `*-SNAPSHOT`.

relates to #14701