### PR TITLE
Fix race condition between receiving a new snapshot and aborting previous pending one

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
@@ -78,7 +78,7 @@ public class NoopSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ReceivedSnapshot newReceivedSnapshot(final String snapshotId) {
+  public ActorFuture<ReceivedSnapshot> newReceivedSnapshot(final String snapshotId) {
     return null;
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -114,17 +114,19 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ReceivedSnapshot newReceivedSnapshot(final String snapshotId) {
+  public ActorFuture<ReceivedSnapshot> newReceivedSnapshot(final String snapshotId) {
     if (Optional.ofNullable(currentPersistedSnapshot.get())
         .map(PersistedSnapshot::getId)
         .orElse("")
         .equals(snapshotId)) {
-      throw new SnapshotAlreadyExistsException("Snapshot with this ID is already persisted");
+      CompletableActorFuture.completedExceptionally(
+          new SnapshotAlreadyExistsException("Snapshot with this ID is already persisted"));
     }
 
     final var newSnapshot = new InMemorySnapshot(this, snapshotId);
     receivedSnapshots.add(newSnapshot);
-    return newSnapshot;
+
+    return CompletableActorFuture.completed(newSnapshot);
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/ReceivableSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/ReceivableSnapshotStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.snapshots;
 
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
 public interface ReceivableSnapshotStore extends PersistedSnapshotStore {
 
   /**
@@ -16,5 +18,5 @@ public interface ReceivableSnapshotStore extends PersistedSnapshotStore {
    *     index-term-timestamp-processedposition-exportedposition}
    * @return the new volatile received snapshot
    */
-  ReceivedSnapshot newReceivedSnapshot(String snapshotId);
+  ActorFuture<? extends ReceivedSnapshot> newReceivedSnapshot(String snapshotId);
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -355,20 +355,16 @@ public final class FileBasedSnapshotStore extends Actor
                         + snapshotId
                         + "'."));
 
-    final var directory = buildSnapshotDirectory(parsedSnapshotId);
-    if (directory.toFile().exists()) {
-      actor.run(
-          () -> {
-            try {
-              checkAndCleanupExistingDirectory(snapshotId, parsedSnapshotId, directory);
-              createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
-            } catch (final Exception e) {
-              newSnapshotFuture.completeExceptionally(e);
-            }
-          });
-    } else {
-      createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
-    }
+    actor.run(
+        () -> {
+          final var directory = buildSnapshotDirectory(parsedSnapshotId);
+          try {
+            checkAndCleanupExistingDirectory(snapshotId, parsedSnapshotId, directory);
+            createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
+          } catch (final Exception e) {
+            newSnapshotFuture.completeExceptionally(e);
+          }
+        });
     return newSnapshotFuture;
   }
 

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -70,7 +70,7 @@ public class PersistedSnapshotStoreTest {
     final var index = 1L;
 
     // when
-    final var transientSnapshot = persistedSnapshotStore.newReceivedSnapshot("1-0-123-121");
+    final var transientSnapshot = persistedSnapshotStore.newReceivedSnapshot("1-0-123-121").join();
 
     // then
     assertThat(transientSnapshot.index()).isEqualTo(index);

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -28,7 +28,9 @@ public class PersistedSnapshotStoreTest {
     final var partitionId = 1;
     final var root = temporaryFolder.getRoot();
 
-    persistedSnapshotStore = new FileBasedSnapshotStore(partitionId, root.toPath());
+    final var snapshotStore = new FileBasedSnapshotStore(partitionId, root.toPath());
+    scheduler.submitActor(snapshotStore).join();
+    persistedSnapshotStore = snapshotStore;
   }
 
   @Test

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -69,7 +69,7 @@ public class FileBasedReceivedSnapshotTest {
 
     // when
     final ReceivedSnapshot receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot("1-0-123-121");
+        receiverSnapshotStore.newReceivedSnapshot("1-0-123-121").join();
 
     // then
     assertThat(receivedSnapshot.getPath())
@@ -97,7 +97,7 @@ public class FileBasedReceivedSnapshotTest {
     // given
     final var persistedSnapshot = takePersistedSnapshot(1L);
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
 
     // when
     final SnapshotChunk expectedChunk;
@@ -224,7 +224,7 @@ public class FileBasedReceivedSnapshotTest {
 
     // when
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
 
     final SnapshotChunk firstChunk;
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
@@ -251,7 +251,7 @@ public class FileBasedReceivedSnapshotTest {
     // when
     final SnapshotChunk firstChunk;
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       firstChunk = snapshotChunkReader.next();
       receivedSnapshot.apply(firstChunk).join();
@@ -276,7 +276,7 @@ public class FileBasedReceivedSnapshotTest {
     // when
     final SnapshotChunk firstChunk;
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       firstChunk = snapshotChunkReader.next();
       receivedSnapshot.apply(firstChunk).join();
@@ -303,7 +303,7 @@ public class FileBasedReceivedSnapshotTest {
     // when
     final SnapshotChunk firstChunk;
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       firstChunk = snapshotChunkReader.next();
       receivedSnapshot.apply(firstChunk).join();
@@ -342,7 +342,7 @@ public class FileBasedReceivedSnapshotTest {
 
   private ReceivedSnapshot receiveSnapshot(final PersistedSnapshot persistedSnapshot) {
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
 
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       while (snapshotChunkReader.hasNext()) {


### PR DESCRIPTION
## Description

When `newReceivedSnapshot` is run on the caller thread (raft), the directory deletion conflicts with the concurrent abort run on the SnapshotStore actor. Ideally, all access/changes to snapshot should be serialized via snapshot store actor.

To fix this, now `newReceivedSnapshot` runs on the SnapshotStore actor and returns an ActorFuture. Since raft thread has to wait until a new pending snapshot is created, as an optimization, we only run the code that has to modify snapshot store state/directory in the actor. 

This has a minor impact on raft thread, as raft thread will be blocked during this operation. However, we use the same pattern when applying a snapshot chunk or when committing. Also, since this code is executed on the slowest follower, this is not in the critical path. So blocking raft thread is an acceptable trade-off between performance and complexity.

## Related issues

closes #14670 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
