### PR TITLE
Use correct generation templates for Daily QA

### DIFF
--- a/.github/workflows/daily-qa.yml
+++ b/.github/workflows/daily-qa.yml
@@ -61,9 +61,18 @@ jobs:
           - ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-version) }}
           - ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-version) }}
+        include:
+          - branch: 'main'
+            generation_template: 'Zeebe SNAPSHOT'
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.latest-version) }}
+            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.latest-version) }}
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-latest-version) }}
+            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.previous-latest-version) }}
+          - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-version) }}
+            generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.previous-previous-latest-version) }}
     name: Daily QA
     uses: ./.github/workflows/qa-testbench.yaml
     with:
       branch: ${{ matrix.branch }}
-      generation: Zeebe SNAPSHOT
+      generation: ${{ matrix.generation_template }}
     secrets: inherit


### PR DESCRIPTION

## Description

Use correct generation templates for the daily QA tests, instead of using always SNAPSHOT, which is likely to fail.

Related to changes we have done in e2e test https://github.com/camunda/zeebe/blob/main/.github/workflows/weekly-e2e.yml
