### PR TITLE
[Backport stable/8.3] refactor(msgpack): require a hint for the number of declared properties

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -17,6 +17,7 @@ public final class CheckpointInfo extends UnpackedObject implements DbValue {
   private final LongProperty positionProperty = new LongProperty("position");
 
   public CheckpointInfo() {
+    super(2);
     declareProperty(idProperty).declareProperty(positionProperty);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
@@ -24,6 +24,7 @@ public class ExporterStateEntry extends UnpackedObject implements DbValue {
       new BinaryProperty("exporterMetadata", EMPTY_METADATA);
 
   public ExporterStateEntry() {
+    super(2);
     declareProperty(positionProp).declareProperty(metadataProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentRaw.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentRaw.java
@@ -21,7 +21,12 @@ public class DeploymentRaw extends UnpackedObject implements DbValue {
       new ObjectProperty<>("deploymentRecord", new DeploymentRecord());
 
   public DeploymentRaw() {
+    super(1);
     declareProperty(deploymentRecordProperty);
+  }
+
+  public DeploymentRecord getDeploymentRecord() {
+    return deploymentRecordProperty.getValue();
   }
 
   public void setDeploymentRecord(final DeploymentRecord deploymentRecord) {
@@ -31,9 +36,5 @@ public class DeploymentRaw extends UnpackedObject implements DbValue {
 
     deploymentRecord.write(valueBuffer, 0);
     deploymentRecordProperty.getValue().wrap(valueBuffer, 0, encodedLength);
-  }
-
-  public DeploymentRecord getDeploymentRecord() {
-    return deploymentRecordProperty.getValue();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/Digest.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/Digest.java
@@ -16,6 +16,7 @@ public class Digest extends UnpackedObject implements DbValue {
   private final BinaryProperty digestProp = new BinaryProperty("digest");
 
   public Digest() {
+    super(1);
     declareProperty(digestProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/LatestProcessVersion.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/LatestProcessVersion.java
@@ -15,6 +15,7 @@ public class LatestProcessVersion extends UnpackedObject implements DbValue {
   private final LongProperty latestProcessVersionProp = new LongProperty("latestProcessVersion");
 
   public LatestProcessVersion() {
+    super(1);
     declareProperty(latestProcessVersionProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
@@ -34,6 +34,7 @@ public final class PersistedDecision extends UnpackedObject implements DbValue {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public PersistedDecision() {
+    super(7);
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(versionProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
@@ -37,6 +37,7 @@ public final class PersistedDecisionRequirements extends UnpackedObject implemen
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public PersistedDecisionRequirements() {
+    super(8);
     declareProperty(decisionRequirementsIdProp)
         .declareProperty(decisionRequirementsNameProp)
         .declareProperty(decisionRequirementsVersionProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
@@ -32,6 +32,7 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public PersistedForm() {
+    super(7);
     declareProperty(formIdProp)
         .declareProperty(versionProp)
         .declareProperty(formKeyProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -32,6 +32,7 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public PersistedProcess() {
+    super(7);
     declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(bpmnProcessIdProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/VersionInfo.java
@@ -26,6 +26,7 @@ public final class VersionInfo extends UnpackedObject implements DbValue {
       new ArrayProperty<>("knownVersions", LongValue::new);
 
   public VersionInfo() {
+    super(2);
     declareProperty(highestVersionProp).declareProperty(knownVersions);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/distribution/PersistedCommandDistribution.java
@@ -24,9 +24,10 @@ public class PersistedCommandDistribution extends UnpackedObject implements DbVa
       new EnumProperty<>("valueType", ValueType.class);
   private final IntegerProperty intentProperty = new IntegerProperty("intent", Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
-      new ObjectProperty<>("commandValue", new UnifiedRecordValue());
+      new ObjectProperty<>("commandValue", new UnifiedRecordValue(10));
 
   public PersistedCommandDistribution() {
+    super(3);
     declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)
         .declareProperty(commandValueProperty);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
@@ -24,6 +24,7 @@ public final class AwaitProcessInstanceResultMetadata extends UnpackedObject imp
       new ArrayProperty<>("fetchVariables", StringValue::new);
 
   public AwaitProcessInstanceResultMetadata() {
+    super(3);
     declareProperty(requestIdProperty)
         .declareProperty(requestStreamIdProperty)
         .declareProperty(fetchVariablesProperty);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -41,6 +41,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
       new IntegerProperty("activeSequenceFlows", 0);
 
   public ElementInstance() {
+    super(11);
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(childActivatedCountProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
@@ -29,6 +29,7 @@ public final class EventScopeInstance extends UnpackedObject implements DbValue 
       new ArrayProperty<>("boundaryElementIds", StringValue::new);
 
   public EventScopeInstance() {
+    super(4);
     declareProperty(acceptingProp)
         .declareProperty(interruptingElementIdsProp)
         .declareProperty(boundaryElementIdsProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventTrigger.java
@@ -26,6 +26,7 @@ public final class EventTrigger extends UnpackedObject implements DbValue {
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
 
   public EventTrigger() {
+    super(4);
     declareProperty(elementIdProp)
         .declareProperty(variablesProp)
         .declareProperty(eventKeyProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/Incident.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/Incident.java
@@ -17,6 +17,7 @@ public class Incident extends UnpackedObject implements DbValue {
       new ObjectProperty<>("incidentRecord", new IncidentRecord());
 
   public Incident() {
+    super(1);
     declareProperty(recordProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IncidentKey.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IncidentKey.java
@@ -16,6 +16,7 @@ public class IncidentKey extends UnpackedObject implements DbValue {
   private final LongProperty keyProp = new LongProperty("key");
 
   public IncidentKey() {
+    super(1);
     declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IndexedRecord.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IndexedRecord.java
@@ -26,6 +26,7 @@ public final class IndexedRecord extends UnpackedObject implements DbValue {
       new ObjectProperty<>("processInstanceRecord", new ProcessInstanceRecord());
 
   IndexedRecord() {
+    super(3);
     declareProperty(keyProp).declareProperty(stateProp).declareProperty(valueProp);
   }
 
@@ -77,7 +78,7 @@ public final class IndexedRecord extends UnpackedObject implements DbValue {
   }
 
   @Override
-  public void wrap(final DirectBuffer buffer, int offset, final int length) {
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     final byte[] bytes = new byte[length];
     final UnsafeBuffer mutableBuffer = new UnsafeBuffer(bytes);
     buffer.getBytes(offset, bytes, 0, length);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobRecordValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobRecordValue.java
@@ -18,6 +18,7 @@ public class JobRecordValue extends UnpackedObject implements DbValue {
       new ObjectProperty<>("jobRecord", new JobRecord());
 
   public JobRecordValue() {
+    super(1);
     declareProperty(recordProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobStateValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobStateValue.java
@@ -18,6 +18,7 @@ public class JobStateValue extends UnpackedObject implements DbValue {
       new EnumProperty<>("jobState", JobState.State.class);
 
   public JobStateValue() {
+    super(1);
     declareProperty(stateProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ParentScopeKey.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ParentScopeKey.java
@@ -15,6 +15,7 @@ public class ParentScopeKey extends UnpackedObject implements DbValue {
   private final LongProperty keyProp = new LongProperty("parentScopeKey", -1L);
 
   public ParentScopeKey() {
+    super(1);
     declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TimerInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TimerInstance.java
@@ -34,6 +34,7 @@ public final class TimerInstance extends UnpackedObject implements DbValue, Tena
   private final IntegerProperty repetitionsProp = new IntegerProperty("repetitions", 0);
 
   public TimerInstance() {
+    super(8);
     declareProperty(handlerNodeIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(keyProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscription.java
@@ -21,15 +21,16 @@ public class MessageStartEventSubscription extends UnpackedObject implements DbV
   private final LongProperty keyProp = new LongProperty("key");
 
   public MessageStartEventSubscription() {
+    super(2);
     declareProperty(recordProp).declareProperty(keyProp);
-  }
-
-  public void setRecord(final MessageStartEventSubscriptionRecord record) {
-    recordProp.getValue().wrap(record);
   }
 
   public MessageStartEventSubscriptionRecord getRecord() {
     return recordProp.getValue();
+  }
+
+  public void setRecord(final MessageStartEventSubscriptionRecord record) {
+    recordProp.getValue().wrap(record);
   }
 
   public long getKey() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageSubscription.java
@@ -24,6 +24,7 @@ public final class MessageSubscription extends UnpackedObject implements DbValue
   private final BooleanProperty correlatingProp = new BooleanProperty("correlating", false);
 
   public MessageSubscription() {
+    super(3);
     declareProperty(recordProp).declareProperty(keyProp).declareProperty(correlatingProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscription.java
@@ -23,6 +23,7 @@ public final class ProcessMessageSubscription extends UnpackedObject implements 
   private final LongProperty keyProp = new LongProperty("key");
 
   public ProcessMessageSubscription() {
+    super(3);
     declareProperty(recordProp).declareProperty(stateProp).declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/StoredMessage.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/StoredMessage.java
@@ -21,6 +21,7 @@ public class StoredMessage extends UnpackedObject implements DbValue {
       new ObjectProperty<>("message", new MessageRecord());
 
   public StoredMessage() {
+    super(2);
     declareProperty(messageKeyProp).declareProperty(messageProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTaskState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTaskState.java
@@ -17,6 +17,7 @@ public final class MigrationTaskState extends UnpackedObject implements DbValue 
       new EnumProperty<>("state", State.class, State.NOT_STARTED);
 
   public MigrationTaskState() {
+    super(1);
     declareProperty(stateProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariables.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariables.java
@@ -16,6 +16,7 @@ public class TemporaryVariables extends UnpackedObject implements DbValue {
   private final BinaryProperty valueProp = new BinaryProperty("temporaryVariables");
 
   public TemporaryVariables() {
+    super(1);
     declareProperty(valueProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/LastProcessedPosition.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/LastProcessedPosition.java
@@ -15,6 +15,7 @@ public class LastProcessedPosition extends UnpackedObject implements DbValue {
   private final LongProperty positionProp = new LongProperty("lastProcessPosition");
 
   public LastProcessedPosition() {
+    super(1);
     declareProperty(positionProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/signal/SignalSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/signal/SignalSubscription.java
@@ -20,6 +20,7 @@ public class SignalSubscription extends UnpackedObject implements DbValue {
   private final LongProperty keyProp = new LongProperty("key");
 
   public SignalSubscription() {
+    super(2);
     declareProperty(recordProp).declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/variable/VariableInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/variable/VariableInstance.java
@@ -19,6 +19,7 @@ public final class VariableInstance extends UnpackedObject implements DbValue {
   private final BinaryProperty valueProp = new BinaryProperty("value");
 
   public VariableInstance() {
+    super(2);
     declareProperty(keyProp).declareProperty(valueProp);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
@@ -235,6 +235,10 @@ public final class BanInstanceTest {
 
   private final class Value extends UnifiedRecordValue implements ProcessInstanceRelated {
 
+    public Value() {
+      super(10);
+    }
+
     @Override
     public long getProcessInstanceKey() {
       return processInstanceKey;

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyMessageSubscription.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyMessageSubscription.java
@@ -23,6 +23,7 @@ public final class LegacyMessageSubscription extends UnpackedObject implements D
   private final LongProperty commandSentTimeProp = new LongProperty("commandSentTime", 0);
 
   public LegacyMessageSubscription() {
+    super(3);
     declareProperty(recordProp).declareProperty(keyProp).declareProperty(commandSentTimeProp);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyProcessMessageSubscription.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyProcessMessageSubscription.java
@@ -24,6 +24,7 @@ public final class LegacyProcessMessageSubscription extends UnpackedObject imple
   private final LongProperty keyProp = new LongProperty("key");
 
   public LegacyProcessMessageSubscription() {
+    super(4);
     declareProperty(recordProp)
         .declareProperty(commandSentTimeProp)
         .declareProperty(stateProp)

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogAppendEntryTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogAppendEntryTest.java
@@ -18,7 +18,7 @@ public class LogAppendEntryTest {
   public void shouldWrapValues() {
     // given
     final var recordMetadata = new RecordMetadata();
-    final var unifiedRecordValue = new UnifiedRecordValue();
+    final var unifiedRecordValue = new UnifiedRecordValue(0);
 
     // when
     final var logAppendEntry = LogAppendEntry.of(recordMetadata, unifiedRecordValue);
@@ -32,7 +32,7 @@ public class LogAppendEntryTest {
   public void shouldNotBeProcessedPerDefault() {
     // given
     final var recordMetadata = new RecordMetadata();
-    final var unifiedRecordValue = new UnifiedRecordValue();
+    final var unifiedRecordValue = new UnifiedRecordValue(0);
 
     // when
     final var logAppendEntry = LogAppendEntry.of(recordMetadata, unifiedRecordValue);
@@ -47,7 +47,7 @@ public class LogAppendEntryTest {
   public void shouldMarkEntryAsProcessed() {
     // given
     final var recordMetadata = new RecordMetadata();
-    final var unifiedRecordValue = new UnifiedRecordValue();
+    final var unifiedRecordValue = new UnifiedRecordValue(0);
     final var logAppendEntry = LogAppendEntry.of(recordMetadata, unifiedRecordValue);
 
     // when

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestEntry.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/TestEntry.java
@@ -53,7 +53,7 @@ public record TestEntry(
       }
 
       final var loggedMetadata = new RecordMetadata();
-      final var loggedValue = new UnifiedRecordValue();
+      final var loggedValue = new UnifiedRecordValue(10);
       loggedEvent.readValue(loggedValue);
       loggedEvent.readMetadata(loggedMetadata);
 
@@ -77,7 +77,7 @@ public record TestEntry(
   public static class TestLogAppendEntryBuilder {
     private long key = -1L;
     private int sourceIndex = -1;
-    private UnifiedRecordValue recordValue = new UnifiedRecordValue();
+    private UnifiedRecordValue recordValue = new UnifiedRecordValue(10);
     private RecordMetadata recordMetadata = new RecordMetadata().intent(Intent.UNKNOWN);
 
     public TestLogAppendEntryBuilder withKey(final long key) {

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
@@ -20,6 +20,16 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
   protected final MsgPackReader reader = new MsgPackReader();
   protected final MsgPackWriter writer = new MsgPackWriter();
 
+  /**
+   * Creates a new UnpackedObject
+   *
+   * @param expectedDeclaredProperties a size hint for the number of declared properties. Providing
+   *     the correct number helps to avoid allocations and memory copies.
+   */
+  public UnpackedObject(final int expectedDeclaredProperties) {
+    super(expectedDeclaredProperties);
+  }
+
   public void wrap(final DirectBuffer buff) {
     wrap(buff, 0, buff.capacity());
   }

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -16,11 +16,21 @@ import java.util.List;
 import java.util.Objects;
 
 public class ObjectValue extends BaseValue {
-  private final List<BaseProperty<? extends BaseValue>> declaredProperties = new ArrayList<>();
+  private final List<BaseProperty<? extends BaseValue>> declaredProperties;
   private final List<UndeclaredProperty> undeclaredProperties = new ArrayList<>();
   private final List<UndeclaredProperty> recycledProperties = new ArrayList<>();
 
   private final StringValue decodedKey = new StringValue();
+
+  /**
+   * Creates a new ObjectValue
+   *
+   * @param expectedDeclaredProperties a size hint for the number of declared properties. Providing
+   *     the correct number helps to avoid allocations and memory copies.
+   */
+  public ObjectValue(final int expectedDeclaredProperties) {
+    declaredProperties = new ArrayList<>(expectedDeclaredProperties);
+  }
 
   public ObjectValue declareProperty(final BaseProperty<? extends BaseValue> prop) {
     declaredProperties.add(prop);

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -17,8 +17,8 @@ import java.util.Objects;
 
 public class ObjectValue extends BaseValue {
   private final List<BaseProperty<? extends BaseValue>> declaredProperties;
-  private final List<UndeclaredProperty> undeclaredProperties = new ArrayList<>();
-  private final List<UndeclaredProperty> recycledProperties = new ArrayList<>();
+  private final List<UndeclaredProperty> undeclaredProperties = new ArrayList<>(0);
+  private final List<UndeclaredProperty> recycledProperties = new ArrayList<>(0);
 
   private final StringValue decodedKey = new StringValue();
 

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
@@ -21,7 +21,6 @@ public final class StringValue extends BaseValue {
 
   private final MutableDirectBuffer bytes = new UnsafeBuffer(0, 0);
   private int length;
-  private int hashCode;
 
   public StringValue() {
     this(EMPTY_STRING);
@@ -43,13 +42,11 @@ public final class StringValue extends BaseValue {
   public void reset() {
     bytes.wrap(0, 0);
     length = 0;
-    hashCode = 0;
   }
 
   public void wrap(final byte[] bytes) {
     this.bytes.wrap(bytes);
     length = bytes.length;
-    hashCode = 0;
   }
 
   public void wrap(final DirectBuffer buff) {
@@ -63,7 +60,6 @@ public final class StringValue extends BaseValue {
       bytes.wrap(buff, offset, length);
     }
     this.length = length;
-    hashCode = 0;
   }
 
   public void wrap(final StringValue anotherString) {

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/AllTypesDefaultValuesPOJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/AllTypesDefaultValuesPOJO.java
@@ -35,6 +35,7 @@ public final class AllTypesDefaultValuesPOJO extends UnpackedObject {
       final DirectBuffer packedDefault,
       final DirectBuffer binaryDefault,
       final POJONested objectDefault) {
+    super(7);
     enumProp = new EnumProperty<>("enumProp", POJOEnum.class, enumDefault);
     longProp = new LongProperty("longProp", longDefault);
     intProp = new IntegerProperty("intProp", intDefault);
@@ -42,7 +43,6 @@ public final class AllTypesDefaultValuesPOJO extends UnpackedObject {
     packedProp = new PackedProperty("packedProp", packedDefault);
     binaryProp = new BinaryProperty("binaryProp", binaryDefault);
     objectProp = new ObjectProperty<>("objectProp", objectDefault);
-
     declareProperty(enumProp)
         .declareProperty(longProp)
         .declareProperty(intProp)

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -461,6 +461,7 @@ public final class ArrayValueTest {
     private final StringProperty barProp = new StringProperty("bar");
 
     private Foo() {
+      super(2);
       declareProperty(fooProp).declareProperty(barProp);
     }
 
@@ -479,6 +480,7 @@ public final class ArrayValueTest {
     private final StringProperty barProp = new StringProperty("bar");
 
     private Bar() {
+      super(1);
       declareProperty(barProp);
     }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DefaultValuesPOJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DefaultValuesPOJO.java
@@ -15,6 +15,7 @@ public final class DefaultValuesPOJO extends UnpackedObject {
   protected final LongProperty noDefaultValueProperty = new LongProperty("noDefaultValueProp");
 
   public DefaultValuesPOJO(final long defaultValue) {
+    super(2);
     defaultValueProperty = new LongProperty("defaultValueProp", defaultValue);
 
     declareProperty(defaultValueProperty).declareProperty(noDefaultValueProperty);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
@@ -225,6 +225,7 @@ public final class DocumentPropertyTest {
     private final DocumentProperty documentProperty = new DocumentProperty("documentProp");
 
     Document() {
+      super(1);
       declareProperty(documentProperty);
     }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/MinimalPOJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/MinimalPOJO.java
@@ -14,6 +14,7 @@ public final class MinimalPOJO extends UnpackedObject {
   private final LongProperty longProp = new LongProperty("longProp");
 
   public MinimalPOJO() {
+    super(1);
     declareProperty(longProp);
   }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJO.java
@@ -28,6 +28,7 @@ public final class POJO extends UnpackedObject {
       new ObjectProperty<>("objectProp", new POJONested());
 
   public POJO() {
+    super(7);
     declareProperty(enumProp)
         .declareProperty(longProp)
         .declareProperty(intProp)

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
@@ -15,6 +15,7 @@ public final class POJOArray extends UnpackedObject {
   protected final ArrayProperty<MinimalPOJO> simpleArrayProp;
 
   public POJOArray() {
+    super(1);
     simpleArrayProp = new ArrayProperty<>("simpleArray", MinimalPOJO::new);
 
     declareProperty(simpleArrayProp);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJONested.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJONested.java
@@ -13,6 +13,7 @@ public final class POJONested extends UnpackedObject {
   private final LongProperty longProp = new LongProperty("foo", -1L);
 
   public POJONested() {
+    super(1);
     declareProperty(longProp);
   }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
@@ -29,7 +29,7 @@ public class UnpackedObjectTest {
     public void shouldResetObjectBeforeReadingValue() {
       // given
       final var property = new StringProperty("property", "default");
-      final var unpackedObject = new UnpackedObject();
+      final var unpackedObject = new UnpackedObject(1);
 
       unpackedObject.declareProperty(property);
 
@@ -53,10 +53,10 @@ public class UnpackedObjectTest {
   public class SchemaEvolution {
     private final StringProperty sharedProperty = new StringProperty("shared", "default");
 
-    private final UnpackedObject oldSchemaObject = new UnpackedObject();
+    private final UnpackedObject oldSchemaObject = new UnpackedObject(2);
     private final IntegerProperty removedProperty = new IntegerProperty("removedProperty", 42);
 
-    private final UnpackedObject newSchemaObject = new UnpackedObject();
+    private final UnpackedObject newSchemaObject = new UnpackedObject(2);
     private final BooleanProperty addedProperty = new BooleanProperty("addedProperty", false);
 
     private final MutableDirectBuffer bufferSerializedWithOldSchema =

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
@@ -21,6 +21,7 @@ public class ProcessMetadata extends UnpackedObject {
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
 
   public ProcessMetadata() {
+    super(4);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(versionProp)
         .declareProperty(bpmnProcessIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/AuthInfo.java
@@ -27,6 +27,7 @@ public class AuthInfo extends UnpackedObject {
   private final StringProperty authDataProp = new StringProperty("authData", "");
 
   public AuthInfo() {
+    super(2);
     declareProperty(formatProp).declareProperty(authDataProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -14,6 +14,16 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 
 public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
 
+  /**
+   * Creates a new {@link UnifiedRecordValue}.
+   *
+   * @param expectedDeclaredProperties the expected number of declared properties. Providing the
+   *     correct number helps to avoid allocations and memory copies.
+   */
+  public UnifiedRecordValue(final int expectedDeclaredProperties) {
+    super(expectedDeclaredProperties);
+  }
+
   @Override
   @JsonIgnore
   public int getLength() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -62,6 +62,7 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DecisionEvaluationRecord() {
+    super(17);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -47,6 +47,7 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public EvaluatedDecisionRecord() {
+    super(9);
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(decisionKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedInputRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedInputRecord.java
@@ -24,6 +24,7 @@ public final class EvaluatedInputRecord extends UnifiedRecordValue implements Ev
   private final BinaryProperty inputValueProp = new BinaryProperty("inputValue");
 
   public EvaluatedInputRecord() {
+    super(3);
     declareProperty(inputIdProp).declareProperty(inputNameProp).declareProperty(inputValueProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedOutputRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedOutputRecord.java
@@ -25,6 +25,7 @@ public final class EvaluatedOutputRecord extends UnifiedRecordValue
   private final BinaryProperty outputValueProp = new BinaryProperty("outputValue");
 
   public EvaluatedOutputRecord() {
+    super(3);
     declareProperty(outputIdProp).declareProperty(outputNameProp).declareProperty(outputValueProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
@@ -31,6 +31,7 @@ public final class MatchedRuleRecord extends UnifiedRecordValue implements Match
       new ArrayProperty<>("evaluatedOutputs", EvaluatedOutputRecord::new);
 
   public MatchedRuleRecord() {
+    super(3);
     declareProperty(ruleIdProp)
         .declareProperty(ruleIndexProp)
         .declareProperty(evaluatedOutputsProp);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -36,6 +36,7 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DecisionRecord() {
+    super(8);
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(versionProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
@@ -42,6 +42,7 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DecisionRequirementsMetadataRecord() {
+    super(9);
     declareProperty(decisionRequirementsIdProp)
         .declareProperty(decisionRequirementsNameProp)
         .declareProperty(decisionRequirementsVersionProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -40,6 +40,7 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DecisionRequirementsRecord() {
+    super(9);
     declareProperty(decisionRequirementsIdProp)
         .declareProperty(decisionRequirementsNameProp)
         .declareProperty(decisionRequirementsVersionProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentDistributionRecord.java
@@ -24,6 +24,7 @@ public class DeploymentDistributionRecord extends UnifiedRecordValue
   private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId");
 
   public DeploymentDistributionRecord() {
+    super(1);
     declareProperty(partitionIdProperty);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -47,6 +47,7 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public DeploymentRecord() {
+    super(6);
     declareProperty(resourcesProp)
         .declareProperty(processesMetadataProp)
         .declareProperty(decisionRequirementsMetadataProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
@@ -30,6 +30,7 @@ public final class DeploymentResource extends UnpackedObject
   private final StringProperty resourceNameProp = new StringProperty("resourceName", "resource");
 
   public DeploymentResource() {
+    super(2);
     declareProperty(resourceNameProp).declareProperty(resourceProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormMetadataRecord.java
@@ -33,6 +33,7 @@ public class FormMetadataRecord extends UnifiedRecordValue implements FormMetada
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public FormMetadataRecord() {
+    super(7);
     declareProperty(formIdProp)
         .declareProperty(versionProp)
         .declareProperty(formKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormRecord.java
@@ -32,6 +32,7 @@ public final class FormRecord extends UnifiedRecordValue implements Form {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public FormRecord() {
+    super(7);
     declareProperty(formIdProp)
         .declareProperty(versionProp)
         .declareProperty(formKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -41,6 +41,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessMetadata() {
+    super(7);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -34,6 +34,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessRecord() {
+    super(7);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -48,11 +48,12 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
       new EnumProperty<>("valueType", ValueType.class, ValueType.NULL_VAL);
   private final IntegerProperty intentProperty = new IntegerProperty("intent", Intent.NULL_VAL);
   private final ObjectProperty<UnifiedRecordValue> commandValueProperty =
-      new ObjectProperty<>("commandValue", new UnifiedRecordValue());
+      new ObjectProperty<>("commandValue", new UnifiedRecordValue(10));
   private final MsgPackWriter commandValueWriter = new MsgPackWriter();
   private final MsgPackReader commandValueReader = new MsgPackReader();
 
   public CommandDistributionRecord() {
+    super(4);
     declareProperty(partitionIdProperty)
         .declareProperty(valueTypeProperty)
         .declareProperty(intentProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/error/ErrorRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/error/ErrorRecord.java
@@ -29,6 +29,7 @@ public final class ErrorRecord extends UnifiedRecordValue implements ErrorRecord
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
 
   public ErrorRecord() {
+    super(4);
     declareProperty(exceptionMessageProp)
         .declareProperty(stacktraceProp)
         .declareProperty(errorEventPositionProp)
@@ -69,10 +70,12 @@ public final class ErrorRecord extends UnifiedRecordValue implements ErrorRecord
     return BufferUtil.bufferAsString(stacktraceProp.getValue());
   }
 
+  @Override
   public long getErrorEventPosition() {
     return errorEventPositionProp.getValue();
   }
 
+  @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProp.getValue();
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/escalation/EscalationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/escalation/EscalationRecord.java
@@ -23,6 +23,7 @@ public class EscalationRecord extends UnifiedRecordValue implements EscalationRe
   private final StringProperty catchElementIdProp = new StringProperty("catchElementId", "");
 
   public EscalationRecord() {
+    super(4);
     declareProperty(processInstanceKeyProp)
         .declareProperty(escalationCodeProp)
         .declareProperty(throwElementIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -35,6 +35,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public IncidentRecord() {
+    super(10);
     declareProperty(errorTypeProp)
         .declareProperty(errorMessageProp)
         .declareProperty(bpmnProcessIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -43,6 +43,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final BooleanProperty truncatedProp = new BooleanProperty("truncated", false);
 
   public JobBatchRecord() {
+    super(9);
     declareProperty(typeProp)
         .declareProperty(workerProp)
         .declareProperty(timeoutProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -64,6 +64,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public JobRecord() {
+    super(17);
     declareProperty(deadlineProp)
         .declareProperty(workerProp)
         .declareProperty(retriesProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
@@ -21,6 +21,7 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
       new LongProperty(CHECKPOINT_POSITION_KEY, -1L);
 
   public CheckpointRecord() {
+    super(2);
     declareProperty(checkpointIdProperty).declareProperty(checkpointPositionProperty);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageBatchRecord.java
@@ -23,6 +23,7 @@ public final class MessageBatchRecord extends UnifiedRecordValue
       new ArrayProperty<>("messageKeys", LongValue::new);
 
   public MessageBatchRecord() {
+    super(1);
     declareProperty(messageKeysProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -34,6 +34,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageRecord() {
+    super(7);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(timeToLiveProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -37,6 +37,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageStartEventSubscriptionRecord() {
+    super(9);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(startEventIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -37,6 +37,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public MessageSubscriptionRecord() {
+    super(9);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(messageKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -41,6 +41,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessMessageSubscriptionRecord() {
+    super(11);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
@@ -34,6 +34,7 @@ public final class ProcessEventRecord extends UnifiedRecordValue
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public ProcessEventRecord() {
+    super(6);
     declareProperty(scopeKeyProperty)
         .declareProperty(targetElementIdProperty)
         .declareProperty(variablesProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
@@ -35,6 +35,7 @@ public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
   private final LongProperty indexProperty = new LongProperty("index", -1L);
 
   public ProcessInstanceBatchRecord() {
+    super(3);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(batchElementInstanceKeyProperty)
         .declareProperty(indexProperty);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -45,6 +45,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>("startInstructions", ProcessInstanceCreationStartInstruction::new);
 
   public ProcessInstanceCreationRecord() {
+    super(8);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -26,6 +26,7 @@ public final class ProcessInstanceCreationStartInstruction extends ObjectValue
   private final StringProperty elementIdProp = new StringProperty("elementId");
 
   public ProcessInstanceCreationStartInstruction() {
+    super(1);
     declareProperty(elementIdProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
@@ -41,6 +41,7 @@ public final class ProcessInstanceModificationActivateInstruction extends Object
       new ArrayProperty<>("ancestorScopeKeys", LongValue::new);
 
   public ProcessInstanceModificationActivateInstruction() {
+    super(4);
     declareProperty(elementIdProperty)
         .declareProperty(ancestorScopeKeyProperty)
         .declareProperty(variableInstructionsProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -37,6 +37,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new ArrayProperty<>("activatedElementInstanceKeys", LongValue::new);
 
   public ProcessInstanceModificationRecord() {
+    super(4);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
@@ -23,6 +23,7 @@ public final class ProcessInstanceModificationTerminateInstruction extends Objec
   private final LongProperty elementInstanceKeyProperty = new LongProperty("elementInstanceKey");
 
   public ProcessInstanceModificationTerminateInstruction() {
+    super(1);
     declareProperty(elementInstanceKeyProperty);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
@@ -30,6 +30,7 @@ public final class ProcessInstanceModificationVariableInstruction extends Object
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
 
   public ProcessInstanceModificationVariableInstruction() {
+    super(2);
     declareProperty(variablesProp).declareProperty(elementIdProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -60,6 +60,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
       new LongProperty("parentElementInstanceKey", -1L);
 
   public ProcessInstanceRecord() {
+    super(11);
     declareProperty(bpmnElementTypeProp)
         .declareProperty(elementIdProp)
         .declareProperty(bpmnProcessIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
@@ -35,6 +35,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
       new LongProperty("processInstanceKey", -1);
 
   public ProcessInstanceResultRecord() {
+    super(6);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/resource/ResourceDeletionRecord.java
@@ -18,6 +18,7 @@ public class ResourceDeletionRecord extends UnifiedRecordValue
   private final LongProperty resourceKeyProp = new LongProperty("resourceKey");
 
   public ResourceDeletionRecord() {
+    super(1);
     declareProperty(resourceKeyProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalRecord.java
@@ -25,6 +25,7 @@ public final class SignalRecord extends UnifiedRecordValue implements SignalReco
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
 
   public SignalRecord() {
+    super(2);
     declareProperty(signalNameProp).declareProperty(variablesProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/signal/SignalSubscriptionRecord.java
@@ -29,6 +29,7 @@ public final class SignalSubscriptionRecord extends UnifiedRecordValue
       new LongProperty("catchEventInstanceKey", -1L);
 
   public SignalSubscriptionRecord() {
+    super(5);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(signalNameProp)
         .declareProperty(catchEventIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
@@ -31,6 +31,7 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public TimerRecord() {
+    super(7);
     declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
@@ -31,6 +31,7 @@ public final class VariableDocumentRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public VariableDocumentRecord() {
+    super(3);
     declareProperty(scopeKeyProperty)
         .declareProperty(updateSemanticsProperty)
         .declareProperty(variablesProperty);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -32,6 +32,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public VariableRecord() {
+    super(7);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/ActivatedJobImpl.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/ActivatedJobImpl.java
@@ -19,6 +19,7 @@ public class ActivatedJobImpl extends UnpackedObject implements ActivatedJob {
       new ObjectProperty<>("record", new JobRecord());
 
   public ActivatedJobImpl() {
+    super(2);
     declareProperty(jobKey).declareProperty(jobRecord);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/stream/job/JobActivationPropertiesImpl.java
@@ -27,6 +27,7 @@ public class JobActivationPropertiesImpl extends UnpackedObject implements JobAc
           "tenantIds", () -> new StringValue(TenantOwned.DEFAULT_TENANT_IDENTIFIER));
 
   public JobActivationPropertiesImpl() {
+    super(4);
     declareProperty(workerProp)
         .declareProperty(timeoutProp)
         .declareProperty(fetchVariablesProp)

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/LastProcessedPosition.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/LastProcessedPosition.java
@@ -15,6 +15,7 @@ public final class LastProcessedPosition extends UnpackedObject implements DbVal
   private final LongProperty positionProp = new LongProperty("lastProcessPosition");
 
   public LastProcessedPosition() {
+    super(1);
     declareProperty(positionProp);
   }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/NextValue.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/state/NextValue.java
@@ -15,6 +15,7 @@ public class NextValue extends UnpackedObject implements DbValue {
   private final LongProperty nextValueProp = new LongProperty("nextValue", -1L);
 
   public NextValue() {
+    super(1);
     declareProperty(nextValueProp);
   }
 


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/15518.

Size hints needed to be adjusted.