### PR TITLE
Prototype: Try to transfer leadership when stepping down

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftElectionConfig.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/RaftElectionConfig.java
@@ -15,28 +15,33 @@
  */
 package io.atomix.raft.partition;
 
+import io.atomix.cluster.MemberId;
+
 public final class RaftElectionConfig {
 
   private final boolean priorityElectionEnabled;
   private final int initialTargetPriority;
   private int nodePriority;
+  private MemberId primary;
 
   private RaftElectionConfig(
+      final MemberId primary,
       final boolean priorityElectionEnabled,
       final int initialTargetPriority,
       final int nodePriority) {
+    this.primary = primary;
     this.priorityElectionEnabled = priorityElectionEnabled;
     this.initialTargetPriority = initialTargetPriority;
     this.nodePriority = nodePriority;
   }
 
   public static RaftElectionConfig ofPriorityElection(
-      final int initialTargetPriority, final int nodePriority) {
-    return new RaftElectionConfig(true, initialTargetPriority, nodePriority);
+      final MemberId primary, final int initialTargetPriority, final int nodePriority) {
+    return new RaftElectionConfig(primary, true, initialTargetPriority, nodePriority);
   }
 
   public static RaftElectionConfig ofDefaultElection() {
-    return new RaftElectionConfig(false, -1, -1);
+    return new RaftElectionConfig(null, false, -1, -1);
   }
 
   public boolean isPriorityElectionEnabled() {
@@ -53,5 +58,13 @@ public final class RaftElectionConfig {
 
   public void setNodePriority(final int nodePriority) {
     this.nodePriority = nodePriority;
+  }
+
+  public MemberId getPrimary() {
+    return primary;
+  }
+
+  public void setPrimary(final MemberId primary) {
+    this.primary = primary;
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftPartitionServer.java
@@ -157,7 +157,9 @@ public class RaftPartitionServer implements HealthMonitorable {
     final var electionConfig =
         config.isPriorityElectionEnabled()
             ? RaftElectionConfig.ofPriorityElection(
-                partitionMetadata.getTargetPriority(), partitionMetadata.getPriority(localMemberId))
+                partitionMetadata.getPrimary().orElse(null),
+                partitionMetadata.getTargetPriority(),
+                partitionMetadata.getPriority(localMemberId))
             : RaftElectionConfig.ofDefaultElection();
 
     return RaftServer.builder(localMemberId)

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/FollowerRole.java
@@ -22,6 +22,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.ElectionTimer;
 import io.atomix.raft.ElectionTimerFactory;
 import io.atomix.raft.RaftServer;
+import io.atomix.raft.RaftServer.Role;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.impl.RaftContext;
@@ -33,6 +34,9 @@ import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
+import io.atomix.raft.protocol.RaftResponse.Status;
+import io.atomix.raft.protocol.TransferRequest;
+import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
@@ -179,6 +183,16 @@ public final class FollowerRole extends ActiveRole {
       onHeartbeatFromLeader();
     }
     return future;
+  }
+
+  @Override
+  public CompletableFuture<TransferResponse> onTransfer(final TransferRequest request) {
+    log.info(
+        "Current leader {} tries to transfer leadership, transitioning to candidate now.",
+        request.member());
+    raft.transition(Role.CANDIDATE);
+    return CompletableFuture.completedFuture(
+        logResponse(TransferResponse.builder().withStatus(Status.OK).build()));
   }
 
   @Override

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -330,6 +330,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   /** Ensures the local server is not the leader. */
   private void stepDown() {
+    raft.transferLeadership();
     if (raft.getLeader() != null && raft.getLeader().equals(raft.getCluster().getLocalMember())) {
       raft.setLeader(null);
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -118,7 +118,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     return super.stop()
         .thenRun(appender::close)
         .thenRun(this::cancelTimers)
-        .thenRun(this::stepDown);
+        .thenRun(this::stepDown)
+        .thenCompose(ignored -> raft.transferLeadership());
   }
 
   @Override
@@ -330,7 +331,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   /** Ensures the local server is not the leader. */
   private void stepDown() {
-    raft.transferLeadership();
     if (raft.getLeader() != null && raft.getLeader().equals(raft.getCluster().getLocalMember())) {
       raft.setLeader(null);
     }

--- a/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -192,7 +192,8 @@ public final class ControllableRaftContexts {
             storage,
             getRaftThreadContextFactory(memberId),
             () -> random,
-            RaftElectionConfig.ofPriorityElection(nodeCount, Integer.parseInt(memberId.id()) + 1),
+            RaftElectionConfig.ofPriorityElection(
+                null, nodeCount, Integer.parseInt(memberId.id()) + 1),
             new RaftPartitionConfig());
     raft.setEntryValidator(new NoopEntryValidator());
     return raft;

--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftPriorityElectionTest.java
@@ -41,7 +41,7 @@ public class RaftPriorityElectionTest {
               @Override
               public void configure(final MemberId id, final Builder builder) {
                 builder.withElectionConfig(
-                    RaftElectionConfig.ofPriorityElection(3, Integer.parseInt(id.id()) + 1));
+                    RaftElectionConfig.ofPriorityElection(null, 3, Integer.parseInt(id.id()) + 1));
               }
             })
       },
@@ -52,7 +52,7 @@ public class RaftPriorityElectionTest {
               @Override
               public void configure(final MemberId id, final Builder builder) {
                 builder.withElectionConfig(
-                    RaftElectionConfig.ofPriorityElection(4, Integer.parseInt(id.id()) + 1));
+                    RaftElectionConfig.ofPriorityElection(null, 4, Integer.parseInt(id.id()) + 1));
               }
             })
       },
@@ -63,7 +63,7 @@ public class RaftPriorityElectionTest {
               @Override
               public void configure(final MemberId id, final Builder builder) {
                 builder.withElectionConfig(
-                    RaftElectionConfig.ofPriorityElection(5, Integer.parseInt(id.id()) + 1));
+                    RaftElectionConfig.ofPriorityElection(null, 5, Integer.parseInt(id.id()) + 1));
               }
             })
       }

--- a/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/roles/LeaderRoleTest.java
@@ -49,6 +49,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -92,6 +93,9 @@ public class LeaderRoleTest {
     when(context.getPersistedSnapshotStore()).thenReturn(persistedSnapshotStore);
     when(context.getEntryValidator()).thenReturn((a, b) -> ValidationResult.ok());
     when(context.getStorage()).thenReturn(RaftStorage.builder().withMaxSegmentSize(1024).build());
+
+    // Called during shutdown, needs to return a completed future so that shutdown completes
+    when(context.transferLeadership()).thenReturn(CompletableFuture.completedFuture(null));
 
     leaderRole = new LeaderRole(context);
     // since we mock RaftContext we should simulate leader close on transition

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LeadershipTransferTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/LeadershipTransferTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering;
+
+import static io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert.assertThat;
+import static org.awaitility.Awaitility.await;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.cluster.TestHealthProbe;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that leadership transfer works as expected.
+ *
+ * <p>Leadership transfer is supposed to make the failover process faster. We start with a cluster
+ * with an unreasonable election timeout of 10 minutes.
+ *
+ * <p>To ensure that this cluster can start and elect a leader for the only partition, we start with
+ * replication factor 1. This ensures that the only member becomes leader without waiting for the 10
+ * minutes election timeout.
+ *
+ * <p>We then have the other two members join the partition such that we have replication factor 3.
+ * This allows us to stop the initial member and await a new leader to be elected.
+ *
+ * <p>Usually this would time out because the election timeout is so high. With leadership transfer,
+ * we don't depend on the timeout and can assert that another member becomes leader.
+ */
+@ZeebeIntegration
+final class LeadershipTransferTest {
+  @TestZeebe(awaitStarted = true, awaitReady = false, awaitCompleteTopology = false)
+  static TestCluster cluster =
+      TestCluster.builder()
+          .withEmbeddedGateway(true)
+          .withBrokersCount(3)
+          .withPartitionsCount(1)
+          .withReplicationFactor(1)
+          .withBrokerConfig(
+              broker ->
+                  broker.brokerConfig().getCluster().setElectionTimeout(Duration.ofMinutes(10)))
+          .build();
+
+  @BeforeAll
+  static void setup() {
+    // Only wait for the first broker to be ready, the others won't become ready until we join them
+    cluster.brokers().get(MemberId.from("0")).probe(TestHealthProbe.READY);
+
+    final var clusterActuator = ClusterActuator.of(cluster.availableGateway());
+    final var scaleUp = clusterActuator.scaleBrokers(List.of(0, 1, 2));
+    await().untilAsserted(() -> assertThat(cluster).hasAppliedChanges(scaleUp));
+
+    final var firstJoin = clusterActuator.joinPartition(1, 1, 2);
+    await().untilAsserted(() -> assertThat(cluster).hasAppliedChanges(firstJoin));
+
+    final var secondJoin = clusterActuator.joinPartition(2, 1, 3);
+    await().untilAsserted(() -> assertThat(cluster).hasAppliedChanges(secondJoin));
+
+    // now wait for the full cluster to be ready
+    cluster.await(TestHealthProbe.READY);
+  }
+
+  @Test
+  void canFailOverThroughLeadershipTransfer() {
+    // given
+    final var initialLeader = cluster.brokers().get(MemberId.from("0"));
+
+    // when
+    initialLeader.stop();
+
+    // then
+    try (final var client = cluster.newClientBuilder().build()) {
+      await("new leader is elected")
+          .untilAsserted(
+              () ->
+                  TopologyAssert.assertThat(client.newTopologyRequest().send().join())
+                      // partition has a leader and it's not (still) the stopped broker
+                      .hasLeaderForPartition(
+                          1, leader -> leader != null && leader.getNodeId() != 0));
+    }
+  }
+}


### PR DESCRIPTION
This is a prototype to directly transfer leadership to another node when stepping down as leader.
Here I just repurposed the `TransferRequest` which was supposed to be a request from follower to leader, by sending it from the leader to the partition primary or the member with the highest index. When a follower receives a transfer request, it directly transitions to candidate which starts the election.
This is a best-effort approach to avoid the usual electionTimeout delay between the previous leader stepping down and the next member polling for votes.

### Todo
Currently, the partition primary is determined once during startup. With dynamic scaling, the primary can change and we'd need to update the primary on all partition members. This could be supported similar to `PartitionReconfigurePriorityOperation`