### PR TITLE
docs: fix default snapshot interval

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -259,7 +259,7 @@
 
       # How often we take snapshots of streams (time unit)
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
-      # snapshotPeriod: 15m
+      # snapshotPeriod: 5m
 
       # Configure whether to monitor disk usage to prevent out of disk space issues.
       # If set to false the broker might run out of disk space and end in a non recoverable state.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -151,7 +151,7 @@
 
       # How often we take snapshots of streams (time unit)
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_DATA_SNAPSHOTPERIOD.
-      # snapshotPeriod: 15m
+      # snapshotPeriod: 5m
 
       # Configure whether to monitor disk usage to prevent out of disk space issues.
       # If set to false the broker might run out of disk space and end in a non recoverable state.


### PR DESCRIPTION
The default changed from 15m to 5m a while back but we forgot to update the config templates.

Closes #15625
