### PR TITLE
fix(github): static owner and repo value for add-to-projects

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -21,8 +21,8 @@ jobs:
                 }
               }
             }
-          owner: ${{ github.event.repository.owner.name }}
-          repo: ${{ github.event.repository.name }}
+          owner: "camunda"
+          repo: "zeebe"
           issue: ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Seems like owner is not available 🤦 , decided to just use static values for owner and repo

https://github.com/camunda/zeebe/actions/runs/7208076301/job/19636241310#logs

```
> owner: undefined
> repo: zeebe
> issue: 15615
> mediaType: undefined
```

missed when testing https://github.com/camunda/zeebe/pull/15545 with mocked data