### PR TITLE
[Backport stable/8.4] fix(dist): silence noisy info logs from ehcache

### DIFF
--- a/dist/src/main/config/log4j2.xml
+++ b/dist/src/main/config/log4j2.xml
@@ -45,6 +45,9 @@
       <!-- remove to disable console logging -->
       <AppenderRef ref="${env:ZEEBE_LOG_APPENDER:-Console}"/>
     </Root>
+
+    <!-- disable noisy loggers -->
+    <Logger name="org.ehcache.core.EhcacheManager" level="warn"/>
   </Loggers>
 
 </Configuration>


### PR DESCRIPTION
# Description
Backport of #15828 to `stable/8.4`.

relates to #15624
original author: @oleschoenburg