### PR TITLE
[Backport stable/8.1] ci: directly call GH API to put PRs into merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -528,4 +528,5 @@ jobs:
         if: github.actor == 'backport-action' || github.actor == 'renovate[bot]'
         run: |
           gh pr review ${{ github.event.pull_request.number }} --approve
-          gh pr merge ${{ github.event.pull_request.number }} --auto --merge
+          # Call the API directly to work around https://github.com/cli/cli/issues/8352
+          gh api graphql -f query='mutation PullRequestAutoMerge {enablePullRequestAutoMerge(input: {pullRequestId: "${{ github.event.pull_request.node_id }}"}) {clientMutationId}}'


### PR DESCRIPTION
# Description
Backport of #15873 to `stable/8.1`.

relates to cli/cli#8352
original author: @oleschoenburg