### PR TITLE
[HACKDAY] Publish message and await correlation

### DIFF
--- a/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -139,7 +139,7 @@ public class CommandApiRequestHandlerTest {
     scheduler.workUntilDone();
 
     final var request =
-        new BrokerPublishMessageRequest("test", "1").setMessageId("1").setTimeToLive(0);
+        new BrokerPublishMessageRequest("test", "1", false).setMessageId("1").setTimeToLive(0);
     request.serializeValue();
 
     // when
@@ -163,7 +163,7 @@ public class CommandApiRequestHandlerTest {
     scheduler.workUntilDone();
 
     final var request =
-        new BrokerPublishMessageRequest("test", "1").setMessageId("1").setTimeToLive(0);
+        new BrokerPublishMessageRequest("test", "1", false).setMessageId("1").setTimeToLive(0);
     request.serializeValue();
 
     // when
@@ -184,7 +184,7 @@ public class CommandApiRequestHandlerTest {
     scheduler.workUntilDone();
 
     final var request =
-        new BrokerPublishMessageRequest("test", "1").setMessageId("1").setTimeToLive(0);
+        new BrokerPublishMessageRequest("test", "1", false).setMessageId("1").setTimeToLive(0);
     request.serializeValue();
 
     // when
@@ -204,7 +204,7 @@ public class CommandApiRequestHandlerTest {
     when(logStreamWriter.canWriteEvents(anyInt(), anyInt())).thenReturn(false);
 
     final var request =
-        new BrokerPublishMessageRequest("test", "1").setMessageId("1").setTimeToLive(0);
+        new BrokerPublishMessageRequest("test", "1", false).setMessageId("1").setTimeToLive(0);
     request.serializeValue();
 
     // when

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
@@ -116,5 +116,9 @@ public interface PublishMessageCommandStep1 {
      *     it to the broker.
      */
     PublishMessageCommandStep3 variable(String key, Object value);
+
+    PublishMessageCommandStep3 awaitCorrelation();
+
+    PublishMessageCommandStep3 awaitCorrelation(boolean awaitCorrelation);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -74,6 +74,18 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
   }
 
   @Override
+  public PublishMessageCommandStep3 awaitCorrelation() {
+    builder.setAwaitCorrelation(true);
+    return this;
+  }
+
+  @Override
+  public PublishMessageCommandStep3 awaitCorrelation(final boolean awaitCorrelation) {
+    builder.setAwaitCorrelation(awaitCorrelation);
+    return this;
+  }
+
+  @Override
   public PublishMessageCommandStep3 correlationKey(final String correlationKey) {
     builder.setCorrelationKey(correlationKey);
     return this;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/ProcessMessageSubscriptionCorrelateProcessor.java
@@ -155,6 +155,7 @@ public final class ProcessMessageSubscriptionCorrelateProcessor
         subscription.getElementInstanceKey(),
         subscription.getBpmnProcessIdBuffer(),
         subscription.getMessageNameBuffer(),
+        subscription.getMessageKey(),
         subscription.getTenantId());
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSender.java
@@ -203,6 +203,7 @@ public class SubscriptionCommandSender {
       final long elementInstanceKey,
       final DirectBuffer bpmnProcessId,
       final DirectBuffer messageName,
+      final long messageKey,
       final String tenantId) {
     return handleFollowUpCommandBasedOnPartition(
         subscriptionPartitionId,
@@ -212,7 +213,7 @@ public class SubscriptionCommandSender {
             .setProcessInstanceKey(processInstanceKey)
             .setElementInstanceKey(elementInstanceKey)
             .setBpmnProcessId(bpmnProcessId)
-            .setMessageKey(-1)
+            .setMessageKey(messageKey)
             .setMessageName(messageName)
             .setTenantId(tenantId));
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageState.java
@@ -224,7 +224,11 @@ public final class DbMessageState implements MutableMessageState {
   @Override
   public void put(final long key, final MessageRecord record) {
     messageKey.wrapLong(key);
-    message.setMessageKey(key).setMessage(record);
+    message
+        .setMessageKey(key)
+        .setMessage(record)
+        .setRequestId(record.getRequestId())
+        .setRequestStreamId(record.getRequestStreamId());
     messageColumnFamily.insert(messageKey, message);
 
     tenantIdKey.wrapString(record.getTenantId());

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/StoredMessage.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/StoredMessage.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.state.message;
 
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
@@ -16,6 +17,8 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 public class StoredMessage extends UnpackedObject implements DbValue {
 
   private final LongProperty messageKeyProp = new LongProperty("messageKey");
+  private final LongProperty requestIdProp = new LongProperty("requestId", -1L);
+  private final IntegerProperty requestStreamIdProp = new IntegerProperty("requestStreamId", -1);
 
   private final ObjectProperty<MessageRecord> messageProp =
       new ObjectProperty<>("message", new MessageRecord());
@@ -39,6 +42,24 @@ public class StoredMessage extends UnpackedObject implements DbValue {
 
   public StoredMessage setMessage(final MessageRecord record) {
     messageProp.getValue().wrap(record);
+    return this;
+  }
+
+  public long getRequestId() {
+    return requestIdProp.getValue();
+  }
+
+  public StoredMessage setRequestId(final long requestId) {
+    requestIdProp.setValue(requestId);
+    return this;
+  }
+
+  public int getRequestStreamId() {
+    return requestStreamIdProp.getValue();
+  }
+
+  public StoredMessage setRequestStreamId(final int requestStreamId) {
+    requestStreamIdProp.setValue(requestStreamId);
     return this;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/command/SubscriptionCommandSenderTest.java
@@ -366,6 +366,7 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_NAME,
+        DEFAULT_MESSAGE_KEY,
         TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then
@@ -384,6 +385,7 @@ public class SubscriptionCommandSenderTest {
         DEFAULT_ELEMENT_INSTANCE_KEY,
         DEFAULT_PROCESS_ID,
         DEFAULT_MESSAGE_NAME,
+        DEFAULT_MESSAGE_KEY,
         TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // then

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -37,6 +37,15 @@
             "deadline": {
               "type": "long"
             },
+            "awaitCorrelation": {
+              "type": "boolean"
+            },
+            "requestId": {
+              "type": "long"
+            },
+            "requestStreamId": {
+              "type": "integer"
+            },
             "tenantId": {
               "type": "keyword"
             }

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-template.json
@@ -37,6 +37,15 @@
             "deadline": {
               "type": "long"
             },
+            "awaitCorrelation": {
+              "type": "boolean"
+            },
+            "requestId": {
+              "type": "long"
+            },
+            "requestStreamId": {
+              "type": "integer"
+            },
             "tenantId": {
               "type": "keyword"
             }

--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -467,6 +467,7 @@ message PublishMessageRequest {
   string variables = 5;
   // the tenant id of the message
   string tenantId = 6;
+  bool awaitCorrelation = 7;
 }
 
 message PublishMessageResponse {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -925,6 +925,11 @@
                 "id": 6,
                 "name": "tenantId",
                 "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "awaitCorrelation",
+                "type": "bool"
               }
             ]
           },

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -113,7 +113,10 @@ public final class RequestMapper {
   public static BrokerPublishMessageRequest toPublishMessageRequest(
       final PublishMessageRequest grpcRequest) {
     final BrokerPublishMessageRequest brokerRequest =
-        new BrokerPublishMessageRequest(grpcRequest.getName(), grpcRequest.getCorrelationKey());
+        new BrokerPublishMessageRequest(
+            grpcRequest.getName(),
+            grpcRequest.getCorrelationKey(),
+            grpcRequest.getAwaitCorrelation());
 
     brokerRequest
         .setMessageId(grpcRequest.getMessageId())

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPublishMessageRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerPublishMessageRequest.java
@@ -16,9 +16,13 @@ public final class BrokerPublishMessageRequest extends BrokerExecuteCommand<Mess
 
   private final MessageRecord requestDto = new MessageRecord();
 
-  public BrokerPublishMessageRequest(final String messageName, final String correlationKey) {
+  public BrokerPublishMessageRequest(
+      final String messageName, final String correlationKey, final boolean awaitCorrelation) {
     super(ValueType.MESSAGE, MessageIntent.PUBLISH);
-    requestDto.setName(messageName).setCorrelationKey(correlationKey);
+    requestDto
+        .setName(messageName)
+        .setCorrelationKey(correlationKey)
+        .setAwaitCorrelation(awaitCorrelation);
   }
 
   public DirectBuffer getCorrelationKey() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -10,7 +10,9 @@ package io.camunda.zeebe.protocol.impl.record.value.message;
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -32,6 +34,10 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   private final StringProperty messageIdProp = new StringProperty("messageId", "");
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final BooleanProperty awaitCorrelationProp =
+      new BooleanProperty("awaitCorrelation", false);
+  private final LongProperty requestId = new LongProperty("requestId", -1);
+  private final IntegerProperty requestStreamId = new IntegerProperty("requestStreamId", -1);
 
   public MessageRecord() {
     declareProperty(nameProp)
@@ -40,7 +46,10 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
         .declareProperty(variablesProp)
         .declareProperty(messageIdProp)
         .declareProperty(deadlineProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(awaitCorrelationProp)
+        .declareProperty(requestId)
+        .declareProperty(requestStreamId);
   }
 
   public void wrap(final MessageRecord record) {
@@ -99,6 +108,36 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
 
   public MessageRecord setDeadline(final long deadline) {
     deadlineProp.setValue(deadline);
+    return this;
+  }
+
+  @Override
+  public boolean getAwaitCorrelation() {
+    return awaitCorrelationProp.getValue();
+  }
+
+  public MessageRecord setAwaitCorrelation(final boolean awaitCorrelation) {
+    awaitCorrelationProp.setValue(awaitCorrelation);
+    return this;
+  }
+
+  @Override
+  public long getRequestId() {
+    return requestId.getValue();
+  }
+
+  public MessageRecord setRequestId(final long requestId) {
+    this.requestId.setValue(requestId);
+    return this;
+  }
+
+  @Override
+  public int getRequestStreamId() {
+    return requestStreamId.getValue();
+  }
+
+  public MessageRecord setRequestStreamId(final int requestStreamId) {
+    this.requestStreamId.setValue(requestStreamId);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -829,6 +829,9 @@ final class JsonSerializableToJsonTest {
                   .setTimeToLive(timeToLive)
                   .setDeadline(22L)
                   .setMessageId(wrapString(messageId))
+                  .setAwaitCorrelation(true)
+                  .setRequestId(2)
+                  .setRequestStreamId(6)
                   .setTenantId("foo");
             },
         """
@@ -841,7 +844,10 @@ final class JsonSerializableToJsonTest {
           "messageId": "test-id",
           "name": "test-message",
           "deadline": 22,
-          "tenantId": "foo"
+          "tenantId": "foo",
+          "awaitCorrelation": true,
+          "requestId": 2,
+          "requestStreamId": 6
         }
         """
       },
@@ -869,7 +875,10 @@ final class JsonSerializableToJsonTest {
           "messageId": "",
           "name": "test-message",
           "deadline": -1,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "awaitCorrelation": false,
+          "requestId": -1,
+          "requestStreamId": -1
         }
         """
       },

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageRecordValue.java
@@ -57,4 +57,20 @@ public interface MessageRecordValue extends RecordValueWithVariables, TenantOwne
    *     set, it returns -1 instead.
    */
   long getDeadline();
+
+  /**
+   * @return true if the user requested to await the correlation of the message before receiving a
+   *     response
+   */
+  boolean getAwaitCorrelation();
+
+  /**
+   * @return the id of the request if {@link #getAwaitCorrelation()} is true, otherwise -1
+   */
+  long getRequestId();
+
+  /**
+   * @return the stream id of the request if {@link #getAwaitCorrelation()} is true, otherwise -1
+   */
+  int getRequestStreamId();
 }


### PR DESCRIPTION
When publishing messages, client's can set `awaitCorrelation`. If this is set, the `MessageIntent.PUBLISHED` response is only sent if and when the message was successfully correlated. If the message can't be correlated fast enough, the request times out.

TODO: this doesn't work with TTL <= 0 because the message is cleaned up directly after publishing such that the message is no longer in the state and we can't find the request id to respond after correlation.