### PR TITLE
1553 process user task claim command

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState;
+import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.List;
+
+public class UserTaskClaimProcessor implements TypedRecordProcessor<UserTaskRecord> {
+
+  private final UserTaskState userTaskState;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final UserTaskCommandPreconditionChecker preconditionChecker;
+
+  public UserTaskClaimProcessor(final ProcessingState state, final Writers writers) {
+    userTaskState = state.getUserTaskState();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    preconditionChecker =
+        new UserTaskCommandPreconditionChecker(
+            List.of(LifecycleState.CREATED), "claim", userTaskState);
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<UserTaskRecord> command) {
+    preconditionChecker
+        .check(command)
+        .ifRightOrLeft(
+            persistedRecord -> claimUserTask(command, persistedRecord),
+            violation -> {
+              rejectionWriter.appendRejection(command, violation.getLeft(), violation.getRight());
+              responseWriter.writeRejectionOnCommand(
+                  command, violation.getLeft(), violation.getRight());
+            });
+  }
+
+  private void claimUserTask(
+      final TypedRecord<UserTaskRecord> command, final UserTaskRecord userTaskRecord) {
+    final long userTaskKey = command.getKey();
+
+    userTaskRecord.setAssignee(command.getValue().getAssignee());
+
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
+    responseWriter.writeEventOnCommand(userTaskKey, UserTaskIntent.CLAIM, userTaskRecord, command);
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
@@ -59,6 +59,7 @@ public class UserTaskClaimProcessor implements TypedRecordProcessor<UserTaskReco
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);
-    responseWriter.writeEventOnCommand(userTaskKey, UserTaskIntent.CLAIM, userTaskRecord, command);
+    responseWriter.writeEventOnCommand(
+        userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord, command);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
@@ -22,6 +22,8 @@ public class UserTaskCommandPreconditionChecker {
       "Expected to %s user task with key '%d', but no such user task was found";
   private static final String INVALID_USER_TASK_STATE_MESSAGE =
       "Expected to %s user task with key '%d', but it is in state '%s'";
+  private static final String INVALID_USER_TASK_ASSIGNEE_MESSAGE =
+      "Expected to %s user task with key '%d', but it has already been assigned";
 
   private final List<LifecycleState> validLifecycleStates;
   private final String intent;
@@ -52,13 +54,24 @@ public class UserTaskCommandPreconditionChecker {
 
     final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
 
-    if (validLifecycleStates.contains(lifecycleState)) {
-      return Either.right(persistedRecord);
+    // TODO explain code refactoring
+    if (!validLifecycleStates.contains(lifecycleState)) {
+      return Either.left(
+          Tuple.of(
+              RejectionType.INVALID_STATE,
+              String.format(INVALID_USER_TASK_STATE_MESSAGE, intent, userTaskKey, lifecycleState)));
     }
 
-    return Either.left(
-        Tuple.of(
-            RejectionType.INVALID_STATE,
-            String.format(INVALID_USER_TASK_STATE_MESSAGE, intent, userTaskKey, lifecycleState)));
+    if (intent.contains("claim")) {
+      if (!(persistedRecord.getAssignee().isBlank())
+          && !persistedRecord.getAssignee().equals(command.getValue().getAssignee())) {
+        return Either.left(
+            Tuple.of(
+                RejectionType.INVALID_STATE,
+                String.format(INVALID_USER_TASK_ASSIGNEE_MESSAGE, intent, userTaskKey)));
+      }
+    }
+
+    return Either.right(persistedRecord);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
@@ -25,7 +25,7 @@ public class UserTaskCommandPreconditionChecker {
   private static final String INVALID_USER_TASK_ASSIGNEE_MESSAGE =
       "Expected to %s user task with key '%d', but it has already been assigned";
   private static final String INVALID_USER_TASK_EMPTY_ASSIGNEE_MESSAGE =
-      "Expected to %s user task with key '%d', but the assignee is empty";
+      "Expected to %s user task with key '%d', but provided assignee is empty";
 
   private static final String CLAIM_INTENT = "claim";
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
@@ -25,6 +25,8 @@ public class UserTaskCommandPreconditionChecker {
   private static final String INVALID_USER_TASK_ASSIGNEE_MESSAGE =
       "Expected to %s user task with key '%d', but it has already been assigned";
 
+  private static final String CLAIM_INTENT = "claim";
+
   private final List<LifecycleState> validLifecycleStates;
   private final String intent;
 
@@ -61,7 +63,7 @@ public class UserTaskCommandPreconditionChecker {
               String.format(INVALID_USER_TASK_STATE_MESSAGE, intent, userTaskKey, lifecycleState)));
     }
 
-    if (intent.equals("claim")) {
+    if (intent.equals(CLAIM_INTENT)) {
       final String assignee = persistedRecord.getAssignee();
       final boolean canClaim =
           assignee.isBlank() || assignee.equals(command.getValue().getAssignee());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
@@ -54,7 +54,6 @@ public class UserTaskCommandPreconditionChecker {
 
     final LifecycleState lifecycleState = userTaskState.getLifecycleState(userTaskKey);
 
-    // TODO explain code refactoring
     if (!validLifecycleStates.contains(lifecycleState)) {
       return Either.left(
           Tuple.of(
@@ -62,9 +61,11 @@ public class UserTaskCommandPreconditionChecker {
               String.format(INVALID_USER_TASK_STATE_MESSAGE, intent, userTaskKey, lifecycleState)));
     }
 
-    if (intent.contains("claim")) {
-      if (!(persistedRecord.getAssignee().isBlank())
-          && !persistedRecord.getAssignee().equals(command.getValue().getAssignee())) {
+    if (intent.equals("claim")) {
+      final String assignee = persistedRecord.getAssignee();
+      final boolean canClaim =
+          assignee.isBlank() || assignee.equals(command.getValue().getAssignee());
+      if (!canClaim) {
         return Either.left(
             Tuple.of(
                 RejectionType.INVALID_STATE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCommandPreconditionChecker.java
@@ -24,6 +24,8 @@ public class UserTaskCommandPreconditionChecker {
       "Expected to %s user task with key '%d', but it is in state '%s'";
   private static final String INVALID_USER_TASK_ASSIGNEE_MESSAGE =
       "Expected to %s user task with key '%d', but it has already been assigned";
+  private static final String INVALID_USER_TASK_EMPTY_ASSIGNEE_MESSAGE =
+      "Expected to %s user task with key '%d', but the assignee is empty";
 
   private static final String CLAIM_INTENT = "claim";
 
@@ -64,9 +66,16 @@ public class UserTaskCommandPreconditionChecker {
     }
 
     if (intent.equals(CLAIM_INTENT)) {
-      final String assignee = persistedRecord.getAssignee();
-      final boolean canClaim =
-          assignee.isBlank() || assignee.equals(command.getValue().getAssignee());
+      final String assignee = command.getValue().getAssignee();
+      if (assignee.isBlank()) {
+        return Either.left(
+            Tuple.of(
+                RejectionType.INVALID_STATE,
+                String.format(INVALID_USER_TASK_EMPTY_ASSIGNEE_MESSAGE, intent, userTaskKey)));
+      }
+
+      final String currentAssignee = persistedRecord.getAssignee();
+      final boolean canClaim = currentAssignee.isBlank() || currentAssignee.equals(assignee);
       if (!canClaim) {
         return Either.left(
             Tuple.of(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskEventProcessors.java
@@ -42,6 +42,10 @@ public final class UserTaskEventProcessors {
         .onCommand(
             ValueType.USER_TASK,
             UserTaskIntent.ASSIGN,
-            new UserTaskAssignProcessor(processingState, writers));
+            new UserTaskAssignProcessor(processingState, writers))
+        .onCommand(
+            ValueType.USER_TASK,
+            UserTaskIntent.CLAIM,
+            new UserTaskClaimProcessor(processingState, writers));
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -128,6 +128,25 @@ public class ClaimUserTaskTest {
   }
 
   @Test
+  public void shouldRejectUserTaskWithEmptyAssignee() {
+    // given
+    ENGINE.deployment().withXmlResource(process(b -> b.zeebeAssignee("foo"))).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE.userTask().withKey(userTaskKey).withAssignee("").expectRejection().claim();
+
+    // then
+    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.INVALID_STATE);
+  }
+
+  @Test
   public void shouldClaimUserTaskWithAssigneeSelf() {
     // given
     ENGINE.deployment().withXmlResource(process(b -> b.zeebeAssignee("foo"))).deploy();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.usertask;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ClaimUserTaskTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private static BpmnModelInstance process() {
+    return process(b -> {});
+  }
+
+  private static BpmnModelInstance process(final Consumer<UserTaskBuilder> consumer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().userTask("task").zeebeUserTask();
+
+    consumer.accept(builder);
+
+    return builder.endEvent().done();
+  }
+
+  @Test
+  public void shouldEmitAssigningEventForClaimedUserTask() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE.userTask().withKey(userTaskKey).withAssignee("foo").claim();
+
+    // then
+    final UserTaskRecordValue recordValue = claimedRecord.getValue();
+
+    Assertions.assertThat(claimedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.ASSIGNING);
+
+    Assertions.assertThat(recordValue)
+        .hasUserTaskKey(userTaskKey)
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldClaimUserTaskForAssignee() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("foo").claim();
+
+    // then
+    Assertions.assertThat(claimedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.ASSIGNING);
+    Assertions.assertThat(claimedRecord.getValue()).hasAssignee("foo");
+  }
+
+  @Test
+  public void shouldRejectClaimIfUserTaskNotFound() {
+    // given
+    final int key = 123;
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE.userTask().withKey(key).withAssignee("foo").expectRejection().claim();
+
+    // then
+    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldRejectUserTaskWithAssigneeAlreadyAssigned() {
+    // given
+    ENGINE.deployment().withXmlResource(process(b -> b.zeebeAssignee("foo"))).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE
+            .userTask()
+            .withKey(userTaskKey)
+            .withAssignee("new assignee")
+            .expectRejection()
+            .claim();
+
+    // then
+    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.INVALID_STATE);
+  }
+
+  @Test
+  public void shouldRejectClaimIfUserTaskIsCompleted() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.userTask().ofInstance(processInstanceKey).complete();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).expectRejection().claim();
+
+    // then
+    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+
+  @Test
+  public void shouldClaimUserTaskForCustomTenant() {
+    // given
+    final String tenantId = "acme";
+    ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAuthorizedTenantIds(tenantId)
+            .withAssignee("foo")
+            .claim();
+
+    // then
+    final UserTaskRecordValue recordValue = claimedRecord.getValue();
+
+    Assertions.assertThat(claimedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.ASSIGNING);
+
+    Assertions.assertThat(recordValue).hasTenantId(tenantId);
+  }
+
+  @Test
+  public void shouldRejectClaimIfTenantIsUnauthorized() {
+    // given
+    final String tenantId = "acme";
+    final String falseTenantId = "foo";
+    ENGINE.deployment().withXmlResource(process()).withTenantId(tenantId).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withTenantId(tenantId).create();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE
+            .userTask()
+            .ofInstance(processInstanceKey)
+            .withAuthorizedTenantIds(falseTenantId)
+            .expectRejection()
+            .claim();
+
+    // then
+    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.NOT_FOUND);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/ClaimUserTaskTest.java
@@ -91,6 +91,20 @@ public class ClaimUserTaskTest {
   }
 
   @Test
+  public void shouldRejectClaimUserTaskForEmptyAssignee() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    final Record<UserTaskRecordValue> claimedRecord =
+        ENGINE.userTask().ofInstance(processInstanceKey).withAssignee("").expectRejection().claim();
+
+    // then
+    Assertions.assertThat(claimedRecord).hasRejectionType(RejectionType.INVALID_STATE);
+  }
+
+  @Test
   public void shouldRejectClaimIfUserTaskNotFound() {
     // given
     final int key = 123;
@@ -128,7 +142,7 @@ public class ClaimUserTaskTest {
   }
 
   @Test
-  public void shouldRejectUserTaskWithEmptyAssignee() {
+  public void shouldRejectUserTaskWithEmptyAssigneeWhenAlreadyAssigned() {
     // given
     ENGINE.deployment().withXmlResource(process(b -> b.zeebeAssignee("foo"))).deploy();
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -122,6 +122,17 @@ public final class UserTaskClient {
     return expectation.apply(position);
   }
 
+  public Record<UserTaskRecordValue> claim() {
+    final long userTaskKey = findUserTaskKey();
+    final long position =
+        writer.writeCommand(
+            userTaskKey,
+            UserTaskIntent.CLAIM,
+            userTaskRecord.setUserTaskKey(userTaskKey),
+            authorizedTenantIds.toArray(new String[0]));
+    return expectation.apply(position);
+  }
+
   public Record<UserTaskRecordValue> complete() {
     final long userTaskKey = findUserTaskKey();
     final long position =

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -28,7 +28,9 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
 
   ASSIGN(7),
   ASSIGNING(8),
-  ASSIGNED(9);
+  ASSIGNED(9),
+
+  CLAIM(10);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -68,6 +70,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return ASSIGNING;
       case 9:
         return ASSIGNED;
+      case 10:
+        return CLAIM;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

In this PR:

Implementation of a processor for the UserTaskIntent.CLAIM command issued for the UserTask value type:
- Added `UserTaskClaimProcessor`
- Updated `UserTaskCommandPreconditionChecker`. Ensured the user task can be assigned: checked for the internal state CREATED. Added verification to check if the task's assignee is empty and if the task already has assignee that is different from the assignee provided by the command
- Registered `UserTaskClaimProcessor` in `UserTaskEventProcessors`

Added the following tests:
- `ClaimUserTaskTest`
- Updated `NativeUserTaskTest`

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15531

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
