### PR TITLE
feat(client): make `correlationKey` step optional

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/PublishMessageCommandStep1.java
@@ -41,6 +41,18 @@ public interface PublishMessageCommandStep1 {
      * @return the builder for this command
      */
     PublishMessageCommandStep3 correlationKey(String correlationKey);
+
+    /**
+     * Skip specifying a correlation key for the message.
+     *
+     * <p>This method allows the message to be published without a correlation key, making it
+     * suitable for scenarios where the correlation key is not necessary (e.g. for the message start
+     * event). When used, this will create a new process instance without checking for an active
+     * instance with the same correlation key.
+     *
+     * @return the builder for this command, continuing to the next step without a correlation key.
+     */
+    PublishMessageCommandStep3 withoutCorrelationKey();
   }
 
   interface PublishMessageCommandStep3

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -80,6 +80,11 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
   }
 
   @Override
+  public PublishMessageCommandStep3 withoutCorrelationKey() {
+    return this;
+  }
+
+  @Override
   public PublishMessageCommandStep2 messageName(final String messageName) {
     builder.setName(messageName);
     return this;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/PublishMessageTest.java
@@ -155,6 +155,31 @@ public final class PublishMessageTest extends ClientTest {
   }
 
   @Test
+  public void shouldPublishMessageWithoutCorrelationKey() {
+    // given
+    final long messageKey = 456L;
+    gatewayService.onPublishMessageRequest(messageKey);
+
+    // when
+    final PublishMessageResponse response =
+        client
+            .newPublishMessageCommand()
+            .messageName("name_msg-without-correlation-key")
+            .withoutCorrelationKey()
+            .messageId("id_msg-without-correlation-key")
+            .send()
+            .join();
+
+    // then
+    final PublishMessageRequest request = gatewayService.getLastRequest();
+    assertThat(request.getName()).isEqualTo("name_msg-without-correlation-key");
+    assertThat(request.getCorrelationKey()).isEmpty();
+    assertThat(request.getMessageId()).isEqualTo("id_msg-without-correlation-key");
+    assertThat(request.getTenantId()).isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(response.getMessageKey()).isEqualTo(messageKey);
+  }
+
+  @Test
   public void shouldThrowErrorWhenTryToPublishMessageWithNullVariable() {
     // when
     Assertions.assertThatThrownBy(

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -619,7 +619,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newPublishMessageCommand()
               .messageName(messageName)
-              .correlationKey("")
+              .withoutCorrelationKey()
               .tenantId(TENANT_A)
               .send();
 
@@ -650,7 +650,7 @@ public class MultiTenancyOverIdentityIT {
           client
               .newPublishMessageCommand()
               .messageName(messageName)
-              .correlationKey("")
+              .withoutCorrelationKey()
               .tenantId(TENANT_B)
               .send();
 


### PR DESCRIPTION
## Description

This PR adds the `withoutCorrelationKey` method to the `PublishMessageCommandStep1` interface, allowing optional use of `correlationKey` in message publishing. 
This update caters to scenarios where a correlationKey is not necessary, particularly in cases involving message start events.

With the new `withoutCorrelationKey` method, it is now possible to seamlessly progress to `PublishMessageCommandStep3` without the need to explicitly define a `correlationKey`. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #13649 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
