### PR TITLE
[Backport stable/8.1] ci: sync auto-merge job with main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
   pull_request: { }
   workflow_dispatch: { }
   workflow_call: { }
+  merge_group: { }
 
 defaults:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -503,44 +503,28 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   auto-merge:
-    # This workflow will auto merge a PR authored by dependabot[bot], backport-action or renovate[bot].
+    # This workflow will auto merge a PR authored by backport-action or renovate[bot].
     # It runs only on open PRs ready for review.
     #
-    # It will merge the PR only if: it is authored by dependabot[bot], is a minor or patch semantic
-    # update, and all CI checks are successful.
-    # OR if it is authored by backport-action and all CI checks are successful
+    # It will merge the PR only if it is authored by backport-action and all CI checks are successful
     # OR if it is authored by renovate[bot] and all CI checks are successful.
     #
     # The workflow is divided into multiple sequential jobs to allow giving only minimal permissions to
     # the GitHub token passed around.
-    #
-    # Once we're using the merge queue feature, I think we can simplify this workflow a lot by relying
-    # on dependabot merging PRs via its commands, as it will always wait for checks to be green before
-    # merging.
-    name: Auto-merge dependabot, backport and renovate PRs
+    name: Auto-merge backport and renovate PRs
     runs-on: ubuntu-latest
     needs: [ test-summary ]
-    if: github.repository == 'camunda/zeebe' && (github.actor == 'dependabot[bot]' || github.actor == 'backport-action' || github.actor == 'renovate[bot]')
+    if: github.repository == 'camunda/zeebe' && (github.actor == 'backport-action' || github.actor == 'renovate[bot]')
     permissions:
       checks: read
       pull-requests: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
     steps:
-      - uses: actions/checkout@v3
-      - id: metadata
-        name: Fetch dependency metadata
-        if: github.actor == 'dependabot[bot]'
-        uses: dependabot/fetch-metadata@v1.3.6
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - id: approve-and-merge-dependabot
-        name: Approve and merge dependabot PR
-        if: github.actor == 'dependabot[bot]' && (steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
-        env:
-          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+      - uses: actions/checkout@v4
       - id: approve-and-merge-backport-renovate
         name: Approve and merge backport PR
         if: github.actor == 'backport-action' || github.actor == 'renovate[bot]'
-        run: gh pr review ${{ github.event.pull_request.number }} --approve -b "bors merge"
-        env:
-          GITHUB_TOKEN: "${{secrets.GITHUB_TOKEN}}"
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} --approve
+          gh pr merge ${{ github.event.pull_request.number }} --auto --merge


### PR DESCRIPTION
This copies the auto-merge job from main. Dependabot is no longer used and we need to use the right tokens.