### PR TITLE
fix(logstream): handle log reset while iterating though log entries

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReader.java
@@ -90,7 +90,13 @@ public final class AtomixLogStorageReader implements LogStorageReader {
 
   private boolean readNextBlock() {
     while (reader.hasNext()) {
-      final IndexedRaftLogEntry entry = reader.next();
+      final IndexedRaftLogEntry entry;
+      try {
+        entry = reader.next();
+      } catch (final NoSuchElementException e) {
+        // log was reset between checking `hasNext` and calling `next`
+        return false;
+      }
       if (entry.isApplicationEntry()) {
         // application entries read from the log should always be `SerializedApplicationEntry`
         final SerializedApplicationEntry nextEntry =


### PR DESCRIPTION
Iterating through the log is done by calling `hasNext` to check if there is another entry to read, and `next` to actually retrieve it. Because we don't hold a lock between `hasNext` and `next`, it can happen that the log is reset between both calls. The `NoSuchElementException` thrown by `next` would previously kill the partition which is unnecessary.

Instead, we now catch that exception and treat it as if `hasNext` had returned false.

Closes #15721