### PR TITLE
ci: check for unfinished test runs

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -41,3 +41,24 @@ runs:
       fi
       echo "No test execution found in build output, thus nothing to check."
       exit 0
+  - name: Unfinished tests
+    if: always()
+    shell: bash
+    env:
+      BUILD_OUTPUT_FILE_PATH: ${{ inputs.buildOutputFilePath }}
+    run: |
+      if [ ! -s "$BUILD_OUTPUT_FILE_PATH" ]; then
+        echo "::error::Build output file does not exist or is empty!"
+        exit 1
+      fi
+      running=$(mktemp)
+      finished=$(mktemp)
+      unfinished=$(mktemp)
+      grep -oP "\[INFO\] Running \K(.*)$" "$BUILD_OUTPUT_FILE_PATH" > "$running"
+      grep -oP 'Tests run.*?-- in \K(.*)$' "$BUILD_OUTPUT_FILE_PATH" > "$finished"
+      sort $running $finished | uniq -u > "$unfinished"
+      if [ -s "$unfinished" ]; then
+        echo "### ⚠️ Unfinished test runs" >> $GITHUB_STEP_SUMMARY
+        cat $unfinished >> $GITHUB_STEP_SUMMARY
+      fi
+      exit 0

--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -12,7 +12,6 @@ runs:
   using: composite
   steps:
   - name: Duplicate test runs
-    if: always()
     shell: bash
     env:
       BUILD_OUTPUT_FILE_PATH: ${{ inputs.buildOutputFilePath }}

--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -1,5 +1,5 @@
 ---
-name: Check for duplicated test runs
+name: Analyze test runs
 
 description: Check for duplicated test runs from a maven build output file and fail if found.
 
@@ -11,8 +11,8 @@ inputs:
 runs:
   using: composite
   steps:
-
-  - name: Parse the build log output and write duplicate tests to the output file
+  - name: Duplicate test runs
+    if: always()
     shell: bash
     env:
       BUILD_OUTPUT_FILE_PATH: ${{ inputs.buildOutputFilePath }}

--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -29,6 +29,8 @@ runs:
           sort "$tmpFile" | uniq -d | tee "$outputFile"
           if [ -s "$outputFile" ]; then
             echo "::error::Found duplicate test runs!"
+            echo "### ⚠️ Duplicate test runs" >> $GITHUB_STEP_SUMMARY
+            cat $outputFile >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
           echo "No duplicate test runs found, all good!"

--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -42,7 +42,7 @@ runs:
       echo "No test execution found in build output, thus nothing to check."
       exit 0
   - name: Unfinished tests
-    if: always()
+    if: failure() || cancelled()
     shell: bash
     env:
       BUILD_OUTPUT_FILE_PATH: ${{ inputs.buildOutputFilePath }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,9 @@ jobs:
         uses: atomicjar/testcontainers-cloud-setup-action@v1
         with:
           action: terminate
-      - name: Duplicate Test Check
-        uses: ./.github/actions/check-duplicate-tests
+      - name: Analyze Test Runs
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
         with:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
@@ -152,8 +153,9 @@ jobs:
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Normalize artifact name
         run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
-      - name: Duplicate Test Check
-        uses: ./.github/actions/check-duplicate-tests
+      - name: Analyze Test Runs
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
         with:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
@@ -245,8 +247,9 @@ jobs:
           -D skipChecks
           test
           | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Duplicate Test Check
-        uses: ./.github/actions/check-duplicate-tests
+      - name: Analyze Test Runs
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
         with:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Upload test artifacts
@@ -283,8 +286,9 @@ jobs:
           | tee "${BUILD_OUTPUT_FILE_PATH}"
         env:
           LARGE_STATE_CONTROLLER_PERFORMANCE_TEST_SIZE_GB: "4"
-      - name: Duplicate Test Check
-        uses: ./.github/actions/check-duplicate-tests
+      - name: Analyze Test Runs
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
         with:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
       - name: Summarize test results


### PR DESCRIPTION
Refactors our existing action to run always and adds a new analysis step to find tests which did not finish.

Idea for the script from @deepthidevaki 