### PR TITLE
[Backport stable/8.3]: copies of records shouldn't share memory

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecision.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public final class PersistedDecision extends UnpackedObject implements DbValue {
@@ -56,11 +57,11 @@ public final class PersistedDecision extends UnpackedObject implements DbValue {
 
   public PersistedDecision copy() {
     final var copy = new PersistedDecision();
-    copy.decisionIdProp.setValue(getDecisionId());
-    copy.decisionNameProp.setValue(getDecisionName());
+    copy.decisionIdProp.setValue(BufferUtil.cloneBuffer(getDecisionId()));
+    copy.decisionNameProp.setValue(BufferUtil.cloneBuffer(getDecisionName()));
     copy.decisionKeyProp.setValue(getDecisionKey());
     copy.versionProp.setValue(getVersion());
-    copy.decisionRequirementsIdProp.setValue(getDecisionRequirementsId());
+    copy.decisionRequirementsIdProp.setValue(BufferUtil.cloneBuffer(getDecisionRequirementsId()));
     copy.decisionRequirementsKeyProp.setValue(getDecisionRequirementsKey());
     copy.tenantIdProp.setValue(getTenantId());
     return copy;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirements.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public final class PersistedDecisionRequirements extends UnpackedObject implements DbValue {
@@ -61,13 +62,14 @@ public final class PersistedDecisionRequirements extends UnpackedObject implemen
 
   public PersistedDecisionRequirements copy() {
     final var copy = new PersistedDecisionRequirements();
-    copy.decisionRequirementsIdProp.setValue(getDecisionRequirementsId());
-    copy.decisionRequirementsNameProp.setValue(getDecisionRequirementsName());
+    copy.decisionRequirementsIdProp.setValue(BufferUtil.cloneBuffer(getDecisionRequirementsId()));
+    copy.decisionRequirementsNameProp.setValue(
+        BufferUtil.cloneBuffer(getDecisionRequirementsName()));
     copy.decisionRequirementsVersionProp.setValue(getDecisionRequirementsVersion());
     copy.decisionRequirementsKeyProp.setValue(getDecisionRequirementsKey());
-    copy.resourceNameProp.setValue(getResourceName());
-    copy.checksumProp.setValue(getChecksum());
-    copy.resourceProp.setValue(getResource());
+    copy.resourceNameProp.setValue(BufferUtil.cloneBuffer(getResourceName()));
+    copy.checksumProp.setValue(BufferUtil.cloneBuffer(getChecksum()));
+    copy.resourceProp.setValue(BufferUtil.cloneBuffer(getResource()));
     copy.tenantIdProp.setValue(getTenantId());
     return copy;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedForm.java
@@ -44,12 +44,12 @@ public final class PersistedForm extends UnpackedObject implements DbValue {
 
   public PersistedForm copy() {
     final var copy = new PersistedForm();
-    copy.formIdProp.setValue(getFormId());
+    copy.formIdProp.setValue(BufferUtil.cloneBuffer(getFormId()));
     copy.versionProp.setValue(getVersion());
     copy.formKeyProp.setValue(getFormKey());
-    copy.resourceNameProp.setValue(getResourceName());
-    copy.resourceProp.setValue(getResource());
-    copy.checksumProp.setValue(getChecksum());
+    copy.resourceNameProp.setValue(BufferUtil.cloneBuffer(getResourceName()));
+    copy.resourceProp.setValue(BufferUtil.cloneBuffer(getResource()));
+    copy.checksumProp.setValue(BufferUtil.cloneBuffer(getChecksum()));
     copy.tenantIdProp.setValue(getTenantId());
     return copy;
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirementsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionRequirementsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+final class PersistedDecisionRequirementsTest {
+  @Test
+  void copyIsIndependent() {
+    // given
+    final var original = new PersistedDecisionRequirements();
+    original.wrap(
+        new DecisionRequirementsRecord()
+            .setResourceName("resourceName")
+            .setDecisionRequirementsId("decisionRequirements")
+            .setDecisionRequirementsKey(1)
+            .setDecisionRequirementsVersion(1)
+            .setDecisionRequirementsName("test")
+            .setResource(new UnsafeBuffer(new byte[] {1, 2, 3, 4}))
+            .setChecksum(new UnsafeBuffer(new byte[] {1, 2, 3, 4})));
+    final var copy = original.copy();
+
+    // when -- modify original
+    original.getResourceName().byteArray()[0] = 'x';
+    original.getResource().byteArray()[0] = 0;
+    original.getChecksum().byteArray()[0] = 0;
+
+    // then -- copy is not modified
+    final var copiedResourceName = new byte[copy.getResourceName().capacity()];
+    copy.getResourceName().getBytes(0, copiedResourceName);
+    final var copiedResource = new byte[copy.getResource().capacity()];
+    copy.getResource().getBytes(0, copiedResource);
+    final var copiedChecksum = new byte[copy.getChecksum().capacity()];
+    copy.getChecksum().getBytes(0, copiedChecksum);
+
+    assertThat(copiedResourceName).isEqualTo("resourceName".getBytes());
+    assertThat(copiedResource).isEqualTo(new byte[] {1, 2, 3, 4});
+    assertThat(copiedChecksum).isEqualTo(new byte[] {1, 2, 3, 4});
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/PersistedDecisionTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
+import org.junit.jupiter.api.Test;
+
+final class PersistedDecisionTest {
+  @Test
+  void copyIsIndependent() {
+    // given
+    final var original = new PersistedDecision();
+    original.wrap(
+        new DecisionRecord()
+            .setDecisionId("decision")
+            .setDecisionName("name")
+            .setDecisionKey(1)
+            .setVersion(1)
+            .setDecisionRequirementsId("test")
+            .setDecisionRequirementsKey(1));
+    final var copy = original.copy();
+
+    // when -- modify original
+    original.getDecisionId().byteArray()[0] = 'x';
+    original.getDecisionRequirementsId().byteArray()[0] = 'x';
+
+    // then -- copy is not modified
+    final var copiedDecisionId = new byte[copy.getDecisionId().capacity()];
+    copy.getDecisionId().getBytes(0, copiedDecisionId);
+    final var copiedDecisionRequirementsId = new byte[copy.getDecisionRequirementsId().capacity()];
+    copy.getDecisionRequirementsId().getBytes(0, copiedDecisionRequirementsId);
+
+    assertEquals("decision", new String(copiedDecisionId));
+    assertEquals("test", new String(copiedDecisionRequirementsId));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/PersistedFormTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/PersistedFormTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.deployment;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.zeebe.protocol.impl.record.value.deployment.FormRecord;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.jupiter.api.Test;
+
+class PersistedFormTest {
+  @Test
+  void copyIsIndependent() {
+    // given
+    final var original = new PersistedForm();
+    original.wrap(
+        new FormRecord()
+            .setFormId("form")
+            .setFormKey(1)
+            .setVersion(1)
+            .setResourceName("test")
+            .setResource(new UnsafeBuffer(new byte[] {1, 2, 3, 4}))
+            .setChecksum(new UnsafeBuffer(new byte[] {1, 2, 3, 4})));
+    final var copy = original.copy();
+
+    // when -- modify original
+    original.getResourceName().byteArray()[0] = 'x';
+    original.getResource().byteArray()[0] = 0;
+    original.getChecksum().byteArray()[0] = 0;
+
+    // then -- copy is not modified
+    final var copiedResourceName = new byte[copy.getResourceName().capacity()];
+    copy.getResourceName().getBytes(0, copiedResourceName);
+    final var copiedResource = new byte[copy.getResource().capacity()];
+    copy.getResource().getBytes(0, copiedResource);
+    final var copiedChecksum = new byte[copy.getChecksum().capacity()];
+    copy.getChecksum().getBytes(0, copiedChecksum);
+
+    assertThat(copiedResourceName).isEqualTo("test".getBytes());
+    assertThat(copiedResource).isEqualTo(new byte[] {1, 2, 3, 4});
+    assertThat(copiedChecksum).isEqualTo(new byte[] {1, 2, 3, 4});
+  }
+}


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/15722 to fix https://github.com/camunda/zeebe/issues/15720 in 8.3