### PR TITLE
[Backport stable/8.2] fix(restore): validate partition count when restoring

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -23,7 +23,8 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication(
     scanBasePackages = {"io.camunda.zeebe.restore", "io.camunda.zeebe.broker.shared"})
-@ConfigurationPropertiesScan(basePackages = {"io.camunda.zeebe.broker.shared"})
+@ConfigurationPropertiesScan(
+    basePackages = {"io.camunda.zeebe.broker.shared", "io.camunda.zeebe.restore"})
 public class RestoreApp implements ApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(RestoreApp.class);
@@ -34,10 +35,16 @@ public class RestoreApp implements ApplicationRunner {
   // Parsed from commandline Eg:-`--backupId=100`
   private long backupId;
 
+  private final RestoreConfiguration restoreConfiguration;
+
   @Autowired
-  public RestoreApp(final BrokerCfg configuration, final BackupStore backupStore) {
+  public RestoreApp(
+      final BrokerCfg configuration,
+      final BackupStore backupStore,
+      final RestoreConfiguration restoreConfiguration) {
     this.configuration = configuration;
     this.backupStore = backupStore;
+    this.restoreConfiguration = restoreConfiguration;
   }
 
   public static void main(final String[] args) {
@@ -54,7 +61,9 @@ public class RestoreApp implements ApplicationRunner {
   @Override
   public void run(final ApplicationArguments args) {
     LOG.info("Starting to restore from backup {}", backupId);
-    new RestoreManager(configuration, backupStore).restore(backupId).join();
+    new RestoreManager(configuration, backupStore)
+        .restore(backupId, restoreConfiguration.validateConfig())
+        .join();
     LOG.info("Successfully restored broker from backup {}", backupId);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreConfiguration.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.restore;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "zeebe.restore")
+public record RestoreConfiguration(@DefaultValue("true") boolean validateConfig) {}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -287,7 +287,7 @@ class BackupMultiPartitionTest {
   private void restoreBroker(final long backupId, final int brokerId) {
     try {
       new RestoreManager(clusteringRule.getBrokerCfg(brokerId), s3BackupStore)
-          .restore(backupId)
+          .restore(backupId, true)
           .get(120, TimeUnit.SECONDS);
     } catch (final Exception e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
Adds a new flag `validateConfig` that is enabled by default. When enabled, we validate that the locally configured partition count matches the number of partitions in the backup.

We allow setting `validateConfig` to false as an escape hatch for manual recovery actions, for example to add or remove partitions.

(cherry picked from commit 4611c534af88ef36a409920ced73c41ac84b69c4)

Manual backport of https://github.com/camunda/zeebe/pull/15814