### PR TITLE
15366 support update job timeout go client

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:dupl after the line 15
+
 package commands
 
 import (

--- a/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
@@ -12,8 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint
 package commands
+
+//nolint:dupl
 
 import (
 	"context"

--- a/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
@@ -1,0 +1,68 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package commands
+
+import (
+	"context"
+	"fmt"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"github.com/spf13/cobra"
+)
+
+var (
+	updateTimeoutKey  int64
+	updateTimeoutFlag int64
+)
+
+type UpdateJobTimeoutResponseWrapper struct {
+	response *pb.UpdateJobTimeoutResponse
+}
+
+func (u UpdateJobTimeoutResponseWrapper) human() (string, error) {
+	return fmt.Sprint("Updated the timeout of job with key '", updateTimeoutKey, "' to '", updateTimeoutFlag, "'"), nil
+}
+
+func (u UpdateJobTimeoutResponseWrapper) json() (string, error) {
+	return toJSON(u.response)
+}
+
+var updateTimeoutCmd = &cobra.Command{
+	Use:     "timeout <key>",
+	Short:   "Update timeout of a job",
+	Args:    keyArg(&updateTimeoutKey),
+	PreRunE: initClient,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(context.Background(), timeoutFlag)
+		defer cancel()
+
+		resp, err := client.NewUpdateJobTimeoutCommand().JobKey(updateTimeoutKey).Timeout(updateTimeoutFlag).Send(ctx)
+		if err != nil {
+			return err
+		}
+		err = printOutput(UpdateJobTimeoutResponseWrapper{resp})
+
+		return err
+	},
+}
+
+func init() {
+	addOutputFlag(updateTimeoutCmd)
+	updateCmd.AddCommand(updateTimeoutCmd)
+	updateTimeoutCmd.Flags().Int64Var(&updateTimeoutFlag, "timeout", commands.DefaultJobTimeoutInMs, "Specify timeout of job")
+	if err := updateTimeoutCmd.MarkFlagRequired("timeout"); err != nil {
+		panic(err)
+	}
+}

--- a/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
@@ -45,7 +45,7 @@ var updateTimeoutCmd = &cobra.Command{
 	Args:    keyArg(&updateTimeoutKey),
 	PreRunE: initClient,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx, cancel := context.WithTimeout(context.Background(), timeoutFlag)
+		ctx, cancel := context.WithTimeout(cmd.Context(), timeoutFlag)
 		defer cancel()
 
 		resp, err := client.NewUpdateJobTimeoutCommand().JobKey(updateTimeoutKey).Timeout(updateTimeoutFlag).Send(ctx)

--- a/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:dupl after the line 15
-
+// nolint
 package commands
 
 import (

--- a/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateJobTimeout.go
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package commands
-
 //nolint:dupl
+package commands
 
 import (
 	"context"

--- a/clients/go/cmd/zbctl/internal/commands/updateRetries.go
+++ b/clients/go/cmd/zbctl/internal/commands/updateRetries.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:dupl
 package commands
 
 import (

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -234,7 +234,7 @@ var tests = []testCase{
 			strings.Fields("--insecure create instance jobProcess"),
 			strings.Fields("--insecure activate jobs jobType --maxJobsToActivate 1"),
 		},
-		cmd:        strings.Fields("--insecure update timeout 2251799813685359 --timeout 10000"),
+		cmd:        strings.Fields("--insecure update timeout 2251799813685360 --timeout 10000"),
 		goldenFile: "testdata/update_job_timeout.golden",
 	},
 }

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -226,6 +226,9 @@ var tests = []testCase{
 		cmd:        strings.Fields("--insecure update timeout 2251799813685253 --timeout 10000"),
 		goldenFile: "testdata/update_unknown_job_timeout.golden",
 	},
+	// In order to determine the job id: strings.Fields("--insecure activate jobs jobType --maxJobsToActivate 1")
+	// command was run in the below test (in the "cmd" part instead of a setup part)
+	// to check it's output - the job key of the generated job was always the same
 	{
 		name: "update job timeout",
 		setupCmds: [][]string{

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"os"
 	"os/exec"
 	"regexp"
@@ -219,6 +220,22 @@ var tests = []testCase{
 		},
 		cmd:        strings.Fields("--insecure delete resource 2251799813685257"),
 		goldenFile: "testdata/delete_resource.golden",
+	},
+	{
+		name:       "update unknown job timeout",
+		setupCmds:  [][]string{},
+		cmd:        strings.Fields("--insecure update timeout 2251799813685253 --timeout 10000"),
+		goldenFile: "testdata/update_unknown_job_timeout.golden",
+	},
+	{
+		name: "update job timeout",
+		setupCmds: [][]string{
+			strings.Fields("--insecure deploy resource testdata/job_model.bpmn"),
+			strings.Fields("--insecure create instance jobProcess"),
+			strings.Fields("--insecure activate jobs jobType --maxJobsToActivate 1"),
+		},
+		cmd:        strings.Fields("--insecure update timeout 2251799813685359 --timeout 10000"),
+		goldenFile: "testdata/update_job_timeout.golden",
 	},
 }
 

--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/zbc"
 	"os"
 	"os/exec"
 	"regexp"
@@ -234,7 +233,7 @@ var tests = []testCase{
 			strings.Fields("--insecure create instance jobProcess"),
 			strings.Fields("--insecure activate jobs jobType --maxJobsToActivate 1"),
 		},
-		cmd:        strings.Fields("--insecure update timeout 2251799813685360 --timeout 10000"),
+		cmd:        strings.Fields("--insecure update timeout 2251799813685371 --timeout 10000"),
 		goldenFile: "testdata/update_job_timeout.golden",
 	},
 }

--- a/clients/go/cmd/zbctl/testdata/update_job_timeout.golden
+++ b/clients/go/cmd/zbctl/testdata/update_job_timeout.golden
@@ -1,0 +1,1 @@
+Updated the timeout of job with key '2251799813685359' to '10000'

--- a/clients/go/cmd/zbctl/testdata/update_unknown_job_timeout.golden
+++ b/clients/go/cmd/zbctl/testdata/update_unknown_job_timeout.golden
@@ -1,0 +1,1 @@
+Error: rpc error: code = NotFound desc = Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job deadline with key '2251799813685253', but no such job was found

--- a/clients/go/pkg/commands/update_job_timeout.go
+++ b/clients/go/pkg/commands/update_job_timeout.go
@@ -11,7 +11,6 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
 
 package commands
 

--- a/clients/go/pkg/commands/update_job_timeout.go
+++ b/clients/go/pkg/commands/update_job_timeout.go
@@ -1,0 +1,71 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package commands
+
+import (
+	"context"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+)
+
+type DispatchUpdateJobTimeoutCommand interface {
+	Send(context.Context) (*pb.UpdateJobTimeoutResponse, error)
+}
+
+type UpdateJobTimeoutCommandStep1 interface {
+	JobKey(int64) UpdateJobTimeoutCommandStep2
+}
+
+type UpdateJobTimeoutCommandStep2 interface {
+	DispatchUpdateJobTimeoutCommand
+
+	Timeout(int64) DispatchUpdateJobTimeoutCommand
+}
+
+type UpdateJobTimeoutCommand struct {
+	Command
+	request pb.UpdateJobTimeoutRequest
+}
+
+func (cmd *UpdateJobTimeoutCommand) JobKey(jobKey int64) UpdateJobTimeoutCommandStep2 {
+	cmd.request.JobKey = jobKey
+	return cmd
+}
+
+func (cmd *UpdateJobTimeoutCommand) Timeout(timeout int64) DispatchUpdateJobTimeoutCommand {
+	cmd.request.Timeout = timeout
+	return cmd
+}
+
+func (cmd *UpdateJobTimeoutCommand) Send(ctx context.Context) (*pb.UpdateJobTimeoutResponse, error) {
+	response, err := cmd.gateway.UpdateJobTimeout(ctx, &cmd.request)
+	if cmd.shouldRetry(ctx, err) {
+		return cmd.Send(ctx)
+	}
+
+	return response, err
+}
+
+func NewUpdateJobTimeoutCommand(gateway pb.GatewayClient, pred retryPredicate) UpdateJobTimeoutCommandStep1 {
+	return &UpdateJobTimeoutCommand{
+		request: pb.UpdateJobTimeoutRequest{
+			Timeout: DefaultJobTimeoutInMs,
+		},
+		Command: Command{
+			gateway:     gateway,
+			shouldRetry: pred,
+		},
+	}
+}

--- a/clients/go/pkg/commands/update_job_timeout_test.go
+++ b/clients/go/pkg/commands/update_job_timeout_test.go
@@ -4,13 +4,14 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package commands
 
 import (

--- a/clients/go/pkg/commands/update_job_timeout_test.go
+++ b/clients/go/pkg/commands/update_job_timeout_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2018 Camunda Services GmbH (info@camunda.com)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package commands
+
+import (
+	"context"
+	"github.com/camunda/zeebe/clients/go/v8/internal/mock_pb"
+	"github.com/camunda/zeebe/clients/go/v8/internal/utils"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"github.com/golang/mock/gomock"
+	"testing"
+)
+
+func TestUpdateJobsTimeout(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	client := mock_pb.NewMockGatewayClient(ctrl)
+
+	request := &pb.UpdateJobTimeoutRequest{
+		JobKey:  123,
+		Timeout: DefaultJobTimeoutInMs,
+	}
+
+	stub := &pb.UpdateJobTimeoutResponse{}
+
+	client.EXPECT().UpdateJobTimeout(gomock.Any(), &utils.RPCTestMsg{Msg: request}).Return(stub, nil)
+
+	command := NewUpdateJobTimeoutCommand(client, func(context.Context, error) bool { return false })
+
+	response, err := command.JobKey(123).Send(context.Background())
+
+	if err != nil {
+		t.Errorf("Failed to send request")
+	}
+
+	if response != stub {
+		t.Errorf("Failed to receive response")
+	}
+}

--- a/clients/go/pkg/zbc/api.go
+++ b/clients/go/pkg/zbc/api.go
@@ -42,6 +42,7 @@ type Client interface {
 	NewCompleteJobCommand() commands.CompleteJobCommandStep1
 	NewFailJobCommand() commands.FailJobCommandStep1
 	NewUpdateJobRetriesCommand() commands.UpdateJobRetriesCommandStep1
+	NewUpdateJobTimeoutCommand() commands.UpdateJobTimeoutCommandStep1
 	NewThrowErrorCommand() commands.ThrowErrorCommandStep1
 	NewDeleteResourceCommand() commands.DeleteResourceCommandStep1
 

--- a/clients/go/pkg/zbc/client.go
+++ b/clients/go/pkg/zbc/client.go
@@ -132,6 +132,10 @@ func (c *ClientImpl) NewUpdateJobRetriesCommand() commands.UpdateJobRetriesComma
 	return commands.NewUpdateJobRetriesCommand(c.gateway, c.credentialsProvider.ShouldRetryRequest)
 }
 
+func (c *ClientImpl) NewUpdateJobTimeoutCommand() commands.UpdateJobTimeoutCommandStep1 {
+	return commands.NewUpdateJobTimeoutCommand(c.gateway, c.credentialsProvider.ShouldRetryRequest)
+}
+
 func (c *ClientImpl) NewSetVariablesCommand() commands.SetVariablesCommandStep1 {
 	return commands.NewSetVariablesCommand(c.gateway, c.credentialsProvider.ShouldRetryRequest)
 }


### PR DESCRIPTION
## Description

Adding support for update Job Timeout Command to Go client.
More about the command here: [issue](https://github.com/camunda/zeebe/issues/15020)

Added integration tests as well.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15366

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
