### PR TITLE
refactor(journal): throttle segment deletion failure

### DIFF
--- a/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
+++ b/journal/src/main/java/io/camunda/zeebe/journal/file/SegmentsManager.java
@@ -12,11 +12,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.camunda.zeebe.journal.CorruptedJournalException;
 import io.camunda.zeebe.journal.JournalException;
 import io.camunda.zeebe.journal.JournalMetaStore;
+import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,6 +43,7 @@ final class SegmentsManager implements AutoCloseable {
   private static final long INITIAL_ASQN = SegmentedJournal.ASQN_IGNORE;
 
   private static final Logger LOG = LoggerFactory.getLogger(SegmentsManager.class);
+  private static final Logger THROTTLED_LOG = new ThrottledLogger(LOG, Duration.ofSeconds(5));
 
   private final NavigableMap<Long, Segment> segments = new ConcurrentSkipListMap<>();
   private CompletableFuture<UninitializedSegment> nextSegment = null;
@@ -179,7 +182,7 @@ final class SegmentsManager implements AutoCloseable {
     final SortedMap<Long, Segment> compactSegments =
         segments.headMap(segmentEntry.getValue().index());
     if (compactSegments.isEmpty()) {
-      LOG.debug(
+      THROTTLED_LOG.debug(
           "No segments can be deleted with index < {} (first log index: {})",
           index,
           getFirstIndex());


### PR DESCRIPTION
## Description

This PR throttles the debug log when we fail to delete segment if nothing is compact-able. The reason to do this is that in the case of full disks due to no processing or exporting, this is extremely noisy with debug enabled. See for example:

![image](https://github.com/camunda/zeebe/assets/43373/afbd0987-2b1c-42a8-8d84-61a51d2b4de5)

I don't think we lose so much information by throttling it down. We don't have metrics for it of course, so you don't get to see how often it's throttled, but I think that's OK.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
