### PR TITLE
Add back pressure/slow worker tests in Go

### DIFF
--- a/clients/go/internal/containersuite/containerSuite.go
+++ b/clients/go/internal/containersuite/containerSuite.go
@@ -248,11 +248,11 @@ func (s *ContainerSuite) SetupSuite() {
 
 	s.logConsumer = testLogConsumer{func(ignored string) {}}
 	s.container.FollowOutput(&s.logConsumer)
-	s.container.StartLogProducer(ctx)
+	s.Require().NoError(s.container.StartLogProducer(ctx))
 }
 
 func (s *ContainerSuite) TearDownSuite() {
-	s.container.StopLogProducer()
+	_ = s.container.StopLogProducer() // safe to ignore
 	err := s.container.Terminate(context.Background())
 	if err != nil {
 		s.T().Fatal(err)

--- a/clients/go/test/integration_test.go
+++ b/clients/go/test/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -31,6 +32,8 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
+const dockerImageName = "camunda/zeebe:current-test"
+
 type integrationTestSuite struct {
 	*containersuite.ContainerSuite
 	client zbc.Client
@@ -40,7 +43,7 @@ func TestIntegration(t *testing.T) {
 	suite.Run(t, &integrationTestSuite{
 		ContainerSuite: &containersuite.ContainerSuite{
 			WaitTime:       time.Second,
-			ContainerImage: "camunda/zeebe:current-test",
+			ContainerImage: dockerImageName,
 		},
 	})
 }
@@ -66,6 +69,7 @@ func (s *integrationTestSuite) TearDownSuite() {
 
 	s.ContainerSuite.TearDownSuite()
 }
+
 func (s *integrationTestSuite) TestTopology() {
 	// when
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -259,7 +263,7 @@ func (s *integrationTestSuite) TestStreamJobs() {
 	defer cancel()
 
 	taskType := uuid.NewString()
-	bpmn, err := s.readBpmnWithCustomJobType("testdata/service_task.bpmn", taskType)
+	bpmn, err := readBpmnWithCustomJobType("testdata/service_task.bpmn", taskType)
 	s.NoError(err)
 
 	deployment, err := s.client.NewDeployResourceCommand().AddResource(bpmn, "service_task.bpmn").Send(ctx)
@@ -369,7 +373,7 @@ func (s *integrationTestSuite) TestStreamingJobWorker() {
 	defer cancel()
 
 	taskType := uuid.NewString()
-	bpmn, err := s.readBpmnWithCustomJobType("testdata/service_task.bpmn", taskType)
+	bpmn, err := readBpmnWithCustomJobType("testdata/service_task.bpmn", taskType)
 	s.NoError(err)
 
 	deployment, err := s.client.NewDeployResourceCommand().AddResource(bpmn, "service_task.bpmn").Send(ctx)
@@ -439,7 +443,119 @@ func (s *integrationTestSuite) TestStreamingJobWorker() {
 	}
 }
 
-func (s integrationTestSuite) readBpmnWithCustomJobType(path string, jobType string) ([]byte, error) {
+type slowWorkerSuite struct {
+	*integrationTestSuite
+}
+
+func TestSlowWorker(t *testing.T) {
+	suite.Run(t, &slowWorkerSuite{
+		integrationTestSuite: &integrationTestSuite{
+			ContainerSuite: &containersuite.ContainerSuite{
+				WaitTime:       time.Second,
+				ContainerImage: dockerImageName,
+				Env: map[string]string{
+					"ZEEBE_DEBUG":     "true",
+					"ZEEBE_LOG_LEVEL": "debug",
+				},
+			},
+		},
+	})
+}
+
+func (s *slowWorkerSuite) TestSlowStreamingJobWorker() {
+	// given
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	taskType := uuid.NewString()
+	bpmn, err := readBpmnWithCustomJobType("testdata/service_task.bpmn", taskType)
+	s.NoError(err)
+
+	deployment, err := s.client.NewDeployResourceCommand().AddResource(bpmn, "service_task.bpmn").Send(ctx)
+	if err != nil {
+		s.T().Fatal(err)
+	}
+
+	deployedResource := deployment.GetDeployments()[0]
+	s.NotNil(deployedResource)
+
+	process := deployedResource.GetProcess()
+	s.NotNil(process)
+
+	didYield := atomic.Bool{}
+	s.ContainerSuite.ConsumeLogs(func(log string) {
+		if strings.Contains(log, "\"valueType\":\"JOB\"") && strings.Contains(log, "\"intent\":\"YIELDED\"") {
+			didYield.Store(true)
+		}
+	})
+
+	// when
+	// the stream will be closed by the deferred context cancellation
+	ctx, cancel = context.WithCancel(context.Background())
+	defer cancel()
+
+	jobsChan := make(chan entities.Job)
+	defer close(jobsChan)
+
+	workerName := uuid.New().String()
+	jobWorker := s.client.NewJobWorker().
+		JobType(taskType).
+		Handler(func(client worker.JobClient, job entities.Job) {
+			jobsChan <- job
+		}).
+		Timeout(time.Minute * 5).
+		PollInterval(1 * time.Hour). // poll very slowly to make sure we get our jobs from streaming
+		Name(workerName).
+		Concurrency(1).
+		MaxJobsActive(1).
+		StreamEnabled(true).
+		RequestTimeout(time.Duration(1) * time.Second).
+		Open()
+	defer jobWorker.Close()
+
+	// Await until the stream is created on the broker
+	streamExists := utils.AwaitJobStreamExists(workerName, s.MonitoringAddress)
+	s.True(streamExists, "Expected remote stream to exist on broker after 5 seconds, but none yet exist")
+
+	// create PIs until we start yielding; since we only yield once buffers fill up, it's hard to predict how fast
+	// it will take to do so. we can cheat by using 32KB has our payload size, which at the time of writing, is
+	// the hard-coded  threshold for a gRPC stream to become not ready
+	variables := map[string]interface{}{"foo": strings.Repeat("x", 32*1024)}
+	for start := time.Now(); !didYield.Load() && time.Since(start) < 30*time.Second; {
+		cmd, err := s.client.NewCreateInstanceCommand().ProcessDefinitionKey(process.GetProcessDefinitionKey()).VariablesFromMap(variables)
+		s.Require().NoError(err)
+		_, err = cmd.Send(ctx)
+		s.Require().NoError(err)
+		time.Sleep(100 * time.Millisecond)
+	}
+	s.Require().Truef(didYield.Load(), "Expected to have yielded at least one job within 30 seconds, but did not; did back pressure not kick in?")
+
+	// then - consume any remaining jobs
+	jobs := make([]entities.Job, 0)
+jobConsumingLoop:
+	for {
+		select {
+		case job := <-jobsChan:
+			jobs = append(jobs, job)
+		case <-time.After(5 * time.Second):
+			break jobConsumingLoop
+		}
+	}
+
+	s.Require().NotEmptyf(jobs, "Expected to receive some jobs")
+	jobKeys := make([]int64, 0)
+	for _, job := range jobs {
+		s.NotContains(jobKeys, job.Key)
+		s.EqualValues(process.GetProcessDefinitionKey(), job.GetProcessDefinitionKey())
+		s.EqualValues(process.GetBpmnProcessId(), job.GetBpmnProcessId())
+		s.EqualValues("service_task", job.GetElementId())
+		s.Greater(job.GetRetries(), int32(0))
+
+		jobKeys = append(jobKeys, job.Key)
+	}
+}
+
+func readBpmnWithCustomJobType(path string, jobType string) ([]byte, error) {
 	b, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description

This PR adds an integration test which ensures back pressure works as expected in Go. It works primarily because of how channels work - by passing a bounded channel, the job stream will eventually block if the channel is not consumed fast enough. This will get detected upstream, and back pressure will kick in, preventing your worker from crashing due to resource exhaustion.

The test is not quite as accurate as in Java, primarily due to the tooling being worse. But it works - we use the debug log exporter and find the first time we output a YIELDED event. This is then considered a success.

You can check the original issue for an actual live benchmark.

## Related issues

closes #15554 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
