### PR TITLE
ci: remove token override when merging automatically

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,5 +695,3 @@ jobs:
         run: |
           gh pr review ${{ github.event.pull_request.number }} --approve
           gh pr merge ${{ github.event.pull_request.number }} --auto --merge
-        env:
-          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"


### PR DESCRIPTION
This override was making our use of the custom `AUTOMERGE_TOKEN` ineffective.