### PR TITLE
Intermediate signal throw should not send response

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -68,7 +68,10 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
     final var signalRecord = command.getValue();
 
     stateWriter.appendFollowUpEvent(eventKey, SignalIntent.BROADCASTED, signalRecord);
-    responseWriter.writeEventOnCommand(eventKey, SignalIntent.BROADCASTED, signalRecord, command);
+
+    if (command.hasRequestMetadata()) {
+      responseWriter.writeEventOnCommand(eventKey, SignalIntent.BROADCASTED, signalRecord, command);
+    }
 
     signalSubscriptionState.visitBySignalName(
         signalRecord.getSignalNameBuffer(),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
@@ -175,11 +175,15 @@ public class SignalIntermediateThrowEventTest {
   @Test
   public void shouldNotSendResponseWhenPartOfBatch() {
     // given
+    final String businessKey = "42";
+    final String messageName = "start";
+
     final var process =
         Bpmn.createExecutableProcess(PROCESS)
             .startEvent()
             .intermediateCatchEvent(
-                "start", b -> b.message(m -> m.name("start").zeebeCorrelationKey("=businessKey")))
+                "start",
+                b -> b.message(m -> m.name(messageName).zeebeCorrelationKey("=businessKey")))
             .intermediateThrowEvent("signal", b -> b.signal(SIGNAL_NAME_1))
             .endEvent()
             .done();
@@ -190,7 +194,7 @@ public class SignalIntermediateThrowEventTest {
         ENGINE
             .processInstance()
             .ofBpmnProcessId(PROCESS)
-            .withVariables(Map.of("businessKey", "42"))
+            .withVariables(Map.of("businessKey", businessKey))
             .create();
 
     assertThat(
@@ -202,7 +206,7 @@ public class SignalIntermediateThrowEventTest {
         .isTrue();
 
     // when
-    ENGINE.message().withName("start").withCorrelationKey("42").publish();
+    ENGINE.message().withName(messageName).withCorrelationKey(businessKey).publish();
 
     assertThat(
             RecordingExporter.signalRecords(SignalIntent.BROADCASTED)

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.signal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -168,5 +170,48 @@ public class SignalIntermediateThrowEventTest {
 
     final var signalRecord = RecordingExporter.signalRecords(SignalIntent.BROADCASTED).getFirst();
     Assertions.assertThat(signalRecord.getValue()).hasSignalName(SIGNAL_NAME_1);
+  }
+
+  @Test
+  public void shouldNotSendResponseWhenPartOfBatch() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS)
+            .startEvent()
+            .intermediateCatchEvent(
+                "start", b -> b.message(m -> m.name("start").zeebeCorrelationKey("=businessKey")))
+            .intermediateThrowEvent("signal", b -> b.signal(SIGNAL_NAME_1))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS)
+            .withVariables(Map.of("businessKey", "42"))
+            .create();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("start")
+                .limit(1)
+                .exists())
+        .isTrue();
+
+    // when
+    ENGINE.message().withName("start").withCorrelationKey("42").publish();
+
+    assertThat(
+            RecordingExporter.signalRecords(SignalIntent.BROADCASTED)
+                .withSignalName(SIGNAL_NAME_1)
+                .limit(1)
+                .exists())
+        .isTrue();
+
+    // then
+    verify(ENGINE.getCommandResponseWriter(), never()).intent(SignalIntent.BROADCASTED);
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/signal/SignalIntermediateThrowEventTest.java
@@ -193,8 +193,6 @@ public class SignalIntermediateThrowEventTest {
     assertThat(
             RecordingExporter.signalRecords(SignalIntent.BROADCASTED)
                 .withSignalName(SIGNAL_NAME_1)
-                // No need to use .limit(1) here as .exists() uses .findFirst() in order to
-                // determine if the element is present.
                 .exists())
         .isTrue();
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/BroadcastSignalTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/BroadcastSignalTest.java
@@ -151,11 +151,9 @@ public class BroadcastSignalTest {
     final Record<SignalRecordValue> record =
         signalRecords(SignalIntent.BROADCASTED).withSignalName(signalName).getFirst();
 
-    final long recordKey = record.getKey();
-
     // then
     final BroadcastSignalResponse response = responseFuture.join();
-    assertThat(response.getKey()).isEqualTo(recordKey);
+    assertThat(response.getKey()).isEqualTo(record.getKey());
     assertThat(response.getTenantId()).isEqualTo(record.getValue().getTenantId());
   }
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/stream/StreamWrapper.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/stream/StreamWrapper.java
@@ -77,6 +77,7 @@ public abstract class StreamWrapper<T, S extends StreamWrapper<T, S>> implements
 
   // Helper to extract values
 
+  /** This is a short-circuiting terminal operation. */
   public boolean exists() {
     return wrappedStream.findFirst().isPresent();
   }


### PR DESCRIPTION
## Description
Fix for this [bug](https://github.com/camunda/zeebe/issues/15649)

<!-- Please explain the changes you made here. -->

- Added a check to verify if the command has request metadata
- Added a unit test to verify that response is not send if the metadata is not present. Adjusted the test case from the bug above.
- Added an Integration Test to verify the response is sent when the metadata is present

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15649

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
