### PR TITLE
fix(scheduler): allow closing unscheduled actors

### DIFF
--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTask.java
@@ -37,7 +37,9 @@ public class ActorTask {
           AtomicReferenceFieldUpdater.newUpdater(
               ActorTask.class, ActorLifecyclePhase.class, "lifecyclePhase");
 
-  public final CompletableActorFuture<Void> closeFuture = new CompletableActorFuture<>();
+  // Start with a completed future to allow closing unscheduled tasks. The future is reset to
+  // uncompleted in `onTaskScheduled`.
+  public final CompletableActorFuture<Void> closeFuture = CompletableActorFuture.completed(null);
   final Actor actor;
   ActorJob currentJob;
   boolean shouldYield;

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/CompletableActorFuture.java
@@ -314,7 +314,11 @@ public final class CompletableActorFuture<V> implements ActorFuture<V> {
 
     try {
       completionLock.lock();
-      isDoneCondition.signalAll();
+      if (isDoneCondition != null) {
+        // condition is null if the future was created with `completed` or `completedExceptionally`,
+        // i.e. the future was never waiting for a result.
+        isDoneCondition.signalAll();
+      }
     } finally {
       completionLock.unlock();
     }


### PR DESCRIPTION
This is a behavior change to allow closing actors that were never scheduled in the first place. 

This should close #14625