### PR TITLE
Fix: Zeebe gateway fails to stream out activated jobs by not respecting the max message size

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -314,14 +314,14 @@ public final class Gateway implements CloseableSilently {
       return buildLongPollingHandler(brokerClient);
     } else {
       return new RoundRobinActivateJobsHandler(
-          brokerClient, gatewayCfg.getNetwork().getMaxMessageSize());
+          brokerClient, gatewayCfg.getNetwork().getMaxMessageSize().toBytes());
     }
   }
 
   private LongPollingActivateJobsHandler buildLongPollingHandler(final BrokerClient brokerClient) {
     return LongPollingActivateJobsHandler.newBuilder()
         .setBrokerClient(brokerClient)
-        .setMaxMessageSize(gatewayCfg.getNetwork().getMaxMessageSize())
+        .setMaxMessageSize(gatewayCfg.getNetwork().getMaxMessageSize().toBytes())
         .build();
   }
 

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/Gateway.java
@@ -313,12 +313,16 @@ public final class Gateway implements CloseableSilently {
     if (gatewayCfg.getLongPolling().isEnabled()) {
       return buildLongPollingHandler(brokerClient);
     } else {
-      return new RoundRobinActivateJobsHandler(brokerClient);
+      return new RoundRobinActivateJobsHandler(
+          brokerClient, gatewayCfg.getNetwork().getMaxMessageSize());
     }
   }
 
   private LongPollingActivateJobsHandler buildLongPollingHandler(final BrokerClient brokerClient) {
-    return LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
+    return LongPollingActivateJobsHandler.newBuilder()
+        .setBrokerClient(brokerClient)
+        .setMaxMessageSize(gatewayCfg.getNetwork().getMaxMessageSize())
+        .build();
   }
 
   private ServerServiceDefinition applyInterceptors(final BindableService service) {

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -329,11 +329,9 @@ public final class ResponseMapper {
     // is still exceeding the maximum response size, we remove the last added job from the response
     // and add it to the list of jobs to be reactivated.
     // We do this until the response size is below the maximum response size.
-    if (response.getSerializedSize() > maxResponseSize) {
-      while (!responseJobs.isEmpty() && response.getSerializedSize() > maxResponseSize) {
-        sizeExceedingJobs.add(responseJobs.removeLast());
-        response = ActivateJobsResponse.newBuilder().addAllJobs(responseJobs).build();
-      }
+    while (!responseJobs.isEmpty() && response.getSerializedSize() > maxResponseSize) {
+      sizeExceedingJobs.add(responseJobs.removeLast());
+      response = ActivateJobsResponse.newBuilder().addAllJobs(responseJobs).build();
     }
 
     return new JobActivationResult(response, sizeExceedingJobs);

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -278,30 +278,65 @@ public final class ResponseMapper {
     return SetVariablesResponse.newBuilder().setKey(key).build();
   }
 
+  /**
+   * While converting the broker response to the gRPC response, the response size is checked. If the
+   * response size exceeds the maximum response size, exceeding jobs are added to the list of
+   * exceeding jobs to be reactivated.
+   *
+   * <p>This is because the jobs returned from the broker is in MessagePack format and while
+   * converting them to gRPC response the size of the response may increase (e.g. we do JSON and
+   * String conversions see: {@link #toActivatedJob(long, JobRecord)}). That will cause the response
+   * size to exceed the maximum response size allowed by the gateway and the gateway will log a
+   * Stream Error indicating that streaming out the activated jobs failed.
+   *
+   * <p>If we do not respect the actual max response size, Zeebe Java Client rejects the response
+   * containing the activated jobs and the client cancels the channel/stream/connection as well.
+   * Leaving failed jobs non-activatable until their configured timeout.
+   *
+   * @param key the key of the request
+   * @param brokerResponse the broker response
+   * @param maxResponseSize the maximum size of the response
+   * @return a pair of the response and a list of jobs that could not be included in the response
+   *     because the response size exceeded the maximum response size
+   */
   public static JobActivationResult toActivateJobsResponse(
-      final long key, final JobBatchRecord brokerResponse, final int maxMessageSize) {
-    final ActivateJobsResponse.Builder responseBuilder = ActivateJobsResponse.newBuilder();
-
+      final long key, final JobBatchRecord brokerResponse, final long maxResponseSize) {
     final Iterator<LongValue> jobKeys = brokerResponse.jobKeys().iterator();
     final Iterator<JobRecord> jobs = brokerResponse.jobs().iterator();
 
-    int currentResponseSize = 0;
-    final List<ActivatedJob> jobsToDefer = new ArrayList<>();
+    long currentResponseSize = 0L;
+    final List<ActivatedJob> sizeExceedingJobs = new ArrayList<>();
+    final List<ActivatedJob> responseJobs = new ArrayList<>();
 
     while (jobKeys.hasNext() && jobs.hasNext()) {
       final LongValue jobKey = jobKeys.next();
       final JobRecord job = jobs.next();
       final ActivatedJob activatedJob = toActivatedJob(jobKey.getValue(), job);
 
-      currentResponseSize += activatedJob.getSerializedSize();
-      if (currentResponseSize <= maxMessageSize) {
-        responseBuilder.addJobs(activatedJob);
+      final int activatedJobSize = activatedJob.getSerializedSize();
+      if (currentResponseSize + activatedJobSize <= maxResponseSize) {
+        responseJobs.add(activatedJob);
+        currentResponseSize += activatedJobSize;
       } else {
-        jobsToDefer.add(activatedJob);
+        sizeExceedingJobs.add(activatedJob);
       }
     }
 
-    return new JobActivationResult(responseBuilder.build(), jobsToDefer);
+    ActivateJobsResponse response =
+        ActivateJobsResponse.newBuilder().addAllJobs(responseJobs).build();
+    // Response size can still exceed the maximum response size because of the metadata added on
+    // building the response. Therefore, we check the response size again and if the response size
+    // is still exceeding the maximum response size, we remove the last added job from the response
+    // and add it to the list of jobs to be reactivated.
+    // We do this until the response size is below the maximum response size.
+    if (response.getSerializedSize() > maxResponseSize) {
+      while (!responseJobs.isEmpty() && response.getSerializedSize() > maxResponseSize) {
+        sizeExceedingJobs.add(responseJobs.removeLast());
+        response = ActivateJobsResponse.newBuilder().addAllJobs(responseJobs).build();
+      }
+    }
+
+    return new JobActivationResult(response, sizeExceedingJobs);
   }
 
   public static ActivatedJob toActivatedJob(

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsHandler.java
@@ -27,7 +27,6 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import org.slf4j.Logger;
-import org.springframework.util.unit.DataSize;
 
 /**
  * Adds long polling to the handling of activate job requests. When there are no jobs available to
@@ -55,7 +54,7 @@ public final class LongPollingActivateJobsHandler implements ActivateJobsHandler
 
   private LongPollingActivateJobsHandler(
       final BrokerClient brokerClient,
-      final DataSize maxMessageSize,
+      final long maxMessageSize,
       final long longPollingTimeout,
       final long probeTimeoutMillis,
       final int failedAttemptThreshold) {
@@ -377,7 +376,7 @@ public final class LongPollingActivateJobsHandler implements ActivateJobsHandler
     private static final int EMPTY_RESPONSE_THRESHOLD = 3;
 
     private BrokerClient brokerClient;
-    private DataSize maxMessageSize;
+    private long maxMessageSize;
     private long longPollingTimeout = DEFAULT_LONG_POLLING_TIMEOUT;
     private long probeTimeoutMillis = DEFAULT_PROBE_TIMEOUT;
     private int minEmptyResponses = EMPTY_RESPONSE_THRESHOLD;
@@ -387,7 +386,7 @@ public final class LongPollingActivateJobsHandler implements ActivateJobsHandler
       return this;
     }
 
-    public Builder setMaxMessageSize(final DataSize maxMessageSize) {
+    public Builder setMaxMessageSize(final long maxMessageSize) {
       this.maxMessageSize = maxMessageSize;
       return this;
     }
@@ -409,7 +408,6 @@ public final class LongPollingActivateJobsHandler implements ActivateJobsHandler
 
     public LongPollingActivateJobsHandler build() {
       Objects.requireNonNull(brokerClient, "brokerClient");
-      Objects.requireNonNull(maxMessageSize, "maxMessageSize");
       return new LongPollingActivateJobsHandler(
           brokerClient, maxMessageSize, longPollingTimeout, probeTimeoutMillis, minEmptyResponses);
     }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -34,7 +34,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-import org.springframework.util.unit.DataSize;
 
 /**
  * Iterates in round-robin fashion over partitions to activate jobs. Uses a map from job type to
@@ -52,15 +51,14 @@ public final class RoundRobinActivateJobsHandler implements ActivateJobsHandler 
       new ConcurrentHashMap<>();
   private final BrokerClient brokerClient;
   private final BrokerTopologyManager topologyManager;
-  private final int maxMessageSize;
+  private final long maxMessageSize;
 
   private ActorControl actor;
 
-  public RoundRobinActivateJobsHandler(
-      final BrokerClient brokerClient, final DataSize maxMessageSize) {
+  public RoundRobinActivateJobsHandler(final BrokerClient brokerClient, final long maxMessageSize) {
     this.brokerClient = brokerClient;
     topologyManager = brokerClient.getTopologyManager();
-    this.maxMessageSize = (int) maxMessageSize.toBytes();
+    this.maxMessageSize = maxMessageSize;
   }
 
   @Override

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/impl/job/RoundRobinActivateJobsHandler.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.client.impl.PartitionIdIterator;
 import io.camunda.zeebe.broker.client.impl.RoundRobinDispatchStrategy;
 import io.camunda.zeebe.gateway.Loggers;
 import io.camunda.zeebe.gateway.ResponseMapper;
+import io.camunda.zeebe.gateway.ResponseMapper.JobActivationResult;
 import io.camunda.zeebe.gateway.grpc.ServerStreamObserver;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
@@ -33,6 +34,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import org.springframework.util.unit.DataSize;
 
 /**
  * Iterates in round-robin fashion over partitions to activate jobs. Uses a map from job type to
@@ -43,17 +45,22 @@ public final class RoundRobinActivateJobsHandler implements ActivateJobsHandler 
   private static final String ACTIVATE_JOB_NOT_SENT_MSG = "Failed to send activated jobs to client";
   private static final String ACTIVATE_JOB_NOT_SENT_MSG_WITH_REASON =
       ACTIVATE_JOB_NOT_SENT_MSG + ", failed with: %s";
+  private static final String MAX_MESSAGE_SIZE_EXCEEDED_MSG =
+      "the response is bigger than the maximum allowed message size %d";
 
   private final Map<String, RoundRobinDispatchStrategy> jobTypeToNextPartitionId =
       new ConcurrentHashMap<>();
   private final BrokerClient brokerClient;
   private final BrokerTopologyManager topologyManager;
+  private final int maxMessageSize;
 
   private ActorControl actor;
 
-  public RoundRobinActivateJobsHandler(final BrokerClient brokerClient) {
+  public RoundRobinActivateJobsHandler(
+      final BrokerClient brokerClient, final DataSize maxMessageSize) {
     this.brokerClient = brokerClient;
     topologyManager = brokerClient.getTopologyManager();
+    this.maxMessageSize = (int) maxMessageSize.toBytes();
   }
 
   @Override
@@ -151,11 +158,23 @@ public final class RoundRobinActivateJobsHandler implements ActivateJobsHandler 
     actor.run(
         () -> {
           final var response = brokerResponse.getResponse();
-          final ActivateJobsResponse grpcResponse =
-              ResponseMapper.toActivateJobsResponse(brokerResponse.getKey(), response);
+          final JobActivationResult jobActivationResult =
+              ResponseMapper.toActivateJobsResponse(
+                  brokerResponse.getKey(), response, maxMessageSize);
+
+          final List<ActivatedJob> jobsToDefer = jobActivationResult.jobsToDefer();
+          if (!jobsToDefer.isEmpty()) {
+            final var jobKeys = jobsToDefer.stream().map(ActivatedJob::getKey).toList();
+            final var jobType = request.getType();
+            final var reason = String.format(MAX_MESSAGE_SIZE_EXCEEDED_MSG, maxMessageSize);
+
+            logResponseNotSent(jobType, jobKeys, reason);
+            reactivateJobs(jobsToDefer, reason);
+          }
+
+          final ActivateJobsResponse grpcResponse = jobActivationResult.activateJobsResponse();
           final var jobsCount = grpcResponse.getJobsCount();
           final var jobsActivated = jobsCount > 0;
-
           if (jobsActivated) {
             final var result = request.tryToSendActivatedJobs(grpcResponse);
             final var responseWasSent = result.getOrElse(false);

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -136,12 +136,16 @@ public final class StubbedGateway {
     if (config.getLongPolling().isEnabled()) {
       return buildLongPollingHandler(brokerClient);
     } else {
-      return new RoundRobinActivateJobsHandler(brokerClient);
+      return new RoundRobinActivateJobsHandler(
+          brokerClient, config.getNetwork().getMaxMessageSize());
     }
   }
 
   private LongPollingActivateJobsHandler buildLongPollingHandler(final BrokerClient brokerClient) {
-    return LongPollingActivateJobsHandler.newBuilder().setBrokerClient(brokerClient).build();
+    return LongPollingActivateJobsHandler.newBuilder()
+        .setBrokerClient(brokerClient)
+        .setMaxMessageSize(config.getNetwork().getMaxMessageSize())
+        .build();
   }
 
   /**

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -137,14 +137,14 @@ public final class StubbedGateway {
       return buildLongPollingHandler(brokerClient);
     } else {
       return new RoundRobinActivateJobsHandler(
-          brokerClient, config.getNetwork().getMaxMessageSize());
+          brokerClient, config.getNetwork().getMaxMessageSize().toBytes());
     }
   }
 
   private LongPollingActivateJobsHandler buildLongPollingHandler(final BrokerClient brokerClient) {
     return LongPollingActivateJobsHandler.newBuilder()
         .setBrokerClient(brokerClient)
-        .setMaxMessageSize(config.getNetwork().getMaxMessageSize())
+        .setMaxMessageSize(config.getNetwork().getMaxMessageSize().toBytes())
         .build();
   }
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -64,6 +64,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.util.unit.DataSize;
 
 public final class LongPollingActivateJobsTest {
 
@@ -73,6 +74,7 @@ public final class LongPollingActivateJobsTest {
   private static final long PROBE_TIMEOUT = 20000;
   private static final int FAILED_RESPONSE_THRESHOLD = 3;
   private static final int MAX_JOBS_TO_ACTIVATE = 2;
+  private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4);
   private final ControlledActorClock actorClock = new ControlledActorClock();
   @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
   private LongPollingActivateJobsHandler handler;
@@ -87,6 +89,7 @@ public final class LongPollingActivateJobsTest {
     handler =
         LongPollingActivateJobsHandler.newBuilder()
             .setBrokerClient(brokerClient)
+            .setMaxMessageSize(MAX_MESSAGE_SIZE)
             .setLongPollingTimeout(LONG_POLLING_TIMEOUT)
             .setProbeTimeoutMillis(PROBE_TIMEOUT)
             .setMinEmptyResponses(FAILED_RESPONSE_THRESHOLD)
@@ -246,6 +249,7 @@ public final class LongPollingActivateJobsTest {
     handler =
         LongPollingActivateJobsHandler.newBuilder()
             .setBrokerClient(brokerClient)
+            .setMaxMessageSize(MAX_MESSAGE_SIZE)
             .setLongPollingTimeout(20000)
             .setProbeTimeoutMillis(probeTimeout)
             .build();
@@ -270,6 +274,7 @@ public final class LongPollingActivateJobsTest {
     handler =
         LongPollingActivateJobsHandler.newBuilder()
             .setBrokerClient(brokerClient)
+            .setMaxMessageSize(MAX_MESSAGE_SIZE)
             .setLongPollingTimeout(longPollingTimeout)
             .setProbeTimeoutMillis(probeTimeout)
             .build();

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/impl/job/LongPollingActivateJobsTest.java
@@ -74,7 +74,7 @@ public final class LongPollingActivateJobsTest {
   private static final long PROBE_TIMEOUT = 20000;
   private static final int FAILED_RESPONSE_THRESHOLD = 3;
   private static final int MAX_JOBS_TO_ACTIVATE = 2;
-  private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4);
+  private static final long MAX_MESSAGE_SIZE = DataSize.ofMegabytes(4).toBytes();
   private final ControlledActorClock actorClock = new ControlledActorClock();
   @Rule public final ActorSchedulerRule actorSchedulerRule = new ActorSchedulerRule(actorClock);
   private LongPollingActivateJobsHandler handler;

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/LargeMessageSizeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/LargeMessageSizeTest.java
@@ -7,14 +7,27 @@
  */
 package io.camunda.zeebe.it.network;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.api.worker.JobHandler;
+import io.camunda.zeebe.client.api.worker.JobWorker;
+import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.ByteValue;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Map;
+import java.util.Random;
+import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -24,6 +37,10 @@ import org.springframework.util.unit.DataSize;
 
 public final class LargeMessageSizeTest {
 
+  private static final JobHandler COMPLETING_JOB_HANDLER =
+      (client, job) -> {
+        client.newCompleteCommand(job.getKey()).send().join();
+      };
   private static final DataSize MAX_MESSAGE_SIZE = DataSize.ofMegabytes(5);
   // only use half of the max message size because some commands produce two events
   private static final long LARGE_SIZE = ByteValue.ofMegabytes(1);
@@ -133,5 +150,65 @@ public final class LargeMessageSizeTest {
 
     // then
     ZeebeAssertHelper.assertProcessInstanceCompleted(processInstanceEvent.getProcessInstanceKey());
+  }
+
+  @Test
+  public void shouldActivateJobsByRespectingMaxMessageSize() {
+    // given
+    final var modelInstance =
+        Bpmn.createExecutableProcess("foo")
+            .startEvent()
+            .serviceTask()
+            .zeebeJobType("foo")
+            .endEvent()
+            .done();
+
+    CLIENT_RULE
+        .getClient()
+        .newDeployResourceCommand()
+        .addProcessModel(modelInstance, "foo.bpmn")
+        .send()
+        .join();
+
+    final var byteArray = new byte[1024 * 1024]; // 1 MB
+    new Random().nextBytes(byteArray);
+    final var message = new String(byteArray, StandardCharsets.UTF_8);
+
+    final int numberOfJobsToActivate = 5;
+    for (int i = 0; i < numberOfJobsToActivate; i++) {
+      final ProcessInstanceEvent event =
+          CLIENT_RULE
+              .getClient()
+              .newCreateInstanceCommand()
+              .bpmnProcessId("foo")
+              .latestVersion()
+              .variables(Map.of("message_content", message))
+              .send()
+              .join();
+
+      RecordingExporter.processInstanceRecords()
+          .withProcessInstanceKey(event.getProcessInstanceKey())
+          .withElementType(BpmnElementType.PROCESS)
+          .await();
+    }
+
+    // when
+    final JobWorkerBuilderStep3 builder =
+        CLIENT_RULE.getClient().newWorker().jobType("foo").handler(COMPLETING_JOB_HANDLER);
+
+    // then
+    try (final JobWorker ignored = builder.open()) {
+      Awaitility.await("until all jobs are completed")
+          .pollInterval(Duration.ofMillis(100))
+          .atMost(Duration.ofSeconds(5))
+          .untilAsserted(
+              () ->
+                  assertThat(
+                          RecordingExporter.jobRecords(JobIntent.COMPLETED)
+                              .withType("foo")
+                              .limit(numberOfJobsToActivate)
+                              .count())
+                      .isEqualTo(numberOfJobsToActivate));
+    }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/LargeMessageSizeTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/LargeMessageSizeTest.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.it.network;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
-import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.worker.JobHandler;
 import io.camunda.zeebe.client.api.worker.JobWorker;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilderStep3;
@@ -26,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Random;
+import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -175,25 +175,25 @@ public final class LargeMessageSizeTest {
 
     final int numberOfJobsToActivate = 5;
     for (int i = 0; i < numberOfJobsToActivate; i++) {
-      final ProcessInstanceEvent event =
-          CLIENT_RULE
-              .getClient()
-              .newCreateInstanceCommand()
-              .bpmnProcessId("foo")
-              .latestVersion()
-              .variables(Map.of("message_content", message))
-              .send()
-              .join();
+      CLIENT_RULE
+          .getClient()
+          .newCreateInstanceCommand()
+          .bpmnProcessId("foo")
+          .latestVersion()
+          .variables(Map.of("message_content", message))
+          .send();
     }
+
+    Assertions.assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withType("foo")
+                .limit(numberOfJobsToActivate))
+        .describedAs("Expect that all jobs are created.")
+        .hasSize(numberOfJobsToActivate);
 
     // when
     final JobWorkerBuilderStep3 builder =
         CLIENT_RULE.getClient().newWorker().jobType("foo").handler(COMPLETING_JOB_HANDLER);
-
-    RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withType("foo")
-        .limit(numberOfJobsToActivate)
-        .await();
 
     // then
     try (final JobWorker ignored = builder.open()) {
@@ -246,25 +246,25 @@ public final class LargeMessageSizeTest {
 
     final int numberOfJobsToActivate = 5;
     for (int i = 0; i < numberOfJobsToActivate; i++) {
-      final ProcessInstanceEvent event =
-          CLIENT_RULE
-              .getClient()
-              .newCreateInstanceCommand()
-              .bpmnProcessId("foo")
-              .latestVersion()
-              .variables(Map.of("message_content", message))
-              .send()
-              .join();
+      CLIENT_RULE
+          .getClient()
+          .newCreateInstanceCommand()
+          .bpmnProcessId("foo")
+          .latestVersion()
+          .variables(Map.of("message_content", message))
+          .send();
     }
+
+    Assertions.assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withType("foo")
+                .limit(numberOfJobsToActivate))
+        .describedAs("Expect that all jobs are created.")
+        .hasSize(numberOfJobsToActivate);
 
     // when
     final JobWorkerBuilderStep3 builder =
         CLIENT_RULE.getClient().newWorker().jobType("foo").handler(COMPLETING_JOB_HANDLER);
-
-    RecordingExporter.jobRecords(JobIntent.CREATED)
-        .withType("foo")
-        .limit(numberOfJobsToActivate)
-        .await();
 
     // then
     try (final JobWorker ignored = builder.open()) {


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

There were three options to solve original problem:
1) When mapping the broker response to the client response, do bookkeeping
on the response size to ensure the maxMessageSize.
2) Double the max inbound message size in the Zeebe Java Client by default.
3) Bring the WARNING: Stream Error exception into the control flow of the Gateway
so that the Gateway can react to it and potentially make the jobs re-activatable again.

I used mixed of option 1 and 3 for better UX. With option 2, it is still possible for
client users to override default maxInboundMessage which might result in the same issue.

In the ResponseMapper, we check if the gRPC response size of the activated job will
exceed the allowed maxMessageSize in the gateway. Afterward, we re-activate exceeding
jobs in RoundRobinActivateJobsHandler in a similar way that we do for failed jobs.

Using `getSerializedSize()` method shouldn't have any performance impact here since
the result of it will be cached to be used while actually returning the response.
See: https://protobuf.dev/reference/java/api-docs/com/google/protobuf/AbstractMessage.html#getSerializedSize--

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #12778 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
