### PR TITLE
Reject process instance migration if event subscriptions exist

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -172,6 +172,7 @@ public class ProcessInstanceMigrationMigrateProcessor
           command,
           RejectionType.INVALID_STATE,
           ERROR_MESSAGE_EVENT_SUBPROCESS_NOT_SUPPORTED_IN_PROCESS_INSTANCE);
+      return;
     }
 
     final boolean targetProcessHasEventSubprocess =
@@ -186,6 +187,7 @@ public class ProcessInstanceMigrationMigrateProcessor
           command,
           RejectionType.INVALID_STATE,
           ERROR_MESSAGE_EVENT_SUBPROCESS_NOT_SUPPORTED_IN_TARGET_PROCESS);
+      return;
     }
 
     final Map<String, String> mappedElementIds =

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceConcurrentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceConcurrentTest.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -201,6 +202,7 @@ public class MigrateProcessInstanceConcurrentTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithTimerBefore() {
     // given
@@ -297,6 +299,7 @@ public class MigrateProcessInstanceConcurrentTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithTimerAfter() {
     // given
@@ -353,20 +356,6 @@ public class MigrateProcessInstanceConcurrentTest {
             .timer(TimerIntent.TRIGGER, timerCreated.getValue())
             .key(timerCreated.getKey()));
 
-    final var migrationRejection =
-        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
-            .withProcessInstanceKey(processInstanceKey)
-            .onlyCommandRejections()
-            .getFirst();
-
-    assertThat(migrationRejection)
-        .hasRejectionType(RejectionType.INVALID_STATE)
-        .hasRejectionReason(
-            """
-            Expected to migrate process instance '%s' but active element with id 'A' has a boundary event. \
-            Migrating active elements with boundary events is not possible yet."""
-                .formatted(processInstanceKey));
-
     ENGINE.increaseTime(Duration.ofHours(1));
 
     ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
@@ -378,15 +367,16 @@ public class MigrateProcessInstanceConcurrentTest {
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSubsequence(
-            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED))
-        .doesNotContain(
             tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithMessageBefore() {
     // given
@@ -497,6 +487,7 @@ public class MigrateProcessInstanceConcurrentTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithMessageAfter() {
     // given
@@ -567,22 +558,13 @@ public class MigrateProcessInstanceConcurrentTest {
                     .setCorrelationKey(helper.getCorrelationValue())
                     .setTimeToLive(Duration.ofHours(1).toMillis())));
 
-    final var migrationRejection =
-        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
-            .withProcessInstanceKey(processInstanceKey)
-            .onlyCommandRejections()
-            .getFirst();
-
-    assertThat(migrationRejection)
-        .hasRejectionType(RejectionType.INVALID_STATE)
-        .hasRejectionReason(
-            """
-            Expected to migrate process instance '%s' but active element with id 'A' has a boundary event. \
-            Migrating active elements with boundary events is not possible yet."""
-                .formatted(processInstanceKey));
-
+    // The new process waits for a message with a different name. Continue the process instance by
     // publishing the message.
-    ENGINE.message().withName("message").withCorrelationKey(helper.getCorrelationValue()).publish();
+    ENGINE
+        .message()
+        .withName("message2")
+        .withCorrelationKey(helper.getCorrelationValue())
+        .publish();
 
     ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
 
@@ -593,15 +575,16 @@ public class MigrateProcessInstanceConcurrentTest {
                 .limitToProcessInstanceCompleted())
         .extracting(r -> r.getValue().getElementId(), Record::getIntent)
         .containsSubsequence(
-            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED))
-        .doesNotContain(
             tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
-            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithMessageCorrelateBefore() {
     // given
@@ -715,6 +698,7 @@ public class MigrateProcessInstanceConcurrentTest {
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Ignore("Ignore until the migration is supported for tasks with boundary events")
   @Test
   public void shouldContinueMigratedInstanceWithNonInterruptingTimerBefore() {
     // given
@@ -779,17 +763,40 @@ public class MigrateProcessInstanceConcurrentTest {
             .onlyCommandRejections()
             .getFirst();
 
-    // then
     assertThat(migrationRejection)
         .hasRejectionType(RejectionType.INVALID_STATE)
         .hasRejectionReason(
             """
-            Expected to migrate process instance '%d' but active element with id 'A' has a boundary event. \
-            Migrating active elements with boundary events is not possible yet."""
+            Expected to migrate process instance '%d' but no mapping instruction defined for active element with id 'B_v1'. \
+            Elements cannot be migrated without a mapping."""
                 .formatted(processInstanceKey));
 
-    // It is not possible to assert continuation of the process instance because boundary events
-    // are not supported yet.
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .addMappingInstruction("B_v1", "B_v2")
+        .migrate();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("B_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(targetProcessId, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   private static long extractProcessDefinitionKeyByProcessId(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -710,6 +711,135 @@ public class MigrateProcessInstanceRejectionTest {
             String.format(
                 "Expected to migrate process instance '%s' but the mapping instructions contain duplicate source element ids '%s'.",
                 processInstanceKey, "[A]"))
+        .hasKey(processInstanceKey);
+  }
+
+  @Test
+  public void
+      shouldRejectCommandWhenTheMigratedProcessInstanceContainsATaskSubscribedToABoundaryEvent() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process")
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("boundary")
+                    .message(
+                        m -> m.name("message").zeebeCorrelationKeyExpression("\"correlationKey\""))
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process2")
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .endEvent("end")
+                    .done())
+            .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName("message")
+        .withCorrelationKey("correlationKey")
+        .await();
+
+    final long targetProcessDefinitionKey =
+        extractTargetProcessDefinitionKey(deployment, "process2");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+              Expected to migrate process instance '%s' \
+              but active element with id 'A' has a boundary event. \
+              Migrating active elements with boundary events is not possible yet."""
+                .formatted(processInstanceKey))
+        .hasKey(processInstanceKey);
+  }
+
+  @Test
+  public void shouldRejectCommandWhenTheMigratedProcessInstanceSubscribedToAnEventSubprocess() {
+    // given
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process")
+                    .eventSubProcess(
+                        "eventSubProcess",
+                        sub ->
+                            sub.startEvent(
+                                    "eventSubProcessStart",
+                                    s ->
+                                        s.message(
+                                            m ->
+                                                m.name("message")
+                                                    .zeebeCorrelationKeyExpression(
+                                                        "\"correlationKey\"")))
+                                .endEvent())
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess("process2")
+                    .startEvent()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withMessageName("message")
+        .withCorrelationKey("correlationKey")
+        .await();
+
+    final long targetProcessDefinitionKey =
+        extractTargetProcessDefinitionKey(deployment, "process2");
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .expectRejection()
+        .migrate();
+
+    // then
+    final var rejectionRecord =
+        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
+
+    assertThat(rejectionRecord)
+        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            "Expected to migrate process instance but process instance has an event subprocess. "
+                + "Process instances with event subprocesses cannot be migrated yet.")
         .hasKey(processInstanceKey);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
@@ -584,11 +584,9 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
     assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
     Assertions.assertThat(rejection.getRejectionReason())
         .contains(
-            String.format(
-                """
-                Expected to migrate process instance '%s' but active element with id '%s' \
-                has an unsupported type. The migration of a %s is not supported""",
-                processInstanceKey, "SUB", "EVENT_SUB_PROCESS"));
+            """
+                Expected to migrate process instance but process instance has an event subprocess. \
+                Process instances with event subprocesses cannot be migrated yet.""");
   }
 
   @Test


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Both #15405 and #15406 is implemented in this PR in order to get this merged faster.

@saig0 Please consider checking commit messages for implementation decisions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15405 #15406

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
