### PR TITLE
Enable custom-tenant providing interceptor creation in Zeebe

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -21,7 +21,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerRequest;
 import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.stream.StreamJobsHandler;
-import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivatedJob;
@@ -489,7 +489,7 @@ public final class EndpointManager {
 
     final List<String> authorizedTenants =
         multiTenancy.isEnabled()
-            ? Context.current().call(IdentityInterceptor.AUTHORIZED_TENANTS_KEY::get)
+            ? Context.current().call(InterceptorUtil.getAuthorizedTenantsKey()::get)
             : List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     final String authorizationToken =
         Authorization.jwtEncoder()

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -31,7 +31,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerThrowErrorRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobTimeoutRequest;
-import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.BroadcastSignalRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.CancelProcessInstanceRequest;
@@ -345,7 +345,7 @@ public final class RequestMapper {
 
     final List<String> authorizedTenants;
     try {
-      authorizedTenants = Context.current().call(IdentityInterceptor.AUTHORIZED_TENANTS_KEY::get);
+      authorizedTenants = Context.current().call(InterceptorUtil.getAuthorizedTenantsKey()::get);
     } catch (final Exception e) {
       throw new InvalidTenantRequestException(
           commandName, tenantId, "tenant could not be retrieved from the request context", e);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -10,10 +10,13 @@ package io.camunda.zeebe.gateway.interceptors;
 import io.camunda.zeebe.gateway.query.QueryApi;
 import io.grpc.Context;
 import io.grpc.Context.Key;
+import java.util.List;
 
 /** A set of utilities which interceptor authors can use in their interceptors. */
 public final class InterceptorUtil {
   private static final Key<QueryApi> QUERY_API_KEY = Context.key("zeebe-query-api");
+  private static final Context.Key<List<String>> AUTHORIZED_TENANTS_KEY =
+      Context.key("io.camunda.zeebe:authorized_tenants");
 
   private InterceptorUtil() {}
 
@@ -59,4 +62,39 @@ public final class InterceptorUtil {
   public static Key<QueryApi> getQueryApiKey() {
     return QUERY_API_KEY;
   }
+
+  /**
+   * Returns a gRPC context {@link Key} that can be used to set a List of authorized tenant IDs in
+   * an interceptor. Note that, as per the gRPC documentation, it's perfectly fine to block in a
+   * call and/or listener, which may greatly simplify the usage of the API in your code.
+   *
+   * <p>If you use the API asynchronously, there are a few gotchas to remember:
+   *
+   * <ul>
+   *   <li>if your interceptor is loaded via an external JAR, and it uses directly or indirectly the
+   *       {@link Thread#getContextClassLoader()} to load classes, you will need to make sure to set
+   *       the appropriate context class loader in your callbacks, otherwise you may run into {@link
+   *       ClassNotFoundException} errors
+   *   <li>your callback may be executed on a different thread than the initial call, so you will
+   *       have to deal with thread safety; using a {@link io.grpc.internal.SerializingExecutor} or
+   *       similar may help
+   *   <li>since your callback may be executed on a different thread, the {@link Context#current()}
+   *       maybe different; if you want to use the same original context, you will need to close on
+   *       it in your callback, or extract what you need from it beforehand and close on that
+   * </ul>
+   *
+   * <p>Example usage:
+   *
+   * <pre>{@code
+   * final List<String> authorizedTenantIds = List.of("tenant-1", "tenant-2");
+   * final Context context = Context.current();
+   * context.withValue(InterceptorUtil.getAuthorizedTenantsKey(), authorizedTenantIds);
+   * }</pre>
+   *
+   * @return the context key associated with the current List of authorized tenant IDs
+   */
+  public static Key<List<String>> getAuthorizedTenantsKey() {
+    return AUTHORIZED_TENANTS_KEY;
+  }
+
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -96,5 +96,4 @@ public final class InterceptorUtil {
   public static Key<List<String>> getAuthorizedTenantsKey() {
     return AUTHORIZED_TENANTS_KEY;
   }
-
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/InterceptorUtil.java
@@ -64,9 +64,9 @@ public final class InterceptorUtil {
   }
 
   /**
-   * Returns a gRPC context {@link Key} that can be used to set a List of authorized tenant IDs in
-   * an interceptor. Note that, as per the gRPC documentation, it's perfectly fine to block in a
-   * call and/or listener, which may greatly simplify the usage of the API in your code.
+   * Returns a gRPC context {@link Key} that can be used to set a {@link List<String>} of authorized
+   * tenant IDs in an interceptor. Note that, as per the gRPC documentation, it's perfectly fine to
+   * block in a call and/or listener, which may greatly simplify the usage of the API in your code.
    *
    * <p>If you use the API asynchronously, there are a few gotchas to remember:
    *
@@ -95,5 +95,17 @@ public final class InterceptorUtil {
    */
   public static Key<List<String>> getAuthorizedTenantsKey() {
     return AUTHORIZED_TENANTS_KEY;
+  }
+
+  /**
+   * A helper method to set a {@link List<String>} of authorized tenant IDs on the {@code
+   * AUTHORIZED_TENANTS_KEY} gRPC Context key.
+   *
+   * @param authorizedTenants - a List of Strings that specify the authorized tenants for the gRPC
+   *     request
+   * @return the current {@link Context}
+   */
+  public static Context setAuthorizedTenants(final List<String> authorizedTenants) {
+    return Context.current().withValue(getAuthorizedTenantsKey(), authorizedTenants);
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -14,7 +14,6 @@ import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.zeebe.gateway.impl.configuration.IdentityCfg;
 import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
 import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
-import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -98,8 +97,7 @@ public final class IdentityInterceptor implements ServerInterceptor {
     try {
       final List<String> authorizedTenants =
           identity.tenants().forToken(token).stream().map(Tenant::getTenantId).toList();
-      final var context =
-          Context.current().withValue(InterceptorUtil.getAuthorizedTenantsKey(), authorizedTenants);
+      final var context = InterceptorUtil.setAuthorizedTenants(authorizedTenants);
       return Contexts.interceptCall(context, call, headers, next);
 
     } catch (final RuntimeException e) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptor.java
@@ -13,6 +13,7 @@ import io.camunda.identity.sdk.authentication.exception.TokenVerificationExcepti
 import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.zeebe.gateway.impl.configuration.IdentityCfg;
 import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.grpc.Context;
 import io.grpc.Contexts;
 import io.grpc.Metadata;
@@ -25,8 +26,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class IdentityInterceptor implements ServerInterceptor {
-  public static final Context.Key<List<String>> AUTHORIZED_TENANTS_KEY =
-      Context.key("io.camunda.zeebe:authorized_tenants");
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IdentityInterceptor.class);
   private static final Metadata.Key<String> AUTH_KEY =
@@ -99,7 +98,8 @@ public final class IdentityInterceptor implements ServerInterceptor {
     try {
       final List<String> authorizedTenants =
           identity.tenants().forToken(token).stream().map(Tenant::getTenantId).toList();
-      final var context = Context.current().withValue(AUTHORIZED_TENANTS_KEY, authorizedTenants);
+      final var context =
+          Context.current().withValue(InterceptorUtil.getAuthorizedTenantsKey(), authorizedTenants);
       return Contexts.interceptCall(context, call, headers, next);
 
     } catch (final RuntimeException e) {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTenantTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTenantTest.java
@@ -15,7 +15,6 @@ import io.camunda.zeebe.gateway.cmd.InvalidTenantRequestException;
 import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.logging.RecordingAppender;
-import io.grpc.Context;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import java.util.List;
@@ -96,9 +95,7 @@ public class GrpcErrorMapperTenantTest {
         multiTenancyEnabled
             ? List.of(validTenantId)
             : List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    Context.current()
-        .withValue(InterceptorUtil.getAuthorizedTenantsKey(), authorizedTenants)
-        .attach();
+    InterceptorUtil.setAuthorizedTenants(authorizedTenants).attach();
 
     // when
     RequestMapper.setMultiTenancyEnabled(multiTenancyEnabled);
@@ -146,9 +143,7 @@ public class GrpcErrorMapperTenantTest {
     final String requestName = "ActivateJobs";
     final List<String> authorizedTenants =
         multiTenancyEnabled ? validTenantIds : List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-    Context.current()
-        .withValue(InterceptorUtil.getAuthorizedTenantsKey(), authorizedTenants)
-        .attach();
+    InterceptorUtil.setAuthorizedTenants(authorizedTenants).attach();
 
     // when
     RequestMapper.setMultiTenancyEnabled(multiTenancyEnabled);

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTenantTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTenantTest.java
@@ -12,7 +12,7 @@ import static org.assertj.core.api.Assertions.fail;
 
 import io.camunda.zeebe.gateway.RequestMapper;
 import io.camunda.zeebe.gateway.cmd.InvalidTenantRequestException;
-import io.camunda.zeebe.gateway.interceptors.impl.IdentityInterceptor;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.logging.RecordingAppender;
 import io.grpc.Context;
@@ -97,7 +97,7 @@ public class GrpcErrorMapperTenantTest {
             ? List.of(validTenantId)
             : List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     Context.current()
-        .withValue(IdentityInterceptor.AUTHORIZED_TENANTS_KEY, authorizedTenants)
+        .withValue(InterceptorUtil.getAuthorizedTenantsKey(), authorizedTenants)
         .attach();
 
     // when
@@ -147,7 +147,7 @@ public class GrpcErrorMapperTenantTest {
     final List<String> authorizedTenants =
         multiTenancyEnabled ? validTenantIds : List.of(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
     Context.current()
-        .withValue(IdentityInterceptor.AUTHORIZED_TENANTS_KEY, authorizedTenants)
+        .withValue(InterceptorUtil.getAuthorizedTenantsKey(), authorizedTenants)
         .attach();
 
     // when

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/InterceptorIT.java
@@ -24,12 +24,15 @@ import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.gateway.impl.stream.JobStreamClientImpl;
 import io.camunda.zeebe.gateway.interceptors.util.ContextInspectingInterceptor;
 import io.camunda.zeebe.gateway.interceptors.util.TestInterceptor;
+import io.camunda.zeebe.gateway.interceptors.util.TestTenantProvidingInterceptor;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.grpc.StatusRuntimeException;
 import io.netty.util.NetUtil;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import org.agrona.CloseHelper;
@@ -152,6 +155,113 @@ final class InterceptorIT {
 
     // then
     assertThat(ContextInspectingInterceptor.CONTEXT_QUERY_API.get()).isNotNull();
+  }
+
+  @Test
+  void shouldSetAuthorizedTenantsViaContext() {
+    // given
+    final var tenantInterceptorCfg = new InterceptorCfg();
+    tenantInterceptorCfg.setId("tenantProviderTest");
+    tenantInterceptorCfg.setClassName(TestTenantProvidingInterceptor.class.getName());
+    final var contextInspectingInterceptorCfg = new InterceptorCfg();
+    contextInspectingInterceptorCfg.setId("test");
+    contextInspectingInterceptorCfg.setClassName(ContextInspectingInterceptor.class.getName());
+
+    config.getInterceptors().add(0, tenantInterceptorCfg);
+    config.getInterceptors().add(1, contextInspectingInterceptorCfg);
+
+    // when
+    gateway.start().join();
+    try (final var client = createZeebeClient()) {
+      try {
+        client.newTopologyRequest().send().join();
+      } catch (final ClientStatusException ignored) {
+        // ignore any errors, we just really care that the interceptor was called
+      }
+    }
+
+    // then
+    assertThat(ContextInspectingInterceptor.CONTEXT_TENANT_IDS.get()).isNotNull();
+    assertThat(ContextInspectingInterceptor.CONTEXT_TENANT_IDS.get())
+        .containsExactlyInAnyOrderElementsOf(List.of("tenant-1"));
+  }
+
+  @Test
+  void shouldUseLastValueOfAuthorizedTenantsSetViaContext() {
+    // given
+    final var tenantInterceptorCfg = new InterceptorCfg();
+    tenantInterceptorCfg.setId("tenantProviderTest");
+    tenantInterceptorCfg.setClassName(TestTenantProvidingInterceptor.class.getName());
+    final var secondTenantInterceptorCfg = new InterceptorCfg();
+    secondTenantInterceptorCfg.setId("secondTenantProviderTest");
+    secondTenantInterceptorCfg.setClassName(TestTenantProvidingInterceptor.class.getName());
+    final var contextInspectingInterceptorCfg = new InterceptorCfg();
+    contextInspectingInterceptorCfg.setId("test");
+    contextInspectingInterceptorCfg.setClassName(ContextInspectingInterceptor.class.getName());
+
+    config.getInterceptors().addFirst(tenantInterceptorCfg);
+    config.getInterceptors().add(secondTenantInterceptorCfg);
+    config.getInterceptors().addLast(contextInspectingInterceptorCfg);
+
+    // reset calls from previous tests
+    TestTenantProvidingInterceptor.resetInterceptorsCalls();
+
+    // when
+    gateway.start().join();
+    try (final var client = createZeebeClient()) {
+      try {
+        client.newTopologyRequest().send().join();
+      } catch (final ClientStatusException ignored) {
+        // ignore any errors, we just really care that the interceptor was called
+      }
+    }
+
+    // then
+    assertThat(ContextInspectingInterceptor.CONTEXT_TENANT_IDS.get()).isNotNull();
+    assertThat(ContextInspectingInterceptor.CONTEXT_TENANT_IDS.get())
+        .containsExactlyInAnyOrderElementsOf(List.of("tenant-2"));
+  }
+
+  @Test
+  void shouldNotUseAuthorizedTenantsSetViaContextWhenMultiTenancyIsDisabled() {
+    // given
+    final var tenantInterceptorCfg = new InterceptorCfg();
+    tenantInterceptorCfg.setId("tenantProviderTest");
+    tenantInterceptorCfg.setClassName(TestTenantProvidingInterceptor.class.getName());
+    final var contextInspectingInterceptorCfg = new InterceptorCfg();
+    contextInspectingInterceptorCfg.setId("test");
+    contextInspectingInterceptorCfg.setClassName(ContextInspectingInterceptor.class.getName());
+
+    config.getInterceptors().addFirst(tenantInterceptorCfg);
+    config.getInterceptors().addLast(contextInspectingInterceptorCfg);
+    config.getMultiTenancy().setEnabled(false);
+
+    // reset calls from previous tests
+    TestTenantProvidingInterceptor.resetInterceptorsCalls();
+
+    // when
+    gateway.start().join();
+    try (final var client = createZeebeClient()) {
+      try {
+        // TODO: capture Broker request to assert that tenant id is set to <default>
+        final DeploymentEvent response =
+            client
+                .newDeployResourceCommand()
+                .addResourceFromClasspath("processes/one-task-process.bpmn")
+                .send()
+                .join();
+
+        // then
+        // the tenant authorizations list is still set on the gRPC context
+        assertThat(ContextInspectingInterceptor.CONTEXT_TENANT_IDS.get()).isNotNull();
+        assertThat(ContextInspectingInterceptor.CONTEXT_TENANT_IDS.get())
+            .containsExactlyInAnyOrderElementsOf(List.of("tenant-1"));
+        // but the tenant authorizations list is ignored, and the <default> tenant is used
+        assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+      } catch (final ClientStatusException ignored) {
+        // ignore any errors, we just really care that the interceptor was called
+      }
+    }
   }
 
   private ZeebeClient createZeebeClient() {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/CustomTenantProvidingInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/CustomTenantProvidingInterceptorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.camunda.zeebe.gateway.interceptors.util.TestTenantProvidingInterceptor;
+import io.grpc.Context;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import io.grpc.internal.NoopServerCall;
+import org.assertj.core.api.ListAssert;
+import org.junit.jupiter.api.Test;
+
+public class CustomTenantProvidingInterceptorTest {
+
+  @Test
+  public void addsAuthorizedTenantsToContext() {
+    // given
+    final var interceptor = new TestTenantProvidingInterceptor();
+
+    // when / then
+    interceptor.interceptCall(
+        new NoopServerCall<>() {},
+        new Metadata(),
+        (call, headers) -> {
+          // then
+          assertAuthorizedTenants()
+              .describedAs("Expect that the authorized tenants is stored in the current Context")
+              .contains("tenant-1");
+          call.close(Status.OK, headers);
+          return null;
+        });
+  }
+
+  private static ListAssert<String> assertAuthorizedTenants() {
+    try {
+      return assertThat(
+          Context.current().call(() -> InterceptorUtil.getAuthorizedTenantsKey().get()));
+    } catch (final Exception e) {
+      throw new RuntimeException("Unable to retrieve authorized tenants from context", e);
+    }
+  }
+}

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
@@ -18,6 +18,7 @@ import io.camunda.identity.sdk.Identity;
 import io.camunda.identity.sdk.authentication.exception.TokenVerificationException;
 import io.camunda.identity.sdk.tenants.dto.Tenant;
 import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
@@ -205,7 +206,7 @@ public class IdentityInterceptorTest {
   private static ListAssert<String> assertAuthorizedTenants() {
     try {
       return assertThat(
-          Context.current().call(() -> IdentityInterceptor.AUTHORIZED_TENANTS_KEY.get()));
+          Context.current().call(() -> InterceptorUtil.getAuthorizedTenantsKey().get()));
     } catch (final Exception e) {
       throw new RuntimeException("Unable to retrieve authorized tenants from context", e);
     }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/ContextInspectingInterceptor.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/ContextInspectingInterceptor.java
@@ -14,10 +14,12 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
 public final class ContextInspectingInterceptor implements ServerInterceptor {
   public static final AtomicReference<QueryApi> CONTEXT_QUERY_API = new AtomicReference<>();
+  public static final AtomicReference<List<String>> CONTEXT_TENANT_IDS = new AtomicReference<>();
 
   @Override
   public <ReqT, RespT> Listener<ReqT> interceptCall(
@@ -25,6 +27,7 @@ public final class ContextInspectingInterceptor implements ServerInterceptor {
       final Metadata headers,
       final ServerCallHandler<ReqT, RespT> next) {
     CONTEXT_QUERY_API.set(InterceptorUtil.getQueryApiKey().get());
+    CONTEXT_TENANT_IDS.set(InterceptorUtil.getAuthorizedTenantsKey().get());
     return next.startCall(call, headers);
   }
 }

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/TestTenantProvidingInterceptor.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/util/TestTenantProvidingInterceptor.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.util;
+
+import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
+import io.grpc.Contexts;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestTenantProvidingInterceptor implements ServerInterceptor {
+
+  public static final AtomicInteger TENANT_CALLS = new AtomicInteger(0);
+
+  @Override
+  public <ReqT, RespT> Listener<ReqT> interceptCall(
+      final ServerCall<ReqT, RespT> call,
+      final Metadata headers,
+      final ServerCallHandler<ReqT, RespT> next) {
+    try {
+      final var context = InterceptorUtil.setAuthorizedTenants(getAuthorizedTenants());
+      return Contexts.interceptCall(context, call, headers, next);
+    } catch (final Exception e) {
+      // re-throw unexpected exception
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static List<String> getAuthorizedTenants() {
+    return List.of("tenant-" + TENANT_CALLS.incrementAndGet());
+  }
+
+  public static void resetInterceptorsCalls() {
+    TENANT_CALLS.set(0);
+  }
+}


### PR DESCRIPTION
## Description

Enable users to use their own tenant provider. This should be made available using [custom interceptors](https://docs.camunda.io/docs/next/self-managed/zeebe-deployment/zeebe-gateway/interceptors/) by exposing the `AUTHORIZED_TENANTS_KEY` gRPC Context key through the `InterceptorUtil` class.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14285
closes #15677

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
