### PR TITLE
Add StreamJobsCommand to Go client

### DIFF
--- a/clients/go/pkg/commands/stream_jobs.go
+++ b/clients/go/pkg/commands/stream_jobs.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Camunda Services GmbH (info@camunda.com)
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clients/go/pkg/commands/stream_jobs.go
+++ b/clients/go/pkg/commands/stream_jobs.go
@@ -1,0 +1,159 @@
+// Copyright © 2023 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"io"
+	"log"
+	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"google.golang.org/grpc"
+)
+
+type StreamJobsConsumer chan<- *entities.Job
+
+type DispatchStreamJobsCommand interface {
+	RequestTimeout(time.Duration) DispatchStreamJobsCommand
+	Send(ctx context.Context) error
+}
+
+type StreamJobsCommandStep1 interface {
+	JobType(string) StreamJobsCommandStep2
+}
+
+type StreamJobsCommandStep2 interface {
+	Consumer(StreamJobsConsumer) StreamJobsCommandStep3
+}
+
+type StreamJobsCommandStep3 interface {
+	DispatchStreamJobsCommand
+
+	TenantIds(...string) StreamJobsCommandStep3
+	Timeout(time.Duration) StreamJobsCommandStep3
+	WorkerName(string) StreamJobsCommandStep3
+	FetchVariables(...string) StreamJobsCommandStep3
+}
+
+type StreamJobsCommand struct {
+	Command
+	request        pb.StreamActivatedJobsRequest
+	consumer       StreamJobsConsumer
+	requestTimeout time.Duration
+}
+
+func (cmd *StreamJobsCommand) JobType(jobType string) StreamJobsCommandStep2 {
+	cmd.request.Type = jobType
+	return cmd
+}
+
+func (cmd *StreamJobsCommand) Consumer(consumer StreamJobsConsumer) StreamJobsCommandStep3 {
+	cmd.consumer = consumer
+	return cmd
+}
+
+func (cmd *StreamJobsCommand) TenantIds(tenantIds ...string) StreamJobsCommandStep3 {
+	cmd.request.TenantIds = tenantIds
+	return cmd
+}
+
+func (cmd *StreamJobsCommand) Timeout(timeout time.Duration) StreamJobsCommandStep3 {
+	cmd.request.Timeout = int64(timeout / time.Millisecond)
+	return cmd
+}
+
+func (cmd *StreamJobsCommand) WorkerName(workerName string) StreamJobsCommandStep3 {
+	cmd.request.Worker = workerName
+	return cmd
+}
+
+func (cmd *StreamJobsCommand) FetchVariables(fetchVariables ...string) StreamJobsCommandStep3 {
+	cmd.request.FetchVariable = fetchVariables
+	return cmd
+}
+
+func (cmd *StreamJobsCommand) RequestTimeout(requestTimeout time.Duration) DispatchStreamJobsCommand {
+	cmd.requestTimeout = requestTimeout
+	return cmd
+}
+
+func (cmd *StreamJobsCommand) Send(ctx context.Context) error {
+	if cmd.requestTimeout > 0 {
+		streamContext, cancelCtx := context.WithTimeout(ctx, cmd.requestTimeout)
+		ctx = streamContext
+		defer cancelCtx()
+	}
+
+	stream, err := cmd.openStream(ctx)
+	if err != nil {
+		return err
+	}
+
+	for {
+		job, err := stream.Recv()
+		if err == io.EOF {
+			break
+		}
+
+		if cmd.shouldRetry(ctx, err) {
+			stream, err = cmd.openStream(ctx)
+			if err != nil {
+				log.Printf("Failed to reopen job stream: %v\n", err)
+			}
+
+			continue
+		}
+
+		if err != nil {
+			return err
+		}
+
+		cmd.consumer <- &entities.Job{ActivatedJob: job}
+	}
+
+	return nil
+}
+
+func (cmd *StreamJobsCommand) openStream(ctx context.Context) (pb.Gateway_StreamActivatedJobsClient, error) {
+	onFinish := grpc.OnFinishCallOption{OnFinish: func(err error) {
+		close(cmd.consumer)
+	}}
+	stream, err := cmd.gateway.StreamActivatedJobs(ctx, &cmd.request, onFinish)
+
+	if err != nil {
+		if cmd.shouldRetry(ctx, err) {
+			return cmd.openStream(ctx)
+		}
+
+		return nil, err
+	}
+
+	return stream, nil
+}
+
+func NewStreamJobsCommand(gateway pb.GatewayClient, pred retryPredicate) StreamJobsCommandStep1 {
+	return &StreamJobsCommand{
+		request: pb.StreamActivatedJobsRequest{
+			Timeout: DefaultJobTimeoutInMs,
+			Worker:  DefaultJobWorkerName,
+		},
+		Command: Command{
+			gateway:     gateway,
+			shouldRetry: pred,
+		},
+	}
+}

--- a/clients/go/pkg/commands/stream_jobs.go
+++ b/clients/go/pkg/commands/stream_jobs.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-type StreamJobsConsumer chan<- *entities.Job
+type StreamJobsConsumer chan<- entities.Job
 
 type DispatchStreamJobsCommand interface {
 	RequestTimeout(time.Duration) DispatchStreamJobsCommand
@@ -122,7 +122,7 @@ func (cmd *StreamJobsCommand) Send(ctx context.Context) error {
 			return err
 		}
 
-		cmd.consumer <- &entities.Job{ActivatedJob: job}
+		cmd.consumer <- entities.Job{ActivatedJob: job}
 	}
 
 	return nil

--- a/clients/go/pkg/commands/stream_jobs.go
+++ b/clients/go/pkg/commands/stream_jobs.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
-	"google.golang.org/grpc"
 )
 
 type StreamJobsConsumer chan<- entities.Job
@@ -129,10 +128,7 @@ func (cmd *StreamJobsCommand) Send(ctx context.Context) error {
 }
 
 func (cmd *StreamJobsCommand) openStream(ctx context.Context) (pb.Gateway_StreamActivatedJobsClient, error) {
-	onFinish := grpc.OnFinishCallOption{OnFinish: func(err error) {
-		close(cmd.consumer)
-	}}
-	stream, err := cmd.gateway.StreamActivatedJobs(ctx, &cmd.request, onFinish)
+	stream, err := cmd.gateway.StreamActivatedJobs(ctx, &cmd.request)
 
 	if err != nil {
 		if cmd.shouldRetry(ctx, err) {

--- a/clients/go/pkg/commands/stream_jobs_test.go
+++ b/clients/go/pkg/commands/stream_jobs_test.go
@@ -1,4 +1,4 @@
-// Copyright © 2023 Camunda Services GmbH (info@camunda.com)
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/clients/go/pkg/commands/stream_jobs_test.go
+++ b/clients/go/pkg/commands/stream_jobs_test.go
@@ -68,7 +68,7 @@ func TestStreamJobsCommand(t *testing.T) {
 		Variables:     "{}",
 	}
 
-	expectedJobs := []*entities.Job{{ActivatedJob: &job1}, {ActivatedJob: &job2}}
+	expectedJobs := []entities.Job{{ActivatedJob: &job1}, {ActivatedJob: &job2}}
 
 	gomock.InOrder(
 		stream.EXPECT().Recv().Return(&job1, nil),
@@ -86,7 +86,7 @@ func TestStreamJobsCommand(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
 
-	jobsChan := make(chan *entities.Job, 2)
+	jobsChan := make(chan entities.Job, 2)
 	defer close(jobsChan)
 	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
 		return false
@@ -95,7 +95,7 @@ func TestStreamJobsCommand(t *testing.T) {
 	assert.NoError(t, err)
 
 	// simulate job receive
-	jobs := []*entities.Job{<-jobsChan, <-jobsChan}
+	jobs := []entities.Job{<-jobsChan, <-jobsChan}
 
 	if len(jobs) != len(expectedJobs) {
 		t.Error("Failed to receive all jobs: ", jobs, expectedJobs)
@@ -136,7 +136,7 @@ func TestConsumerClosedOnStreamClose(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
 
-	jobsChan := make(chan *entities.Job, 2)
+	jobsChan := make(chan entities.Job, 2)
 	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
 		return false
 	}).JobType("foo").Consumer(jobsChan).Send(ctx)
@@ -171,7 +171,7 @@ func TestStreamJobsCommandWithTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
 
-	jobsChan := make(chan *entities.Job, 5)
+	jobsChan := make(chan entities.Job, 5)
 	defer close(jobsChan)
 	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
 		return false
@@ -203,7 +203,7 @@ func TestStreamJobsCommandWithWorkerName(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
 
-	jobsChan := make(chan *entities.Job, 5)
+	jobsChan := make(chan entities.Job, 5)
 	defer close(jobsChan)
 	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
 		return false
@@ -235,7 +235,7 @@ func TestStreamJobsCommandWithTenantIds(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
 	defer cancel()
 
-	jobsChan := make(chan *entities.Job, 5)
+	jobsChan := make(chan entities.Job, 5)
 	defer close(jobsChan)
 	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
 		return false

--- a/clients/go/pkg/commands/stream_jobs_test.go
+++ b/clients/go/pkg/commands/stream_jobs_test.go
@@ -1,0 +1,247 @@
+// Copyright © 2023 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/internal/mock_pb"
+	"github.com/camunda/zeebe/clients/go/v8/internal/utils"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+)
+
+func TestStreamJobsCommand(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_StreamActivatedJobsClient(ctrl)
+
+	request := &pb.StreamActivatedJobsRequest{
+		Type:    "foo",
+		Timeout: DefaultJobTimeoutInMs,
+		Worker:  DefaultJobWorkerName,
+	}
+
+	job1 := pb.ActivatedJob{
+		Key:                      123,
+		Type:                     "foo",
+		Retries:                  3,
+		Deadline:                 123123,
+		Worker:                   DefaultJobWorkerName,
+		ElementInstanceKey:       123,
+		ProcessDefinitionKey:     124,
+		BpmnProcessId:            "fooProcess",
+		ProcessInstanceKey:       1233,
+		ElementId:                "foobar",
+		ProcessDefinitionVersion: 12345,
+		CustomHeaders:            "{\"foo\": \"bar\"}",
+		Variables:                "{\"foo\": \"bar\"}",
+	}
+	job2 := pb.ActivatedJob{
+		Key:           123,
+		Type:          "foo",
+		Retries:       3,
+		Deadline:      123123,
+		Worker:        DefaultJobWorkerName,
+		CustomHeaders: "{}",
+		Variables:     "{}",
+	}
+
+	expectedJobs := []*entities.Job{{ActivatedJob: &job1}, {ActivatedJob: &job2}}
+
+	gomock.InOrder(
+		stream.EXPECT().Recv().Return(&job1, nil),
+		stream.EXPECT().Recv().Return(&job2, nil),
+		stream.EXPECT().Recv().Return(nil, io.EOF),
+	)
+
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}, gomock.Any()).Return(stream, nil)
+	// var finishCallback func(error)
+	// client.EXPECT().StreamActivatedJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}, gomock.AssignableToTypeOf(&grpc.OnFinishCallOption{})).DoAndReturn(func(onFinish grpc.OnFinishCallOption) (interface{}, error) {
+	// 	finishCallback = onFinish.OnFinish
+	// 	return stream, nil
+	// })
+
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobsChan := make(chan *entities.Job, 2)
+	defer close(jobsChan)
+	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").Consumer(jobsChan).Send(ctx)
+
+	assert.NoError(t, err)
+
+	// simulate job receive
+	jobs := []*entities.Job{<-jobsChan, <-jobsChan}
+
+	if len(jobs) != len(expectedJobs) {
+		t.Error("Failed to receive all jobs: ", jobs, expectedJobs)
+	}
+
+	for i, job := range jobs {
+		if !reflect.DeepEqual(job, expectedJobs[i]) {
+			t.Error("Failed to receive job: ", job, expectedJobs[i])
+		}
+	}
+
+}
+
+func TestConsumerClosedOnStreamClose(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_StreamActivatedJobsClient(ctrl)
+
+	request := &pb.StreamActivatedJobsRequest{
+		Type:    "foo",
+		Timeout: DefaultJobTimeoutInMs,
+		Worker:  DefaultJobWorkerName,
+	}
+
+	gomock.InOrder(
+		stream.EXPECT().Recv().Return(nil, io.EOF),
+	)
+
+	var finishCallback func(error)
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}, gomock.AssignableToTypeOf(grpc.OnFinishCallOption{})).
+		DoAndReturn(func(ctx context.Context, request *pb.StreamActivatedJobsRequest, onFinish grpc.OnFinishCallOption) (interface{}, error) {
+			finishCallback = onFinish.OnFinish
+			return stream, nil
+		})
+
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobsChan := make(chan *entities.Job, 2)
+	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").Consumer(jobsChan).Send(ctx)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, finishCallback)
+
+	finishCallback(nil)
+	select {
+	case <-jobsChan:
+	default:
+		assert.Fail(t, "Channel is not closed since we can still receive on it")
+	}
+}
+
+func TestStreamJobsCommandWithTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_StreamActivatedJobsClient(ctrl)
+
+	request := &pb.StreamActivatedJobsRequest{
+		Type:    "foo",
+		Timeout: 60 * 1000,
+		Worker:  DefaultJobWorkerName,
+	}
+
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}, gomock.Any()).Return(stream, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobsChan := make(chan *entities.Job, 5)
+	defer close(jobsChan)
+	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").Consumer(jobsChan).Timeout(1 * time.Minute).Send(ctx)
+
+	if err != nil {
+		assert.NoError(t, err, "Failed to send request")
+	}
+}
+
+func TestStreamJobsCommandWithWorkerName(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_StreamActivatedJobsClient(ctrl)
+
+	fetchVariables := []string{"foo", "bar", "baz"}
+	request := &pb.StreamActivatedJobsRequest{
+		Type:          "foo",
+		Timeout:       300 * 1000,
+		Worker:        DefaultJobWorkerName,
+		FetchVariable: fetchVariables,
+	}
+
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}, gomock.Any()).Return(stream, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobsChan := make(chan *entities.Job, 5)
+	defer close(jobsChan)
+	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").Consumer(jobsChan).FetchVariables(fetchVariables...).Send(ctx)
+
+	if err != nil {
+		assert.NoError(t, err, "Failed to send request")
+	}
+}
+
+func TestStreamJobsCommandWithTenantIds(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_StreamActivatedJobsClient(ctrl)
+
+	tenantIds := []string{"1234", "5555"}
+	request := &pb.StreamActivatedJobsRequest{
+		Type:      "foo",
+		Timeout:   300 * 1000,
+		Worker:    DefaultJobWorkerName,
+		TenantIds: tenantIds,
+	}
+
+	stream.EXPECT().Recv().Return(nil, io.EOF)
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), &utils.RPCTestMsg{Msg: request}, gomock.Any()).Return(stream, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), utils.DefaultTestTimeout)
+	defer cancel()
+
+	jobsChan := make(chan *entities.Job, 5)
+	defer close(jobsChan)
+	err := NewStreamJobsCommand(client, func(context.Context, error) bool {
+		return false
+	}).JobType("foo").Consumer(jobsChan).TenantIds(tenantIds...).Send(ctx)
+
+	if err != nil {
+		assert.NoError(t, err, "Failed to send request")
+	}
+}

--- a/clients/go/pkg/zbc/api.go
+++ b/clients/go/pkg/zbc/api.go
@@ -38,6 +38,7 @@ type Client interface {
 	NewBroadcastSignalCommand() commands.BroadcastSignalCommandStep1
 
 	NewActivateJobsCommand() commands.ActivateJobsCommandStep1
+	NewStreamJobsCommand() commands.StreamJobsCommandStep1
 	NewCompleteJobCommand() commands.CompleteJobCommandStep1
 	NewFailJobCommand() commands.FailJobCommandStep1
 	NewUpdateJobRetriesCommand() commands.UpdateJobRetriesCommandStep1

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -18,13 +18,14 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"github.com/camunda/zeebe/clients/go/v8/internal/embedded"
-	"google.golang.org/grpc/credentials/insecure"
 	"log"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/internal/embedded"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"
@@ -145,6 +146,10 @@ func (c *ClientImpl) NewThrowErrorCommand() commands.ThrowErrorCommandStep1 {
 
 func (c *ClientImpl) NewDeleteResourceCommand() commands.DeleteResourceCommandStep1 {
 	return commands.NewDeleteResourceCommand(c.gateway, c.credentialsProvider.ShouldRetryRequest)
+}
+
+func (c *ClientImpl) NewStreamJobsCommand() commands.StreamJobsCommandStep1 {
+	return commands.NewStreamJobsCommand(c.gateway, c.credentialsProvider.ShouldRetryRequest)
 }
 
 func (c *ClientImpl) NewJobWorker() worker.JobWorkerBuilderStep1 {

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -281,20 +281,20 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	for start := time.Now(); !streamExists && time.Since(start) < 5*time.Second; {
 		response, err := http.Get(fmt.Sprintf("http://%s/actuator/jobstreams/remote", s.MonitoringAddress))
 		if err != nil {
-			time.Sleep(1)
+			time.Sleep(time.Second)
 			continue
 		}
 
 		remoteStreams := make([]remoteJobStream, 1)
 		responseData, err := io.ReadAll(response.Body)
 		if err != nil {
-			time.Sleep(1)
+			time.Sleep(time.Second)
 			continue
 		}
 
 		err = json.Unmarshal(responseData, &remoteStreams)
 		if err != nil {
-			time.Sleep(1)
+			time.Sleep(time.Second)
 			continue
 		}
 
@@ -312,11 +312,10 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	// then - expect two jobs
 	jobs := make([]*entities.Job, 0)
 	for i := 0; i < 2; i++ {
-		select {
-		case job, ok := <-jobsChan:
-			if ok {
-				jobs = append(jobs, job)
-			}
+		job, ok := <-jobsChan
+		if ok {
+			jobs = append(jobs, job)
+		} else {
 			break
 		}
 	}

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -390,6 +390,6 @@ type remoteJobStreamMetadata struct {
 }
 
 type remoteJobStreamConsumer struct {
-	Id       string `json:"id"`
+	ID       string `json:"id"`
 	Receiver string `json:"receiver"`
 }

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -16,11 +16,17 @@ package test
 
 import (
 	"context"
-	"github.com/camunda/zeebe/clients/go/v8/internal/containersuite"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
-	"github.com/stretchr/testify/suite"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
 	"testing"
 	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/internal/containersuite"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
+	"github.com/stretchr/testify/suite"
 )
 
 type integrationTestSuite struct {
@@ -245,6 +251,85 @@ func (s *integrationTestSuite) TestActivateJobs() {
 	}
 }
 
+func (s *integrationTestSuite) TestStreamJobs() {
+	// given
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	deployment, err := s.client.NewDeployResourceCommand().AddResourceFile("testdata/service_task.bpmn").Send(ctx)
+	if err != nil {
+		s.T().Fatal(err)
+	}
+
+	deployedResource := deployment.GetDeployments()[0]
+	s.NotNil(deployedResource)
+
+	process := deployedResource.GetProcess()
+	s.NotNil(process)
+
+	// when
+	// the stream will be closed by the deferred context cancellation
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+	jobsChan := make(chan *entities.Job)
+	go s.client.NewStreamJobsCommand().JobType("task").Consumer(jobsChan).Timeout(time.Minute * 5).
+		WorkerName("worker").RequestTimeout(time.Duration(1) * time.Minute).Send(ctx)
+
+	// Await until the stream is created on the broker
+	// TODO: find a less verbose way of doing this
+	streamExists := false
+	for start := time.Now(); !streamExists && time.Since(start) < 5*time.Second; {
+		response, err := http.Get(fmt.Sprintf("http://%s/actuator/jobstreams/remote", s.MonitoringAddress))
+		if err != nil {
+			time.Sleep(1)
+			continue
+		}
+
+		remoteStreams := make([]remoteJobStream, 1)
+		responseData, err := io.ReadAll(response.Body)
+		if err != nil {
+			time.Sleep(1)
+			continue
+		}
+
+		err = json.Unmarshal(responseData, &remoteStreams)
+		if err != nil {
+			time.Sleep(1)
+			continue
+		}
+
+		streamExists = len(remoteStreams) > 0
+	}
+
+	s.True(streamExists, "Expected remote stream to exist on broker after 5 seconds, but none yet exist")
+
+	// create two PIs and expect two jobs
+	_, err = s.client.NewCreateInstanceCommand().ProcessDefinitionKey(process.GetProcessDefinitionKey()).Send(ctx)
+	s.NoError(err)
+	_, err = s.client.NewCreateInstanceCommand().ProcessDefinitionKey(process.GetProcessDefinitionKey()).Send(ctx)
+	s.NoError(err)
+
+	// then - expect two jobs
+	jobs := make([]*entities.Job, 0)
+	for i := 0; i < 2; i++ {
+		select {
+		case job, ok := <-jobsChan:
+			if ok {
+				jobs = append(jobs, job)
+			}
+			break
+		}
+	}
+	s.Len(jobs, 2, "Expected to receive 2 jobs")
+
+	for _, job := range jobs {
+		s.EqualValues(process.GetProcessDefinitionKey(), job.GetProcessDefinitionKey())
+		s.EqualValues(process.GetBpmnProcessId(), job.GetBpmnProcessId())
+		s.EqualValues("service_task", job.GetElementId())
+		s.Greater(job.GetRetries(), int32(0))
+	}
+}
+
 func (s *integrationTestSuite) TestFailJob() {
 	// given
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -291,4 +376,21 @@ func (s *integrationTestSuite) TestFailJob() {
 			s.T().Fatal("Empty fail job response")
 		}
 	}
+}
+
+type remoteJobStream struct {
+	JobType   string                    `json:"jobType"`
+	Metadata  remoteJobStreamMetadata   `json:"metadata"`
+	Consumers []remoteJobStreamConsumer `json:"consumers"`
+}
+
+type remoteJobStreamMetadata struct {
+	Worker         string   `json:"worker"`
+	Timeout        string   `json:"timeout"`
+	FetchVariables []string `json:"fetchVariables"`
+}
+
+type remoteJobStreamConsumer struct {
+	Id       string `json:"id"`
+	Receiver string `json:"receiver"`
 }

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -272,6 +272,7 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 	jobsChan := make(chan entities.Job)
+	defer close(jobsChan)
 	go s.client.NewStreamJobsCommand().JobType("task").Consumer(jobsChan).Timeout(time.Minute * 5).
 		WorkerName("worker").RequestTimeout(time.Duration(1) * time.Minute).Send(ctx)
 

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -271,7 +271,7 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	// the stream will be closed by the deferred context cancellation
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
-	jobsChan := make(chan *entities.Job)
+	jobsChan := make(chan entities.Job)
 	go s.client.NewStreamJobsCommand().JobType("task").Consumer(jobsChan).Timeout(time.Minute * 5).
 		WorkerName("worker").RequestTimeout(time.Duration(1) * time.Minute).Send(ctx)
 
@@ -310,7 +310,7 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	s.NoError(err)
 
 	// then - expect two jobs
-	jobs := make([]*entities.Job, 0)
+	jobs := make([]entities.Job, 0)
 	for i := 0; i < 2; i++ {
 		job, ok := <-jobsChan
 		if ok {


### PR DESCRIPTION
## Description

This PR adds basic support for job streaming to the Go client. Jobs are consumed via a provided channel. The idea is that if the channel blocks (i.e. it has reached its buffer size), the sender (i.e. the job stream) will block, which will trigger the `isReady` flag of the transport, thus applying back pressure to the stream, and the server will stop pushing jobs downstream.

I've added basic unit and integration tests, as support for these is quite limited on the Go side.

## Related issues

closes #15539

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
