### PR TITLE
Invoke compensation handler attached to a compensation boundary event

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import org.agrona.DirectBuffer;
 
 /** Process instance-related data of the element that is executed. */
@@ -46,6 +47,8 @@ public interface BpmnElementContext {
   ProcessInstanceIntent getIntent();
 
   String getTenantId();
+
+  BpmnEventType getBpmnEventType();
 
   BpmnElementContext copy(
       long elementInstanceKey, ProcessInstanceRecord recordValue, ProcessInstanceIntent intent);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementContextImpl.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import org.agrona.DirectBuffer;
 
 public final class BpmnElementContextImpl implements BpmnElementContext {
@@ -83,6 +84,11 @@ public final class BpmnElementContextImpl implements BpmnElementContext {
   @Override
   public String getTenantId() {
     return recordValue.getTenantId();
+  }
+
+  @Override
+  public BpmnEventType getBpmnEventType() {
+    return recordValue.getBpmnEventType();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -53,4 +53,6 @@ public interface BpmnBehaviors {
   BpmnJobActivationBehavior jobActivationBehavior();
 
   BpmnUserTaskBehavior userTaskBehavior();
+
+  BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -46,6 +46,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final BpmnSignalBehavior signalBehavior;
   private final BpmnUserTaskBehavior userTaskBehavior;
+  private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
 
   public BpmnBehaviorsImpl(
       final MutableProcessingState processingState,
@@ -169,6 +170,9 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             jobActivationBehavior,
             jobMetrics,
             userTaskBehavior);
+
+    compensationSubscriptionBehaviour =
+        new BpmnCompensationSubscriptionBehaviour(processingState, writers);
   }
 
   @Override
@@ -264,5 +268,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public BpmnUserTaskBehavior userTaskBehavior() {
     return userTaskBehavior;
+  }
+
+  @Override
+  public BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour() {
+    return compensationSubscriptionBehaviour;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBoundaryEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.CompensationSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.Set;
+import org.agrona.DirectBuffer;
+
+public class BpmnCompensationSubscriptionBehaviour {
+
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final CompensationSubscriptionState compensationSubscriptionState;
+  private final ProcessState processState;
+  private final TypedCommandWriter commandWriter;
+
+  public BpmnCompensationSubscriptionBehaviour(
+      final MutableProcessingState processingState, final Writers writers) {
+    keyGenerator = processingState.getKeyGenerator();
+    stateWriter = writers.state();
+    compensationSubscriptionState = processingState.getCompensationSubscriptionState();
+    processState = processingState.getProcessState();
+    commandWriter = writers.command();
+  }
+
+  public Set<String> getCompletedActivitiesToCompensate(final BpmnElementContext context) {
+    return compensationSubscriptionState.findSubscriptionsByProcessInstanceKey(
+        context.getTenantId(), context.getProcessInstanceKey());
+  }
+
+  public void activateCompensationHandler(
+      final String elementId, final BpmnElementContext context) {
+
+    // find the boundary event
+    final var activityToCompensate =
+        processState.getFlowElement(
+            context.getProcessDefinitionKey(),
+            context.getTenantId(),
+            BufferUtil.wrapString(elementId),
+            ExecutableActivity.class);
+
+    final ExecutableBoundaryEvent boundaryEvent =
+        activityToCompensate.getBoundaryEvents().stream()
+            .filter(b -> b.getEventType() == BpmnEventType.COMPENSATION)
+            .findFirst()
+            .orElseThrow();
+
+    activateAndCompleteCompensationBoundaryEvent(context, boundaryEvent);
+
+    // activate the compensation handler
+    final ExecutableActivity compensationHandler =
+        boundaryEvent.getCompensation().getCompensationHandler();
+    final DirectBuffer compensationHandlerId = compensationHandler.getId();
+
+    final ProcessInstanceRecord compensationHandlerRecord = new ProcessInstanceRecord();
+    compensationHandlerRecord.wrap(context.getRecordValue());
+    compensationHandlerRecord.setBpmnElementType(compensationHandler.getElementType());
+    compensationHandlerRecord.setElementId(compensationHandlerId);
+
+    commandWriter.appendNewCommand(
+        ProcessInstanceIntent.ACTIVATE_ELEMENT, compensationHandlerRecord);
+  }
+
+  public void createCompensationSubscription(
+      final ExecutableFlowNode element, final BpmnElementContext context) {
+    if (hasCompensationBoundaryEvent(element)) {
+      final var key = keyGenerator.nextKey();
+      final var compensation =
+          new CompensationSubscriptionRecord()
+              .setTenantId(context.getTenantId())
+              .setProcessInstanceKey(context.getProcessInstanceKey())
+              .setProcessDefinitionKey(context.getProcessDefinitionKey())
+              .setCompensableActivityId(BufferUtil.bufferAsString(context.getElementId()))
+              .setCompensableActivityScopeId(context.getFlowScopeKey());
+      stateWriter.appendFollowUpEvent(key, CompensationSubscriptionIntent.CREATED, compensation);
+    }
+  }
+
+  public void updateCompensationSubscription(final BpmnElementContext context) {
+    if (isCompensationThrowEvent(context)) {
+      final var key = keyGenerator.nextKey();
+      final var compensation =
+          new CompensationSubscriptionRecord()
+              .setTenantId(context.getTenantId())
+              .setProcessInstanceKey(context.getProcessInstanceKey())
+              .setProcessDefinitionKey(context.getProcessDefinitionKey())
+              .setThrowEventId(BufferUtil.bufferAsString(context.getElementId()))
+              .setThrowEventInstanceKey(context.getElementInstanceKey());
+      stateWriter.appendFollowUpEvent(key, CompensationSubscriptionIntent.TRIGGERED, compensation);
+    }
+  }
+
+  private boolean hasCompensationBoundaryEvent(final ExecutableFlowNode element) {
+    if (!(element instanceof ExecutableActivity)) {
+      return false;
+    }
+    final var compensationBoundaryEvent =
+        ((ExecutableActivity) element)
+            .getBoundaryEvents().stream()
+                .filter(boundaryEvent -> boundaryEvent.getEventType() == BpmnEventType.COMPENSATION)
+                .findFirst();
+    return compensationBoundaryEvent.isPresent();
+  }
+
+  private boolean isCompensationThrowEvent(final BpmnElementContext context) {
+    return BpmnEventType.COMPENSATION.equals(context.getBpmnEventType())
+        && (BpmnElementType.INTERMEDIATE_THROW_EVENT.equals(context.getBpmnElementType())
+            || BpmnElementType.END_EVENT.equals(context.getBpmnElementType()));
+  }
+
+  private void activateAndCompleteCompensationBoundaryEvent(
+      final BpmnElementContext context, final ExecutableBoundaryEvent boundaryEvent) {
+    final long boundaryEventKey = keyGenerator.nextKey();
+
+    final ProcessInstanceRecord boundaryEventRecord = new ProcessInstanceRecord();
+    boundaryEventRecord.wrap(context.getRecordValue());
+    boundaryEventRecord.setBpmnElementType(BpmnElementType.BOUNDARY_EVENT);
+    boundaryEventRecord.setElementId(boundaryEvent.getId());
+
+    stateWriter.appendFollowUpEvent(
+        boundaryEventKey, ProcessInstanceIntent.ELEMENT_ACTIVATING, boundaryEventRecord);
+    stateWriter.appendFollowUpEvent(
+        boundaryEventKey, ProcessInstanceIntent.ELEMENT_ACTIVATED, boundaryEventRecord);
+    stateWriter.appendFollowUpEvent(
+        boundaryEventKey, ProcessInstanceIntent.ELEMENT_COMPLETING, boundaryEventRecord);
+    stateWriter.appendFollowUpEvent(
+        boundaryEventKey, ProcessInstanceIntent.ELEMENT_COMPLETED, boundaryEventRecord);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnEventPublicationBehavior.java
@@ -13,16 +13,24 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBoundaryEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer;
 import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTuple;
+import io.camunda.zeebe.engine.state.immutable.CompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.escalation.EscalationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
@@ -36,6 +44,9 @@ public final class BpmnEventPublicationBehavior {
   private final CatchEventAnalyzer catchEventAnalyzer;
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
+  private final CompensationSubscriptionState compensationSubscriptionState;
+  private final ProcessState processState;
+  private final TypedCommandWriter commandWriter;
 
   public BpmnEventPublicationBehavior(
       final ProcessingState processingState,
@@ -56,6 +67,9 @@ public final class BpmnEventPublicationBehavior {
         new CatchEventAnalyzer(processingState.getProcessState(), elementInstanceState);
     stateWriter = writers.state();
     this.keyGenerator = keyGenerator;
+    compensationSubscriptionState = processingState.getCompensationSubscriptionState();
+    processState = processingState.getProcessState();
+    commandWriter = writers.command();
   }
 
   /**
@@ -179,5 +193,36 @@ public final class BpmnEventPublicationBehavior {
     }
 
     return canBeCompleted;
+  }
+
+  public void activateCompensationHandler(
+      final String elementId, final BpmnElementContext context) {
+
+    // find the boundary event
+    final var activityToCompensate =
+        processState.getFlowElement(
+            context.getProcessDefinitionKey(),
+            context.getTenantId(),
+            BufferUtil.wrapString(elementId),
+            ExecutableActivity.class);
+
+    final ExecutableBoundaryEvent boundaryEvent =
+        activityToCompensate.getBoundaryEvents().stream()
+            .filter(b -> b.getEventType() == BpmnEventType.COMPENSATION)
+            .findFirst()
+            .orElseThrow();
+
+    // activate the compensation handler
+    final ExecutableActivity compensationHandler =
+        boundaryEvent.getCompensation().getCompensationHandler();
+    final DirectBuffer compensationHandlerId = compensationHandler.getId();
+
+    final ProcessInstanceRecord compensationHandlerRecord = new ProcessInstanceRecord();
+    compensationHandlerRecord.wrap(context.getRecordValue());
+    compensationHandlerRecord.setBpmnElementType(compensationHandler.getElementType());
+    compensationHandlerRecord.setElementId(compensationHandlerId);
+
+    commandWriter.appendNewCommand(
+        ProcessInstanceIntent.ACTIVATE_ELEMENT, compensationHandlerRecord);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.engine.state.immutable.CompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -22,7 +21,6 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class BpmnStateBehavior {
@@ -31,7 +29,6 @@ public final class BpmnStateBehavior {
   private final VariableState variablesState;
   private final JobState jobState;
   private final ProcessState processState;
-  private final CompensationSubscriptionState compensationSubscriptionState;
   private final VariableBehavior variableBehavior;
 
   public BpmnStateBehavior(
@@ -42,7 +39,6 @@ public final class BpmnStateBehavior {
     elementInstanceState = processingState.getElementInstanceState();
     variablesState = processingState.getVariableState();
     jobState = processingState.getJobState();
-    compensationSubscriptionState = processingState.getCompensationSubscriptionState();
   }
 
   public ElementInstance getElementInstance(final BpmnElementContext context) {
@@ -238,10 +234,5 @@ public final class BpmnStateBehavior {
   public int getNumberOfTakenSequenceFlows(
       final long flowScopeKey, final DirectBuffer gatewayElementId) {
     return elementInstanceState.getNumberOfTakenSequenceFlows(flowScopeKey, gatewayElementId);
-  }
-
-  public Set<String> getCompletedActivitiesToCompensate(final BpmnElementContext context) {
-    return compensationSubscriptionState.getCompletedActivitiesToCompensate(
-        context.getTenantId(), context.getProcessInstanceKey());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.engine.state.immutable.CompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class BpmnStateBehavior {
@@ -29,6 +31,7 @@ public final class BpmnStateBehavior {
   private final VariableState variablesState;
   private final JobState jobState;
   private final ProcessState processState;
+  private final CompensationSubscriptionState compensationSubscriptionState;
   private final VariableBehavior variableBehavior;
 
   public BpmnStateBehavior(
@@ -39,6 +42,7 @@ public final class BpmnStateBehavior {
     elementInstanceState = processingState.getElementInstanceState();
     variablesState = processingState.getVariableState();
     jobState = processingState.getJobState();
+    compensationSubscriptionState = processingState.getCompensationSubscriptionState();
   }
 
   public ElementInstance getElementInstance(final BpmnElementContext context) {
@@ -234,5 +238,10 @@ public final class BpmnStateBehavior {
   public int getNumberOfTakenSequenceFlows(
       final long flowScopeKey, final DirectBuffer gatewayElementId) {
     return elementInstanceState.getNumberOfTakenSequenceFlows(flowScopeKey, gatewayElementId);
+  }
+
+  public Set<String> getCompletedActivitiesToCompensate(final BpmnElementContext context) {
+    return compensationSubscriptionState.getCompletedActivitiesToCompensate(
+        context.getTenantId(), context.getProcessInstanceKey());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceLifecycle;
 import io.camunda.zeebe.engine.processing.common.Failure;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
@@ -22,14 +23,17 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
 import java.util.function.Function;
 
@@ -180,6 +184,9 @@ public final class BpmnStateTransitionBehavior {
     }
 
     final var completed = transitionTo(context, ProcessInstanceIntent.ELEMENT_COMPLETED);
+    if (hasCompensationBoundaryEvent(element)) {
+      createCompensationSubscription(context);
+    }
     metrics.elementInstanceCompleted(context, element.getEventType());
 
     if (endOfExecutionPath) {
@@ -528,6 +535,30 @@ public final class BpmnStateTransitionBehavior {
             child ->
                 terminateElement(context.copy(child.getKey(), child.getValue(), child.getState())),
             () -> containerProcessor.onChildTerminated(element, context, null));
+  }
+
+  private boolean hasCompensationBoundaryEvent(final ExecutableFlowNode element) {
+    if (!(element instanceof ExecutableActivity)) {
+      return false;
+    }
+    final var compensationBoundaryEvent =
+        ((ExecutableActivity) element)
+            .getBoundaryEvents().stream()
+                .filter(boundaryEvent -> boundaryEvent.getEventType() == BpmnEventType.COMPENSATION)
+                .findFirst();
+    return compensationBoundaryEvent.isPresent();
+  }
+
+  private void createCompensationSubscription(final BpmnElementContext context) {
+    final var key = keyGenerator.nextKey();
+    final var compensation =
+        new CompensationSubscriptionRecord()
+            .setTenantId(context.getTenantId())
+            .setProcessInstanceKey(context.getProcessInstanceKey())
+            .setProcessDefinitionKey(context.getProcessDefinitionKey())
+            .setCompensableActivityId(BufferUtil.bufferAsString(context.getElementId()))
+            .setCompensableActivityScopeId(context.getFlowScopeKey());
+    stateWriter.appendFollowUpEvent(key, CompensationSubscriptionIntent.CREATED, compensation);
   }
 
   private static final class ChildTerminationStackOverflowException extends RuntimeException {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -328,7 +328,6 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
 
     @Override
     public void onActivate(final ExecutableEndEvent element, final BpmnElementContext activating) {
-      compensationSubscriptionBehaviour.updateCompensationSubscription(activating);
       final var activated =
           stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
       // check for activities that are completed and have compensation handlers
@@ -342,6 +341,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
         // activate the compensation handler
         completedActivities.forEach(
             activity -> {
+              compensationSubscriptionBehaviour.triggerCompensationSubscription(activating);
               compensationSubscriptionBehaviour.activateCompensationHandler(activity, activated);
             });
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
+import java.util.Set;
 import org.agrona.DirectBuffer;
 
 public final class EndEventProcessor implements BpmnElementProcessor<ExecutableEndEvent> {
@@ -326,8 +327,20 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
     public void onActivate(final ExecutableEndEvent element, final BpmnElementContext activating) {
       final var activated =
           stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
-      final var completing = stateTransitionBehavior.transitionToCompleting(activated);
-      onComplete(element, completing);
+      // check for activities that are completed and have compensation handlers
+      final Set<String> completedActivities =
+          stateBehavior.getCompletedActivitiesToCompensate(activated);
+
+      if (completedActivities.isEmpty()) {
+        final var completing = stateTransitionBehavior.transitionToCompleting(activated);
+        onComplete(element, completing);
+      } else {
+        // activate the compensation handler
+        completedActivities.forEach(
+            activity -> {
+              eventPublicationBehavior.activateCompensationHandler(activity, activated);
+            });
+      }
     }
 
     @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -315,7 +315,6 @@ public class IntermediateThrowEventProcessor
     @Override
     public void onActivate(
         final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating) {
-      compensationSubscriptionBehaviour.updateCompensationSubscription(activating);
       final BpmnElementContext activated =
           stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
 
@@ -329,6 +328,7 @@ public class IntermediateThrowEventProcessor
         // activate the compensation handler
         completedActivities.forEach(
             activity -> {
+              compensationSubscriptionBehaviour.triggerCompensationSubscription(activating);
               compensationSubscriptionBehaviour.activateCompensationHandler(activity, activated);
             });
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn.task;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnCompensationSubscriptionBehaviour;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
@@ -30,6 +31,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnJobBehavior jobBehavior;
   private final BpmnStateBehavior stateBehavior;
+  private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
 
   public JobWorkerTaskProcessor(
       final BpmnBehaviors behaviors, final BpmnStateTransitionBehavior stateTransitionBehavior) {
@@ -39,6 +41,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
     variableMappingBehavior = behaviors.variableMappingBehavior();
     jobBehavior = behaviors.jobBehavior();
     stateBehavior = behaviors.stateBehavior();
+    compensationSubscriptionBehaviour = behaviors.compensationSubscriptionBehaviour();
   }
 
   @Override
@@ -67,6 +70,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
         .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
+              compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
               return stateTransitionBehavior.transitionToCompleted(element, context);
             })
         .ifRightOrLeft(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn.task;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnCompensationSubscriptionBehaviour;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
@@ -18,12 +19,14 @@ public class UndefinedTaskProcessor implements BpmnElementProcessor<ExecutableAc
 
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final BpmnIncidentBehavior incidentBehavior;
+  private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
 
   public UndefinedTaskProcessor(
       final BpmnBehaviors bpmnBehaviors,
       final BpmnStateTransitionBehavior stateTransitionBehavior) {
     this.stateTransitionBehavior = stateTransitionBehavior;
     incidentBehavior = bpmnBehaviors.incidentBehavior();
+    compensationSubscriptionBehaviour = bpmnBehaviors.compensationSubscriptionBehaviour();
   }
 
   @Override
@@ -40,6 +43,7 @@ public class UndefinedTaskProcessor implements BpmnElementProcessor<ExecutableAc
 
   @Override
   public void onComplete(final ExecutableActivity element, final BpmnElementContext context) {
+    compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
     stateTransitionBehavior
         .transitionToCompleted(element, context)
         .ifRightOrLeft(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.bpmn.task;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnCompensationSubscriptionBehaviour;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnEventSubscriptionBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
@@ -26,6 +27,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
   private final BpmnEventSubscriptionBehavior eventSubscriptionBehavior;
   private final BpmnUserTaskBehavior userTaskBehavior;
   private final BpmnStateBehavior stateBehavior;
+  private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
 
   public UserTaskProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -37,6 +39,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
     variableMappingBehavior = bpmnBehaviors.variableMappingBehavior();
     userTaskBehavior = bpmnBehaviors.userTaskBehavior();
     stateBehavior = bpmnBehaviors.stateBehavior();
+    compensationSubscriptionBehaviour = bpmnBehaviors.compensationSubscriptionBehaviour();
   }
 
   @Override
@@ -82,6 +85,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
         .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
+              compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
               return stateTransitionBehavior.transitionToCompleted(element, context);
             })
         .ifRightOrLeft(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCatchEventElement.java
@@ -25,6 +25,7 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
   private ExecutableError error;
   private ExecutableEscalation escalation;
   private ExecutableSignal signal;
+  private ExecutableCompensation compensation;
   private boolean interrupting;
   private BiFunction<ExpressionProcessor, Long, Either<Failure, Timer>> timerFactory;
 
@@ -119,10 +120,6 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
     this.signal = signal;
   }
 
-  public void setCompensation(final boolean isCompensation) {
-    this.isCompensation = isCompensation;
-  }
-
   public void setLink(final boolean isLink) {
     this.isLink = isLink;
   }
@@ -156,5 +153,17 @@ public class ExecutableCatchEventElement extends ExecutableFlowNode
 
   public void setConnectedToEventBasedGateway(final boolean connectedToEventBasedGateway) {
     isConnectedToEventBasedGateway = connectedToEventBasedGateway;
+  }
+
+  public ExecutableCompensation getCompensation() {
+    return compensation;
+  }
+
+  public void setCompensation(final boolean isCompensation) {
+    this.isCompensation = isCompensation;
+  }
+
+  public void setCompensation(final ExecutableCompensation compensation) {
+    this.compensation = compensation;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCompensation.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCompensation.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+public class ExecutableCompensation extends AbstractFlowElement {
+
+  private ExecutableActivity compensationHandler;
+
+  public ExecutableCompensation(final String id) {
+    super(id);
+  }
+
+  public ExecutableActivity getCompensationHandler() {
+    return compensationHandler;
+  }
+
+  public void setCompensationHandler(final ExecutableActivity compensationHandler) {
+    this.compensationHandler = compensationHandler;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.state.compensation.DbCompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
 import io.camunda.zeebe.engine.state.deployment.DbFormState;
@@ -32,6 +33,7 @@ import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
 import io.camunda.zeebe.engine.state.mutable.MutableDistributionState;
@@ -85,6 +87,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableSignalSubscriptionState signalSubscriptionState;
   private final MutableDistributionState distributionState;
   private final MutableUserTaskState userTaskState;
+  private final MutableCompensationSubscriptionState compensationSubscriptionState;
   private final int partitionId;
 
   public ProcessingDbState(
@@ -122,10 +125,10 @@ public class ProcessingDbState implements MutableProcessingState {
     formState = new DbFormState(zeebeDb, transactionContext);
     signalSubscriptionState = new DbSignalSubscriptionState(zeebeDb, transactionContext);
     distributionState = new DbDistributionState(zeebeDb, transactionContext);
-
     mutableMigrationState = new DbMigrationState(zeebeDb, transactionContext);
-
     userTaskState = new DbUserTaskState(zeebeDb, transactionContext);
+    compensationSubscriptionState =
+        new DbCompensationSubscriptionState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -229,6 +232,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableUserTaskState getUserTaskState() {
     return userTaskState;
+  }
+
+  @Override
+  public MutableCompensationSubscriptionState getCompensationSubscriptionState() {
+    return compensationSubscriptionState;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionCreatedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionCreatedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+
+public class CompensationSubscriptionCreatedApplier
+    implements TypedEventApplier<CompensationSubscriptionIntent, CompensationSubscriptionRecord> {
+
+  private final MutableCompensationSubscriptionState compensationState;
+
+  public CompensationSubscriptionCreatedApplier(
+      final MutableCompensationSubscriptionState compensationState) {
+    this.compensationState = compensationState;
+  }
+
+  @Override
+  public void applyState(final long key, final CompensationSubscriptionRecord value) {
+    compensationState.put(key, value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionTriggeredApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionTriggeredApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+
+public class CompensationSubscriptionTriggeredApplier
+    implements TypedEventApplier<CompensationSubscriptionIntent, CompensationSubscriptionRecord> {
+
+  private final MutableCompensationSubscriptionState compensationState;
+
+  public CompensationSubscriptionTriggeredApplier(
+      final MutableCompensationSubscriptionState compensationState) {
+    this.compensationState = compensationState;
+  }
+
+  @Override
+  public void applyState(final long key, final CompensationSubscriptionRecord value) {
+    compensationState.update(value);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionTriggeredApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionTriggeredApplier.java
@@ -24,6 +24,6 @@ public class CompensationSubscriptionTriggeredApplier
 
   @Override
   public void applyState(final long key, final CompensationSubscriptionRecord value) {
-    compensationState.update(value);
+    compensationState.update(key, value);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -323,6 +323,10 @@ public final class EventAppliers implements EventApplier {
         CompensationSubscriptionIntent.CREATED,
         new CompensationSubscriptionCreatedApplier(
             processingState.getCompensationSubscriptionState()));
+    register(
+        CompensationSubscriptionIntent.TRIGGERED,
+        new CompensationSubscriptionTriggeredApplier(
+            processingState.getCompensationSubscriptionState()));
   }
 
   private void registerCommandDistributionAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -82,6 +83,8 @@ public final class EventAppliers implements EventApplier {
     registerUserTaskAppliers(state);
 
     registerSignalSubscriptionAppliers(state);
+
+    registerCompensationSubscriptionApplier(state);
 
     registerCommandDistributionAppliers(state);
     return this;
@@ -312,6 +315,14 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.COMPLETED, new UserTaskCompletedApplier(state));
     register(UserTaskIntent.ASSIGNING, new UserTaskAssigningApplier(state));
     register(UserTaskIntent.ASSIGNED, new UserTaskAssignedApplier(state));
+  }
+
+  private void registerCompensationSubscriptionApplier(
+      final MutableProcessingState processingState) {
+    register(
+        CompensationSubscriptionIntent.CREATED,
+        new CompensationSubscriptionCreatedApplier(
+            processingState.getCompensationSubscriptionState()));
   }
 
   private void registerCommandDistributionAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -21,6 +21,7 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
   private final LongProperty keyProp = new LongProperty("key");
 
   public CompensationSubscription() {
+    super(2);
     declareProperty(recordProp).declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.compensation;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+
+public class CompensationSubscription extends UnpackedObject implements DbValue {
+
+  private final ObjectProperty<CompensationSubscriptionRecord> recordProp =
+      new ObjectProperty<>("compensationSubscriptionRecord", new CompensationSubscriptionRecord());
+
+  private final LongProperty keyProp = new LongProperty("key");
+
+  public CompensationSubscription() {
+    declareProperty(recordProp).declareProperty(keyProp);
+  }
+
+  public CompensationSubscriptionRecord getRecord() {
+    return recordProp.getValue();
+  }
+
+  public void setRecord(final CompensationSubscriptionRecord record) {
+    recordProp.getValue().wrap(record);
+  }
+
+  public long getKey() {
+    return keyProp.getValue();
+  }
+
+  public CompensationSubscription setKey(final long key) {
+    keyProp.setValue(key);
+    return this;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -24,6 +24,22 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     declareProperty(recordProp).declareProperty(keyProp);
   }
 
+  public CompensationSubscription copy() {
+    final var copy = new CompensationSubscription();
+    copy.keyProp.setValue(getKey());
+    copy.recordProp.getValue().setTenantId(getRecord().getTenantId());
+    copy.recordProp.getValue().setProcessInstanceKey(getRecord().getProcessInstanceKey());
+    copy.recordProp.getValue().setProcessDefinitionKey(getRecord().getProcessDefinitionKey());
+    copy.recordProp.getValue().setCompensableActivityId(getRecord().getCompensableActivityId());
+    copy.recordProp
+        .getValue()
+        .setCompensableActivityScopeId(getRecord().getCompensableActivityScopeId());
+    copy.recordProp.getValue().setThrowEventId(getRecord().getThrowEventId());
+    copy.recordProp.getValue().setThrowEventInstanceKey(getRecord().getThrowEventInstanceKey());
+    copy.recordProp.getValue().setVariables(getRecord().getVariablesBuffer());
+    return copy;
+  }
+
   public CompensationSubscriptionRecord getRecord() {
     return recordProp.getValue();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/DbCompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/DbCompensationSubscriptionState.java
@@ -61,7 +61,8 @@ public class DbCompensationSubscriptionState implements MutableCompensationSubsc
   }
 
   @Override
-  public Set<String> getCompletedActivitiesToCompensate(final String tenantId, final long piKey) {
+  public Set<String> findSubscriptionsByProcessInstanceKey(
+      final String tenantId, final long piKey) {
     tenantIdKey.wrapString(tenantId);
     processInstanceKey.wrapLong(piKey);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/DbCompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/DbCompensationSubscriptionState.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.compensation;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbLong;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey;
+import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+
+public class DbCompensationSubscriptionState implements MutableCompensationSubscriptionState {
+
+  private final DbLong processInstanceKey;
+  private final DbString compensableActivityIdKey;
+  private final DbString tenantIdKey;
+  private final DbTenantAwareKey<DbLong> tenantAwareProcessInstanceKey;
+  private final DbCompositeKey<DbTenantAwareKey<DbLong>, DbString>
+      tenantAwareProcessInstanceKeyCompensableActivityId;
+  private final ColumnFamily<
+          DbCompositeKey<DbTenantAwareKey<DbLong>, DbString>, CompensationSubscription>
+      compensationSubscriptionColumnFamily;
+  private final CompensationSubscription compensationSubscription = new CompensationSubscription();
+
+  public DbCompensationSubscriptionState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    processInstanceKey = new DbLong();
+    compensableActivityIdKey = new DbString();
+    tenantIdKey = new DbString();
+    tenantAwareProcessInstanceKey =
+        new DbTenantAwareKey<>(tenantIdKey, processInstanceKey, PlacementType.PREFIX);
+    tenantAwareProcessInstanceKeyCompensableActivityId =
+        new DbCompositeKey<>(tenantAwareProcessInstanceKey, compensableActivityIdKey);
+    compensationSubscriptionColumnFamily =
+        zeebeDb.createColumnFamily(
+            ZbColumnFamilies.COMPENSATION_SUBSCRIPTION,
+            transactionContext,
+            tenantAwareProcessInstanceKeyCompensableActivityId,
+            compensationSubscription);
+  }
+
+  @Override
+  public CompensationSubscription get(
+      final String tenantId, final long processInstanceKey, final String compensableActivityId) {
+    wrapCompensationKeys(processInstanceKey, compensableActivityId, tenantId);
+    return compensationSubscriptionColumnFamily.get(
+        tenantAwareProcessInstanceKeyCompensableActivityId);
+  }
+
+  @Override
+  public void put(final long key, final CompensationSubscriptionRecord compensation) {
+    compensationSubscription.setKey(key).setRecord(compensation);
+
+    wrapCompensationKeys(
+        compensation.getProcessInstanceKey(),
+        compensation.getCompensableActivityId(),
+        compensation.getTenantId());
+
+    compensationSubscriptionColumnFamily.upsert(
+        tenantAwareProcessInstanceKeyCompensableActivityId, compensationSubscription);
+  }
+
+  private void wrapCompensationKeys(
+      final long processInstance, final String compensableActivityId, final String tenantId) {
+    processInstanceKey.wrapLong(processInstance);
+    compensableActivityIdKey.wrapString(compensableActivityId);
+    tenantIdKey.wrapString(tenantId);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
@@ -15,5 +15,5 @@ public interface CompensationSubscriptionState {
   CompensationSubscription get(
       String tenantId, long processInstanceKey, String compensableActivityId);
 
-  Set<String> getCompletedActivitiesToCompensate(String tenantId, long processInstanceKey);
+  Set<String> findSubscriptionsByProcessInstanceKey(String tenantId, long processInstanceKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.engine.state.compensation.CompensationSubscription;
+
+public interface CompensationSubscriptionState {
+
+  CompensationSubscription get(
+      String tenantId, long processInstanceKey, String compensableActivityId);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
@@ -15,5 +15,6 @@ public interface CompensationSubscriptionState {
   CompensationSubscription get(
       String tenantId, long processInstanceKey, String compensableActivityId);
 
-  Set<String> findSubscriptionsByProcessInstanceKey(String tenantId, long processInstanceKey);
+  Set<CompensationSubscription> findSubscriptionsByProcessInstanceKey(
+      String tenantId, long processInstanceKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
@@ -8,9 +8,12 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.compensation.CompensationSubscription;
+import java.util.Set;
 
 public interface CompensationSubscriptionState {
 
   CompensationSubscription get(
       String tenantId, long processInstanceKey, String compensableActivityId);
+
+  Set<String> getCompletedActivitiesToCompensate(String tenantId, long processInstanceKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -54,6 +54,8 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
 
   UserTaskState getUserTaskState();
 
+  CompensationSubscriptionState getCompensationSubscriptionState();
+
   int getPartitionId();
 
   boolean isEmpty(final ZbColumnFamilies column);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.CompensationSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+
+public interface MutableCompensationSubscriptionState extends CompensationSubscriptionState {
+
+  void put(final long key, CompensationSubscriptionRecord compensation);
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
@@ -14,5 +14,5 @@ public interface MutableCompensationSubscriptionState extends CompensationSubscr
 
   void put(final long key, CompensationSubscriptionRecord compensation);
 
-  void update(CompensationSubscriptionRecord compensation);
+  void update(final long key, CompensationSubscriptionRecord compensation);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
@@ -13,4 +13,6 @@ import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubs
 public interface MutableCompensationSubscriptionState extends CompensationSubscriptionState {
 
   void put(final long key, CompensationSubscriptionRecord compensation);
+
+  void update(CompensationSubscriptionRecord compensation);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -69,5 +69,8 @@ public interface MutableProcessingState extends ProcessingState {
   @Override
   MutableUserTaskState getUserTaskState();
 
+  @Override
+  MutableCompensationSubscriptionState getCompensationSubscriptionState();
+
   KeyGenerator getKeyGenerator();
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -135,7 +135,7 @@ public class CompensationEventExecutionTest {
   }
 
   @Test
-  public void shouldCreateCompensationSubscriptionForCompletedTask() {
+  public void shouldCreateAndUpdateCompensationSubscriptionForCompletedTask() {
     // given
     final var process =
         createModelFromClasspathResource("/compensation/compensation-throw-event.bpmn");
@@ -183,7 +183,8 @@ public class CompensationEventExecutionTest {
                 .withProcessInstanceKey(processInstanceKey))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSequence(
-            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.CREATED));
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.CREATED),
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.TRIGGERED));
   }
 
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -12,8 +12,11 @@ import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
@@ -129,5 +132,62 @@ public class CompensationEventExecutionTest {
                 BpmnElementType.PROCESS,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
                 BpmnEventType.UNSPECIFIED));
+  }
+
+  @Test
+  public void shouldCreateCompensationSubscriptionForCompletedTask() {
+    // given
+    final var process =
+        createModelFromClasspathResource("/compensation/compensation-throw-event.bpmn");
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(Protocol.USER_TASK_JOB_TYPE).complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            Record::getIntent,
+            r -> r.getValue().getBpmnEventType())
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.USER_TASK,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                BpmnEventType.UNSPECIFIED),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                BpmnEventType.COMPENSATION),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                BpmnEventType.COMPENSATION),
+            tuple(
+                BpmnElementType.END_EVENT,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                BpmnEventType.NONE),
+            tuple(
+                BpmnElementType.PROCESS,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                BpmnEventType.UNSPECIFIED));
+
+    assertThat(
+            RecordingExporter.compensationSubscriptionRecords()
+                .withProcessInstanceKey(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSequence(
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.CREATED));
+  }
+
+  private BpmnModelInstance createModelFromClasspathResource(final String classpath) {
+    final var resourceAsStream = getClass().getResourceAsStream(classpath);
+    return Bpmn.readModelFromStream(resourceAsStream);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -194,46 +194,56 @@ public class CompensationEventExecutionTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
+                .limit("CompensationHandler", ProcessInstanceIntent.ELEMENT_ACTIVATED))
         .extracting(
             r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getBpmnEventType(),
             Record::getIntent,
             r -> r.getValue().getElementId())
         .containsSubsequence(
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "ActivityToCompensate"),
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
                 "ActivityToCompensate"),
             tuple(
                 BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationThrowEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATING,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETING,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATING,
                 "CompensationHandler"),
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationHandler"));
   }
@@ -255,46 +265,56 @@ public class CompensationEventExecutionTest {
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
+                .limit("CompensationHandler", ProcessInstanceIntent.ELEMENT_ACTIVATED))
         .extracting(
             r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getBpmnEventType(),
             Record::getIntent,
             r -> r.getValue().getElementId())
         .containsSubsequence(
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "ActivityToCompensate"),
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
                 "ActivityToCompensate"),
             tuple(
                 BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationEndEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATING,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETING,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
                 "CompensationBoundaryEvent"),
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATING,
                 "CompensationHandler"),
             tuple(
                 BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationHandler"));
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -149,42 +149,78 @@ public class CompensationEventExecutionTest {
 
     // then
     assertThat(
-            RecordingExporter.processInstanceRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .limitToProcessInstanceCompleted())
-        .extracting(
-            r -> r.getValue().getBpmnElementType(),
-            Record::getIntent,
-            r -> r.getValue().getBpmnEventType())
-        .containsSubsequence(
-            tuple(
-                BpmnElementType.USER_TASK,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                BpmnEventType.UNSPECIFIED),
-            tuple(
-                BpmnElementType.INTERMEDIATE_THROW_EVENT,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                BpmnEventType.COMPENSATION),
-            tuple(
-                BpmnElementType.INTERMEDIATE_THROW_EVENT,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                BpmnEventType.COMPENSATION),
-            tuple(
-                BpmnElementType.END_EVENT,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                BpmnEventType.NONE),
-            tuple(
-                BpmnElementType.PROCESS,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                BpmnEventType.UNSPECIFIED));
-
-    assertThat(
             RecordingExporter.compensationSubscriptionRecords()
                 .withProcessInstanceKey(processInstanceKey))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSequence(
             tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.CREATED),
             tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.TRIGGERED));
+  }
+
+  @Test
+  public void shouldActivateCompensationHandlerForIntermediateThrowEvent() {
+    // given
+    final var process =
+        createModelFromClasspathResource("/compensation/compensation-throw-event.bpmn");
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(Protocol.USER_TASK_JOB_TYPE).complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            Record::getIntent,
+            r -> r.getValue().getElementId())
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.USER_TASK,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "Activity_1epoz0g"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "Activity_1epoz0g"));
+  }
+
+  @Test
+  public void shouldActivateCompensationHandlerForEndEvent() {
+    // given
+    final var process =
+        createModelFromClasspathResource("/compensation/compensation-end-event.bpmn");
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(Protocol.USER_TASK_JOB_TYPE).complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            Record::getIntent,
+            r -> r.getValue().getElementId())
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.USER_TASK,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "Activity_1epoz0g"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "Activity_1epoz0g"));
   }
 
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -173,7 +173,7 @@ public class CompensationEventExecutionTest {
                 CompensationSubscriptionIntent.TRIGGERED,
                 TenantOwned.DEFAULT_TENANT_IDENTIFIER,
                 processInstanceKey,
-                "",
+                "ActivityToCompensate",
                 "CompensationThrowEvent"));
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -71,10 +71,13 @@ public class CompensationSubscriptionStateTest {
         new CompensationSubscriptionRecord()
             .setTenantId(TENANT_ID)
             .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
+            .setProcessDefinitionKey(PROCESS_DEFINITION_KEY)
+            .setCompensableActivityId(COMPENSABLE_ACTIVITY_ID)
+            .setCompensableActivityScopeId(COMPENSABLE_ACTIVITY_SCOPE_ID)
             .setThrowEventId("updateThrowEventId")
             .setThrowEventInstanceKey(2L);
 
-    state.update(updatedCompensationInfo);
+    state.update(1L, updatedCompensationInfo);
 
     final var updatedCompensation =
         state
@@ -117,7 +120,9 @@ public class CompensationSubscriptionStateTest {
     final var subscriptions =
         state.findSubscriptionsByProcessInstanceKey(TENANT_ID, PROCESS_INSTANCE_KEY);
     assertThat(subscriptions.size()).isEqualTo(2);
-    assertThat(subscriptions).contains(COMPENSABLE_ACTIVITY_ID, "anotherCompensableActivityId");
+    assertThat(subscriptions)
+        .extracting(c -> c.getRecord().getCompensableActivityId())
+        .contains(COMPENSABLE_ACTIVITY_ID, "anotherCompensableActivityId");
   }
 
   private CompensationSubscriptionRecord createCompensation(final long key) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.compensation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CompensationSubscriptionStateTest {
+
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+
+  private MutableCompensationSubscriptionState state;
+
+  @Before
+  public void setUp() {
+    state = stateRule.getProcessingState().getCompensationSubscriptionState();
+  }
+
+  @Test
+  public void shouldPutCompensationSubscriptionRecord() {
+    final var compensation = createCompensation();
+    state.put(1L, compensation);
+    assertThat(
+            state.get(
+                compensation.getTenantId(),
+                compensation.getProcessInstanceKey(),
+                compensation.getCompensableActivityId()))
+        .isNotNull();
+  }
+
+  private CompensationSubscriptionRecord createCompensation() {
+    return new CompensationSubscriptionRecord()
+        .setTenantId("tenantId")
+        .setProcessInstanceKey(1L)
+        .setProcessDefinitionKey(1L)
+        .setCompensableActivityId("compensableActivityId")
+        .setCompensableActivityScopeId(1L)
+        .setThrowEventId("throwEventId")
+        .setThrowEventInstanceKey(1L);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -22,11 +22,11 @@ public class CompensationSubscriptionStateTest {
 
   private static final String TENANT_ID = "tenantId";
   private static final long PROCESS_INSTANCE_KEY = 1L;
-  private static final long PROCESS_DEFINITION_KEY = 1L;
+  private static final long PROCESS_DEFINITION_KEY = 2L;
   private static final String COMPENSABLE_ACTIVITY_ID = "compensableActivityId";
-  private static final long COMPENSABLE_ACTIVITY_SCOPE_ID = 1L;
+  private static final String COMPENSABLE_ACTIVITY_SCOPE_ID = "compensableActivityScopeId";
   private static final String THROW_EVENT_ID = "throwEventId";
-  private static final long THROW_EVENT_INSTANCE_KEY = 1L;
+  private static final long THROW_EVENT_INSTANCE_KEY = 4L;
 
   private MutableCompensationSubscriptionState state;
   private MutableProcessingState processingState;
@@ -99,7 +99,8 @@ public class CompensationSubscriptionStateTest {
     assertThat(notUpdatedCompensation.getCompensableActivityId())
         .isEqualTo(COMPENSABLE_ACTIVITY_ID);
     assertThat(notUpdatedCompensation.getThrowEventId()).isEqualTo(THROW_EVENT_ID);
-    assertThat(notUpdatedCompensation.getThrowEventInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
+    assertThat(notUpdatedCompensation.getThrowEventInstanceKey())
+        .isEqualTo(THROW_EVENT_INSTANCE_KEY);
   }
 
   @Test

--- a/engine/src/test/resources/compensation/compensation-end-event.bpmn
+++ b/engine/src/test/resources/compensation/compensation-end-event.bpmn
@@ -4,38 +4,38 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1evmw69</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_1evmw69" sourceRef="StartEvent_1" targetRef="Activity_05iamly" />
-    <bpmn:userTask id="Activity_05iamly" name="A">
+    <bpmn:sequenceFlow id="Flow_1evmw69" sourceRef="StartEvent_1" targetRef="ActivityToCompensate" />
+    <bpmn:userTask id="ActivityToCompensate" name="A">
       <bpmn:incoming>Flow_1evmw69</bpmn:incoming>
       <bpmn:outgoing>Flow_13spwoi</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:sequenceFlow id="Flow_13spwoi" sourceRef="Activity_05iamly" targetRef="Event_0iasuoa" />
-    <bpmn:boundaryEvent id="Event_14k1uqy" attachedToRef="Activity_05iamly">
+    <bpmn:sequenceFlow id="Flow_13spwoi" sourceRef="ActivityToCompensate" targetRef="CompensationEndEvent" />
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" attachedToRef="ActivityToCompensate">
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_0o178oi" />
     </bpmn:boundaryEvent>
-    <bpmn:userTask id="Activity_1epoz0g" name="undo A" isForCompensation="true" />
-    <bpmn:endEvent id="Event_0iasuoa">
+    <bpmn:userTask id="CompensationHandler" name="undo A" isForCompensation="true" />
+    <bpmn:endEvent id="CompensationEndEvent">
       <bpmn:incoming>Flow_13spwoi</bpmn:incoming>
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_1n06ebt" />
     </bpmn:endEvent>
-    <bpmn:association id="Association_1jwpcsv" associationDirection="One" sourceRef="Event_14k1uqy" targetRef="Activity_1epoz0g" />
+    <bpmn:association id="Association_1jwpcsv" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="CompensationHandler" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1761rwu_di" bpmnElement="Activity_05iamly">
+      <bpmndi:BPMNShape id="Activity_1761rwu_di" bpmnElement="ActivityToCompensate">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1en6ywx_di" bpmnElement="Activity_1epoz0g">
+      <bpmndi:BPMNShape id="Activity_1en6ywx_di" bpmnElement="CompensationHandler">
         <dc:Bounds x="440" y="200" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_00v7ezm_di" bpmnElement="Event_0iasuoa">
+      <bpmndi:BPMNShape id="Event_00v7ezm_di" bpmnElement="CompensationEndEvent">
         <dc:Bounds x="632" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="Event_14k1uqy">
+      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="CompensationBoundaryEvent">
         <dc:Bounds x="352" y="139" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1evmw69_di" bpmnElement="Flow_1evmw69">

--- a/engine/src/test/resources/compensation/compensation-throw-event.bpmn
+++ b/engine/src/test/resources/compensation/compensation-throw-event.bpmn
@@ -1,49 +1,50 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
   <bpmn:process id="compensation-process" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1">
+    <bpmn:startEvent id="StartEvent">
       <bpmn:outgoing>Flow_1evmw69</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_1evmw69" sourceRef="StartEvent_1" targetRef="Activity_05iamly" />
-    <bpmn:userTask id="Activity_05iamly" name="A">
+    <bpmn:sequenceFlow id="Flow_1evmw69" sourceRef="StartEvent" targetRef="ActivityToCompensate" />
+    <bpmn:userTask id="ActivityToCompensate" name="A">
       <bpmn:incoming>Flow_1evmw69</bpmn:incoming>
       <bpmn:outgoing>Flow_13spwoi</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:endEvent id="Event_0iasuoa">
+    <bpmn:endEvent id="EndEvent">
       <bpmn:incoming>Flow_0n0oakg</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_13spwoi" sourceRef="Activity_05iamly" targetRef="Event_1afnxa2" />
-    <bpmn:boundaryEvent id="Event_14k1uqy" attachedToRef="Activity_05iamly">
+    <bpmn:sequenceFlow id="Flow_13spwoi" sourceRef="ActivityToCompensate" targetRef="CompensationThrowEvent" />
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" attachedToRef="ActivityToCompensate">
+      <bpmn:extensionElements />
       <bpmn:compensateEventDefinition id="CompensateEventDefinition_0o178oi" />
     </bpmn:boundaryEvent>
-    <bpmn:userTask id="Activity_1epoz0g" name="undo A" isForCompensation="true" />
-    <bpmn:sequenceFlow id="Flow_0n0oakg" sourceRef="Event_1afnxa2" targetRef="Event_0iasuoa" />
-    <bpmn:intermediateThrowEvent id="Event_1afnxa2">
+    <bpmn:userTask id="CompensationHandler" name="undo A" isForCompensation="true" />
+    <bpmn:sequenceFlow id="Flow_0n0oakg" sourceRef="CompensationThrowEvent" targetRef="EndEvent" />
+    <bpmn:intermediateThrowEvent id="CompensationThrowEvent">
       <bpmn:incoming>Flow_13spwoi</bpmn:incoming>
       <bpmn:outgoing>Flow_0n0oakg</bpmn:outgoing>
-      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" activityRef="Activity_05iamly" />
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" activityRef="ActivityToCompensate" />
     </bpmn:intermediateThrowEvent>
-    <bpmn:association id="Association_1jwpcsv" associationDirection="One" sourceRef="Event_14k1uqy" targetRef="Activity_1epoz0g" />
+    <bpmn:association id="Association_1jwpcsv" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="CompensationHandler" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1761rwu_di" bpmnElement="Activity_05iamly">
+      <bpmndi:BPMNShape id="Activity_1761rwu_di" bpmnElement="ActivityToCompensate">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1en6ywx_di" bpmnElement="Activity_1epoz0g">
+      <bpmndi:BPMNShape id="Event_0iasuoa_di" bpmnElement="EndEvent">
+        <dc:Bounds x="632" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1en6ywx_di" bpmnElement="CompensationHandler">
         <dc:Bounds x="440" y="200" width="100" height="80" />
         <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0iasuoa_di" bpmnElement="Event_0iasuoa">
-        <dc:Bounds x="632" y="99" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qpwd18_di" bpmnElement="Event_1afnxa2">
+      <bpmndi:BPMNShape id="Event_1qpwd18_di" bpmnElement="CompensationThrowEvent">
         <dc:Bounds x="472" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="Event_14k1uqy">
+      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="CompensationBoundaryEvent">
         <dc:Bounds x="352" y="139" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_1evmw69_di" bpmnElement="Flow_1evmw69">
@@ -54,14 +55,14 @@
         <di:waypoint x="370" y="117" />
         <di:waypoint x="472" y="117" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n0oakg_di" bpmnElement="Flow_0n0oakg">
+        <di:waypoint x="508" y="117" />
+        <di:waypoint x="632" y="117" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
         <di:waypoint x="350" y="175" />
         <di:waypoint x="350" y="240" />
         <di:waypoint x="420" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0n0oakg_di" bpmnElement="Flow_0n0oakg">
-        <di:waypoint x="508" y="117" />
-        <di:waypoint x="632" y="117" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -32,7 +32,7 @@
               "type": "keyword"
             },
             "compensableActivityScopeId": {
-              "type": "long"
+              "type": "keyword"
             },
             "throwEventId": {
               "type": "keyword"

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -32,7 +32,7 @@
               "type": "keyword"
             },
             "compensableActivityScopeId": {
-              "type": "long"
+              "type": "keyword"
             },
             "throwEventId": {
               "type": "keyword"

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.protocol.impl.record.value.compensation;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -49,6 +50,17 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(throwEventIdProperty)
         .declareProperty(throwEventInstanceKeyProperty)
         .declareProperty(variablesProperty);
+  }
+
+  public void wrap(final CompensationSubscriptionRecord record) {
+    tenantIdProperty.setValue(record.getTenantId());
+    processInstanceKeyProperty.setValue(record.getProcessInstanceKey());
+    processDefinitionKeyProperty.setValue(record.getProcessDefinitionKey());
+    compensableActivityIdProperty.setValue(record.getCompensableActivityId());
+    compensableActivityScopeIdProperty.setValue(record.getCompensableActivityScopeId());
+    throwEventIdProperty.setValue(record.getThrowEventId());
+    throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
+    variablesProperty.setValue(record.getVariablesBuffer());
   }
 
   @Override
@@ -131,5 +143,10 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
       final String compensableActivityId) {
     compensableActivityIdProperty.setValue(compensableActivityId);
     return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProperty.getValue();
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -32,8 +32,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1);
   private final StringProperty compensableActivityIdProperty =
       new StringProperty("compensableActivityId", EMPTY_STRING);
-  private final LongProperty compensableActivityScopeIdProperty =
-      new LongProperty("compensableActivityScopeId", -1);
+  private final StringProperty compensableActivityScopeIdProperty =
+      new StringProperty("compensableActivityScopeId", EMPTY_STRING);
   private final StringProperty throwEventIdProperty =
       new StringProperty("throwEventId", EMPTY_STRING);
   private final LongProperty throwEventInstanceKeyProperty =
@@ -99,8 +99,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getCompensableActivityScopeId() {
-    return compensableActivityScopeIdProperty.getValue();
+  public String getCompensableActivityScopeId() {
+    return BufferUtil.bufferAsString(compensableActivityScopeIdProperty.getValue());
   }
 
   @Override
@@ -134,7 +134,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   public CompensationSubscriptionRecord setCompensableActivityScopeId(
-      final long compensableActivityScopeId) {
+      final String compensableActivityScopeId) {
     compensableActivityScopeIdProperty.setValue(compensableActivityScopeId);
     return this;
   }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2271,7 +2271,7 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": -1,
           "processDefinitionKey": -1,
           "compensableActivityId": "",
-          "compensableActivityScopeId": -1,
+          "compensableActivityScopeId": "",
           "throwEventId": "",
           "throwEventInstanceKey": -1,
           "variables": {}

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2239,7 +2239,7 @@ final class JsonSerializableToJsonTest {
                     .setProcessInstanceKey(123L)
                     .setProcessDefinitionKey(456L)
                     .setCompensableActivityId("elementActivityId")
-                    .setCompensableActivityScopeId(789L)
+                    .setCompensableActivityScopeId("elementActivityScopeId")
                     .setThrowEventId("elementThrowEventId")
                     .setThrowEventInstanceKey(123L)
                     .setVariables(VARIABLES_MSGPACK),
@@ -2249,7 +2249,7 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": 123,
           "processDefinitionKey": 456,
           "compensableActivityId": "elementActivityId",
-          "compensableActivityScopeId": 789,
+          "compensableActivityScopeId": "elementActivityScopeId",
           "throwEventId": "elementThrowEventId",
           "throwEventInstanceKey": 123,
           "variables": {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -174,4 +174,5 @@ public enum ZbColumnFamilies {
 
   USER_TASKS,
   USER_TASK_STATES,
+  COMPENSATION_SUBSCRIPTION
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -48,7 +48,7 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
    * @return the element id of the flow scope that contains the activity with the compensation
    *     handler
    */
-  long getCompensableActivityScopeId();
+  String getCompensableActivityScopeId();
 
   /**
    * @return the element id of compensation throw event

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
@@ -90,6 +91,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.PROCESS_INSTANCE_BATCH, ProcessInstanceBatchRecord.class);
     registry.put(ValueType.FORM, FormRecord.class);
     registry.put(ValueType.USER_TASK, UserTaskRecord.class);
+    registry.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompensationSubscriptionRecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompensationSubscriptionRecordStream.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
+import java.util.stream.Stream;
+
+public class CompensationSubscriptionRecordStream
+    extends ExporterRecordStream<
+        CompensationSubscriptionRecordValue, CompensationSubscriptionRecordStream> {
+
+  public CompensationSubscriptionRecordStream(
+      final Stream<Record<CompensationSubscriptionRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected CompensationSubscriptionRecordStream supply(
+      final Stream<Record<CompensationSubscriptionRecordValue>> wrappedStream) {
+    return new CompensationSubscriptionRecordStream(wrappedStream);
+  }
+
+  public CompensationSubscriptionRecordStream withProcessInstanceKey(
+      final long processInstanceKey) {
+    return valueFilter(v -> v.getProcessInstanceKey() == processInstanceKey);
+  }
+}

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
@@ -404,6 +405,11 @@ public final class RecordingExporter implements Exporter {
 
   public static UserTaskRecordStream userTaskRecords(final UserTaskIntent intent) {
     return userTaskRecords().withIntent(intent);
+  }
+
+  public static CompensationSubscriptionRecordStream compensationSubscriptionRecords() {
+    return new CompensationSubscriptionRecordStream(
+        records(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecordValue.class));
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When a process instance enters a compensation intermediate throw or end event all the compensation handler attached to completed activities with compensation boundary event should be activated.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #14970 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
