### PR TITLE
Azure backups: Restore and Delete Backups Implementation

### DIFF
--- a/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.backup.api.BackupIdentifierWildcard;
 import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
+import io.camunda.zeebe.backup.azure.AzureBackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.azure.manifest.Manifest;
 import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
@@ -128,11 +129,11 @@ public final class AzureBackupStore implements BackupStore {
         () -> {
           final var manifest = manifestManager.getManifest(id);
           if (manifest == null) {
-            throw new RuntimeException(ERROR_MSG_BACKUP_NOT_FOUND.formatted(id));
+            throw new UnexpectedManifestState(ERROR_MSG_BACKUP_NOT_FOUND.formatted(id));
           }
           return switch (manifest.statusCode()) {
             case FAILED, IN_PROGRESS ->
-                throw new RuntimeException(
+                throw new UnexpectedManifestState(
                     ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE.formatted(id, manifest.statusCode()));
             case COMPLETED -> {
               final var completed = manifest.asCompleted();

--- a/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -108,7 +108,13 @@ public final class AzureBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Void> delete(final BackupIdentifier id) {
-    throw new UnsupportedOperationException();
+    return CompletableFuture.runAsync(
+        () -> {
+          manifestManager.deleteManifest(id);
+          fileSetManager.delete(id, SNAPSHOT_FILESET_NAME);
+          fileSetManager.delete(id, SEGMENTS_FILESET_NAME);
+        },
+        executor);
   }
 
   @Override

--- a/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
+++ b/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/AzureBackupStore.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.azure.manifest.Manifest;
+import io.camunda.zeebe.backup.common.BackupImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -36,6 +37,10 @@ import org.slf4j.LoggerFactory;
  * scheme: {@code basePath/partitionId/checkpointId/nodeId}.
  */
 public final class AzureBackupStore implements BackupStore {
+  public static final String ERROR_MSG_BACKUP_NOT_FOUND =
+      "Expected to restore from backup with id '%s', but does not exist.";
+  public static final String ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE =
+      "Expected to restore from completed backup with id '%s', but was in state '%s'";
   public static final String SNAPSHOT_FILESET_NAME = "snapshot";
   public static final String SEGMENTS_FILESET_NAME = "segments";
   private static final Logger LOG = LoggerFactory.getLogger(AzureBackupStore.class);
@@ -119,7 +124,29 @@ public final class AzureBackupStore implements BackupStore {
 
   @Override
   public CompletableFuture<Backup> restore(final BackupIdentifier id, final Path targetFolder) {
-    throw new UnsupportedOperationException();
+    return CompletableFuture.supplyAsync(
+        () -> {
+          final var manifest = manifestManager.getManifest(id);
+          if (manifest == null) {
+            throw new RuntimeException(ERROR_MSG_BACKUP_NOT_FOUND.formatted(id));
+          }
+          return switch (manifest.statusCode()) {
+            case FAILED, IN_PROGRESS ->
+                throw new RuntimeException(
+                    ERROR_MSG_BACKUP_WRONG_STATE_TO_RESTORE.formatted(id, manifest.statusCode()));
+            case COMPLETED -> {
+              final var completed = manifest.asCompleted();
+              final var snapshot =
+                  fileSetManager.restore(
+                      id, SNAPSHOT_FILESET_NAME, completed.snapshot(), targetFolder);
+              final var segments =
+                  fileSetManager.restore(
+                      id, SEGMENTS_FILESET_NAME, completed.segments(), targetFolder);
+              yield new BackupImpl(id, manifest.descriptor(), snapshot, segments);
+            }
+          };
+        },
+        executor);
   }
 
   @Override

--- a/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
+++ b/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/FileSetManager.java
@@ -13,11 +13,17 @@ import com.azure.storage.blob.BlobContainerClient;
 import com.azure.storage.blob.models.BlobErrorCode;
 import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.blob.models.ListBlobsOptions;
+import com.azure.storage.blob.specialized.BlockBlobClient;
 import io.camunda.zeebe.backup.api.BackupIdentifier;
 import io.camunda.zeebe.backup.api.NamedFileSet;
 import io.camunda.zeebe.backup.azure.AzureBackupStoreException.BlobAlreadyExists;
+import io.camunda.zeebe.backup.azure.manifest.FileSet;
+import io.camunda.zeebe.backup.azure.manifest.FileSet.NamedFile;
+import io.camunda.zeebe.backup.common.NamedFileSetImpl;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.stream.Collectors;
 
 final class FileSetManager {
   // The path format is constructed by partitionId/checkpointId/nodeId/nameOfFile
@@ -58,6 +64,30 @@ final class FileSetManager {
         .forEach(
             blobItem ->
                 containerClient.getBlobClient(blobItem.getName()).getBlockBlobClient().delete());
+  }
+
+  public NamedFileSet restore(
+      final BackupIdentifier id,
+      final String fileSetName,
+      final FileSet fileSet,
+      final Path targetFolder) {
+
+    final var pathByName =
+        fileSet.files().stream()
+            .collect(Collectors.toMap(NamedFile::name, f -> targetFolder.resolve(f.name())));
+
+    for (final var entry : pathByName.entrySet()) {
+      final var fileName = entry.getKey();
+      final var filePath = entry.getValue();
+
+      final BlockBlobClient blobClient =
+          containerClient
+              .getBlobClient(fileSetPath(id, fileSetName) + fileName)
+              .getBlockBlobClient();
+      blobClient.downloadToFile(String.valueOf(filePath), true);
+    }
+
+    return new NamedFileSetImpl(pathByName);
   }
 
   void assureContainerCreated() {

--- a/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
+++ b/backup-stores/azure/src/main/java/io/camunda/zeebe/backup/azure/ManifestManager.java
@@ -161,6 +161,13 @@ public final class ManifestManager {
     }
   }
 
+  public void deleteManifest(final BackupIdentifier id) {
+    final BlobClient blobClient = blobContainerClient.getBlobClient(manifestIdPath(id));
+    if (blobClient.exists()) {
+      blobClient.delete();
+    }
+  }
+
   Manifest getManifest(final BackupIdentifier id) {
     final BlobClient blobClient;
     final BinaryData binaryData;

--- a/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -15,13 +15,13 @@ import io.camunda.zeebe.backup.azure.AzureBackupStoreException.UnexpectedManifes
 import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
 import io.camunda.zeebe.backup.testkit.DeletingBackup;
 import io.camunda.zeebe.backup.testkit.QueryingBackupStatus;
+import io.camunda.zeebe.backup.testkit.RestoringBackup;
 import io.camunda.zeebe.backup.testkit.SavingBackup;
 import io.camunda.zeebe.backup.testkit.UpdatingBackupStatus;
 import io.camunda.zeebe.backup.testkit.support.TestBackupProvider;
 import java.io.FileNotFoundException;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.junit.jupiter.Container;
@@ -29,7 +29,11 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 public class AzureBackupStoreIT
-    implements SavingBackup, QueryingBackupStatus, UpdatingBackupStatus, DeletingBackup {
+    implements SavingBackup,
+        QueryingBackupStatus,
+        UpdatingBackupStatus,
+        DeletingBackup,
+        RestoringBackup {
 
   @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
   public AzureBackupConfig azureBackupConfig;
@@ -76,10 +80,5 @@ public class AzureBackupStoreIT
     final var status = getStore().getStatus(backup.id()).join();
     assertThat(status.statusCode()).isEqualTo(BackupStatusCode.COMPLETED);
     assertThat(status.lastModified()).isEqualTo(firstStatus.lastModified());
-  }
-
-  @Test
-  void cannotDeleteUploadingBlock() {
-    // TODO: when delete feature is done
   }
 }

--- a/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -65,6 +65,11 @@ public class AzureBackupStoreIT
     return FileNotFoundException.class;
   }
 
+  @Override
+  public Class<? extends Exception> getFailToRestoreDuetoUnexistingFileExceptionClass() {
+    return UnexpectedManifestState.class;
+  }
+
   @ParameterizedTest
   @ArgumentsSource(TestBackupProvider.class)
   void backupShouldExistAfterStoreIsClosed(final Backup backup) {

--- a/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
+++ b/backup-stores/azure/src/test/java/io/camunda/zeebe/backup/azure/AzureBackupStoreIT.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.backup.api.Backup;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.azure.AzureBackupStoreException.UnexpectedManifestState;
 import io.camunda.zeebe.backup.azure.util.AzuriteContainer;
+import io.camunda.zeebe.backup.testkit.DeletingBackup;
 import io.camunda.zeebe.backup.testkit.QueryingBackupStatus;
 import io.camunda.zeebe.backup.testkit.SavingBackup;
 import io.camunda.zeebe.backup.testkit.UpdatingBackupStatus;
@@ -28,7 +29,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Testcontainers
 public class AzureBackupStoreIT
-    implements SavingBackup, QueryingBackupStatus, UpdatingBackupStatus {
+    implements SavingBackup, QueryingBackupStatus, UpdatingBackupStatus, DeletingBackup {
 
   @Container private static final AzuriteContainer AZURITE_CONTAINER = new AzuriteContainer();
   public AzureBackupConfig azureBackupConfig;

--- a/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
+++ b/backup-stores/gcs/src/test/java/io/camunda/zeebe/backup/gcs/GcsBackupStoreIT.java
@@ -77,6 +77,11 @@ public class GcsBackupStoreIT {
     public Class<? extends Exception> getFileNotFoundExceptionClass() {
       return NoSuchFileException.class;
     }
+
+    @Override
+    public Class<? extends Exception> getFailToRestoreDuetoUnexistingFileExceptionClass() {
+      return RuntimeException.class;
+    }
   }
 
   @Nested
@@ -120,6 +125,11 @@ public class GcsBackupStoreIT {
     @Override
     public Class<? extends Exception> getFileNotFoundExceptionClass() {
       return NoSuchFileException.class;
+    }
+
+    @Override
+    public Class<? extends Exception> getFailToRestoreDuetoUnexistingFileExceptionClass() {
+      return RuntimeException.class;
     }
   }
 }

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/MinioBackupStoreIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.backup.s3;
 
 import io.camunda.zeebe.backup.s3.S3BackupConfig.Builder;
+import io.camunda.zeebe.backup.s3.S3BackupStoreException.BackupInInvalidStateException;
 import java.nio.file.NoSuchFileException;
 import java.time.Duration;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -104,6 +105,11 @@ final class MinioBackupStoreIT implements S3BackupStoreTests {
   @Override
   public S3BackupStore getStore() {
     return store;
+  }
+
+  @Override
+  public Class<? extends Exception> getFailToRestoreDuetoUnexistingFileExceptionClass() {
+    return BackupInInvalidStateException.class;
   }
 
   @Override

--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/S3BackupStoreTests.java
@@ -44,6 +44,11 @@ public interface S3BackupStoreTests extends BackupStoreTestKit {
     return BackupInInvalidStateException.class;
   }
 
+  @Override
+  default Class<? extends Exception> getFailToRestoreDuetoUnexistingFileExceptionClass() {
+    return BackupInInvalidStateException.class;
+  }
+
   @ParameterizedTest
   @ArgumentsSource(TestBackupProvider.class)
   default void savesManifest(final Backup backup) throws IOException {


### PR DESCRIPTION
## Description

Restore and Delete Backups implementation.
Additional Test cannotRestoreUploadingBackup in RestoringBackup.java.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/15809
closes https://github.com/camunda/zeebe/issues/15808

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
