### PR TITLE
Wait until the compensation handlers are completed

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceLifecycle;
 import io.camunda.zeebe.engine.processing.common.Failure;
-import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCallActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
@@ -23,17 +22,14 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedCommandWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
-import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
-import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Arrays;
 import java.util.function.Function;
 
@@ -533,30 +529,6 @@ public final class BpmnStateTransitionBehavior {
             child ->
                 terminateElement(context.copy(child.getKey(), child.getValue(), child.getState())),
             () -> containerProcessor.onChildTerminated(element, context, null));
-  }
-
-  private boolean hasCompensationBoundaryEvent(final ExecutableFlowNode element) {
-    if (!(element instanceof ExecutableActivity)) {
-      return false;
-    }
-    final var compensationBoundaryEvent =
-        ((ExecutableActivity) element)
-            .getBoundaryEvents().stream()
-                .filter(boundaryEvent -> boundaryEvent.getEventType() == BpmnEventType.COMPENSATION)
-                .findFirst();
-    return compensationBoundaryEvent.isPresent();
-  }
-
-  private void createCompensationSubscription(final BpmnElementContext context) {
-    final var key = keyGenerator.nextKey();
-    final var compensation =
-        new CompensationSubscriptionRecord()
-            .setTenantId(context.getTenantId())
-            .setProcessInstanceKey(context.getProcessInstanceKey())
-            .setProcessDefinitionKey(context.getProcessDefinitionKey())
-            .setCompensableActivityId(BufferUtil.bufferAsString(context.getElementId()))
-            .setCompensableActivityScopeId(context.getFlowScopeKey());
-    stateWriter.appendFollowUpEvent(key, CompensationSubscriptionIntent.CREATED, compensation);
   }
 
   private static final class ChildTerminationStackOverflowException extends RuntimeException {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -74,7 +74,10 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
               return stateTransitionBehavior.transitionToCompleted(element, context);
             })
         .ifRightOrLeft(
-            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+            completed -> {
+              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
+            },
             failure -> incidentBehavior.createIncident(failure, context));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
@@ -97,7 +97,10 @@ public final class ScriptTaskProcessor
               return stateTransitionBehavior.transitionToCompleted(element, context);
             })
         .ifRightOrLeft(
-            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+            completed -> {
+              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
+            },
             failure -> incidentBehavior.createIncident(failure, context));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
@@ -47,7 +47,10 @@ public class UndefinedTaskProcessor implements BpmnElementProcessor<ExecutableAc
     stateTransitionBehavior
         .transitionToCompleted(element, context)
         .ifRightOrLeft(
-            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+            completed -> {
+              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
+            },
             failure -> incidentBehavior.createIncident(failure, context));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -86,11 +86,13 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
               compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
-              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
               return stateTransitionBehavior.transitionToCompleted(element, context);
             })
         .ifRightOrLeft(
-            completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed),
+            completed -> {
+              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
+            },
             failure -> incidentBehavior.createIncident(failure, context));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -86,6 +86,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
               compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
+              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
               return stateTransitionBehavior.transitionToCompleted(element, context);
             })
         .ifRightOrLeft(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionCompletedApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+
+public class CompensationSubscriptionCompletedApplier
+    implements TypedEventApplier<CompensationSubscriptionIntent, CompensationSubscriptionRecord> {
+
+  private final MutableCompensationSubscriptionState compensationState;
+
+  public CompensationSubscriptionCompletedApplier(
+      final MutableCompensationSubscriptionState compensationState) {
+    this.compensationState = compensationState;
+  }
+
+  @Override
+  public void applyState(final long key, final CompensationSubscriptionRecord value) {
+    compensationState.remove(
+        value.getTenantId(), value.getProcessInstanceKey(), value.getCompensableActivityId());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionCompletedApplier.java
@@ -24,7 +24,7 @@ public class CompensationSubscriptionCompletedApplier
 
   @Override
   public void applyState(final long key, final CompensationSubscriptionRecord value) {
-    compensationState.remove(
+    compensationState.delete(
         value.getTenantId(), value.getProcessInstanceKey(), value.getCompensableActivityId());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionDeletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionDeletedApplier.java
@@ -24,7 +24,7 @@ public class CompensationSubscriptionDeletedApplier
 
   @Override
   public void applyState(final long key, final CompensationSubscriptionRecord value) {
-    compensationState.remove(
+    compensationState.delete(
         value.getTenantId(), value.getProcessInstanceKey(), value.getCompensableActivityId());
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionDeletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/CompensationSubscriptionDeletedApplier.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
+import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+
+public class CompensationSubscriptionDeletedApplier
+    implements TypedEventApplier<CompensationSubscriptionIntent, CompensationSubscriptionRecord> {
+
+  private final MutableCompensationSubscriptionState compensationState;
+
+  public CompensationSubscriptionDeletedApplier(
+      final MutableCompensationSubscriptionState compensationState) {
+    this.compensationState = compensationState;
+  }
+
+  @Override
+  public void applyState(final long key, final CompensationSubscriptionRecord value) {
+    compensationState.remove(
+        value.getTenantId(), value.getProcessInstanceKey(), value.getCompensableActivityId());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -327,13 +327,13 @@ public final class EventAppliers implements EventApplier {
         CompensationSubscriptionIntent.TRIGGERED,
         new CompensationSubscriptionTriggeredApplier(
             processingState.getCompensationSubscriptionState()));
-  }
-
-  private void registerCompensationSubscriptionApplier(
-      final MutableProcessingState processingState) {
     register(
-        CompensationSubscriptionIntent.CREATED,
-        new CompensationSubscriptionCreatedApplier(
+        CompensationSubscriptionIntent.COMPLETED,
+        new CompensationSubscriptionCompletedApplier(
+            processingState.getCompensationSubscriptionState()));
+    register(
+        CompensationSubscriptionIntent.DELETED,
+        new CompensationSubscriptionDeletedApplier(
             processingState.getCompensationSubscriptionState()));
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -329,6 +329,14 @@ public final class EventAppliers implements EventApplier {
             processingState.getCompensationSubscriptionState()));
   }
 
+  private void registerCompensationSubscriptionApplier(
+      final MutableProcessingState processingState) {
+    register(
+        CompensationSubscriptionIntent.CREATED,
+        new CompensationSubscriptionCreatedApplier(
+            processingState.getCompensationSubscriptionState()));
+  }
+
   private void registerCommandDistributionAppliers(final MutableProcessingState state) {
     final var distributionState = state.getDistributionState();
     register(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -40,6 +40,9 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     copy.recordProp.getValue().setThrowEventInstanceKey(getRecord().getThrowEventInstanceKey());
     copy.recordProp
         .getValue()
+        .setCompensationActivityElementId(getRecord().getCompensationActivityElementId());
+    copy.recordProp
+        .getValue()
         .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));
     return copy;
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -38,9 +38,7 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
         .setCompensableActivityScopeId(getRecord().getCompensableActivityScopeId());
     copy.recordProp.getValue().setThrowEventId(getRecord().getThrowEventId());
     copy.recordProp.getValue().setThrowEventInstanceKey(getRecord().getThrowEventInstanceKey());
-    copy.recordProp
-        .getValue()
-        .setCompensationActivityElementId(getRecord().getCompensationActivityElementId());
+    copy.recordProp.getValue().setCompensationHandlerId(getRecord().getCompensationHandlerId());
     copy.recordProp
         .getValue()
         .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.compensation.CompensationSubscription;
+import java.util.Optional;
 import java.util.Set;
 
 public interface CompensationSubscriptionState {
@@ -17,4 +18,7 @@ public interface CompensationSubscriptionState {
 
   Set<CompensationSubscription> findSubscriptionsByProcessInstanceKey(
       String tenantId, long processInstanceKey);
+
+  Optional<CompensationSubscription> findCompensationByCompensationHandlerId(
+      String tenantId, long processInstanceKey, String compensationHandlerId);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
@@ -19,6 +19,9 @@ public interface CompensationSubscriptionState {
   Set<CompensationSubscription> findSubscriptionsByProcessInstanceKey(
       String tenantId, long processInstanceKey);
 
-  Optional<CompensationSubscription> findCompensationByCompensationHandlerId(
+  Optional<CompensationSubscription> findSubscriptionByCompensationHandlerId(
       String tenantId, long processInstanceKey, String compensationHandlerId);
+
+  Set<CompensationSubscription> findSubscriptionsByThrowEventInstanceKey(
+      String tenantId, long processInstanceKey, long throwEventInstanceKey);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
@@ -15,4 +15,6 @@ public interface MutableCompensationSubscriptionState extends CompensationSubscr
   void put(final long key, CompensationSubscriptionRecord compensation);
 
   void update(final long key, CompensationSubscriptionRecord compensation);
+
+  void remove(String tenantId, long processInstanceKey, String compensableActivityId);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableCompensationSubscriptionState.java
@@ -16,5 +16,5 @@ public interface MutableCompensationSubscriptionState extends CompensationSubscr
 
   void update(final long key, CompensationSubscriptionRecord compensation);
 
-  void remove(String tenantId, long processInstanceKey, String compensableActivityId);
+  void delete(String tenantId, long processInstanceKey, String compensableActivityId);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.BpmnEventType;
@@ -178,7 +179,7 @@ public class CompensationEventExecutionTest {
   }
 
   @Test
-  public void shouldActivateCompensationHandlerForIntermediateThrowEvent() {
+  public void shouldActivateAndCompleteCompensationHandlerForIntermediateThrowEvent() {
     // given
     final var process =
         createModelFromClasspathResource("/compensation/compensation-throw-event.bpmn");
@@ -190,11 +191,19 @@ public class CompensationEventExecutionTest {
     // when
     ENGINE.job().ofInstance(processInstanceKey).withType(Protocol.USER_TASK_JOB_TYPE).complete();
 
+    final long jobKeyOfCompensationHandler =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withElementId("CompensationHandler")
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().withKey(jobKeyOfCompensationHandler).complete();
+
     // then
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit("CompensationHandler", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+                .limitToProcessInstanceCompleted())
         .extracting(
             r -> r.getValue().getBpmnElementType(),
             r -> r.getValue().getBpmnEventType(),
@@ -245,11 +254,21 @@ public class CompensationEventExecutionTest {
                 BpmnElementType.USER_TASK,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationHandler"));
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationThrowEvent"));
   }
 
   @Test
-  public void shouldActivateCompensationHandlerForEndEvent() {
+  public void shouldActivateAndCompleteCompensationHandlerForEndEvent() {
     // given
     final var process =
         createModelFromClasspathResource("/compensation/compensation-end-event.bpmn");
@@ -261,11 +280,19 @@ public class CompensationEventExecutionTest {
     // when
     ENGINE.job().ofInstance(processInstanceKey).withType(Protocol.USER_TASK_JOB_TYPE).complete();
 
+    final long jobKeyOfCompensationHandler =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withElementId("CompensationHandler")
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().withKey(jobKeyOfCompensationHandler).complete();
+
     // then
     assertThat(
             RecordingExporter.processInstanceRecords()
                 .withProcessInstanceKey(processInstanceKey)
-                .limit("CompensationHandler", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+                .limitToProcessInstanceCompleted())
         .extracting(
             r -> r.getValue().getBpmnElementType(),
             r -> r.getValue().getBpmnEventType(),
@@ -316,7 +343,333 @@ public class CompensationEventExecutionTest {
                 BpmnElementType.USER_TASK,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationHandler"));
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationEndEvent"));
+  }
+
+  @Test
+  public void shouldActivateAndCompleteMultipleCompensationHandlerForThrowEvent() {
+    // given
+    final var process =
+        createModelFromClasspathResource("/compensation/multiple-compensation-throw-event.bpmn");
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .withKey(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withElementId("ActivityToCompensate")
+                .getFirst()
+                .getKey())
+        .complete();
+
+    ENGINE
+        .job()
+        .withKey(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withElementId("ActivityToCompensate2")
+                .getFirst()
+                .getKey())
+        .complete();
+
+    final long jobKeyOfCompensationHandler =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withElementId("CompensationHandler")
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().withKey(jobKeyOfCompensationHandler).complete();
+
+    final long jobKeyOfCompensationHandler2 =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withElementId("CompensationHandler2")
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().withKey(jobKeyOfCompensationHandler2).complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getBpmnEventType(),
+            Record::getIntent,
+            r -> r.getValue().getElementId())
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "ActivityToCompensate2"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "ActivityToCompensate"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "ActivityToCompensate"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "ActivityToCompensate2"),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationThrowEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETING,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETING,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationHandler2"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationHandler2"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationHandler2"),
+            tuple(
+                BpmnElementType.INTERMEDIATE_THROW_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationThrowEvent"));
+  }
+
+  @Test
+  public void shouldActivateAndCompleteMultipleCompensationHandlerForEndEvent() {
+    // given
+    final var process =
+        createModelFromClasspathResource("/compensation/multiple-compensation-end-event.bpmn");
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .withKey(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withElementId("ActivityToCompensate")
+                .getFirst()
+                .getKey())
+        .complete();
+
+    ENGINE
+        .job()
+        .withKey(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withElementId("ActivityToCompensate2")
+                .getFirst()
+                .getKey())
+        .complete();
+
+    final long jobKeyOfCompensationHandler =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withElementId("CompensationHandler")
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().withKey(jobKeyOfCompensationHandler).complete();
+
+    final long jobKeyOfCompensationHandler2 =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withElementId("CompensationHandler2")
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().withKey(jobKeyOfCompensationHandler2).complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getBpmnEventType(),
+            Record::getIntent,
+            r -> r.getValue().getElementId())
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "ActivityToCompensate2"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "ActivityToCompensate"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "ActivityToCompensate"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "ActivityToCompensate2"),
+            tuple(
+                BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationEndEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETING,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationBoundaryEvent"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETING,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.BOUNDARY_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationBoundaryEvent2"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                "CompensationHandler2"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                "CompensationHandler2"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationHandler"),
+            tuple(
+                BpmnElementType.USER_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationHandler2"),
+            tuple(
+                BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                "CompensationEndEvent"));
   }
 
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -264,7 +264,12 @@ public class CompensationEventExecutionTest {
                 BpmnElementType.INTERMEDIATE_THROW_EVENT,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationThrowEvent"));
+                "CompensationThrowEvent"),
+            tuple(
+                BpmnElementType.PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                PROCESS_ID));
   }
 
   @Test
@@ -353,7 +358,12 @@ public class CompensationEventExecutionTest {
                 BpmnElementType.END_EVENT,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationEndEvent"));
+                "CompensationEndEvent"),
+            tuple(
+                BpmnElementType.PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                PROCESS_ID));
   }
 
   @Test
@@ -413,91 +423,11 @@ public class CompensationEventExecutionTest {
             r -> r.getValue().getElementId())
         .containsSubsequence(
             tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "ActivityToCompensate2"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "ActivityToCompensate"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "ActivityToCompensate"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "ActivityToCompensate2"),
-            tuple(
                 BpmnElementType.INTERMEDIATE_THROW_EVENT,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationThrowEvent"),
             tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETING,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETING,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationHandler2"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationHandler2"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationHandler"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationHandler"),
-            tuple(
                 BpmnElementType.USER_TASK,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
@@ -511,7 +441,12 @@ public class CompensationEventExecutionTest {
                 BpmnElementType.INTERMEDIATE_THROW_EVENT,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationThrowEvent"));
+                "CompensationThrowEvent"),
+            tuple(
+                BpmnElementType.PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                PROCESS_ID));
   }
 
   @Test
@@ -571,91 +506,11 @@ public class CompensationEventExecutionTest {
             r -> r.getValue().getElementId())
         .containsSubsequence(
             tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "ActivityToCompensate2"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "ActivityToCompensate"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "ActivityToCompensate"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.UNSPECIFIED,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "ActivityToCompensate2"),
-            tuple(
                 BpmnElementType.END_EVENT,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_ACTIVATED,
                 "CompensationEndEvent"),
             tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETING,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationBoundaryEvent"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETING,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.BOUNDARY_EVENT,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationBoundaryEvent2"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationHandler"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationHandler"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATING,
-                "CompensationHandler2"),
-            tuple(
-                BpmnElementType.USER_TASK,
-                BpmnEventType.COMPENSATION,
-                ProcessInstanceIntent.ELEMENT_ACTIVATED,
-                "CompensationHandler2"),
-            tuple(
                 BpmnElementType.USER_TASK,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
@@ -669,7 +524,12 @@ public class CompensationEventExecutionTest {
                 BpmnElementType.END_EVENT,
                 BpmnEventType.COMPENSATION,
                 ProcessInstanceIntent.ELEMENT_COMPLETED,
-                "CompensationEndEvent"));
+                "CompensationEndEvent"),
+            tuple(
+                BpmnElementType.PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED,
+                PROCESS_ID));
   }
 
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -59,7 +59,8 @@ public class CompensationSubscriptionStateTest {
         .isEqualTo(COMPENSABLE_ACTIVITY_SCOPE_ID);
     assertThat(storedCompensation.getThrowEventId()).isEqualTo(THROW_EVENT_ID);
     assertThat(storedCompensation.getThrowEventInstanceKey()).isEqualTo(THROW_EVENT_INSTANCE_KEY);
-    assertThat(storedCompensation.getCompensationActivityElementId()).isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
+    assertThat(storedCompensation.getCompensationActivityElementId())
+        .isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
   }
 
   @Test
@@ -166,9 +167,12 @@ public class CompensationSubscriptionStateTest {
     state.put(1L, compensation);
     state.put(2L, notValidCompensation);
 
-    final var retrievedCompensation = state.findCompensationByCompensationHandlerId(TENANT_ID, PROCESS_INSTANCE_KEY, COMPENSATION_ACTIVITY_ELEMENT_ID);
+    final var retrievedCompensation =
+        state.findCompensationByCompensationHandlerId(
+            TENANT_ID, PROCESS_INSTANCE_KEY, COMPENSATION_ACTIVITY_ELEMENT_ID);
     assertThat(retrievedCompensation.isPresent()).isTrue();
-    assertThat(retrievedCompensation.get().getRecord().getCompensationActivityElementId()).isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
+    assertThat(retrievedCompensation.get().getRecord().getCompensationActivityElementId())
+        .isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
   }
 
   private CompensationSubscriptionRecord createCompensation(final long key) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionStat
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,6 +28,7 @@ public class CompensationSubscriptionStateTest {
   private static final String COMPENSABLE_ACTIVITY_SCOPE_ID = "compensableActivityScopeId";
   private static final String THROW_EVENT_ID = "throwEventId";
   private static final long THROW_EVENT_INSTANCE_KEY = 4L;
+  private static final String COMPENSATION_ACTIVITY_ELEMENT_ID = "compensationActivityElementId";
 
   private MutableCompensationSubscriptionState state;
   private MutableProcessingState processingState;
@@ -57,6 +59,7 @@ public class CompensationSubscriptionStateTest {
         .isEqualTo(COMPENSABLE_ACTIVITY_SCOPE_ID);
     assertThat(storedCompensation.getThrowEventId()).isEqualTo(THROW_EVENT_ID);
     assertThat(storedCompensation.getThrowEventInstanceKey()).isEqualTo(THROW_EVENT_INSTANCE_KEY);
+    assertThat(storedCompensation.getCompensationActivityElementId()).isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
   }
 
   @Test
@@ -125,6 +128,49 @@ public class CompensationSubscriptionStateTest {
         .contains(COMPENSABLE_ACTIVITY_ID, "anotherCompensableActivityId");
   }
 
+  @Test
+  public void shouldRemoveCompensationSubscription() {
+    final var compensation = createCompensation(PROCESS_INSTANCE_KEY);
+    state.put(1L, compensation);
+
+    state.remove(TENANT_ID, PROCESS_INSTANCE_KEY, COMPENSABLE_ACTIVITY_ID);
+
+    final var compensations =
+        state.findSubscriptionsByProcessInstanceKey(TENANT_ID, PROCESS_INSTANCE_KEY);
+    assertThat(compensations).isEmpty();
+  }
+
+  @Test
+  public void shouldRemoveOneCompensationSubscription() {
+    final var compensation = createCompensation(PROCESS_INSTANCE_KEY);
+    final var compensationToRemove = createCompensation(PROCESS_INSTANCE_KEY);
+    compensationToRemove.setCompensableActivityId("anotherCompensableActivityId");
+    state.put(1L, compensation);
+    state.put(2L, compensationToRemove);
+
+    state.remove(TENANT_ID, PROCESS_INSTANCE_KEY, "anotherCompensableActivityId");
+
+    final Set<CompensationSubscription> compensations =
+        state.findSubscriptionsByProcessInstanceKey(TENANT_ID, PROCESS_INSTANCE_KEY);
+    assertThat(compensations.size()).isEqualTo(1);
+    assertThat(compensations.stream().findFirst().get().getRecord().getCompensableActivityId())
+        .isEqualTo(COMPENSABLE_ACTIVITY_ID);
+  }
+
+  @Test
+  public void shouldFindCompensationByHandlerId() {
+    final var compensation = createCompensation(PROCESS_INSTANCE_KEY);
+    final var notValidCompensation = createCompensation(PROCESS_INSTANCE_KEY);
+    notValidCompensation.setCompensableActivityId("anotherCompensableActivityId");
+    notValidCompensation.setCompensationActivityElementId("anotherCompensationActivityElementId");
+    state.put(1L, compensation);
+    state.put(2L, notValidCompensation);
+
+    final var retrievedCompensation = state.findCompensationByCompensationHandlerId(TENANT_ID, PROCESS_INSTANCE_KEY, COMPENSATION_ACTIVITY_ELEMENT_ID);
+    assertThat(retrievedCompensation.isPresent()).isTrue();
+    assertThat(retrievedCompensation.get().getRecord().getCompensationActivityElementId()).isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
+  }
+
   private CompensationSubscriptionRecord createCompensation(final long key) {
     return new CompensationSubscriptionRecord()
         .setTenantId(TENANT_ID)
@@ -133,6 +179,7 @@ public class CompensationSubscriptionStateTest {
         .setCompensableActivityId(COMPENSABLE_ACTIVITY_ID)
         .setCompensableActivityScopeId(COMPENSABLE_ACTIVITY_SCOPE_ID)
         .setThrowEventId(THROW_EVENT_ID)
-        .setThrowEventInstanceKey(THROW_EVENT_INSTANCE_KEY);
+        .setThrowEventInstanceKey(THROW_EVENT_INSTANCE_KEY)
+        .setCompensationActivityElementId(COMPENSATION_ACTIVITY_ELEMENT_ID);
   }
 }

--- a/engine/src/test/resources/compensation/multiple-compensation-end-event.bpmn
+++ b/engine/src/test/resources/compensation/multiple-compensation-end-event.bpmn
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0m7yk26</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="ActivityToCompensate" name="A">
+      <bpmn:incoming>Flow_1keydsx</bpmn:incoming>
+      <bpmn:outgoing>Flow_13spwoi</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_13spwoi" sourceRef="ActivityToCompensate" targetRef="Gateway_1jqriiv" />
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" attachedToRef="ActivityToCompensate">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0o178oi" />
+    </bpmn:boundaryEvent>
+    <bpmn:userTask id="CompensationHandler" name="undo A" isForCompensation="true" />
+    <bpmn:endEvent id="CompensationEndEvent">
+      <bpmn:incoming>Flow_1kt3dm3</bpmn:incoming>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1n06ebt" />
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0m7yk26" sourceRef="StartEvent_1" targetRef="Gateway_0ezjfu3" />
+    <bpmn:sequenceFlow id="Flow_1keydsx" sourceRef="Gateway_0ezjfu3" targetRef="ActivityToCompensate" />
+    <bpmn:sequenceFlow id="Flow_14pwp31" sourceRef="Gateway_0ezjfu3" targetRef="ActivityToCompensate2" />
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent2" attachedToRef="ActivityToCompensate2">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_12ttsw0" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1kt3dm3" sourceRef="Gateway_1jqriiv" targetRef="CompensationEndEvent" />
+    <bpmn:sequenceFlow id="Flow_0o9ojsl" sourceRef="ActivityToCompensate2" targetRef="Gateway_1jqriiv" />
+    <bpmn:userTask id="CompensationHandler2" name="undo B" isForCompensation="true" />
+    <bpmn:parallelGateway id="Gateway_0ezjfu3">
+      <bpmn:incoming>Flow_0m7yk26</bpmn:incoming>
+      <bpmn:outgoing>Flow_1keydsx</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14pwp31</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:parallelGateway id="Gateway_1jqriiv">
+      <bpmn:incoming>Flow_13spwoi</bpmn:incoming>
+      <bpmn:incoming>Flow_0o9ojsl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1kt3dm3</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:userTask id="ActivityToCompensate2" name="B">
+      <bpmn:incoming>Flow_14pwp31</bpmn:incoming>
+      <bpmn:outgoing>Flow_0o9ojsl</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:association id="Association_1jwpcsv" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="CompensationHandler" />
+    <bpmn:association id="Association_0c1akqn" associationDirection="One" sourceRef="CompensationBoundaryEvent2" targetRef="CompensationHandler2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1761rwu_di" bpmnElement="ActivityToCompensate">
+        <dc:Bounds x="460" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1en6ywx_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="610" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_00v7ezm_di" bpmnElement="CompensationEndEvent">
+        <dc:Bounds x="1092" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0aao4o7" bpmnElement="CompensationHandler2">
+        <dc:Bounds x="470" y="480" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1jau318_di" bpmnElement="Gateway_0ezjfu3">
+        <dc:Bounds x="245" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0dq9t6b_di" bpmnElement="Gateway_1jqriiv">
+        <dc:Bounds x="905" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1g7dzaj_di" bpmnElement="ActivityToCompensate2">
+        <dc:Bounds x="310" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0c1akqn_di" bpmnElement="Association_0c1akqn">
+        <di:waypoint x="410" y="448" />
+        <di:waypoint x="410" y="520" />
+        <di:waypoint x="470" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="542" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0r4hudf" bpmnElement="CompensationBoundaryEvent2">
+        <dc:Bounds x="392" y="412" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_13spwoi_di" bpmnElement="Flow_13spwoi">
+        <di:waypoint x="560" y="117" />
+        <di:waypoint x="905" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m7yk26_di" bpmnElement="Flow_0m7yk26">
+        <di:waypoint x="188" y="117" />
+        <di:waypoint x="245" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1keydsx_di" bpmnElement="Flow_1keydsx">
+        <di:waypoint x="295" y="117" />
+        <di:waypoint x="460" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14pwp31_di" bpmnElement="Flow_14pwp31">
+        <di:waypoint x="270" y="142" />
+        <di:waypoint x="270" y="390" />
+        <di:waypoint x="310" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kt3dm3_di" bpmnElement="Flow_1kt3dm3">
+        <di:waypoint x="955" y="117" />
+        <di:waypoint x="1092" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o9ojsl_di" bpmnElement="Flow_0o9ojsl">
+        <di:waypoint x="410" y="390" />
+        <di:waypoint x="930" y="390" />
+        <di:waypoint x="930" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
+        <di:waypoint x="540" y="157" />
+        <di:waypoint x="510" y="157" />
+        <di:waypoint x="510" y="240" />
+        <di:waypoint x="610" y="240" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/engine/src/test/resources/compensation/multiple-compensation-throw-event.bpmn
+++ b/engine/src/test/resources/compensation/multiple-compensation-throw-event.bpmn
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent">
+      <bpmn:outgoing>Flow_1vslwh8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="ActivityToCompensate" name="A">
+      <bpmn:incoming>Flow_10lzjlx</bpmn:incoming>
+      <bpmn:outgoing>Flow_06ult9h</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:endEvent id="EndEvent">
+      <bpmn:incoming>Flow_0n0oakg</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent" attachedToRef="ActivityToCompensate">
+      <bpmn:extensionElements />
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0o178oi" />
+    </bpmn:boundaryEvent>
+    <bpmn:userTask id="CompensationHandler" name="undo A" isForCompensation="true" />
+    <bpmn:sequenceFlow id="Flow_0n0oakg" sourceRef="CompensationThrowEvent" targetRef="EndEvent" />
+    <bpmn:intermediateThrowEvent id="CompensationThrowEvent">
+      <bpmn:incoming>Flow_08yr8s3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0n0oakg</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" activityRef="ActivityToCompensate" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_1vslwh8" sourceRef="StartEvent" targetRef="Gateway_118x39o" />
+    <bpmn:parallelGateway id="Gateway_118x39o">
+      <bpmn:incoming>Flow_1vslwh8</bpmn:incoming>
+      <bpmn:outgoing>Flow_10lzjlx</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ddh5xn</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_10lzjlx" sourceRef="Gateway_118x39o" targetRef="ActivityToCompensate" />
+    <bpmn:sequenceFlow id="Flow_0ddh5xn" sourceRef="Gateway_118x39o" targetRef="ActivityToCompensate2" />
+    <bpmn:boundaryEvent id="CompensationBoundaryEvent2" attachedToRef="ActivityToCompensate2">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_01qjxxf" />
+    </bpmn:boundaryEvent>
+    <bpmn:userTask id="ActivityToCompensate2" name="B">
+      <bpmn:incoming>Flow_0ddh5xn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1235t7q</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_06ult9h" sourceRef="ActivityToCompensate" targetRef="Gateway_0c6gxu8" />
+    <bpmn:parallelGateway id="Gateway_0c6gxu8">
+      <bpmn:incoming>Flow_06ult9h</bpmn:incoming>
+      <bpmn:incoming>Flow_1235t7q</bpmn:incoming>
+      <bpmn:outgoing>Flow_08yr8s3</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_08yr8s3" sourceRef="Gateway_0c6gxu8" targetRef="CompensationThrowEvent" />
+    <bpmn:sequenceFlow id="Flow_1235t7q" sourceRef="ActivityToCompensate2" targetRef="Gateway_0c6gxu8" />
+    <bpmn:userTask id="CompensationHandler2" name="undo B" isForCompensation="true" />
+    <bpmn:association id="Association_1jwpcsv" associationDirection="One" sourceRef="CompensationBoundaryEvent" targetRef="CompensationHandler" />
+    <bpmn:association id="Association_1ebe076" associationDirection="One" sourceRef="CompensationBoundaryEvent2" targetRef="CompensationHandler2" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="Activity_1761rwu_di" bpmnElement="ActivityToCompensate">
+        <dc:Bounds x="350" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1en6ywx_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="500" y="200" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0iasuoa_di" bpmnElement="EndEvent">
+        <dc:Bounds x="972" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1qpwd18_di" bpmnElement="CompensationThrowEvent">
+        <dc:Bounds x="872" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent">
+        <dc:Bounds x="152" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_15dmpht_di" bpmnElement="Gateway_118x39o">
+        <dc:Bounds x="245" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03js6x6_di" bpmnElement="ActivityToCompensate2">
+        <dc:Bounds x="310" y="410" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1q3vr99_di" bpmnElement="Gateway_0c6gxu8">
+        <dc:Bounds x="765" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_02t18oa" bpmnElement="CompensationHandler2">
+        <dc:Bounds x="450" y="550" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
+        <di:waypoint x="430" y="175" />
+        <di:waypoint x="430" y="240" />
+        <di:waypoint x="500" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ebe076_di" bpmnElement="Association_1ebe076">
+        <di:waypoint x="410" y="508" />
+        <di:waypoint x="410" y="590" />
+        <di:waypoint x="450" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="432" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_0rexz0f" bpmnElement="CompensationBoundaryEvent2">
+        <dc:Bounds x="392" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0n0oakg_di" bpmnElement="Flow_0n0oakg">
+        <di:waypoint x="908" y="117" />
+        <di:waypoint x="972" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vslwh8_di" bpmnElement="Flow_1vslwh8">
+        <di:waypoint x="188" y="117" />
+        <di:waypoint x="245" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10lzjlx_di" bpmnElement="Flow_10lzjlx">
+        <di:waypoint x="295" y="117" />
+        <di:waypoint x="350" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ddh5xn_di" bpmnElement="Flow_0ddh5xn">
+        <di:waypoint x="270" y="142" />
+        <di:waypoint x="270" y="450" />
+        <di:waypoint x="310" y="450" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06ult9h_di" bpmnElement="Flow_06ult9h">
+        <di:waypoint x="450" y="117" />
+        <di:waypoint x="765" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08yr8s3_di" bpmnElement="Flow_08yr8s3">
+        <di:waypoint x="815" y="117" />
+        <di:waypoint x="872" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1235t7q_di" bpmnElement="Flow_1235t7q">
+        <di:waypoint x="410" y="450" />
+        <di:waypoint x="790" y="450" />
+        <di:waypoint x="790" y="142" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -40,6 +40,9 @@
             "throwEventInstanceKey": {
               "type": "long"
             },
+            "compensationActivityElementId": {
+              "type": "keyword"
+            },
             "variables": {
               "enabled": false
             }

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -40,7 +40,7 @@
             "throwEventInstanceKey": {
               "type": "long"
             },
-            "compensationActivityElementId": {
+            "compensationHandlerId": {
               "type": "keyword"
             },
             "variables": {

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -40,6 +40,9 @@
             "throwEventInstanceKey": {
               "type": "long"
             },
+            "compensationActivityElementId": {
+              "type": "keyword"
+            },
             "variables": {
               "enabled": false
             }

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -40,7 +40,7 @@
             "throwEventInstanceKey": {
               "type": "long"
             },
-            "compensationActivityElementId": {
+            "compensationHandlerId": {
               "type": "keyword"
             },
             "variables": {

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -38,6 +38,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
       new StringProperty("throwEventId", EMPTY_STRING);
   private final LongProperty throwEventInstanceKeyProperty =
       new LongProperty("throwEventInstanceKey", -1);
+  private final StringProperty compensationActivityElementIdProperty =
+      new StringProperty("compensationActivityElementId", EMPTY_STRING);
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
@@ -49,6 +51,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(compensableActivityScopeIdProperty)
         .declareProperty(throwEventIdProperty)
         .declareProperty(throwEventInstanceKeyProperty)
+        .declareProperty(compensationActivityElementIdProperty)
         .declareProperty(variablesProperty);
   }
 
@@ -60,6 +63,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     compensableActivityScopeIdProperty.setValue(record.getCompensableActivityScopeId());
     throwEventIdProperty.setValue(record.getThrowEventId());
     throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
+    compensationActivityElementIdProperty.setValue(record.getCompensationActivityElementId());
     variablesProperty.setValue(record.getVariablesBuffer());
   }
 
@@ -114,12 +118,23 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
+  public String getCompensationActivityElementId() {
+    return BufferUtil.bufferAsString(compensationActivityElementIdProperty.getValue());
+  }
+
+  @Override
   public Map<String, Object> getVariables() {
     return MsgPackConverter.convertToMap(variablesProperty.getValue());
   }
 
   public CompensationSubscriptionRecord setVariables(final DirectBuffer variables) {
     variablesProperty.setValue(variables);
+    return this;
+  }
+
+  public CompensationSubscriptionRecord setCompensationActivityElementId(
+      final String compensationActivityElementId) {
+    compensationActivityElementIdProperty.setValue(compensationActivityElementId);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -38,8 +38,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
       new StringProperty("throwEventId", EMPTY_STRING);
   private final LongProperty throwEventInstanceKeyProperty =
       new LongProperty("throwEventInstanceKey", -1);
-  private final StringProperty compensationActivityElementIdProperty =
-      new StringProperty("compensationActivityElementId", EMPTY_STRING);
+  private final StringProperty compensationHandlerIdProperty =
+      new StringProperty("compensationHandlerId", EMPTY_STRING);
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
@@ -51,7 +51,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(compensableActivityScopeIdProperty)
         .declareProperty(throwEventIdProperty)
         .declareProperty(throwEventInstanceKeyProperty)
-        .declareProperty(compensationActivityElementIdProperty)
+        .declareProperty(compensationHandlerIdProperty)
         .declareProperty(variablesProperty);
   }
 
@@ -63,7 +63,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     compensableActivityScopeIdProperty.setValue(record.getCompensableActivityScopeId());
     throwEventIdProperty.setValue(record.getThrowEventId());
     throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
-    compensationActivityElementIdProperty.setValue(record.getCompensationActivityElementId());
+    compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
     variablesProperty.setValue(record.getVariablesBuffer());
   }
 
@@ -118,8 +118,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public String getCompensationActivityElementId() {
-    return BufferUtil.bufferAsString(compensationActivityElementIdProperty.getValue());
+  public String getCompensationHandlerId() {
+    return BufferUtil.bufferAsString(compensationHandlerIdProperty.getValue());
   }
 
   @Override
@@ -132,9 +132,9 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public CompensationSubscriptionRecord setCompensationActivityElementId(
-      final String compensationActivityElementId) {
-    compensationActivityElementIdProperty.setValue(compensationActivityElementId);
+  public CompensationSubscriptionRecord setCompensationHandlerId(
+      final String compensationHandlerId) {
+    compensationHandlerIdProperty.setValue(compensationHandlerId);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2242,7 +2242,7 @@ final class JsonSerializableToJsonTest {
                     .setCompensableActivityScopeId("elementActivityScopeId")
                     .setThrowEventId("elementThrowEventId")
                     .setThrowEventInstanceKey(123L)
-                    .setCompensationActivityElementId("compensationActivityElementId")
+                    .setCompensationHandlerId("compensationActivityElementId")
                     .setVariables(VARIABLES_MSGPACK),
         """
         {
@@ -2253,7 +2253,7 @@ final class JsonSerializableToJsonTest {
           "compensableActivityScopeId": "elementActivityScopeId",
           "throwEventId": "elementThrowEventId",
           "throwEventInstanceKey": 123,
-          "compensationActivityElementId": "compensationActivityElementId",
+          "compensationHandlerId": "compensationActivityElementId",
           "variables": {
             "foo": "bar"
           }
@@ -2276,7 +2276,7 @@ final class JsonSerializableToJsonTest {
           "compensableActivityScopeId": "",
           "throwEventId": "",
           "throwEventInstanceKey": -1,
-          "compensationActivityElementId": "",
+          "compensationHandlerId": "",
           "variables": {}
         }
         """

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2242,6 +2242,7 @@ final class JsonSerializableToJsonTest {
                     .setCompensableActivityScopeId("elementActivityScopeId")
                     .setThrowEventId("elementThrowEventId")
                     .setThrowEventInstanceKey(123L)
+                    .setCompensationActivityElementId("compensationActivityElementId")
                     .setVariables(VARIABLES_MSGPACK),
         """
         {
@@ -2252,6 +2253,7 @@ final class JsonSerializableToJsonTest {
           "compensableActivityScopeId": "elementActivityScopeId",
           "throwEventId": "elementThrowEventId",
           "throwEventInstanceKey": 123,
+          "compensationActivityElementId": "compensationActivityElementId",
           "variables": {
             "foo": "bar"
           }
@@ -2274,6 +2276,7 @@ final class JsonSerializableToJsonTest {
           "compensableActivityScopeId": "",
           "throwEventId": "",
           "throwEventInstanceKey": -1,
+          "compensationActivityElementId": "",
           "variables": {}
         }
         """

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -61,6 +61,11 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   long getThrowEventInstanceKey();
 
   /**
+   * @return the element id of the compensation handler
+   */
+  String getCompensationActivityElementId();
+
+  /**
    * @return the local variables of activity with compensation handler
    */
   Map<String, Object> getVariables();

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -63,7 +63,7 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   /**
    * @return the element id of the compensation handler
    */
-  String getCompensationActivityElementId();
+  String getCompensationHandlerId();
 
   /**
    * @return the local variables of activity with compensation handler


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When a process instance enters a compensation intermediate throw or end event, we invoke the compensation handlers of completed activities. On completing the last compensation handler, we should complete the compensation throw event and continue the process instance.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15066

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
