### PR TITLE
feat(broker): remove partition data after leaving replication group

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -151,7 +151,7 @@ public final class Partition {
                                     return;
                                   }
                                   try {
-                                    FileUtil.deleteFolder(partitionDirectory);
+                                    FileUtil.deleteFolderIfExists(partitionDirectory);
                                   } catch (final Exception e) {
                                     LOGGER.warn(
                                         "Failed to delete partition directory {} after leaving. Data will remain until manually removed.",

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/Partition.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.partitioning.startup.steps.ZeebePartitionStep;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupProcess;
+import io.camunda.zeebe.util.FileUtil;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,6 +126,7 @@ public final class Partition {
     final var result = concurrencyControl.<Partition>createFuture();
     concurrencyControl.run(
         () -> {
+          final var partitionDirectory = context.partitionDirectory();
           final var raftPartition = raftPartition();
           if (raftPartition == null) {
             result.completeExceptionally(
@@ -134,24 +136,31 @@ public final class Partition {
           raftPartition
               .leave()
               .whenComplete(
-                  (leaveOk, leaveError) -> {
-                    concurrencyControl.run(
-                        () -> {
-                          if (leaveError != null) {
-                            result.completeExceptionally(leaveError);
-                            return;
-                          }
-                          concurrencyControl.runOnCompletion(
-                              startupProcess.shutdown(concurrencyControl, context),
-                              (shutdownOk, shutdownError) -> {
-                                if (shutdownError != null) {
-                                  result.completeExceptionally(shutdownError);
-                                  return;
-                                }
-                                result.complete(this);
-                              });
-                        });
-                  });
+                  (leaveOk, leaveError) ->
+                      concurrencyControl.run(
+                          () -> {
+                            if (leaveError != null) {
+                              result.completeExceptionally(leaveError);
+                              return;
+                            }
+                            concurrencyControl.runOnCompletion(
+                                startupProcess.shutdown(concurrencyControl, context),
+                                (shutdownOk, shutdownError) -> {
+                                  if (shutdownError != null) {
+                                    result.completeExceptionally(shutdownError);
+                                    return;
+                                  }
+                                  try {
+                                    FileUtil.deleteFolder(partitionDirectory);
+                                  } catch (final Exception e) {
+                                    LOGGER.warn(
+                                        "Failed to delete partition directory {} after leaving. Data will remain until manually removed.",
+                                        partitionDirectory,
+                                        e);
+                                  }
+                                  result.complete(this);
+                                });
+                          }));
         });
 
     return result;

--- a/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/partitioning/PartitionLeaveTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning;
 
 import static io.camunda.zeebe.broker.test.EmbeddedBrokerRule.assignSocketAddresses;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -22,6 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -77,6 +79,128 @@ final class PartitionLeaveTest {
 
       // then -- request can still be processed because quorum is still available
       client.newPublishMessageCommand().messageName("msg").correlationKey("key").send().join();
+    } finally {
+      broker0.close();
+      broker1.close();
+    }
+  }
+
+  @Test
+  void shouldRemoveDataAfterLeaving(@TempDir final Path tmp) {
+    // given -- two brokers replicating partition 1
+    final var broker0 =
+        buildBroker(
+            tmp.resolve("broker-0"),
+            brokerCfg -> {
+              final var clusterCfg = brokerCfg.getCluster();
+              clusterCfg.setClusterSize(2);
+              clusterCfg.setNodeId(0);
+              clusterCfg.setPartitionsCount(2);
+              clusterCfg.setReplicationFactor(2);
+            });
+    final var initialContactPoint =
+        broker0.getConfig().getNetwork().getInternalApi().getAdvertisedAddress();
+
+    final var broker1 =
+        buildBroker(
+            tmp.resolve("broker-1"),
+            brokerCfg -> {
+              final var clusterCfg = brokerCfg.getCluster();
+              clusterCfg.setInitialContactPoints(
+                  List.of(initialContactPoint.getHostName() + ":" + initialContactPoint.getPort()));
+
+              clusterCfg.setClusterSize(2);
+              clusterCfg.setNodeId(1);
+              clusterCfg.setPartitionsCount(2);
+              clusterCfg.setReplicationFactor(2);
+            });
+    CompletableFuture.allOf(
+            CompletableFuture.runAsync(broker0::start), CompletableFuture.runAsync(broker1::start))
+        .join();
+
+    try (final var client =
+        ZeebeClient.newClientBuilder()
+            .usePlaintext()
+            .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
+            .build()) {
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                      .isComplete(2, 2, 2));
+
+      // when -- one broker leaves partition 1
+      ((PartitionManagerImpl) broker1.getBrokerContext().getPartitionManager()).leave(1).join();
+
+      // then -- partition-1's data is removed
+      assertThat(tmp.resolve("broker-1/data/raft-partition/partitions/1")).doesNotExist();
+      // then -- all other data is still there
+      assertThat(tmp.resolve("broker-1/data/raft-partition/partitions/2")).isNotEmptyDirectory();
+      assertThat(tmp.resolve("broker-0/data/raft-partition/partitions/1")).isNotEmptyDirectory();
+      assertThat(tmp.resolve("broker-0/data/raft-partition/partitions/2")).isNotEmptyDirectory();
+    } finally {
+      broker0.close();
+      broker1.close();
+    }
+  }
+
+  @Test
+  void shouldNotRemoveDataIfLeavingFails(@TempDir final Path tmp) {
+    // given -- two brokers replicating partition 1
+    final var broker0 =
+        buildBroker(
+            tmp.resolve("broker-0"),
+            brokerCfg -> {
+              final var clusterCfg = brokerCfg.getCluster();
+              clusterCfg.setClusterSize(2);
+              clusterCfg.setNodeId(0);
+              clusterCfg.setPartitionsCount(2);
+              clusterCfg.setReplicationFactor(2);
+            });
+    final var initialContactPoint =
+        broker0.getConfig().getNetwork().getInternalApi().getAdvertisedAddress();
+
+    final var broker1 =
+        buildBroker(
+            tmp.resolve("broker-1"),
+            brokerCfg -> {
+              final var clusterCfg = brokerCfg.getCluster();
+              clusterCfg.setInitialContactPoints(
+                  List.of(initialContactPoint.getHostName() + ":" + initialContactPoint.getPort()));
+
+              clusterCfg.setClusterSize(2);
+              clusterCfg.setNodeId(1);
+              clusterCfg.setPartitionsCount(2);
+              clusterCfg.setReplicationFactor(2);
+            });
+    CompletableFuture.allOf(
+            CompletableFuture.runAsync(broker0::start), CompletableFuture.runAsync(broker1::start))
+        .join();
+
+    try (final var client =
+        ZeebeClient.newClientBuilder()
+            .usePlaintext()
+            .gatewayAddress("localhost:" + broker0.getConfig().getGateway().getNetwork().getPort())
+            .build()) {
+      Awaitility.await()
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                      .isComplete(2, 2, 2));
+
+      // when -- broker 0 stops and thus broker 1 fails to leave
+      broker0.close();
+      Assertions.assertThatThrownBy(
+          () ->
+              ((PartitionManagerImpl) broker1.getBrokerContext().getPartitionManager())
+                  .leave(1)
+                  .join());
+
+      // then -- all data remains
+      assertThat(tmp.resolve("broker-1/data/raft-partition/partitions/1")).isNotEmptyDirectory();
+      assertThat(tmp.resolve("broker-1/data/raft-partition/partitions/2")).isNotEmptyDirectory();
+      assertThat(tmp.resolve("broker-0/data/raft-partition/partitions/1")).isNotEmptyDirectory();
+      assertThat(tmp.resolve("broker-0/data/raft-partition/partitions/2")).isNotEmptyDirectory();
     } finally {
       broker0.close();
       broker1.close();


### PR DESCRIPTION
If leaving is successful, the partition data is removed. If removing the data fails for whatever reason, we log it as a warning and rely on manual cleanup if necessary.

Overall not the most elegant implementation but it gets the job done :shrug: 

Closes https://github.com/camunda/zeebe/issues/15001