### PR TITLE
Ignore ElasticSearch updates that also come from "co.elastic".

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -38,6 +38,14 @@
       "enabled": false
     },
     {
+      "matchPackagePrefixes": ["co.elastic"],
+      "matchUpdateTypes": [
+        "minor",
+        "major"
+      ],
+      "enabled": false
+    },
+    {
       "matchManagers": [
         "dockerfile"
       ],


### PR DESCRIPTION
Ignore ElasticSearch updates that also come from "co.elastic".
Previously we only had minor and major updates being ignored for org.elasticsearch.
This caused updates of elastic search such as: https://github.com/camunda/zeebe/pull/15542