### PR TITLE
fix(github): fixed for add to projects workflow

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -26,7 +26,7 @@ jobs:
             repo: "zeebe"
             issue: ${{ github.event.issue.number }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PROJECT_ADMIN_TOKEN }}
       - id: has-project
         run: echo "result=${{ fromJSON(steps.get_project_count.outputs.data).repository.issue.projectsV2.totalCount > 0 }}" >> $GITHUB_OUTPUT
       - id: add-to-zdp

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -21,9 +21,10 @@ jobs:
                 }
               }
             }
-          owner: "camunda"
-          repo: "zeebe"
-          issue: ${{ github.event.issue.number }}
+          variables: |
+            owner: "camunda"
+            repo: "zeebe"
+            issue: ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - id: has-project

--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -31,7 +31,7 @@ jobs:
         run: echo "result=${{ fromJSON(steps.get_project_count.outputs.data).repository.issue.projectsV2.totalCount > 0 }}" >> $GITHUB_OUTPUT
       - id: add-to-zdp
         name: Add to ZDP project
-        if: ${{ !steps.has-project.outputs.result }}
+        if: ${{ steps.has-project.outputs.result == 'false' }}
         uses: actions/add-to-project@v0.5.0
         with:
           project-url: https://github.com/orgs/camunda/projects/92
@@ -41,7 +41,7 @@ jobs:
       - id: add-to-zda
         name: Add to ZPA project
         uses: actions/add-to-project@v0.5.0
-        if: ${{ !steps.has-project.outputs.result }}
+        if: ${{ steps.has-project.outputs.result == 'false' }}
         with:
           project-url: https://github.com/orgs/camunda/projects/29
           github-token: ${{ secrets.PROJECT_ADMIN_TOKEN }}


### PR DESCRIPTION
## Description

See https://github.com/camunda/zeebe/actions/runs/7208315699/job/19637188599

* resolves a warning on how variables were set
* fixed if conditions, which didn't work as the result of the has-project step is a string not a boolean
* usage of project admin token for the project query, with the github repo token no results were returned as no access to projects


## Related issues

related https://github.com/camunda/zeebe/pull/15545