### PR TITLE
Add job worker streaming capabilities

### DIFF
--- a/clients/go/pkg/worker/jobDispatcher.go
+++ b/clients/go/pkg/worker/jobDispatcher.go
@@ -15,8 +15,9 @@
 package worker
 
 import (
-	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
 	"sync"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
 )
 
 type jobDispatcher struct {

--- a/clients/go/pkg/worker/jobStreamer.go
+++ b/clients/go/pkg/worker/jobStreamer.go
@@ -1,0 +1,115 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package worker
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+)
+
+type jobStreamer struct {
+	request         commands.DispatchStreamJobsCommand
+	jobQueue        chan entities.Job
+	workerFinished  chan bool
+	closeSignal     chan struct{}
+	metrics         JobWorkerMetrics
+	shouldRetry     func(context.Context, error) bool
+	backoffSupplier BackoffSupplier
+	retryDelay      time.Duration
+
+	closedMutex sync.Mutex
+	closed      bool
+
+	streamMutex sync.Mutex
+}
+
+func (streamer *jobStreamer) stream(closeWait *sync.WaitGroup) {
+	defer closeWait.Done()
+
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	defer streamCancel()
+
+	streamClosed := make(chan error, 1)
+	go streamer.openStream(streamCtx, streamClosed)
+
+	var timer *time.Timer
+	retryDelay := time.Duration(0)
+
+	for {
+		select {
+		// stream was closed, check if we need to recreate it
+		case err := <-streamClosed:
+			if streamer.isClosed() {
+				break
+			}
+
+			if err != nil {
+				prevDelay := retryDelay
+				retryDelay = streamer.backoffSupplier.SupplyRetryDelay(time.Duration(prevDelay))
+
+				streamClosed = make(chan error, 1)
+				timer = time.AfterFunc(retryDelay, func() { streamer.openStream(streamCtx, streamClosed) })
+			} else {
+				// if completed successfully just immediately recreate it, no need to back off
+				streamClosed = make(chan error, 1)
+				go streamer.openStream(streamCtx, streamClosed)
+			}
+		// TODO: increment job handled worker metric
+		case <-streamer.workerFinished:
+		// streamer was closed, most likely the worker is closing too
+		case <-streamer.closeSignal:
+			streamer.close()
+
+			streamCancel()
+			if timer != nil {
+				timer.Stop()
+			}
+
+			return
+		}
+	}
+}
+
+func (streamer *jobStreamer) openStream(ctx context.Context, onClose chan<- error) {
+	if streamer.isClosed() {
+		return
+	}
+
+	// only keep one open stream at a time
+	streamer.streamMutex.Lock()
+	defer streamer.streamMutex.Unlock()
+
+	onClose <- streamer.request.Send(ctx)
+	close(onClose)
+}
+
+func (streamer *jobStreamer) isClosed() bool {
+	streamer.closedMutex.Lock()
+	defer streamer.closedMutex.Unlock()
+
+	return streamer.closed
+}
+
+func (streamer *jobStreamer) close() {
+	streamer.closedMutex.Lock()
+	defer streamer.closedMutex.Unlock()
+
+	streamer.closed = true
+}

--- a/clients/go/pkg/worker/jobStreamer_test.go
+++ b/clients/go/pkg/worker/jobStreamer_test.go
@@ -94,7 +94,7 @@ func (s *JobStreamerSuite) TestShouldRecreateStreamOnCompleted() {
 	var ctx context.Context
 	state := newTestState()
 	defer state.close(s)
-	// will block on the second send call
+	// will block on the first send call
 	state.command.setSendChanBuffer(0)
 
 	// when - should not hang because the stream is closed
@@ -129,7 +129,7 @@ func (s *JobStreamerSuite) TestShouldRecreateStreamOnErrorWithBackoff() {
 	defer state.close(s)
 	state.command.err = errors.New("Foo")
 	state.backoff.delaySequence = []time.Duration{1, 2 * time.Hour}
-	// will block on the second send call
+	// will block on the second third call
 	state.command.setSendChanBuffer(2)
 
 	// when - should not hang because the stream is closed

--- a/clients/go/pkg/worker/jobStreamer_test.go
+++ b/clients/go/pkg/worker/jobStreamer_test.go
@@ -1,0 +1,16 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package worker

--- a/clients/go/pkg/worker/jobStreamer_test.go
+++ b/clients/go/pkg/worker/jobStreamer_test.go
@@ -14,3 +14,217 @@
 //
 
 package worker
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/internal/utils"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/stretchr/testify/suite"
+)
+
+type JobStreamerSuite struct {
+	suite.Suite
+	command   mockStreamJobsCommand
+	backoff   mockBackoffSupplier
+	streamer  jobStreamer
+	jobQueue  chan entities.Job
+	waitGroup sync.WaitGroup
+}
+
+func (s *JobStreamerSuite) BeforeTest(_, _ string) {
+	s.jobQueue = make(chan entities.Job)
+	s.command = mockStreamJobsCommand{
+		sendChan: make(chan context.Context, 10),
+	}
+	s.backoff = mockBackoffSupplier{}
+	s.streamer = jobStreamer{
+		request:         &s.command,
+		workerFinished:  make(chan bool),
+		closeSignal:     make(chan struct{}),
+		backoffSupplier: &s.backoff,
+	}
+	s.waitGroup.Add(1)
+}
+
+func (s *JobStreamerSuite) AfterTest(_, _ string) {
+	close(s.streamer.closeSignal)
+
+	c := make(chan struct{})
+	go func() {
+		s.waitGroup.Wait()
+		close(c)
+	}()
+
+	for {
+		select {
+		case <-c:
+			return
+		case <-time.After(utils.DefaultTestTimeout):
+			s.FailNow("Failed to wait for job streamer to close")
+		}
+	}
+}
+
+func TestJobStreamerSuite(t *testing.T) {
+	suite.Run(t, new(JobStreamerSuite))
+}
+
+func (s *JobStreamerSuite) TestShouldNotOpenStreamIfClosed() {
+	// given
+	// since we aren't going to stream, the wait group has to be decremented
+	// to allow the AfterTest to run properly
+	finished := make(chan bool)
+	s.streamer.close()
+
+	// when - should not hang because the stream is closed
+	go func() {
+		s.streamer.stream(&s.waitGroup)
+		finished <- true
+		close(finished)
+	}()
+
+	// then
+	select {
+	case <-finished:
+		s.EqualValues(0, s.command.sendCount)
+	case <-time.After(10 * time.Second):
+		s.FailNow("Timed out waiting for stream call to finish")
+	}
+}
+
+func (s *JobStreamerSuite) TestShouldStopStreamOnCloseSignal() {
+	// given
+	var ctx context.Context
+	s.command.setSendChanBuffer(0)
+
+	// when - should not hang because the stream is closed
+	go s.streamer.stream(&s.waitGroup)
+	select {
+	case ctx = <-s.command.sendChan:
+		s.streamer.closeSignal <- struct{}{}
+	case <-time.After(10 * time.Second):
+		s.FailNow("Timed out waiting for stream call to finish")
+	}
+
+	// then
+	select {
+	case <-ctx.Done():
+		// closing is async, so there will be for sure a second call
+		s.EqualValues(2, s.command.sendCount)
+	case <-time.After(10 * time.Second):
+		s.FailNow("Context was not canceled even though the streamer was closed via a signal")
+	}
+}
+
+func (s *JobStreamerSuite) TestShouldRecreateStreamOnCompleted() {
+	// given
+	var ctx context.Context
+	// will block on the second send call
+	s.command.setSendChanBuffer(0)
+
+	// when - should not hang because the stream is closed
+	go s.streamer.stream(&s.waitGroup)
+	select {
+	// capture second call context
+	case <-s.command.sendChan:
+		select {
+		case ctx = <-s.command.sendChan:
+			s.streamer.closeSignal <- struct{}{}
+		case <-time.After(10 * time.Second):
+			s.FailNow("Timed out waiting for stream call to finish")
+		}
+	case <-time.After(10 * time.Second):
+		s.FailNow("Timed out waiting for stream call to finish")
+	}
+
+	// then
+	select {
+	case <-ctx.Done():
+		s.EqualValues(2, s.command.sendCount)
+		s.EqualValues(0, s.backoff.calledCount)
+	case <-time.After(10 * time.Second):
+		s.FailNow("Context was not canceled even though the streamer was closed via a signal")
+	}
+}
+
+func (s *JobStreamerSuite) TestShouldRecreateStreamOnErrorWithBackoff() {
+	// given
+	var ctx context.Context
+	s.command.err = errors.New("Foo")
+	s.backoff.delaySequence = []time.Duration{1, 2 * time.Hour}
+	// will block on the second send call
+	s.command.setSendChanBuffer(1)
+
+	// when - should not hang because the stream is closed
+	go s.streamer.stream(&s.waitGroup)
+	select {
+	// capture second call context
+	case <-s.command.sendChan:
+		select {
+		case ctx = <-s.command.sendChan:
+			s.streamer.closeSignal <- struct{}{}
+		case <-time.After(10 * time.Second):
+			s.FailNow("Timed out waiting for stream call to finish")
+		}
+	case <-time.After(10 * time.Second):
+		s.FailNow("Timed out waiting for stream call to finish")
+	}
+
+	// then
+
+	select {
+	case <-ctx.Done():
+		s.EqualValues(2, s.backoff.calledCount)
+		s.Require().Len(s.backoff.currentRetryDelays, 2)
+		s.EqualValues(0, s.backoff.currentRetryDelays[0])
+		s.EqualValues(1, s.backoff.currentRetryDelays[1])
+	case <-time.After(10 * time.Second):
+		s.FailNow("Context was not canceled even though the streamer was closed via a signal")
+	}
+}
+
+type mockStreamJobsCommand struct {
+	sendCount int
+	err       error
+	sendChan  chan context.Context
+}
+
+type mockBackoffSupplier struct {
+	calledCount        int
+	delaySequence      []time.Duration
+	currentRetryDelays []time.Duration
+}
+
+func (m *mockStreamJobsCommand) RequestTimeout(_ time.Duration) commands.DispatchStreamJobsCommand {
+	panic(errors.New("Not implemented yet as not expected to be invoked"))
+}
+
+func (m *mockStreamJobsCommand) Send(ctx context.Context) error {
+	m.sendCount++
+	m.sendChan <- ctx
+	return m.err
+}
+
+func (m *mockStreamJobsCommand) setSendChanBuffer(count int) {
+	sendChan := m.sendChan
+	m.sendChan = make(chan context.Context, count)
+	close(sendChan)
+}
+
+func (m *mockBackoffSupplier) SupplyRetryDelay(currentRetryDelay time.Duration) time.Duration {
+	m.currentRetryDelays = append(m.currentRetryDelays, currentRetryDelay)
+
+	index := m.calledCount
+	m.calledCount++
+	if index < len(m.delaySequence) {
+		return m.delaySequence[index]
+	}
+
+	return 0
+}

--- a/clients/go/pkg/worker/jobWorker.go
+++ b/clients/go/pkg/worker/jobWorker.go
@@ -16,7 +16,6 @@
 package worker
 
 import (
-	"log"
 	"sync"
 
 	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
@@ -46,11 +45,8 @@ type jobWorkerController struct {
 }
 
 func (controller jobWorkerController) Close() {
-	log.Printf("Closing poller")
 	close(controller.closePoller)
-	log.Printf("Closing streamer")
 	close(controller.closeStreamer)
-	log.Printf("Closing dispatcher")
 	close(controller.closeDispatcher)
 	controller.AwaitClose()
 }

--- a/clients/go/pkg/worker/jobWorker.go
+++ b/clients/go/pkg/worker/jobWorker.go
@@ -16,9 +16,11 @@
 package worker
 
 import (
+	"log"
+	"sync"
+
 	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
-	"sync"
 )
 
 type JobClient interface {
@@ -39,11 +41,16 @@ type JobWorker interface {
 type jobWorkerController struct {
 	closePoller     chan struct{}
 	closeDispatcher chan struct{}
+	closeStreamer   chan struct{}
 	closeWait       *sync.WaitGroup
 }
 
 func (controller jobWorkerController) Close() {
+	log.Printf("Closing poller")
 	close(controller.closePoller)
+	log.Printf("Closing streamer")
+	close(controller.closeStreamer)
+	log.Printf("Closing dispatcher")
 	close(controller.closeDispatcher)
 	controller.AwaitClose()
 }

--- a/clients/go/pkg/worker/jobWorker_builder.go
+++ b/clients/go/pkg/worker/jobWorker_builder.go
@@ -227,12 +227,9 @@ func (builder *JobWorkerBuilder) Open() JobWorker {
 			WorkerName(builder.request.Worker).
 			RequestTimeout(builder.streamRequestTimeout)
 		streamer := jobStreamer{
-			jobQueue:        jobQueue,
 			workerFinished:  workerFinished,
 			closeSignal:     closeStreamer,
 			request:         streamRequest,
-			metrics:         builder.metrics,
-			shouldRetry:     builder.shouldRetry,
 			backoffSupplier: builder.backoffSupplier,
 			retryDelay:      0,
 		}

--- a/clients/go/pkg/worker/jobWorker_builder.go
+++ b/clients/go/pkg/worker/jobWorker_builder.go
@@ -17,13 +17,14 @@ package worker
 
 import (
 	"context"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"log"
 	"math"
 	"sync"
 	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 )
 
 const (
@@ -33,6 +34,7 @@ const (
 	DefaultJobWorkerPollThreshold = 0.3
 	RequestTimeoutOffset          = 10 * time.Second
 	DefaultRequestTimeout         = 10 * time.Second
+	DefaultStreamEnabled          = false
 )
 
 var defaultBackoffSupplier = NewExponentialBackoffBuilder().Build()
@@ -43,14 +45,16 @@ type JobWorkerBuilder struct {
 	request        *pb.ActivateJobsRequest
 	requestTimeout time.Duration
 
-	handler         JobHandler
-	maxJobsActive   int
-	concurrency     int
-	pollInterval    time.Duration
-	pollThreshold   float64
-	metrics         JobWorkerMetrics
-	shouldRetry     func(context.Context, error) bool
-	backoffSupplier BackoffSupplier
+	handler              JobHandler
+	maxJobsActive        int
+	concurrency          int
+	pollInterval         time.Duration
+	pollThreshold        float64
+	metrics              JobWorkerMetrics
+	shouldRetry          func(context.Context, error) bool
+	backoffSupplier      BackoffSupplier
+	streamEnabled        bool
+	streamRequestTimeout time.Duration
 }
 
 type JobWorkerBuilderStep1 interface {
@@ -86,6 +90,10 @@ type JobWorkerBuilderStep3 interface {
 	Metrics(metrics JobWorkerMetrics) JobWorkerBuilderStep3
 	// BackoffSupplier Set the backoffSupplier to back off polling on errors
 	BackoffSupplier(supplier BackoffSupplier) JobWorkerBuilderStep3
+	// StreamEnabled Enables the job worker to stream jobs. It will still poll for older jobs, but streaming is favored.
+	StreamEnabled(bool) JobWorkerBuilderStep3
+	// StreamRequestTimeout If streaming is enabled, this sets the timeout on the underlying job stream. It's useful to set a few hours to load-balance your streams over time.
+	StreamRequestTimeout(time.Duration) JobWorkerBuilderStep3
 	// Open the job worker and start polling and handling jobs
 	Open() JobWorker
 }
@@ -163,13 +171,24 @@ func (builder *JobWorkerBuilder) BackoffSupplier(backoffSupplier BackoffSupplier
 	return builder
 }
 
+func (builder *JobWorkerBuilder) StreamEnabled(streamEnabled bool) JobWorkerBuilderStep3 {
+	builder.streamEnabled = streamEnabled
+	return builder
+}
+
+func (builder *JobWorkerBuilder) StreamRequestTimeout(requestTimeout time.Duration) JobWorkerBuilderStep3 {
+	builder.streamRequestTimeout = requestTimeout
+	return builder
+}
+
 func (builder *JobWorkerBuilder) Open() JobWorker {
 	jobQueue := make(chan entities.Job, builder.maxJobsActive)
 	workerFinished := make(chan bool, builder.maxJobsActive)
 	closePoller := make(chan struct{})
 	closeDispatcher := make(chan struct{})
+	closeStreamer := make(chan struct{})
 	var closeWait sync.WaitGroup
-	closeWait.Add(2)
+	closeWait.Add(3)
 
 	poller := jobPoller{
 		client:              builder.gatewayClient,
@@ -195,12 +214,39 @@ func (builder *JobWorkerBuilder) Open() JobWorker {
 		closeSignal:    closeDispatcher,
 	}
 
-	go poller.poll(&closeWait)
 	go dispatcher.run(builder.jobClient, builder.handler, builder.concurrency, &closeWait)
+	go poller.poll(&closeWait)
+
+	if builder.streamEnabled {
+		streamRequest := commands.NewStreamJobsCommand(builder.gatewayClient, builder.shouldRetry).
+			JobType(builder.request.Type).
+			Consumer(jobQueue).
+			Timeout(time.Duration(builder.request.Timeout) * time.Millisecond).
+			FetchVariables(builder.request.FetchVariable...).
+			TenantIds(builder.request.TenantIds...).
+			WorkerName(builder.request.Worker).
+			RequestTimeout(builder.streamRequestTimeout)
+		streamer := jobStreamer{
+			jobQueue:        jobQueue,
+			workerFinished:  workerFinished,
+			closeSignal:     closeStreamer,
+			request:         streamRequest,
+			metrics:         builder.metrics,
+			shouldRetry:     builder.shouldRetry,
+			backoffSupplier: builder.backoffSupplier,
+			retryDelay:      0,
+		}
+
+		go streamer.stream(&closeWait)
+	} else {
+		// simulate streamer is already closed
+		closeWait.Done()
+	}
 
 	return jobWorkerController{
 		closePoller:     closePoller,
 		closeDispatcher: closeDispatcher,
+		closeStreamer:   closeStreamer,
 		closeWait:       &closeWait,
 	}
 }

--- a/clients/go/pkg/worker/jobWorker_builder_test.go
+++ b/clients/go/pkg/worker/jobWorker_builder_test.go
@@ -16,13 +16,14 @@
 package worker
 
 import (
+	"testing"
+	"time"
+
 	"github.com/camunda/zeebe/clients/go/v8/internal/mock_pb"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-	"testing"
-	"time"
 )
 
 const testDuration = 12 * time.Minute
@@ -102,4 +103,17 @@ func TestJobWorkerBuilder_Metrics(t *testing.T) {
 	builder.Metrics(workerMetrics)
 
 	assert.Equal(t, workerMetrics, builder.metrics)
+}
+
+func TestJobWorkerBuilder_StreamEnabled(t *testing.T) {
+	builder := JobWorkerBuilder{request: &pb.ActivateJobsRequest{}}
+	builder.StreamEnabled(true)
+	assert.True(t, builder.streamEnabled)
+}
+
+func TestJobWorkerBuilder_StreamRequestTimeout(t *testing.T) {
+	builder := JobWorkerBuilder{request: &pb.ActivateJobsRequest{}}
+	requestTimeout := time.Second
+	builder.StreamRequestTimeout(requestTimeout)
+	assert.Equal(t, requestTimeout, builder.streamRequestTimeout)
 }

--- a/clients/go/pkg/worker/jobWorker_test.go
+++ b/clients/go/pkg/worker/jobWorker_test.go
@@ -16,16 +16,20 @@
 package worker
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"testing"
+	"time"
+
 	"github.com/camunda/zeebe/clients/go/v8/internal/mock_pb"
 	"github.com/camunda/zeebe/clients/go/v8/internal/utils"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"google.golang.org/protobuf/proto"
-	"testing"
-	"time"
 )
 
 // rpcMsg implements the gomock.Matcher interface
@@ -132,5 +136,199 @@ func TestJobWorkerActivateJobsCustom(t *testing.T) {
 		}
 	case <-time.After(utils.DefaultTestTimeout):
 		t.Error("Failed to receive all jobs before timeout")
+	}
+}
+
+func TestJobWorkerStreamDisabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_ActivateJobsClient(ctrl)
+
+	timeout := 7 * time.Minute
+
+	request := &pb.ActivateJobsRequest{
+		Type:              "foo",
+		MaxJobsToActivate: 123,
+		Timeout:           int64(timeout / time.Millisecond),
+		Worker:            "fooWorker",
+		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+	}
+
+	response := &pb.ActivateJobsResponse{
+		Jobs: []*pb.ActivatedJob{
+			{
+				Key: 1,
+			},
+		},
+	}
+
+	stream.EXPECT().Recv().Return(response, nil).AnyTimes()
+	client.EXPECT().ActivateJobs(gomock.Any(), &rpcMsg{msg: request}).Return(stream, nil)
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), gomock.Any()).Times(0)
+
+	jobs := make(chan entities.Job, 1)
+	NewJobWorkerBuilder(client, nil, nil).JobType("foo").Handler(func(client JobClient, job entities.Job) {
+		jobs <- job
+	}).MaxJobsActive(123).Timeout(timeout).RequestTimeout(utils.DefaultTestTimeout).Name("fooWorker").Open()
+
+	select {
+	case job := <-jobs:
+		expected := response.Jobs[0].Key
+		if job.Key != expected {
+			t.Error("Failed to received job", expected, "got", job.Key)
+		}
+	case <-time.After(utils.DefaultTestTimeout):
+		t.Error("Failed to receive all jobs before timeout")
+	}
+}
+
+func TestJobWorkerStreamEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_StreamActivatedJobsClient(ctrl)
+	activateJobsStream := mock_pb.NewMockGateway_ActivateJobsClient(ctrl)
+	timeout := 7 * time.Minute
+	request := &pb.StreamActivatedJobsRequest{
+		Type:    "foo",
+		Timeout: int64(timeout / time.Millisecond),
+		Worker:  "fooWorker",
+	}
+	activateJobsRequest := &pb.ActivateJobsRequest{
+		Type:              "foo",
+		MaxJobsToActivate: 123,
+		Timeout:           int64(timeout / time.Millisecond),
+		Worker:            "fooWorker",
+		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+	}
+
+	response := &pb.ActivatedJob{Key: 1}
+	emptyActivateResponse := &pb.ActivateJobsResponse{}
+
+	stream.EXPECT().Recv().Return(response, nil).AnyTimes()
+	activateJobsStream.EXPECT().Recv().Return(emptyActivateResponse, nil).AnyTimes()
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), &rpcMsg{msg: request}).AnyTimes().Return(stream, nil)
+	client.EXPECT().ActivateJobs(gomock.Any(), &rpcMsg{msg: activateJobsRequest}).Return(activateJobsStream, nil).AnyTimes()
+
+	retryPred := func(ctx context.Context, err error) bool { return true }
+	jobs := make(chan entities.Job, 1)
+	NewJobWorkerBuilder(client, nil, retryPred).
+		JobType("foo").
+		Handler(func(client JobClient, job entities.Job) {
+			jobs <- job
+		}).
+		MaxJobsActive(123).
+		Timeout(timeout).
+		RequestTimeout(utils.DefaultTestTimeout).
+		Name("fooWorker").
+		StreamEnabled(true).
+		PollInterval(time.Minute).
+		Open()
+
+	select {
+	case job := <-jobs:
+		expected := response.Key
+		if job.Key != expected {
+			t.Error("Failed to received job", expected, "got", job.Key)
+		}
+	case <-time.After(utils.DefaultTestTimeout):
+		t.Error("Failed to receive all jobs before timeout")
+	}
+}
+
+func TestStreamingJobWorkerClose(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_StreamActivatedJobsClient(ctrl)
+	activateJobsStream := mock_pb.NewMockGateway_ActivateJobsClient(ctrl)
+	timeout := 7 * time.Minute
+	request := &pb.StreamActivatedJobsRequest{
+		Type:    "foo",
+		Timeout: int64(timeout / time.Millisecond),
+		Worker:  "default",
+	}
+	activateJobsRequest := &pb.ActivateJobsRequest{
+		Type:              "foo",
+		MaxJobsToActivate: 32,
+		Timeout:           int64(timeout / time.Millisecond),
+		Worker:            "default",
+		RequestTimeout:    10000,
+	}
+
+	stream.EXPECT().Recv().Return(nil, io.EOF).AnyTimes()
+	activateJobsStream.EXPECT().Recv().Return(nil, io.EOF).AnyTimes()
+	client.EXPECT().StreamActivatedJobs(gomock.Any(), &rpcMsg{msg: request}).AnyTimes().Return(stream, nil)
+	client.EXPECT().ActivateJobs(gomock.Any(), &rpcMsg{msg: activateJobsRequest}).Return(activateJobsStream, nil).AnyTimes()
+
+	retryPred := func(ctx context.Context, err error) bool { return err != io.EOF }
+	worker := NewJobWorkerBuilder(client, nil, retryPred).
+		JobType("foo").
+		Handler(func(client JobClient, job entities.Job) {}).
+		Timeout(timeout).
+		StreamEnabled(true).
+		Open()
+
+	closedChan := make(chan bool)
+	go func() {
+		worker.Close()
+		closedChan <- true
+		close(closedChan)
+	}()
+
+	select {
+	case closed := <-closedChan:
+		assert.True(t, closed, "Worker should eventually close")
+		break
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "Failed to close worker after 10 seconds")
+		break
+	}
+}
+
+func TestJobWorkerClose(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+	stream := mock_pb.NewMockGateway_ActivateJobsClient(ctrl)
+	timeout := 7 * time.Minute
+	request := &pb.ActivateJobsRequest{
+		Type:              "foo",
+		MaxJobsToActivate: 32,
+		Timeout:           int64(timeout / time.Millisecond),
+		Worker:            "default",
+		RequestTimeout:    10000,
+	}
+
+	stream.EXPECT().Recv().Return(nil, io.EOF).AnyTimes()
+	client.EXPECT().ActivateJobs(gomock.Any(), &rpcMsg{msg: request}).Return(stream, nil).AnyTimes()
+
+	retryPred := func(ctx context.Context, err error) bool { return err != io.EOF }
+	worker := NewJobWorkerBuilder(client, nil, retryPred).
+		JobType("foo").
+		Handler(func(client JobClient, job entities.Job) {}).
+		Timeout(timeout).
+		StreamEnabled(false).
+		Open()
+
+	closedChan := make(chan bool)
+	go func() {
+		worker.Close()
+		closedChan <- true
+		close(closedChan)
+	}()
+
+	select {
+	case closed := <-closedChan:
+		assert.True(t, closed, "Worker should eventually close")
+		break
+	case <-time.After(10 * time.Second):
+		assert.Fail(t, "Failed to close worker after 10 seconds")
+		break
 	}
 }

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -20,12 +20,16 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/camunda/zeebe/clients/go/v8/internal/containersuite"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/worker"
 	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -256,7 +260,11 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	deployment, err := s.client.NewDeployResourceCommand().AddResourceFile("testdata/service_task.bpmn").Send(ctx)
+	taskType := uuid.NewString()
+	bpmn, err := s.readBpmnWithCustomJobType("testdata/service_task.bpmn", taskType)
+	s.NoError(err)
+
+	deployment, err := s.client.NewDeployResourceCommand().AddResource(bpmn, "service_task.bpmn").Send(ctx)
 	if err != nil {
 		s.T().Fatal(err)
 	}
@@ -271,37 +279,16 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	// the stream will be closed by the deferred context cancellation
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
+
 	jobsChan := make(chan entities.Job)
 	defer close(jobsChan)
-	go s.client.NewStreamJobsCommand().JobType("task").Consumer(jobsChan).Timeout(time.Minute * 5).
-		WorkerName("worker").RequestTimeout(time.Duration(1) * time.Minute).Send(ctx)
+
+	workerName := uuid.New().String()
+	go s.client.NewStreamJobsCommand().JobType(taskType).Consumer(jobsChan).Timeout(time.Minute * 5).
+		WorkerName(workerName).RequestTimeout(time.Duration(1) * time.Minute).Send(ctx)
 
 	// Await until the stream is created on the broker
-	// TODO: find a less verbose way of doing this
-	streamExists := false
-	for start := time.Now(); !streamExists && time.Since(start) < 5*time.Second; {
-		response, err := http.Get(fmt.Sprintf("http://%s/actuator/jobstreams/remote", s.MonitoringAddress))
-		if err != nil {
-			time.Sleep(time.Second)
-			continue
-		}
-
-		remoteStreams := make([]remoteJobStream, 1)
-		responseData, err := io.ReadAll(response.Body)
-		if err != nil {
-			time.Sleep(time.Second)
-			continue
-		}
-
-		err = json.Unmarshal(responseData, &remoteStreams)
-		if err != nil {
-			time.Sleep(time.Second)
-			continue
-		}
-
-		streamExists = len(remoteStreams) > 0
-	}
-
+	streamExists := s.awaitJobStreamExists(workerName)
 	s.True(streamExists, "Expected remote stream to exist on broker after 5 seconds, but none yet exist")
 
 	// create two PIs and expect two jobs
@@ -376,6 +363,123 @@ func (s *integrationTestSuite) TestFailJob() {
 			s.T().Fatal("Empty fail job response")
 		}
 	}
+}
+
+func (s *integrationTestSuite) TestStreamingJobWorker() {
+	// given
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	taskType := uuid.NewString()
+	bpmn, err := s.readBpmnWithCustomJobType("testdata/service_task.bpmn", taskType)
+	s.NoError(err)
+
+	deployment, err := s.client.NewDeployResourceCommand().AddResource(bpmn, "service_task.bpmn").Send(ctx)
+	if err != nil {
+		s.T().Fatal(err)
+	}
+
+	deployedResource := deployment.GetDeployments()[0]
+	s.NotNil(deployedResource)
+
+	process := deployedResource.GetProcess()
+	s.NotNil(process)
+
+	// when
+	// the stream will be closed by the deferred context cancellation
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	jobsChan := make(chan entities.Job)
+	defer close(jobsChan)
+
+	workerName := uuid.New().String()
+	jobWorker := s.client.NewJobWorker().
+		JobType(taskType).
+		Handler(func(client worker.JobClient, job entities.Job) {
+			jobsChan <- job
+		}).
+		Timeout(time.Minute * 5).
+		PollInterval(1 * time.Hour). // poll very slowly to make sure we get our jobs from streaming
+		Name(workerName).
+		StreamEnabled(true).
+		RequestTimeout(time.Duration(1) * time.Second).
+		Open()
+	defer jobWorker.Close()
+
+	// Await until the stream is created on the broker
+	streamExists := s.awaitJobStreamExists(workerName)
+	s.True(streamExists, "Expected remote stream to exist on broker after 5 seconds, but none yet exist")
+
+	// create two PIs and expect two jobs
+	_, err = s.client.NewCreateInstanceCommand().ProcessDefinitionKey(process.GetProcessDefinitionKey()).Send(ctx)
+	s.NoError(err)
+	_, err = s.client.NewCreateInstanceCommand().ProcessDefinitionKey(process.GetProcessDefinitionKey()).Send(ctx)
+	s.NoError(err)
+
+	// then - expect two jobs
+	jobs := make([]entities.Job, 0)
+	for i := 0; i < 2; i++ {
+		job, ok := <-jobsChan
+		if ok {
+			jobs = append(jobs, job)
+		} else {
+			break
+		}
+	}
+	s.Len(jobs, 2, "Expected to receive 2 jobs")
+
+	for _, job := range jobs {
+		s.EqualValues(process.GetProcessDefinitionKey(), job.GetProcessDefinitionKey())
+		s.EqualValues(process.GetBpmnProcessId(), job.GetBpmnProcessId())
+		s.EqualValues("service_task", job.GetElementId())
+		s.Greater(job.GetRetries(), int32(0))
+	}
+}
+
+// We use the worker name to differentiate which stream we await
+func (s integrationTestSuite) awaitJobStreamExists(workerName string) bool {
+	streamExists := false
+	for start := time.Now(); !streamExists && time.Since(start) < 5*time.Second; {
+		response, err := http.Get(fmt.Sprintf("http://%s/actuator/jobstreams/remote", s.MonitoringAddress))
+		if err != nil {
+			time.Sleep(time.Second)
+			continue
+		}
+
+		remoteStreams := make([]remoteJobStream, 1)
+		responseData, err := io.ReadAll(response.Body)
+		if err != nil {
+			time.Sleep(time.Second)
+			continue
+		}
+
+		err = json.Unmarshal(responseData, &remoteStreams)
+		if err != nil {
+			time.Sleep(time.Second)
+			continue
+		}
+
+		for _, remoteStream := range remoteStreams {
+			if remoteStream.Metadata.Worker == workerName {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func (s integrationTestSuite) readBpmnWithCustomJobType(path string, jobType string) ([]byte, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	parsed := string(b)
+	bpmn := strings.ReplaceAll(parsed, "<zeebe:taskDefinition type=\"task\" />", fmt.Sprintf("<zeebe:taskDefinition type=\"%s\" />", jobType))
+
+	return []byte(bpmn), nil
 }
 
 type remoteJobStream struct {

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -429,11 +429,15 @@ func (s *integrationTestSuite) TestStreamingJobWorker() {
 	}
 	s.Len(jobs, 2, "Expected to receive 2 jobs")
 
+	jobKeys := make([]int64, 0)
 	for _, job := range jobs {
+		s.NotContains(jobKeys, job.Key)
 		s.EqualValues(process.GetProcessDefinitionKey(), job.GetProcessDefinitionKey())
 		s.EqualValues(process.GetBpmnProcessId(), job.GetBpmnProcessId())
 		s.EqualValues("service_task", job.GetElementId())
 		s.Greater(job.GetRetries(), int32(0))
+
+		jobKeys = append(jobKeys, job.Key)
 	}
 }
 


### PR DESCRIPTION
## Description

This PR adds job push to the Go job worker. It's modeled after the Java client implementation.

Essentially, two new flags are added to the job worker builder:

- `StreamEnabled(bool)`: if true, the worker will use job push in conjunction with job poll.
- `StreamRequestTimeout(time.Duration)`: an optional timeout for the long living job stream. The default timeout, which applies to the polling approach, is much too short for job push, thus the need for a second, optional timeout.

To do so, we added a new component in `jobStreamer.go`. This will maintain a single long living stream (using `commands.StreamJobCommand`) in its own Go routine, which will continuously stream jobs to the shared worker's job channel.

There were a few additional changes required to ensure the job worker can close properly (and some issues opened around it). It seems there were no integration tests previously for the job worker, which may be why this wasn't found earlier.

## Related issues

closes #15553 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
