### PR TITLE
feat(topology): reject partition leave if it has no replica

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
@@ -55,6 +55,17 @@ record PartitionLeaveApplier(
       // topology change can make progress, we do not treat this as an error.
       return Either.right(m -> m);
     } else {
+      final var partitionReplicaCount =
+          currentClusterTopology.members().values().stream()
+              .filter(m -> m.hasPartition(partitionId))
+              .count();
+      if (partitionReplicaCount <= 1) {
+        return Either.left(
+            new IllegalStateException(
+                String.format(
+                    "Expected to leave partition, but the partition %s has only one replica",
+                    partitionId)));
+      }
       return Either.right(
           memberState -> memberState.updatePartition(partitionId, PartitionState::toLeaving));
     }

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
@@ -54,6 +54,25 @@ final class PartitionLeaveApplierTest {
   }
 
   @Test
+  void shouldRejectLeaveWhenPartitionHasOnlyOneReplica() {
+    // given
+    final ClusterTopology topologyWithOneReplica =
+        initialClusterTopology.updateMember(
+            localMemberId, m -> m.addPartition(1, PartitionState.active(1)));
+
+    // when
+    final Either<Exception, UnaryOperator<MemberState>> result =
+        partitionLeaveApplier.init(topologyWithOneReplica);
+
+    // then
+    assertThat(result).isLeft();
+
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("partition 1 has only one replica");
+  }
+
+  @Test
   void shouldUpdateStateToLeavingOnInit() {
     // given
     final ClusterTopology topologyWithPartition =

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplierTest.java
@@ -76,8 +76,10 @@ final class PartitionLeaveApplierTest {
   void shouldUpdateStateToLeavingOnInit() {
     // given
     final ClusterTopology topologyWithPartition =
-        initialClusterTopology.updateMember(
-            localMemberId, m -> m.addPartition(1, PartitionState.active(1)));
+        initialClusterTopology
+            .updateMember(localMemberId, m -> m.addPartition(1, PartitionState.active(1)))
+            .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()))
+            .updateMember(MemberId.from("2"), m -> m.addPartition(1, PartitionState.active(1)));
 
     // when
     final var resultingTopology =
@@ -94,8 +96,11 @@ final class PartitionLeaveApplierTest {
   void shouldExecuteLeaveOnApply() {
     // given
     final var topologyWithPartition =
-        initialClusterTopology.updateMember(
-            localMemberId, m -> m.addPartition(1, PartitionState.active(1)));
+        initialClusterTopology
+            .updateMember(localMemberId, m -> m.addPartition(1, PartitionState.active(1)))
+            .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()))
+            .updateMember(MemberId.from("2"), m -> m.addPartition(1, PartitionState.active(1)));
+
     final var topologyAfterInit =
         topologyWithPartition.updateMember(
             localMemberId, partitionLeaveApplier.init(topologyWithPartition).get());

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImplTest.java
@@ -76,7 +76,9 @@ final class TopologyChangeCoordinatorImplTest {
     clusterTopologyManager.setClusterTopology(
         ClusterTopology.init()
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
-            .updateMember(MemberId.from("1"), m -> m.addPartition(1, PartitionState.active(1))));
+            .updateMember(MemberId.from("1"), m -> m.addPartition(1, PartitionState.active(1)))
+            .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()))
+            .updateMember(MemberId.from("2"), m -> m.addPartition(1, PartitionState.active(1))));
     final var coordinator =
         new TopologyChangeCoordinatorImpl(clusterTopologyManager, new TestConcurrencyControl());
 


### PR DESCRIPTION
## Description

To prevent accidental loss of data, we reject partition leave request if there is only one replica. This scenario would not happen if we use the scale request API. But it can happen when one uses the internal fine-grained api to join or leave individual partitions.

## Related issues

closes #15728 
