### PR TITLE
fix(topology): ensure topology messages are processed in order

### DIFF
--- a/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -152,13 +152,13 @@ final class ClusterTopologyManagerTest {
             .getClusterTopology()
             .join()
             .addMember(MemberId.from("10"), MemberState.initializeAsActive(Map.of()));
-    final var gossipedTopology =
-        clusterTopologyManager.onGossipReceived(topologyFromOtherMember).join();
+
+    clusterTopologyManager.onGossipReceived(topologyFromOtherMember);
 
     // then
     final ClusterTopology clusterTopology = clusterTopologyManager.getClusterTopology().join();
     assertThatClusterTopology(clusterTopology).hasOnlyMembers(Set.of(1, 10));
-    assertThat(gossipedTopology)
+    assertThat(gossipState.get())
         .describedAs("Gossip state contains same topology in topology manager")
         .isEqualTo(clusterTopology);
     assertThat(persistedClusterTopology.getTopology())
@@ -177,7 +177,7 @@ final class ClusterTopologyManagerTest {
             .getClusterTopology()
             .join()
             .addMember(MemberId.from("10"), MemberState.initializeAsActive(Map.of()));
-    clusterTopologyManager.onGossipReceived(topologyFromOtherMember).join();
+    clusterTopologyManager.onGossipReceived(topologyFromOtherMember);
 
     // then
     assertThat(persistedClusterTopology.getTopology().isUninitialized()).isTrue();
@@ -192,7 +192,7 @@ final class ClusterTopologyManagerTest {
     // when
     final ClusterTopology topologyFromOtherMember =
         initialTopology.startTopologyChange(List.of(new PartitionLeaveOperation(localMemberId, 1)));
-    clusterTopologyManager.onGossipReceived(topologyFromOtherMember).join();
+    clusterTopologyManager.onGossipReceived(topologyFromOtherMember);
 
     // then
     Awaitility.await("ClusterTopology is updated after applying topology change operation.")
@@ -242,7 +242,7 @@ final class ClusterTopologyManagerTest {
     // when
     final ClusterTopology topologyFromOtherMember =
         initialTopology.startTopologyChange(List.of(new PartitionLeaveOperation(localMemberId, 1)));
-    clusterTopologyManager.onGossipReceived(topologyFromOtherMember).join();
+    clusterTopologyManager.onGossipReceived(topologyFromOtherMember);
 
     // then
     Awaitility.await("ClusterTopology is updated after applying topology change operation.")


### PR DESCRIPTION
## Description

When gossiper directly updates its local GossipState, the order of execution can differ because the ActorFuture:onComplete enqueues the task at the end of the queue. As a result during initialization, sometimes a valid topology gets overwritten by an uninitialized one. To simplify handling this, we always updated the gossiper from the ClusterTopologyManager directly. This ensures correct ordering, whether Gossiper is running on same exeuctor or not.

## Related issues

closes #15567 
