### PR TITLE
deps(renovate): use description instead of groupName

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -56,7 +56,7 @@
       "matchManagers": [
         "maven"
       ],
-      "groupName" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
+      "description" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
       "matchPackagePatterns": [".*"],
       "allowedVersions": "!/-SNAPSHOT$/"
     }


### PR DESCRIPTION
## Description

Otherwise renovate groups multiple updates with the set groupName 🤦 
see https://github.com/camunda/zeebe/pull/15527