### PR TITLE
[Backport stable/8.3] fix(restore): validate partition count when restoring

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreApp.java
@@ -23,7 +23,8 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication(
     scanBasePackages = {"io.camunda.zeebe.restore", "io.camunda.zeebe.broker.shared"})
-@ConfigurationPropertiesScan(basePackages = {"io.camunda.zeebe.broker.shared"})
+@ConfigurationPropertiesScan(
+    basePackages = {"io.camunda.zeebe.broker.shared", "io.camunda.zeebe.restore"})
 public class RestoreApp implements ApplicationRunner {
 
   private static final Logger LOG = LoggerFactory.getLogger(RestoreApp.class);
@@ -34,10 +35,16 @@ public class RestoreApp implements ApplicationRunner {
   // Parsed from commandline Eg:-`--backupId=100`
   private long backupId;
 
+  private final RestoreConfiguration restoreConfiguration;
+
   @Autowired
-  public RestoreApp(final BrokerCfg configuration, final BackupStore backupStore) {
+  public RestoreApp(
+      final BrokerCfg configuration,
+      final BackupStore backupStore,
+      final RestoreConfiguration restoreConfiguration) {
     this.configuration = configuration;
     this.backupStore = backupStore;
+    this.restoreConfiguration = restoreConfiguration;
   }
 
   public static void main(final String[] args) {
@@ -56,7 +63,9 @@ public class RestoreApp implements ApplicationRunner {
   @Override
   public void run(final ApplicationArguments args) {
     LOG.info("Starting to restore from backup {}", backupId);
-    new RestoreManager(configuration, backupStore).restore(backupId).join();
+    new RestoreManager(configuration, backupStore)
+        .restore(backupId, restoreConfiguration.validateConfig())
+        .join();
     LOG.info("Successfully restored broker from backup {}", backupId);
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/restore/RestoreConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/restore/RestoreConfiguration.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.restore;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.bind.DefaultValue;
+
+@ConfigurationProperties(prefix = "zeebe.restore")
+public record RestoreConfiguration(@DefaultValue("true") boolean validateConfig) {}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupMultiPartitionTest.java
@@ -287,7 +287,7 @@ class BackupMultiPartitionTest {
   private void restoreBroker(final long backupId, final int brokerId) {
     try {
       new RestoreManager(clusteringRule.getBrokerCfg(brokerId), s3BackupStore)
-          .restore(backupId)
+          .restore(backupId, true)
           .get(120, TimeUnit.SECONDS);
     } catch (final Exception e) {
       throw new RuntimeException(e);

--- a/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -56,9 +56,10 @@ public class PartitionRestoreService {
    * @param backupId id of the backup to restore from
    * @return the descriptor of the backup it restored
    */
-  public CompletableFuture<BackupDescriptor> restore(final long backupId) {
+  public CompletableFuture<BackupDescriptor> restore(
+      final long backupId, final BackupValidator validator) {
     return getTargetDirectory(backupId)
-        .thenCompose(targetDirectory -> download(backupId, targetDirectory))
+        .thenCompose(targetDirectory -> download(backupId, targetDirectory, validator))
         .thenApply(this::moveFilesToDataDirectory)
         .thenApply(
             backup -> {
@@ -196,8 +197,8 @@ public class PartitionRestoreService {
   }
 
   private CompletionStage<Backup> download(
-      final long checkpointId, final Path tempRestoringDirectory) {
-    return findValidBackup(checkpointId)
+      final long checkpointId, final Path tempRestoringDirectory, final BackupValidator validator) {
+    return findValidBackup(checkpointId, validator)
         .thenCompose(
             backup -> {
               LOG.info("Downloading backup {} to {}", backup, tempRestoringDirectory);
@@ -205,7 +206,8 @@ public class PartitionRestoreService {
             });
   }
 
-  private CompletionStage<BackupIdentifier> findValidBackup(final long checkpointId) {
+  private CompletionStage<BackupIdentifier> findValidBackup(
+      final long checkpointId, final BackupValidator validator) {
     LOG.info("Searching for a completed backup with id {}", checkpointId);
     return backupStore
         .list(
@@ -215,8 +217,24 @@ public class PartitionRestoreService {
             statuses ->
                 statuses.stream()
                     .filter(status -> status.statusCode() == BackupStatusCode.COMPLETED)
-                    .map(BackupStatus::id)
                     .findAny()
-                    .orElseThrow(() -> new BackupNotFoundException(checkpointId)));
+                    .orElseThrow(() -> new BackupNotFoundException(checkpointId)))
+        .thenApply(validator::validateStatus)
+        .thenApply(BackupStatus::id);
+  }
+
+  @FunctionalInterface
+  public interface BackupValidator {
+    BackupStatus validateStatus(BackupStatus status) throws BackupNotValidException;
+
+    static BackupValidator none() {
+      return status -> status;
+    }
+
+    class BackupNotValidException extends RuntimeException {
+      public BackupNotValidException(final BackupStatus status, final String message) {
+        super("Backup is not valid: " + message + ". Backup status: " + status);
+      }
+    }
   }
 }

--- a/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -10,11 +10,13 @@ package io.camunda.zeebe.restore;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.partition.RaftPartition;
 import io.camunda.zeebe.backup.api.BackupDescriptor;
+import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistributionResolver;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.nio.file.DirectoryNotEmptyException;
@@ -35,7 +37,7 @@ public class RestoreManager {
     this.backupStore = backupStore;
   }
 
-  public CompletableFuture<Void> restore(final long backupId) {
+  public CompletableFuture<Void> restore(final long backupId, final boolean validateConfig) {
     final Path dataDirectory = Path.of(configuration.getData().getDirectory());
     try {
       if (!FileUtil.isEmpty(dataDirectory)) {
@@ -56,7 +58,7 @@ public class RestoreManager {
 
     return CompletableFuture.allOf(
             partitionToRestore.stream()
-                .map(partition -> restorePartition(partition, backupId))
+                .map(partition -> restorePartition(partition, backupId, validateConfig))
                 .toArray(CompletableFuture[]::new))
         .exceptionallyComposeAsync(error -> logFailureAndDeleteDataDirectory(dataDirectory, error));
   }
@@ -83,9 +85,16 @@ public class RestoreManager {
   }
 
   private CompletableFuture<Void> restorePartition(
-      final RaftPartition partition, final long backupId) {
+      final RaftPartition partition, final long backupId, final boolean validateConfig) {
+    final BackupValidator validator;
+    if (validateConfig) {
+      validator = new ValidatePartitionCount(configuration.getCluster().getPartitionsCount());
+    } else {
+      LOG.warn("Restoring without validating backup");
+      validator = BackupValidator.none();
+    }
     return new PartitionRestoreService(backupStore, partition)
-        .restore(backupId)
+        .restore(backupId, validator)
         .thenAccept(backup -> logSuccessfulRestore(backup, partition.id().id(), backupId));
   }
 
@@ -105,5 +114,29 @@ public class RestoreManager {
         .filter(partitionMetadata -> partitionMetadata.members().contains(localMember))
         .map(raftPartitionFactory::createRaftPartition)
         .collect(Collectors.toSet());
+  }
+
+  static final class ValidatePartitionCount implements BackupValidator {
+    private final int expectedPartitionCount;
+
+    ValidatePartitionCount(final int expectedPartitionCount) {
+      this.expectedPartitionCount = expectedPartitionCount;
+    }
+
+    @Override
+    public BackupStatus validateStatus(final BackupStatus status) throws BackupNotValidException {
+      final var descriptor =
+          status
+              .descriptor()
+              .orElseThrow(
+                  () -> new BackupNotValidException(status, "Backup does not have a descriptor"));
+      if (descriptor.numberOfPartitions() != expectedPartitionCount) {
+        throw new BackupNotValidException(
+            status,
+            "Expected backup to have %d partitions, but has %d"
+                .formatted(expectedPartitionCount, descriptor.numberOfPartitions()));
+      }
+      return status;
+    }
   }
 }

--- a/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -20,6 +20,9 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.management.BackupService;
 import io.camunda.zeebe.journal.JournalMetaStore;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
+import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator.BackupNotValidException;
+import io.camunda.zeebe.restore.RestoreManager.ValidatePartitionCount;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -131,7 +134,7 @@ class PartitionRestoreServiceTest {
     final var backup = takeBackup(backupId, 4);
 
     // when
-    restoreService.restore(backupId).join();
+    restoreService.restore(backupId, BackupValidator.none()).join();
 
     // then
     assertThat(dataDirectoryToRestore).isNotEmptyDirectory();
@@ -169,7 +172,7 @@ class PartitionRestoreServiceTest {
     takeBackup(backupId, 5);
 
     // when - then
-    assertThat(restoreService.restore(backupId))
+    assertThat(restoreService.restore(backupId, new ValidatePartitionCount(1)))
         .failsWithin(Duration.ofSeconds(1))
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(IllegalStateException.class)
@@ -195,10 +198,31 @@ class PartitionRestoreServiceTest {
         StandardOpenOption.APPEND);
 
     // when - then
-    assertThat(restoreService.restore(backupId))
+    assertThat(restoreService.restore(backupId, new ValidatePartitionCount(1)))
         .failsWithin(Duration.ofSeconds(1))
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(CorruptedSnapshotException.class);
+  }
+
+  @Test
+  void shouldFailToRestoreWhenPartitionCountIsDifferent() {
+    // given
+    appendRecord(1, "data");
+    appendRecord(2, "data");
+    appendRecord(3, "data");
+    appendRecord(4, "checkpoint");
+
+    takeSnapshot(2, 3);
+
+    final long backupId = 1;
+    takeBackup(backupId, 4);
+
+    // when - then
+    assertThat(restoreService.restore(backupId, new ValidatePartitionCount(2)))
+        .failsWithin(Duration.ofSeconds(1))
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(BackupNotValidException.class)
+        .withMessageContaining("Expected backup to have 2 partitions, but has 1");
   }
 
   private Set<String> getRegularFiles(final Path directory) throws IOException {


### PR DESCRIPTION
Adds a new flag `validateConfig` that is enabled by default. When enabled, we validate that the locally configured partition count matches the number of partitions in the backup.

We allow setting `validateConfig` to false as an escape hatch for manual recovery actions, for example to add or remove partitions.

(cherry picked from commit 4611c534af88ef36a409920ced73c41ac84b69c4)

Manual backport of https://github.com/camunda/zeebe/pull/15814