### PR TITLE
[Backport stable/8.1] refactor(msgpack): require a hint for the number of declared properties

### DIFF
--- a/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
+++ b/backup/src/main/java/io/camunda/zeebe/backup/processing/state/CheckpointInfo.java
@@ -17,6 +17,7 @@ public final class CheckpointInfo extends UnpackedObject implements DbValue {
   private final LongProperty positionProperty = new LongProperty("position");
 
   public CheckpointInfo() {
+    super(2);
     declareProperty(idProperty).declareProperty(positionProperty);
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPosition.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPosition.java
@@ -15,6 +15,7 @@ public class ExporterPosition extends UnpackedObject implements DbValue {
   private final LongProperty positionProp = new LongProperty("exporterPosition");
 
   public ExporterPosition() {
+    super(1);
     declareProperty(positionProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/NextValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/NextValue.java
@@ -15,6 +15,7 @@ public class NextValue extends UnpackedObject implements DbValue {
   private final LongProperty nextValueProp = new LongProperty("nextValue", -1L);
 
   public NextValue() {
+    super(1);
     declareProperty(nextValueProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentRaw.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeploymentRaw.java
@@ -21,7 +21,12 @@ public class DeploymentRaw extends UnpackedObject implements DbValue {
       new ObjectProperty<>("deploymentRecord", new DeploymentRecord());
 
   public DeploymentRaw() {
+    super(1);
     declareProperty(deploymentRecordProperty);
+  }
+
+  public DeploymentRecord getDeploymentRecord() {
+    return deploymentRecordProperty.getValue();
   }
 
   public void setDeploymentRecord(final DeploymentRecord deploymentRecord) {
@@ -31,9 +36,5 @@ public class DeploymentRaw extends UnpackedObject implements DbValue {
 
     deploymentRecord.write(valueBuffer, 0);
     deploymentRecordProperty.getValue().wrap(valueBuffer, 0, encodedLength);
-  }
-
-  public DeploymentRecord getDeploymentRecord() {
-    return deploymentRecordProperty.getValue();
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/Digest.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/Digest.java
@@ -16,6 +16,7 @@ public class Digest extends UnpackedObject implements DbValue {
   private final BinaryProperty digestProp = new BinaryProperty("digest");
 
   public Digest() {
+    super(1);
     declareProperty(digestProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/LatestProcessVersion.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/LatestProcessVersion.java
@@ -15,6 +15,7 @@ public class LatestProcessVersion extends UnpackedObject implements DbValue {
   private final LongProperty latestProcessVersionProp = new LongProperty("latestProcessVersion");
 
   public LatestProcessVersion() {
+    super(1);
     declareProperty(latestProcessVersionProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
@@ -28,6 +28,7 @@ public final class PersistedDecision extends UnpackedObject implements DbValue {
       new LongProperty("decisionRequirementsKey");
 
   public PersistedDecision() {
+    super(6);
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(versionProp)
@@ -36,7 +37,7 @@ public final class PersistedDecision extends UnpackedObject implements DbValue {
         .declareProperty(decisionRequirementsKeyProp);
   }
 
-  public void wrap(DecisionRecord record) {
+  public void wrap(final DecisionRecord record) {
     decisionIdProp.setValue(record.getDecisionId());
     decisionNameProp.setValue(record.getDecisionName());
     versionProp.setValue(record.getVersion());

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
@@ -32,6 +32,7 @@ public final class PersistedDecisionRequirements extends UnpackedObject implemen
   private final BinaryProperty resourceProp = new BinaryProperty("resource");
 
   public PersistedDecisionRequirements() {
+    super(7);
     declareProperty(decisionRequirementsIdProp)
         .declareProperty(decisionRequirementsNameProp)
         .declareProperty(decisionRequirementsVersionProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -24,6 +24,7 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
   private final BinaryProperty resourceProp = new BinaryProperty("resource");
 
   public PersistedProcess() {
+    super(5);
     declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(bpmnProcessIdProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/AwaitProcessInstanceResultMetadata.java
@@ -24,6 +24,7 @@ public final class AwaitProcessInstanceResultMetadata extends UnpackedObject imp
       new ArrayProperty<>("fetchVariables", new StringValue());
 
   public AwaitProcessInstanceResultMetadata() {
+    super(3);
     declareProperty(requestIdProperty)
         .declareProperty(requestStreamIdProperty)
         .declareProperty(fetchVariablesProperty);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -41,6 +41,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
       new IntegerProperty("activeSequenceFlows", 0);
 
   ElementInstance() {
+    super(11);
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(childActivatedCountProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventScopeInstance.java
@@ -29,6 +29,7 @@ public final class EventScopeInstance extends UnpackedObject implements DbValue 
       new ArrayProperty<>("boundaryElementIds", new StringValue());
 
   public EventScopeInstance() {
+    super(4);
     declareProperty(acceptingProp)
         .declareProperty(interruptingElementIdsProp)
         .declareProperty(boundaryElementIdsProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/EventTrigger.java
@@ -26,6 +26,7 @@ public final class EventTrigger extends UnpackedObject implements DbValue {
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
 
   public EventTrigger() {
+    super(4);
     declareProperty(elementIdProp)
         .declareProperty(variablesProp)
         .declareProperty(eventKeyProp)

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/Incident.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/Incident.java
@@ -17,6 +17,7 @@ public class Incident extends UnpackedObject implements DbValue {
       new ObjectProperty<>("incidentRecord", new IncidentRecord());
 
   public Incident() {
+    super(1);
     declareProperty(recordProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IncidentKey.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IncidentKey.java
@@ -16,6 +16,7 @@ public class IncidentKey extends UnpackedObject implements DbValue {
   private final LongProperty keyProp = new LongProperty("key");
 
   public IncidentKey() {
+    super(1);
     declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IndexedRecord.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/IndexedRecord.java
@@ -26,6 +26,7 @@ public final class IndexedRecord extends UnpackedObject implements DbValue {
       new ObjectProperty<>("processInstanceRecord", new ProcessInstanceRecord());
 
   IndexedRecord() {
+    super(3);
     declareProperty(keyProp).declareProperty(stateProp).declareProperty(valueProp);
   }
 
@@ -77,7 +78,7 @@ public final class IndexedRecord extends UnpackedObject implements DbValue {
   }
 
   @Override
-  public void wrap(final DirectBuffer buffer, int offset, final int length) {
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     final byte[] bytes = new byte[length];
     final UnsafeBuffer mutableBuffer = new UnsafeBuffer(bytes);
     buffer.getBytes(offset, bytes, 0, length);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobRecordValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobRecordValue.java
@@ -18,6 +18,7 @@ public class JobRecordValue extends UnpackedObject implements DbValue {
       new ObjectProperty<>("jobRecord", new JobRecord());
 
   public JobRecordValue() {
+    super(1);
     declareProperty(recordProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobStateValue.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/JobStateValue.java
@@ -18,6 +18,7 @@ public class JobStateValue extends UnpackedObject implements DbValue {
       new EnumProperty<>("jobState", JobState.State.class);
 
   public JobStateValue() {
+    super(1);
     declareProperty(stateProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ParentScopeKey.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ParentScopeKey.java
@@ -15,6 +15,7 @@ public class ParentScopeKey extends UnpackedObject implements DbValue {
   private final LongProperty keyProp = new LongProperty("parentScopeKey", -1L);
 
   public ParentScopeKey() {
+    super(1);
     declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TimerInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/TimerInstance.java
@@ -29,6 +29,7 @@ public final class TimerInstance extends UnpackedObject implements DbValue {
   private final IntegerProperty repetitionsProp = new IntegerProperty("repetitions", 0);
 
   public TimerInstance() {
+    super(7);
     declareProperty(handlerNodeIdProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(keyProp)
@@ -95,7 +96,7 @@ public final class TimerInstance extends UnpackedObject implements DbValue {
   }
 
   @Override
-  public void wrap(final DirectBuffer buffer, int offset, final int length) {
+  public void wrap(final DirectBuffer buffer, final int offset, final int length) {
     final byte[] bytes = new byte[length];
     final UnsafeBuffer mutableBuffer = new UnsafeBuffer(bytes);
     buffer.getBytes(offset, bytes, 0, length);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageStartEventSubscription.java
@@ -21,15 +21,16 @@ public class MessageStartEventSubscription extends UnpackedObject implements DbV
   private final LongProperty keyProp = new LongProperty("key");
 
   public MessageStartEventSubscription() {
+    super(2);
     declareProperty(recordProp).declareProperty(keyProp);
-  }
-
-  public void setRecord(final MessageStartEventSubscriptionRecord record) {
-    recordProp.getValue().wrap(record);
   }
 
   public MessageStartEventSubscriptionRecord getRecord() {
     return recordProp.getValue();
+  }
+
+  public void setRecord(final MessageStartEventSubscriptionRecord record) {
+    recordProp.getValue().wrap(record);
   }
 
   public long getKey() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/MessageSubscription.java
@@ -24,6 +24,7 @@ public final class MessageSubscription extends UnpackedObject implements DbValue
   private final BooleanProperty correlatingProp = new BooleanProperty("correlating", false);
 
   public MessageSubscription() {
+    super(3);
     declareProperty(recordProp).declareProperty(keyProp).declareProperty(correlatingProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/ProcessMessageSubscription.java
@@ -23,6 +23,7 @@ public final class ProcessMessageSubscription extends UnpackedObject implements 
   private final LongProperty keyProp = new LongProperty("key");
 
   public ProcessMessageSubscription() {
+    super(3);
     declareProperty(recordProp).declareProperty(stateProp).declareProperty(keyProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/message/StoredMessage.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/message/StoredMessage.java
@@ -21,6 +21,7 @@ public class StoredMessage extends UnpackedObject implements DbValue {
       new ObjectProperty<>("message", new MessageRecord());
 
   public StoredMessage() {
+    super(2);
     declareProperty(messageKeyProp).declareProperty(messageProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTaskState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/MigrationTaskState.java
@@ -17,6 +17,7 @@ public final class MigrationTaskState extends UnpackedObject implements DbValue 
       new EnumProperty<>("state", State.class, State.NOT_STARTED);
 
   public MigrationTaskState() {
+    super(1);
     declareProperty(stateProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariables.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/TemporaryVariables.java
@@ -16,6 +16,7 @@ public class TemporaryVariables extends UnpackedObject implements DbValue {
   private final BinaryProperty valueProp = new BinaryProperty("temporaryVariables");
 
   public TemporaryVariables() {
+    super(1);
     declareProperty(valueProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/processing/LastProcessedPosition.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/processing/LastProcessedPosition.java
@@ -15,6 +15,7 @@ public class LastProcessedPosition extends UnpackedObject implements DbValue {
   private final LongProperty positionProp = new LongProperty("lastProcessPosition");
 
   public LastProcessedPosition() {
+    super(1);
     declareProperty(positionProp);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/variable/VariableInstance.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/variable/VariableInstance.java
@@ -19,6 +19,7 @@ public final class VariableInstance extends UnpackedObject implements DbValue {
   private final BinaryProperty valueProp = new BinaryProperty("value");
 
   public VariableInstance() {
+    super(2);
     declareProperty(keyProp).declareProperty(valueProp);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/BanInstanceTest.java
@@ -222,6 +222,10 @@ public final class BanInstanceTest {
 
   private final class Value extends UnifiedRecordValue implements ProcessInstanceRelated {
 
+    public Value() {
+      super(10);
+    }
+
     @Override
     public long getProcessInstanceKey() {
       return processInstanceKey;

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyMessageSubscription.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyMessageSubscription.java
@@ -23,6 +23,7 @@ public final class LegacyMessageSubscription extends UnpackedObject implements D
   private final LongProperty commandSentTimeProp = new LongProperty("commandSentTime", 0);
 
   public LegacyMessageSubscription() {
+    super(3);
     declareProperty(recordProp).declareProperty(keyProp).declareProperty(commandSentTimeProp);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyProcessMessageSubscription.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_1_1/LegacyProcessMessageSubscription.java
@@ -24,6 +24,7 @@ public final class LegacyProcessMessageSubscription extends UnpackedObject imple
   private final LongProperty keyProp = new LongProperty("key");
 
   public LegacyProcessMessageSubscription() {
+    super(4);
     declareProperty(recordProp)
         .declareProperty(commandSentTimeProp)
         .declareProperty(stateProp)

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/UnpackedObject.java
@@ -20,6 +20,16 @@ public class UnpackedObject extends ObjectValue implements Recyclable, BufferRea
   protected final MsgPackReader reader = new MsgPackReader();
   protected final MsgPackWriter writer = new MsgPackWriter();
 
+  /**
+   * Creates a new UnpackedObject
+   *
+   * @param expectedDeclaredProperties a size hint for the number of declared properties. Providing
+   *     the correct number helps to avoid allocations and memory copies.
+   */
+  public UnpackedObject(final int expectedDeclaredProperties) {
+    super(expectedDeclaredProperties);
+  }
+
   public void wrap(final DirectBuffer buff) {
     wrap(buff, 0, buff.capacity());
   }

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -16,11 +16,21 @@ import java.util.List;
 import java.util.Objects;
 
 public class ObjectValue extends BaseValue {
-  private final List<BaseProperty<? extends BaseValue>> declaredProperties = new ArrayList<>();
+  private final List<BaseProperty<? extends BaseValue>> declaredProperties;
   private final List<UndeclaredProperty> undeclaredProperties = new ArrayList<>();
   private final List<UndeclaredProperty> recycledProperties = new ArrayList<>();
 
   private final StringValue decodedKey = new StringValue();
+
+  /**
+   * Creates a new ObjectValue
+   *
+   * @param expectedDeclaredProperties a size hint for the number of declared properties. Providing
+   *     the correct number helps to avoid allocations and memory copies.
+   */
+  public ObjectValue(final int expectedDeclaredProperties) {
+    declaredProperties = new ArrayList<>(expectedDeclaredProperties);
+  }
 
   public ObjectValue declareProperty(final BaseProperty<? extends BaseValue> prop) {
     declaredProperties.add(prop);

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/ObjectValue.java
@@ -17,8 +17,8 @@ import java.util.Objects;
 
 public class ObjectValue extends BaseValue {
   private final List<BaseProperty<? extends BaseValue>> declaredProperties;
-  private final List<UndeclaredProperty> undeclaredProperties = new ArrayList<>();
-  private final List<UndeclaredProperty> recycledProperties = new ArrayList<>();
+  private final List<UndeclaredProperty> undeclaredProperties = new ArrayList<>(0);
+  private final List<UndeclaredProperty> recycledProperties = new ArrayList<>(0);
 
   private final StringValue decodedKey = new StringValue();
 

--- a/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
+++ b/msgpack-value/src/main/java/io/camunda/zeebe/msgpack/value/StringValue.java
@@ -21,7 +21,6 @@ public final class StringValue extends BaseValue {
 
   private final MutableDirectBuffer bytes = new UnsafeBuffer(0, 0);
   private int length;
-  private int hashCode;
 
   public StringValue() {
     this(EMPTY_STRING);
@@ -43,13 +42,11 @@ public final class StringValue extends BaseValue {
   public void reset() {
     bytes.wrap(0, 0);
     length = 0;
-    hashCode = 0;
   }
 
   public void wrap(final byte[] bytes) {
     this.bytes.wrap(bytes);
     length = bytes.length;
-    hashCode = 0;
   }
 
   public void wrap(final DirectBuffer buff) {
@@ -63,7 +60,6 @@ public final class StringValue extends BaseValue {
       bytes.wrap(buff, offset, length);
     }
     this.length = length;
-    hashCode = 0;
   }
 
   public void wrap(final StringValue anotherString) {

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/AllTypesDefaultValuesPOJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/AllTypesDefaultValuesPOJO.java
@@ -35,6 +35,7 @@ public final class AllTypesDefaultValuesPOJO extends UnpackedObject {
       final DirectBuffer packedDefault,
       final DirectBuffer binaryDefault,
       final POJONested objectDefault) {
+    super(7);
     enumProp = new EnumProperty<>("enumProp", POJOEnum.class, enumDefault);
     longProp = new LongProperty("longProp", longDefault);
     intProp = new IntegerProperty("intProp", intDefault);
@@ -42,7 +43,6 @@ public final class AllTypesDefaultValuesPOJO extends UnpackedObject {
     packedProp = new PackedProperty("packedProp", packedDefault);
     binaryProp = new BinaryProperty("binaryProp", binaryDefault);
     objectProp = new ObjectProperty<>("objectProp", objectDefault);
-
     declareProperty(enumProp)
         .declareProperty(longProp)
         .declareProperty(intProp)

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/ArrayValueTest.java
@@ -453,6 +453,7 @@ public final class ArrayValueTest {
     private final StringProperty barProp = new StringProperty("bar");
 
     Foo() {
+      super(2);
       declareProperty(fooProp).declareProperty(barProp);
     }
 
@@ -480,6 +481,7 @@ public final class ArrayValueTest {
     private final StringProperty barProp = new StringProperty("bar");
 
     Bar() {
+      super(1);
       declareProperty(barProp);
     }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DefaultValuesPOJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DefaultValuesPOJO.java
@@ -15,6 +15,7 @@ public final class DefaultValuesPOJO extends UnpackedObject {
   protected final LongProperty noDefaultValueProperty = new LongProperty("noDefaultValueProp");
 
   public DefaultValuesPOJO(final long defaultValue) {
+    super(2);
     defaultValueProperty = new LongProperty("defaultValueProp", defaultValue);
 
     declareProperty(defaultValueProperty).declareProperty(noDefaultValueProperty);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/DocumentPropertyTest.java
@@ -225,6 +225,7 @@ public final class DocumentPropertyTest {
     private final DocumentProperty documentProperty = new DocumentProperty("documentProp");
 
     Document() {
+      super(1);
       declareProperty(documentProperty);
     }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/MinimalPOJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/MinimalPOJO.java
@@ -14,6 +14,7 @@ public final class MinimalPOJO extends UnpackedObject {
   private final LongProperty longProp = new LongProperty("longProp");
 
   public MinimalPOJO() {
+    super(1);
     declareProperty(longProp);
   }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJO.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJO.java
@@ -28,6 +28,7 @@ public final class POJO extends UnpackedObject {
       new ObjectProperty<>("objectProp", new POJONested());
 
   public POJO() {
+    super(7);
     declareProperty(enumProp)
         .declareProperty(longProp)
         .declareProperty(intProp)

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJOArray.java
@@ -15,6 +15,7 @@ public final class POJOArray extends UnpackedObject {
   protected final ArrayProperty<MinimalPOJO> simpleArrayProp;
 
   public POJOArray() {
+    super(1);
     simpleArrayProp = new ArrayProperty<>("simpleArray", new MinimalPOJO());
 
     declareProperty(simpleArrayProp);

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJONested.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/POJONested.java
@@ -13,6 +13,7 @@ public final class POJONested extends UnpackedObject {
   private final LongProperty longProp = new LongProperty("foo", -1L);
 
   public POJONested() {
+    super(1);
     declareProperty(longProp);
   }
 

--- a/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
+++ b/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
@@ -29,7 +29,7 @@ public class UnpackedObjectTest {
     public void shouldResetObjectBeforeReadingValue() {
       // given
       final var property = new StringProperty("property", "default");
-      final var unpackedObject = new UnpackedObject();
+      final var unpackedObject = new UnpackedObject(1);
 
       unpackedObject.declareProperty(property);
 
@@ -53,10 +53,10 @@ public class UnpackedObjectTest {
   public class SchemaEvolution {
     private final StringProperty sharedProperty = new StringProperty("shared", "default");
 
-    private final UnpackedObject oldSchemaObject = new UnpackedObject();
+    private final UnpackedObject oldSchemaObject = new UnpackedObject(2);
     private final IntegerProperty removedProperty = new IntegerProperty("removedProperty", 42);
 
-    private final UnpackedObject newSchemaObject = new UnpackedObject();
+    private final UnpackedObject newSchemaObject = new UnpackedObject(2);
     private final BooleanProperty addedProperty = new BooleanProperty("addedProperty", false);
 
     private final MutableDirectBuffer bufferSerializedWithOldSchema =

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/data/repository/ProcessMetadata.java
@@ -21,6 +21,7 @@ public class ProcessMetadata extends UnpackedObject {
   private final StringProperty resourceNameProp = new StringProperty("resourceName");
 
   public ProcessMetadata() {
+    super(4);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(versionProp)
         .declareProperty(bpmnProcessIdProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/UnifiedRecordValue.java
@@ -14,6 +14,16 @@ import io.camunda.zeebe.protocol.record.RecordValue;
 
 public class UnifiedRecordValue extends UnpackedObject implements RecordValue {
 
+  /**
+   * Creates a new {@link UnifiedRecordValue}.
+   *
+   * @param expectedDeclaredProperties the expected number of declared properties. Providing the
+   *     correct number helps to avoid allocations and memory copies.
+   */
+  public UnifiedRecordValue(final int expectedDeclaredProperties) {
+    super(expectedDeclaredProperties);
+  }
+
   @Override
   @JsonIgnore
   public int getLength() {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/DecisionEvaluationRecord.java
@@ -56,6 +56,7 @@ public final class DecisionEvaluationRecord extends UnifiedRecordValue
   private final StringProperty failedDecisionIdProp = new StringProperty("failedDecisionId", "");
 
   public DecisionEvaluationRecord() {
+    super(15);
     declareProperty(decisionKeyProp)
         .declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedDecisionRecord.java
@@ -43,6 +43,7 @@ public final class EvaluatedDecisionRecord extends UnifiedRecordValue
       new ArrayProperty<>("matchedRules", new MatchedRuleRecord());
 
   public EvaluatedDecisionRecord() {
+    super(8);
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(decisionKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedInputRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedInputRecord.java
@@ -24,6 +24,7 @@ public final class EvaluatedInputRecord extends UnifiedRecordValue implements Ev
   private final BinaryProperty inputValueProp = new BinaryProperty("inputValue");
 
   public EvaluatedInputRecord() {
+    super(3);
     declareProperty(inputIdProp).declareProperty(inputNameProp).declareProperty(inputValueProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedOutputRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/EvaluatedOutputRecord.java
@@ -25,6 +25,7 @@ public final class EvaluatedOutputRecord extends UnifiedRecordValue
   private final BinaryProperty outputValueProp = new BinaryProperty("outputValue");
 
   public EvaluatedOutputRecord() {
+    super(3);
     declareProperty(outputIdProp).declareProperty(outputNameProp).declareProperty(outputValueProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/decision/MatchedRuleRecord.java
@@ -31,6 +31,7 @@ public final class MatchedRuleRecord extends UnifiedRecordValue implements Match
       new ArrayProperty<>("evaluatedOutputs", new EvaluatedOutputRecord());
 
   public MatchedRuleRecord() {
+    super(3);
     declareProperty(ruleIdProp)
         .declareProperty(ruleIndexProp)
         .declareProperty(evaluatedOutputsProp);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -33,6 +33,7 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
 
   public DecisionRecord() {
+    super(7);
     declareProperty(decisionIdProp)
         .declareProperty(decisionNameProp)
         .declareProperty(versionProp)
@@ -77,33 +78,33 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
     return isDuplicateProp.getValue();
   }
 
-  public DecisionRecord setDecisionId(String decisionId) {
-    decisionIdProp.setValue(decisionId);
+  public DecisionRecord setDecisionRequirementsKey(final long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
     return this;
   }
 
-  public DecisionRecord setDecisionName(String decisionName) {
-    decisionNameProp.setValue(decisionName);
-    return this;
-  }
-
-  public DecisionRecord setVersion(int version) {
-    versionProp.setValue(version);
-    return this;
-  }
-
-  public DecisionRecord setDecisionKey(long decisionKey) {
-    decisionKeyProp.setValue(decisionKey);
-    return this;
-  }
-
-  public DecisionRecord setDecisionRequirementsId(String decisionRequirementsId) {
+  public DecisionRecord setDecisionRequirementsId(final String decisionRequirementsId) {
     decisionRequirementsIdProp.setValue(decisionRequirementsId);
     return this;
   }
 
-  public DecisionRecord setDecisionRequirementsKey(long decisionRequirementsKey) {
-    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+  public DecisionRecord setDecisionKey(final long decisionKey) {
+    decisionKeyProp.setValue(decisionKey);
+    return this;
+  }
+
+  public DecisionRecord setVersion(final int version) {
+    versionProp.setValue(version);
+    return this;
+  }
+
+  public DecisionRecord setDecisionName(final String decisionName) {
+    decisionNameProp.setValue(decisionName);
+    return this;
+  }
+
+  public DecisionRecord setDecisionId(final String decisionId) {
+    decisionIdProp.setValue(decisionId);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
@@ -39,6 +39,7 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
 
   public DecisionRequirementsMetadataRecord() {
+    super(8);
     declareProperty(decisionRequirementsIdProp)
         .declareProperty(decisionRequirementsNameProp)
         .declareProperty(decisionRequirementsVersionProp)
@@ -89,42 +90,42 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
     return isDuplicateProp.getValue();
   }
 
-  public DecisionRequirementsMetadataRecord setDecisionRequirementsId(
-      String decisionRequirementsId) {
-    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+  public DecisionRequirementsMetadataRecord setChecksum(final DirectBuffer checksum) {
+    checksumProp.setValue(checksum);
     return this;
   }
 
-  public DecisionRequirementsMetadataRecord setDecisionRequirementsName(
-      String decisionRequirementsName) {
-    decisionRequirementsNameProp.setValue(decisionRequirementsName);
-    return this;
-  }
-
-  public DecisionRequirementsMetadataRecord setDecisionRequirementsVersion(
-      int decisionRequirementsVersion) {
-    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
-    return this;
-  }
-
-  public DecisionRequirementsMetadataRecord setDecisionRequirementsKey(
-      long decisionRequirementsKey) {
-    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
-    return this;
-  }
-
-  public DecisionRequirementsMetadataRecord setNamespace(String namespace) {
-    namespaceProp.setValue(namespace);
-    return this;
-  }
-
-  public DecisionRequirementsMetadataRecord setResourceName(String resourceName) {
+  public DecisionRequirementsMetadataRecord setResourceName(final String resourceName) {
     resourceNameProp.setValue(resourceName);
     return this;
   }
 
-  public DecisionRequirementsMetadataRecord setChecksum(DirectBuffer checksum) {
-    checksumProp.setValue(checksum);
+  public DecisionRequirementsMetadataRecord setNamespace(final String namespace) {
+    namespaceProp.setValue(namespace);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsKey(
+      final long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsVersion(
+      final int decisionRequirementsVersion) {
+    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsName(
+      final String decisionRequirementsName) {
+    decisionRequirementsNameProp.setValue(decisionRequirementsName);
+    return this;
+  }
+
+  public DecisionRequirementsMetadataRecord setDecisionRequirementsId(
+      final String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -37,6 +37,7 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
   private final BinaryProperty resourceProp = new BinaryProperty("resource");
 
   public DecisionRequirementsRecord() {
+    super(8);
     declareProperty(decisionRequirementsIdProp)
         .declareProperty(decisionRequirementsNameProp)
         .declareProperty(decisionRequirementsVersionProp)
@@ -87,48 +88,49 @@ public final class DecisionRequirementsRecord extends UnifiedRecordValue
     return false;
   }
 
+  public DecisionRequirementsRecord setChecksum(final DirectBuffer checksum) {
+    checksumProp.setValue(checksum);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setResourceName(final String resourceName) {
+    resourceNameProp.setValue(resourceName);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setNamespace(final String namespace) {
+    namespaceProp.setValue(namespace);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsKey(final long decisionRequirementsKey) {
+    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsVersion(
+      final int decisionRequirementsVersion) {
+    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsName(
+      final String decisionRequirementsName) {
+    decisionRequirementsNameProp.setValue(decisionRequirementsName);
+    return this;
+  }
+
+  public DecisionRequirementsRecord setDecisionRequirementsId(final String decisionRequirementsId) {
+    decisionRequirementsIdProp.setValue(decisionRequirementsId);
+    return this;
+  }
+
   @Override
   public byte[] getResource() {
     return bufferAsArray(resourceProp.getValue());
   }
 
-  public DecisionRequirementsRecord setDecisionRequirementsId(String decisionRequirementsId) {
-    decisionRequirementsIdProp.setValue(decisionRequirementsId);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setDecisionRequirementsName(String decisionRequirementsName) {
-    decisionRequirementsNameProp.setValue(decisionRequirementsName);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setDecisionRequirementsVersion(
-      int decisionRequirementsVersion) {
-    decisionRequirementsVersionProp.setValue(decisionRequirementsVersion);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setDecisionRequirementsKey(long decisionRequirementsKey) {
-    decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setNamespace(String namespace) {
-    namespaceProp.setValue(namespace);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setResourceName(String resourceName) {
-    resourceNameProp.setValue(resourceName);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setChecksum(DirectBuffer checksum) {
-    checksumProp.setValue(checksum);
-    return this;
-  }
-
-  public DecisionRequirementsRecord setResource(DirectBuffer resource) {
+  public DecisionRequirementsRecord setResource(final DirectBuffer resource) {
     resourceProp.setValue(resource);
     return this;
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentDistributionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentDistributionRecord.java
@@ -17,6 +17,7 @@ public class DeploymentDistributionRecord extends UnifiedRecordValue
   private final IntegerProperty partitionIdProperty = new IntegerProperty("partitionId");
 
   public DeploymentDistributionRecord() {
+    super(1);
     declareProperty(partitionIdProperty);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -36,6 +36,7 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
       new ArrayProperty<>("decisionRequirementsMetadata", new DecisionRequirementsMetadataRecord());
 
   public DeploymentRecord() {
+    super(4);
     declareProperty(resourcesProp)
         .declareProperty(processesMetadataProp)
         .declareProperty(decisionRequirementsMetadataProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentResource.java
@@ -23,6 +23,7 @@ public final class DeploymentResource extends UnpackedObject
   private final StringProperty resourceNameProp = new StringProperty("resourceName", "resource");
 
   public DeploymentResource() {
+    super(2);
     declareProperty(resourceNameProp).declareProperty(resourceProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -37,6 +37,7 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
 
   public ProcessMetadata() {
+    super(6);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -30,6 +30,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final BinaryProperty resourceProp = new BinaryProperty("resource");
 
   public ProcessRecord() {
+    super(6);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/error/ErrorRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/error/ErrorRecord.java
@@ -29,6 +29,7 @@ public final class ErrorRecord extends UnifiedRecordValue implements ErrorRecord
   private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
 
   public ErrorRecord() {
+    super(4);
     declareProperty(exceptionMessageProp)
         .declareProperty(stacktraceProp)
         .declareProperty(errorEventPositionProp)
@@ -69,10 +70,12 @@ public final class ErrorRecord extends UnifiedRecordValue implements ErrorRecord
     return BufferUtil.bufferAsString(stacktraceProp.getValue());
   }
 
+  @Override
   public long getErrorEventPosition() {
     return errorEventPositionProp.getValue();
   }
 
+  @Override
   public long getProcessInstanceKey() {
     return processInstanceKeyProp.getValue();
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -33,6 +33,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   private final LongProperty variableScopeKeyProp = new LongProperty("variableScopeKey", -1L);
 
   public IncidentRecord() {
+    super(9);
     declareProperty(errorTypeProp)
         .declareProperty(errorMessageProp)
         .declareProperty(bpmnProcessIdProp)
@@ -104,6 +105,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();
   }
@@ -111,6 +113,11 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   public IncidentRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
     return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -123,6 +130,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
   public long getElementInstanceKey() {
     return elementInstanceKeyProp.getValue();
   }
@@ -132,10 +140,12 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
   public long getJobKey() {
     return jobKeyProp.getValue();
   }
 
+  @Override
   public long getVariableScopeKey() {
     return variableScopeKeyProp.getValue();
   }
@@ -147,6 +157,11 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   public IncidentRecord setJobKey(final long jobKey) {
     jobKeyProp.setValue(jobKey);
+    return this;
+  }
+
+  public IncidentRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
     return this;
   }
 
@@ -162,15 +177,6 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   public IncidentRecord setErrorType(final ErrorType errorType) {
     errorTypeProp.setValue(errorType);
-    return this;
-  }
-
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
-  public IncidentRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
     return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobBatchRecord.java
@@ -41,6 +41,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
   private final BooleanProperty truncatedProp = new BooleanProperty("truncated", false);
 
   public JobBatchRecord() {
+    super(8);
     declareProperty(typeProp)
         .declareProperty(workerProp)
         .declareProperty(timeoutProp)
@@ -92,6 +93,7 @@ public final class JobBatchRecord extends UnifiedRecordValue implements JobBatch
     return timeoutProp.getValue();
   }
 
+  @Override
   public int getMaxJobsToActivate() {
     return maxJobsToActivateProp.getValue();
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -61,6 +61,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
 
   public JobRecord() {
+    super(16);
     declareProperty(deadlineProp)
         .declareProperty(workerProp)
         .declareProperty(retriesProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/management/CheckpointRecord.java
@@ -21,6 +21,7 @@ public class CheckpointRecord extends UnifiedRecordValue implements CheckpointRe
       new LongProperty(CHECKPOINT_POSITION_KEY, -1L);
 
   public CheckpointRecord() {
+    super(2);
     declareProperty(checkpointIdProperty).declareProperty(checkpointPositionProperty);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageRecord.java
@@ -30,6 +30,7 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   private final StringProperty messageIdProp = new StringProperty("messageId", "");
 
   public MessageRecord() {
+    super(6);
     declareProperty(nameProp)
         .declareProperty(correlationKeyProp)
         .declareProperty(timeToLiveProp)
@@ -86,6 +87,16 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
     return this;
   }
 
+  @Override
+  public long getDeadline() {
+    return deadlineProp.getValue();
+  }
+
+  public MessageRecord setDeadline(final long deadline) {
+    deadlineProp.setValue(deadline);
+    return this;
+  }
+
   public MessageRecord setMessageId(final String messageId) {
     messageIdProp.setValue(messageId);
     return this;
@@ -134,15 +145,5 @@ public final class MessageRecord extends UnifiedRecordValue implements MessageRe
   @JsonIgnore
   public DirectBuffer getVariablesBuffer() {
     return variablesProp.getValue();
-  }
-
-  @Override
-  public long getDeadline() {
-    return deadlineProp.getValue();
-  }
-
-  public MessageRecord setDeadline(final long deadline) {
-    deadlineProp.setValue(deadline);
-    return this;
   }
 }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageStartEventSubscriptionRecord.java
@@ -34,6 +34,7 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
 
   public MessageStartEventSubscriptionRecord() {
+    super(8);
     declareProperty(processDefinitionKeyProp)
         .declareProperty(messageNameProp)
         .declareProperty(startEventIdProp)
@@ -91,19 +92,9 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
     return this;
   }
 
-  public MessageStartEventSubscriptionRecord setStartEventId(final DirectBuffer startEventId) {
-    startEventIdProp.setValue(startEventId);
-    return this;
-  }
-
-  public MessageStartEventSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
-    bpmnProcessIdProp.setValue(bpmnProcessId);
-    return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getBpmnProcessIdBuffer() {
-    return bpmnProcessIdProp.getValue();
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -126,19 +117,29 @@ public final class MessageStartEventSubscriptionRecord extends UnifiedRecordValu
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getCorrelationKeyBuffer() {
-    return correlationKeyProp.getValue();
-  }
-
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
   public MessageStartEventSubscriptionRecord setProcessInstanceKey(final long key) {
     processInstanceKeyProp.setValue(key);
     return this;
+  }
+
+  public MessageStartEventSubscriptionRecord setStartEventId(final DirectBuffer startEventId) {
+    startEventIdProp.setValue(startEventId);
+    return this;
+  }
+
+  public MessageStartEventSubscriptionRecord setBpmnProcessId(final DirectBuffer bpmnProcessId) {
+    bpmnProcessIdProp.setValue(bpmnProcessId);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getBpmnProcessIdBuffer() {
+    return bpmnProcessIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCorrelationKeyBuffer() {
+    return correlationKeyProp.getValue();
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -34,6 +34,7 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProp = new DocumentProperty("variables");
 
   public MessageSubscriptionRecord() {
+    super(8);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(messageKeyProp)
@@ -55,13 +56,19 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setVariables(record.getVariablesBuffer());
   }
 
-  public boolean isInterrupting() {
-    return interruptingProp.getValue();
-  }
-
   @JsonIgnore
   public DirectBuffer getCorrelationKeyBuffer() {
     return correlationKeyProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getMessageNameBuffer() {
+    return messageNameProp.getValue();
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
   }
 
   @Override
@@ -99,6 +106,16 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return messageKeyProp.getValue();
   }
 
+  @Override
+  public boolean isInterrupting() {
+    return interruptingProp.getValue();
+  }
+
+  public MessageSubscriptionRecord setInterrupting(final boolean interrupting) {
+    interruptingProp.setValue(interrupting);
+    return this;
+  }
+
   public MessageSubscriptionRecord setMessageKey(final long messageKey) {
     messageKeyProp.setValue(messageKey);
     return this;
@@ -114,23 +131,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  @JsonIgnore
-  public DirectBuffer getMessageNameBuffer() {
-    return messageNameProp.getValue();
-  }
-
-  @Override
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
   public MessageSubscriptionRecord setProcessInstanceKey(final long key) {
     processInstanceKeyProp.setValue(key);
-    return this;
-  }
-
-  public MessageSubscriptionRecord setInterrupting(final boolean interrupting) {
-    interruptingProp.setValue(interrupting);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/ProcessMessageSubscriptionRecord.java
@@ -38,6 +38,7 @@ public final class ProcessMessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
 
   public ProcessMessageSubscriptionRecord() {
+    super(10);
     declareProperty(subscriptionPartitionIdProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessEventRecord.java
@@ -30,6 +30,7 @@ public final class ProcessEventRecord extends UnifiedRecordValue
       new LongProperty("processInstanceKey", -1);
 
   public ProcessEventRecord() {
+    super(5);
     declareProperty(scopeKeyProperty)
         .declareProperty(targetElementIdProperty)
         .declareProperty(variablesProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceBatchRecord.java
@@ -34,6 +34,7 @@ public final class ProcessInstanceBatchRecord extends UnifiedRecordValue
   private final LongProperty indexProperty = new LongProperty("index", -1L);
 
   public ProcessInstanceBatchRecord() {
+    super(3);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(batchElementInstanceKeyProperty)
         .declareProperty(indexProperty);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationRecord.java
@@ -41,6 +41,7 @@ public final class ProcessInstanceCreationRecord extends UnifiedRecordValue
       new ArrayProperty<>("startInstructions", new ProcessInstanceCreationStartInstruction());
 
   public ProcessInstanceCreationRecord() {
+    super(7);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceCreationStartInstruction.java
@@ -26,6 +26,7 @@ public final class ProcessInstanceCreationStartInstruction extends ObjectValue
   private final StringProperty elementIdProp = new StringProperty("elementId");
 
   public ProcessInstanceCreationStartInstruction() {
+    super(1);
     declareProperty(elementIdProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationActivateInstruction.java
@@ -41,6 +41,7 @@ public final class ProcessInstanceModificationActivateInstruction extends Object
       new ArrayProperty<>("ancestorScopeKeys", new LongValue());
 
   public ProcessInstanceModificationActivateInstruction() {
+    super(4);
     declareProperty(elementIdProperty)
         .declareProperty(ancestorScopeKeyProperty)
         .declareProperty(variableInstructionsProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationRecord.java
@@ -36,6 +36,7 @@ public final class ProcessInstanceModificationRecord extends UnifiedRecordValue
       new ArrayProperty<>("activatedElementInstanceKeys", new LongValue());
 
   public ProcessInstanceModificationRecord() {
+    super(4);
     declareProperty(processInstanceKeyProperty)
         .declareProperty(terminateInstructionsProperty)
         .declareProperty(activateInstructionsProperty)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationTerminateInstruction.java
@@ -23,6 +23,7 @@ public final class ProcessInstanceModificationTerminateInstruction extends Objec
   private final LongProperty elementInstanceKeyProperty = new LongProperty("elementInstanceKey");
 
   public ProcessInstanceModificationTerminateInstruction() {
+    super(1);
     declareProperty(elementInstanceKeyProperty);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceModificationVariableInstruction.java
@@ -30,6 +30,7 @@ public final class ProcessInstanceModificationVariableInstruction extends Object
   private final StringProperty elementIdProp = new StringProperty("elementId", "");
 
   public ProcessInstanceModificationVariableInstruction() {
+    super(2);
     declareProperty(variablesProp).declareProperty(elementIdProp);
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceRecord.java
@@ -51,6 +51,7 @@ public final class ProcessInstanceRecord extends UnifiedRecordValue
       new LongProperty("parentElementInstanceKey", -1L);
 
   public ProcessInstanceRecord() {
+    super(9);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(processDefinitionKeyProp)

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/processinstance/ProcessInstanceResultRecord.java
@@ -31,6 +31,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
       new LongProperty("processInstanceKey", -1);
 
   public ProcessInstanceResultRecord() {
+    super(5);
     declareProperty(bpmnProcessIdProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(processInstanceKeyProperty)
@@ -38,6 +39,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
         .declareProperty(variablesProperty);
   }
 
+  @Override
   public String getBpmnProcessId() {
     return BufferUtil.bufferAsString(bpmnProcessIdProperty.getValue());
   }
@@ -52,6 +54,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
   public int getVersion() {
     return versionProperty.getValue();
   }
@@ -61,6 +64,7 @@ public final class ProcessInstanceResultRecord extends UnifiedRecordValue
     return this;
   }
 
+  @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProperty.getValue();
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/timer/TimerRecord.java
@@ -26,6 +26,7 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
   private final LongProperty processDefinitionKeyProp = new LongProperty("processDefinitionKey");
 
   public TimerRecord() {
+    super(6);
     declareProperty(elementInstanceKeyProp)
         .declareProperty(processInstanceKeyProp)
         .declareProperty(dueDateProp)
@@ -39,15 +40,6 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
     return targetElementId.getValue();
   }
 
-  public long getProcessInstanceKey() {
-    return processInstanceKeyProp.getValue();
-  }
-
-  public TimerRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
-  }
-
   @Override
   public long getProcessDefinitionKey() {
     return processDefinitionKeyProp.getValue();
@@ -56,6 +48,16 @@ public final class TimerRecord extends UnifiedRecordValue implements TimerRecord
   @Override
   public long getElementInstanceKey() {
     return elementInstanceKeyProp.getValue();
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public TimerRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
   }
 
   @Override

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableDocumentRecord.java
@@ -30,6 +30,7 @@ public final class VariableDocumentRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public VariableDocumentRecord() {
+    super(3);
     declareProperty(scopeKeyProperty)
         .declareProperty(updateSemanticsProperty)
         .declareProperty(variablesProperty);

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/variable/VariableRecord.java
@@ -27,6 +27,7 @@ public final class VariableRecord extends UnifiedRecordValue implements Variable
   private final StringProperty bpmnProcessIdProp = new StringProperty("bpmnProcessId", "");
 
   public VariableRecord() {
+    super(6);
     declareProperty(nameProp)
         .declareProperty(valueProp)
         .declareProperty(scopeKeyProp)


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/15518.

Size hints needed to be adjusted.