### PR TITLE
[Backport stable/8.4] fix(logstream): handle log reset while iterating though log entries

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReader.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReader.java
@@ -90,7 +90,13 @@ public final class AtomixLogStorageReader implements LogStorageReader {
 
   private boolean readNextBlock() {
     while (reader.hasNext()) {
-      final IndexedRaftLogEntry entry = reader.next();
+      final IndexedRaftLogEntry entry;
+      try {
+        entry = reader.next();
+      } catch (final NoSuchElementException e) {
+        // log was reset between checking `hasNext` and calling `next`
+        return false;
+      }
       if (entry.isApplicationEntry()) {
         // application entries read from the log should always be `SerializedApplicationEntry`
         final SerializedApplicationEntry nextEntry =


### PR DESCRIPTION
# Description
Backport of #15826 to `stable/8.4`.

relates to #15721
original author: @oleschoenburg