### PR TITLE
build(topology): add backward compatibility check for protobuf messages

### DIFF
--- a/topology/pom.xml
+++ b/topology/pom.xml
@@ -142,6 +142,15 @@
         </configuration>
       </plugin>
 
+      <!-- enforce backwards compatibility -->
+      <plugin>
+        <groupId>com.salesforce.servicelibs</groupId>
+        <artifactId>proto-backwards-compatibility</artifactId>
+        <configuration>
+          <protoSourceRoot>${proto.dir}</protoSourceRoot>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>

--- a/topology/src/main/resources/proto/proto.lock
+++ b/topology/src/main/resources/proto/proto.lock
@@ -1,0 +1,549 @@
+{
+  "definitions": [
+    {
+      "protopath": "requests.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "ErrorCode",
+            "enum_fields": [
+              {
+                "name": "INVALID_REQUEST"
+              },
+              {
+                "name": "OPERATION_NOT_ALLOWED",
+                "integer": 1
+              },
+              {
+                "name": "CONCURRENT_MODIFICATION",
+                "integer": 2
+              },
+              {
+                "name": "INTERNAL_ERROR",
+                "integer": 3
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "AddMembersRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberIds",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "RemoveMembersRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberIds",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "JoinPartitionRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "partitionId",
+                "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "priority",
+                "type": "int32"
+              },
+              {
+                "id": 4,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "LeavePartitionRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "partitionId",
+                "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "ScaleRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberIds",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "ReassignAllPartitionsRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberIds",
+                "type": "string",
+                "is_repeated": true
+              },
+              {
+                "id": 2,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
+            "name": "CancelTopologyChangeRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "changeId",
+                "type": "int64"
+              }
+            ]
+          },
+          {
+            "name": "TopologyChangeResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "changeId",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "plannedChanges",
+                "type": "topology_protocol.TopologyChangeOperation",
+                "is_repeated": true
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "currentTopology",
+                  "type": "topology_protocol.MemberState"
+                }
+              },
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 3,
+                  "name": "expectedTopology",
+                  "type": "topology_protocol.MemberState"
+                }
+              }
+            ]
+          },
+          {
+            "name": "Response",
+            "fields": [
+              {
+                "id": 1,
+                "name": "error",
+                "type": "ErrorResponse"
+              },
+              {
+                "id": 2,
+                "name": "topologyChangeResponse",
+                "type": "TopologyChangeResponse"
+              },
+              {
+                "id": 3,
+                "name": "clusterTopology",
+                "type": "topology_protocol.ClusterTopology"
+              }
+            ]
+          },
+          {
+            "name": "ErrorResponse",
+            "fields": [
+              {
+                "id": 1,
+                "name": "errorCode",
+                "type": "ErrorCode"
+              },
+              {
+                "id": 2,
+                "name": "errorMessage",
+                "type": "string"
+              }
+            ]
+          }
+        ],
+        "imports": [
+          {
+            "path": "topology.proto"
+          }
+        ],
+        "package": {
+          "name": "topology_requests"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "io.camunda.zeebe.topology.protocol"
+          }
+        ]
+      }
+    },
+    {
+      "protopath": "topology.proto",
+      "def": {
+        "enums": [
+          {
+            "name": "State",
+            "enum_fields": [
+              {
+                "name": "UNKNOWN"
+              },
+              {
+                "name": "JOINING",
+                "integer": 1
+              },
+              {
+                "name": "ACTIVE",
+                "integer": 2
+              },
+              {
+                "name": "LEAVING",
+                "integer": 3
+              },
+              {
+                "name": "LEFT",
+                "integer": 4
+              }
+            ]
+          },
+          {
+            "name": "ChangeStatus",
+            "enum_fields": [
+              {
+                "name": "CHANGE_STATUS_UNKNOWN"
+              },
+              {
+                "name": "IN_PROGRESS",
+                "integer": 1
+              },
+              {
+                "name": "COMPLETED",
+                "integer": 2
+              },
+              {
+                "name": "FAILED",
+                "integer": 3
+              },
+              {
+                "name": "CANCELLED",
+                "integer": 4
+              }
+            ]
+          }
+        ],
+        "messages": [
+          {
+            "name": "GossipState",
+            "fields": [
+              {
+                "id": 1,
+                "name": "clusterTopology",
+                "type": "ClusterTopology"
+              }
+            ]
+          },
+          {
+            "name": "ClusterTopology",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "lastChange",
+                "type": "CompletedChange"
+              },
+              {
+                "id": 4,
+                "name": "currentChange",
+                "type": "ClusterChangePlan"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 2,
+                  "name": "members",
+                  "type": "MemberState"
+                }
+              }
+            ]
+          },
+          {
+            "name": "MemberState",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "lastUpdated",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 3,
+                "name": "state",
+                "type": "State"
+              }
+            ],
+            "maps": [
+              {
+                "key_type": "int32",
+                "field": {
+                  "id": 4,
+                  "name": "partitions",
+                  "type": "PartitionState"
+                }
+              }
+            ]
+          },
+          {
+            "name": "PartitionState",
+            "fields": [
+              {
+                "id": 1,
+                "name": "state",
+                "type": "State"
+              },
+              {
+                "id": 2,
+                "name": "priority",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "ClusterChangePlan",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "version",
+                "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "status",
+                "type": "ChangeStatus"
+              },
+              {
+                "id": 4,
+                "name": "startedAt",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 5,
+                "name": "completedOperations",
+                "type": "CompletedTopologyChangeOperation",
+                "is_repeated": true
+              },
+              {
+                "id": 6,
+                "name": "pendingOperations",
+                "type": "TopologyChangeOperation",
+                "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "CompletedChange",
+            "fields": [
+              {
+                "id": 1,
+                "name": "id",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "status",
+                "type": "ChangeStatus"
+              },
+              {
+                "id": 3,
+                "name": "startedAt",
+                "type": "google.protobuf.Timestamp"
+              },
+              {
+                "id": 4,
+                "name": "completedAt",
+                "type": "google.protobuf.Timestamp"
+              }
+            ]
+          },
+          {
+            "name": "TopologyChangeOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "partitionJoin",
+                "type": "PartitionJoinOperation"
+              },
+              {
+                "id": 3,
+                "name": "partitionLeave",
+                "type": "PartitionLeaveOperation"
+              },
+              {
+                "id": 4,
+                "name": "memberJoin",
+                "type": "MemberJoinOperation"
+              },
+              {
+                "id": 5,
+                "name": "memberLeave",
+                "type": "MemberLeaveOperation"
+              },
+              {
+                "id": 6,
+                "name": "partitionReconfigurePriority",
+                "type": "PartitionReconfigurePriorityOperation"
+              }
+            ]
+          },
+          {
+            "name": "CompletedTopologyChangeOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "operation",
+                "type": "TopologyChangeOperation"
+              },
+              {
+                "id": 2,
+                "name": "completedAt",
+                "type": "google.protobuf.Timestamp"
+              }
+            ]
+          },
+          {
+            "name": "PartitionJoinOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitionId",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "priority",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "PartitionLeaveOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitionId",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "PartitionReconfigurePriorityOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitionId",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "priority",
+                "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "MemberJoinOperation"
+          },
+          {
+            "name": "MemberLeaveOperation"
+          }
+        ],
+        "imports": [
+          {
+            "path": "google/protobuf/timestamp.proto"
+          }
+        ],
+        "package": {
+          "name": "topology_protocol"
+        },
+        "options": [
+          {
+            "name": "java_package",
+            "value": "io.camunda.zeebe.topology.protocol"
+          }
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Description

Add maven plugin to prevent backward incompatible changes to protobuf message in topology module.

## Related issues

closes #15743 