### PR TITLE
fix: Avoid concurrent commands during process instance migration

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -385,6 +385,12 @@ public class ProcessInstanceMigrationMigrateProcessor
       throw new ConcurrentCommandException(processInstanceKey);
     }
 
+    if (elementInstance.getActiveSequenceFlows() > 0) {
+      // An active sequence flow indicates a concurrent command. It is created when taking a
+      // sequence flow and writing an ACTIVATE command for the next element.
+      throw new ConcurrentCommandException(processInstanceKey);
+    }
+
     stateWriter.appendFollowUpEvent(
         elementInstance.getKey(),
         ProcessInstanceIntent.ELEMENT_MIGRATED,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -17,12 +17,14 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseW
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.instance.EventTrigger;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
@@ -76,6 +78,7 @@ public class ProcessInstanceMigrationMigrateProcessor
   private final JobState jobState;
   private final VariableState variableState;
   private final IncidentState incidentState;
+  private final EventScopeInstanceState eventScopeInstanceState;
 
   public ProcessInstanceMigrationMigrateProcessor(
       final Writers writers, final ProcessingState processingState) {
@@ -87,6 +90,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     jobState = processingState.getJobState();
     variableState = processingState.getVariableState();
     incidentState = processingState.getIncidentState();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
   }
 
   @Override
@@ -254,6 +258,11 @@ public class ProcessInstanceMigrationMigrateProcessor
       responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, e.getMessage());
       return ProcessingError.EXPECTED_ERROR;
     }
+    if (error instanceof final ConcurrentCommandException e) {
+      rejectionWriter.appendRejection(command, RejectionType.INVALID_STATE, e.getMessage());
+      responseWriter.writeRejectionOnCommand(command, RejectionType.INVALID_STATE, e.getMessage());
+      return ProcessingError.EXPECTED_ERROR;
+    }
 
     return ProcessingError.UNEXPECTED_ERROR;
   }
@@ -282,9 +291,11 @@ public class ProcessInstanceMigrationMigrateProcessor
       final Map<String, String> sourceElementIdToTargetElementId) {
 
     final var elementInstanceRecord = elementInstance.getValue();
+    final long processInstanceKey = elementInstanceRecord.getProcessInstanceKey();
+
     if (UNSUPPORTED_ELEMENT_TYPES.contains(elementInstanceRecord.getBpmnElementType())) {
       throw new UnsupportedElementMigrationException(
-          elementInstanceRecord.getProcessInstanceKey(),
+          processInstanceKey,
           elementInstanceRecord.getElementId(),
           elementInstanceRecord.getBpmnElementType());
     }
@@ -293,7 +304,7 @@ public class ProcessInstanceMigrationMigrateProcessor
         sourceElementIdToTargetElementId.get(elementInstanceRecord.getElementId());
     if (targetElementId == null) {
       throw new UnmappedActiveElementException(
-          elementInstanceRecord.getProcessInstanceKey(), elementInstanceRecord.getElementId());
+          processInstanceKey, elementInstanceRecord.getElementId());
     }
 
     final boolean hasIncident =
@@ -311,7 +322,7 @@ public class ProcessInstanceMigrationMigrateProcessor
         targetProcessDefinition.getProcess().getElementById(targetElementId).getElementType();
     if (elementInstanceRecord.getBpmnElementType() != targetElementType) {
       throw new ElementTypeChangedException(
-          elementInstanceRecord.getProcessInstanceKey(),
+          processInstanceKey,
           elementInstanceRecord.getElementId(),
           elementInstanceRecord.getBpmnElementType(),
           targetElementId,
@@ -365,6 +376,13 @@ public class ProcessInstanceMigrationMigrateProcessor
           elementInstanceRecord.getProcessInstanceKey(),
           elementInstanceRecord.getElementId(),
           "target");
+    }
+    final EventTrigger eventTrigger =
+        eventScopeInstanceState.peekEventTrigger(elementInstance.getKey());
+    if (eventTrigger != null) {
+      // An event trigger indicates a concurrent command. It is created when completing a job, or
+      // triggering a timer/message/signal event.
+      throw new ConcurrentCommandException(processInstanceKey);
     }
 
     stateWriter.appendFollowUpEvent(
@@ -572,6 +590,24 @@ public class ProcessInstanceMigrationMigrateProcessor
               but %s element with id '%s' has a boundary event. \
               Migrating %s elements with boundary events is not possible yet.""",
               processInstanceKey, source, elementId, source));
+    }
+  }
+
+  /**
+   * Exception that can be thrown during the migration of a process instance, in case the engine
+   * processes another command concurrently for the process instance, for example, a job complete, a
+   * timer trigger, or a message correlation. Since the concurrent command modifies the process
+   * instance, it is not safe to apply the migration in between.
+   */
+  private static final class ConcurrentCommandException extends RuntimeException {
+    ConcurrentCommandException(final long processInstanceKey) {
+      super(
+          String.format(
+              """
+              Expected to migrate process instance '%s' \
+              but a concurrent command was executed on the process instance. \
+              Please retry the migration.""",
+              processInstanceKey));
     }
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceConcurrentNoBatchingTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceConcurrentNoBatchingTest.java
@@ -1,0 +1,940 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance;
+
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.RecordToWrite;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.ClassRule;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class MigrateProcessInstanceConcurrentNoBatchingTest {
+
+  @ClassRule
+  public static final EngineRule ENGINE = EngineRule.singlePartition().maxCommandsInBatch(1);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldContinueMigratedInstanceWithJobCompleteBefore() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .serviceTask("B_v1", s -> s.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .serviceTask("B_v2", s -> s.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command().job(JobIntent.COMPLETE, new JobRecord()).key(jobKey),
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))));
+
+    final var migrationRejection =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(migrationRejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%d' \
+            but a concurrent command was executed on the process instance. \
+            Please retry the migration."""
+                .formatted(processInstanceKey));
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("B_v1")
+        .await();
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B_v1", "B_v2")
+        .migrate();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldContinueMigratedInstanceWithJobCompleteAfter() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .serviceTask("B_v1", s -> s.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .serviceTask("B_v2", s -> s.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))),
+        RecordToWrite.command().job(JobIntent.COMPLETE, new JobRecord()).key(jobKey));
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
+  @Test
+  public void shouldContinueMigratedInstanceWithTimerBefore() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("timer", b -> b.timerWithDuration("PT1H"))
+                    .serviceTask("B_v1", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("timer", b -> b.timerWithDuration("PT1H"))
+                    .serviceTask("B_v2", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final Record<TimerRecordValue> timerCreated =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .timer(TimerIntent.TRIGGER, timerCreated.getValue())
+            .key(timerCreated.getKey()),
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))));
+
+    final var migrationRejection =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(migrationRejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%d' \
+            but a concurrent command was executed on the process instance. \
+            Please retry the migration."""
+                .formatted(processInstanceKey));
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("B_v1")
+        .await();
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B_v1", "B_v2")
+        .migrate();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
+  @Test
+  public void shouldContinueMigratedInstanceWithTimerAfter() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("timer", b -> b.timerWithDuration("PT1H"))
+                    .serviceTask("B_v1", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("timer", b -> b.timerWithDuration("PT1H"))
+                    .serviceTask("B_v2", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final Record<TimerRecordValue> timerCreated =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))),
+        RecordToWrite.command()
+            .timer(TimerIntent.TRIGGER, timerCreated.getValue())
+            .key(timerCreated.getKey()));
+
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.TRIGGER)
+                .withProcessInstanceKey(processInstanceKey)
+                .onlyCommandRejections()
+                .findFirst())
+        .describedAs(
+            "Expect that the timer command is rejected because the migration recreate the subscription")
+        .isPresent();
+
+    ENGINE.increaseTime(Duration.ofHours(1));
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
+  @Test
+  public void shouldContinueMigratedInstanceWithMessageBefore() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    // the new process must use a different message name because of an inconsistent state exception
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "message",
+                        b -> b.message(m -> m.name("message").zeebeCorrelationKeyExpression("key")))
+                    .serviceTask("B_v1", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "message",
+                        b ->
+                            b.message(m -> m.name("message2").zeebeCorrelationKeyExpression("key")))
+                    .serviceTask("B_v2", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("key", helper.getCorrelationValue())
+            .create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord()
+                    .setName("message")
+                    .setCorrelationKey(helper.getCorrelationValue())
+                    .setTimeToLive(Duration.ofHours(1).toMillis())),
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))));
+
+    final var subscriptionRejection =
+        RecordingExporter.processMessageSubscriptionRecords(
+                ProcessMessageSubscriptionIntent.CORRELATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(subscriptionRejection)
+        .describedAs(
+            "Expect that the correlation is rejected because the subscription is already closing.")
+        .hasRejectionType(RejectionType.INVALID_STATE);
+
+    // The new process waits for a message with a different name. Continue the process instance by
+    // publishing the message.
+    ENGINE
+        .message()
+        .withName("message2")
+        .withCorrelationKey(helper.getCorrelationValue())
+        .publish();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
+  @Test
+  public void shouldContinueMigratedInstanceWithMessageAfter() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    // the new process must use a different message name because of an inconsistent state exception
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "message",
+                        b -> b.message(m -> m.name("message").zeebeCorrelationKeyExpression("key")))
+                    .serviceTask("B_v1", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "message",
+                        b ->
+                            b.message(m -> m.name("message2").zeebeCorrelationKeyExpression("key")))
+                    .serviceTask("B_v2", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("key", helper.getCorrelationValue())
+            .create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))),
+        RecordToWrite.command()
+            .message(
+                MessageIntent.PUBLISH,
+                new MessageRecord()
+                    .setName("message")
+                    .setCorrelationKey(helper.getCorrelationValue())
+                    .setTimeToLive(Duration.ofHours(1).toMillis())));
+
+    // The new process waits for a message with a different name. Continue the process instance by
+    // publishing the message.
+    ENGINE
+        .message()
+        .withName("message2")
+        .withCorrelationKey(helper.getCorrelationValue())
+        .publish();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
+  @Test
+  public void shouldContinueMigratedInstanceWithMessageCorrelateBefore() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    // the new process must use a different message name because of an inconsistent state exception
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "message",
+                        b -> b.message(m -> m.name("message").zeebeCorrelationKeyExpression("key")))
+                    .serviceTask("B_v1", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "message",
+                        b ->
+                            b.message(m -> m.name("message2").zeebeCorrelationKeyExpression("key")))
+                    .serviceTask("B_v2", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariable("key", helper.getCorrelationValue())
+            .create();
+
+    final Record<ProcessMessageSubscriptionRecordValue> subscriptionCreated =
+        RecordingExporter.processMessageSubscriptionRecords(
+                ProcessMessageSubscriptionIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var subscriptionCommand = new ProcessMessageSubscriptionRecord();
+    subscriptionCommand.wrap((ProcessMessageSubscriptionRecord) subscriptionCreated.getValue());
+    subscriptionCommand.setMessageKey(1);
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processMessageSubscription(
+                ProcessMessageSubscriptionIntent.CORRELATE, subscriptionCommand)
+            .key(subscriptionCreated.getKey()),
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))));
+
+    final var migrationRejection =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(migrationRejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%d' \
+            but a concurrent command was executed on the process instance. \
+            Please retry the migration."""
+                .formatted(processInstanceKey));
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("B_v1")
+        .await();
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B_v1", "B_v2")
+        .migrate();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
+  @Test
+  public void shouldContinueMigratedInstanceWithNonInterruptingTimerBefore() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("timer", b -> b.timerWithDuration("PT1H"))
+                    .cancelActivity(false)
+                    .serviceTask("B_v1", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("timer", b -> b.timerWithDuration("PT1H"))
+                    .cancelActivity(false)
+                    .serviceTask("B_v2", t -> t.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .moveToActivity("A")
+                    .endEvent("end_2_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final Record<TimerRecordValue> timerCreated =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .timer(TimerIntent.TRIGGER, timerCreated.getValue())
+            .key(timerCreated.getKey()),
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))));
+
+    final var migrationRejection =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(migrationRejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%d' \
+            but active element with id 'timer' has an unsupported type. \
+            The migration of a BOUNDARY_EVENT is not supported."""
+                .formatted(processInstanceKey));
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("B_v1")
+        .await();
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .addMappingInstruction("B_v1", "B_v2")
+        .migrate();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldContinueMigratedInstanceWithElementActivateBefore() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .serviceTask("B_v1", s -> s.zeebeJobType("B"))
+                    .endEvent("end_v1")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .serviceTask("B_v2", s -> s.zeebeJobType("B"))
+                    .endEvent("end_v2")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final Record<ProcessInstanceRecordValue> taskActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+
+    // when
+    ENGINE.writeRecords(
+        RecordToWrite.command()
+            .processInstance(ProcessInstanceIntent.COMPLETE_ELEMENT, taskActivated.getValue())
+            .key(taskActivated.getKey()),
+        RecordToWrite.command()
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))));
+
+    final var migrationRejection =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(migrationRejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%d' \
+            but a concurrent command was executed on the process instance. \
+            Please retry the migration."""
+                .formatted(processInstanceKey));
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("B_v1")
+        .await();
+
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("B_v1", "B_v2")
+        .migrate();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  private static long extractProcessDefinitionKeyByProcessId(
+      final Record<DeploymentRecordValue> deployment, final String processId) {
+    return deployment.getValue().getProcessesMetadata().stream()
+        .filter(p -> p.getBpmnProcessId().equals(processId))
+        .findAny()
+        .orElseThrow()
+        .getProcessDefinitionKey();
+  }
+}


### PR DESCRIPTION
## Description

If the batch processing is disabled, a process instance migration command in combination with a concurrent command for the same process instance could lead to an invalid state. The process instance is migrated but the element instance of the concurrent command continues processing on the previous version of the process.  

To avoid invalid states, Zeebe rejects the process instance migration command if it detects a concurrent command. We use the event trigger and the active sequence flow count as indicators for a concurrent comment. The event trigger is created if an event, like a timer, message, or signal, is triggered. The active sequence flow count is greater than zero if a sequence flow is taken but the connected element is not activated yet. 

## Related issues

requires #15571
closes #15129 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
