### PR TITLE
Support a customizable action attribute in user task commands

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignProcessor.java
@@ -21,6 +21,8 @@ import java.util.List;
 
 public final class UserTaskAssignProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
+  private static final String DEFAULT_ACTION = "assign";
+
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
@@ -53,6 +55,7 @@ public final class UserTaskAssignProcessor implements TypedRecordProcessor<UserT
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setAssignee(command.getValue().getAssignee());
+    userTaskRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskAssignProcessor.java
@@ -55,7 +55,7 @@ public final class UserTaskAssignProcessor implements TypedRecordProcessor<UserT
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setAssignee(command.getValue().getAssignee());
-    userTaskRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
+    userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
@@ -24,6 +24,8 @@ import java.util.List;
 
 public class UserTaskClaimProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
+  private static final String DEFAULT_ACTION = "claim";
+
   private static final String INVALID_USER_TASK_ASSIGNEE_MESSAGE =
       "Expected to claim user task with key '%d', but it has already been assigned";
   private static final String INVALID_USER_TASK_EMPTY_ASSIGNEE_MESSAGE =
@@ -64,6 +66,7 @@ public class UserTaskClaimProcessor implements TypedRecordProcessor<UserTaskReco
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setAssignee(command.getValue().getAssignee());
+    userTaskRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskClaimProcessor.java
@@ -66,7 +66,7 @@ public class UserTaskClaimProcessor implements TypedRecordProcessor<UserTaskReco
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setAssignee(command.getValue().getAssignee());
-    userTaskRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
+    userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNING, userTaskRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.ASSIGNED, userTaskRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
@@ -26,6 +26,8 @@ import java.util.List;
 
 public final class UserTaskCompleteProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
+  private static final String DEFAULT_ACTION = "complete";
+
   private final ElementInstanceState elementInstanceState;
   private final EventHandle eventHandle;
   private final StateWriter stateWriter;
@@ -66,6 +68,7 @@ public final class UserTaskCompleteProcessor implements TypedRecordProcessor<Use
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setVariables(command.getValue().getVariablesBuffer());
+    userTaskRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETING, userTaskRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETED, userTaskRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskCompleteProcessor.java
@@ -68,7 +68,7 @@ public final class UserTaskCompleteProcessor implements TypedRecordProcessor<Use
     final long userTaskKey = command.getKey();
 
     userTaskRecord.setVariables(command.getValue().getVariablesBuffer());
-    userTaskRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
+    userTaskRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETING, userTaskRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.COMPLETED, userTaskRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateProcessor.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 public final class UserTaskUpdateProcessor implements TypedRecordProcessor<UserTaskRecord> {
 
+  private static final String DEFAULT_ACTION = "update";
+
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final TypedResponseWriter responseWriter;
@@ -56,6 +58,7 @@ public final class UserTaskUpdateProcessor implements TypedRecordProcessor<UserT
     final UserTaskRecord updateRecord = new UserTaskRecord();
     updateRecord.wrap(BufferUtil.createCopy(userTaskRecord));
     updateRecord.wrapChangedAttributes(command.getValue(), true);
+    updateRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATING, updateRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, updateRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/usertask/UserTaskUpdateProcessor.java
@@ -58,7 +58,7 @@ public final class UserTaskUpdateProcessor implements TypedRecordProcessor<UserT
     final UserTaskRecord updateRecord = new UserTaskRecord();
     updateRecord.wrap(BufferUtil.createCopy(userTaskRecord));
     updateRecord.wrapChangedAttributes(command.getValue(), true);
-    updateRecord.setAction(command.getValue().getAction(DEFAULT_ACTION));
+    updateRecord.setAction(command.getValue().getActionOrDefault(DEFAULT_ACTION));
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATING, updateRecord);
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.UPDATED, updateRecord);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/AssignUserTaskTest.java
@@ -73,6 +73,40 @@ public final class AssignUserTaskTest {
 
     Assertions.assertThat(recordValue)
         .hasUserTaskKey(userTaskKey)
+        .hasAction("assign")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldTrackCustomActionInAssigningEvent() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<UserTaskRecordValue> assignedRecord =
+        ENGINE
+            .userTask()
+            .withKey(userTaskKey)
+            .withAction("customAction")
+            .withAssignee("foo")
+            .assign();
+
+    // then
+    final UserTaskRecordValue recordValue = assignedRecord.getValue();
+
+    Assertions.assertThat(assignedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.ASSIGNING);
+
+    Assertions.assertThat(recordValue)
+        .hasUserTaskKey(userTaskKey)
+        .hasAction("customAction")
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/CompleteUserTaskTest.java
@@ -71,6 +71,35 @@ public final class CompleteUserTaskTest {
 
     Assertions.assertThat(recordValue)
         .hasUserTaskKey(userTaskKey)
+        .hasAction("complete")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldTrackCustomActionInCompletingEvent() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<UserTaskRecordValue> completedRecord =
+        ENGINE.userTask().withKey(userTaskKey).withAction("customAction").complete();
+
+    // then
+    final UserTaskRecordValue recordValue = completedRecord.getValue();
+
+    Assertions.assertThat(completedRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.COMPLETING);
+
+    Assertions.assertThat(recordValue)
+        .hasUserTaskKey(userTaskKey)
+        .hasAction("customAction")
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/usertask/UpdateUserTaskTest.java
@@ -70,6 +70,37 @@ public final class UpdateUserTaskTest {
 
     Assertions.assertThat(updateRecord.getValue())
         .hasUserTaskKey(userTaskKey)
+        .hasAction("update")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  @Test
+  public void shouldTrackCustomActionInUpdatingEvent() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+    final long userTaskKey =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getKey();
+
+    // when
+    final Record<UserTaskRecordValue> updateRecord =
+        ENGINE
+            .userTask()
+            .withKey(userTaskKey)
+            .withAction("customAction")
+            .update(new UserTaskRecord());
+
+    // then
+    Assertions.assertThat(updateRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(UserTaskIntent.UPDATING);
+
+    Assertions.assertThat(updateRecord.getValue())
+        .hasUserTaskKey(userTaskKey)
+        .hasAction("customAction")
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/client/UserTaskClient.java
@@ -73,6 +73,11 @@ public final class UserTaskClient {
     return this;
   }
 
+  public UserTaskClient withAction(final String action) {
+    userTaskRecord.setAction(action);
+    return this;
+  }
+
   public UserTaskClient withVariables(final String variables) {
     userTaskRecord.setVariables(new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)));
     return this;
@@ -173,12 +178,12 @@ public final class UserTaskClient {
   }
 
   public Record<UserTaskRecordValue> update(final UserTaskRecord changes) {
-    userTaskRecord.wrapWithoutVariables(changes);
-    userTaskRecord
+    changes
         .setCandidateGroupsChanged()
         .setCandidateUsersChanged()
         .setDueDateChanged()
         .setFollowUpDateChanged();
+    userTaskRecord.wrapChangedAttributes(changes, true);
 
     final long userTaskKey = findUserTaskKey();
     final long position =

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -43,6 +43,9 @@
             "formKey": {
               "type": "long"
             },
+            "action": {
+              "type": "text"
+            },
             "elementId": {
               "type": "text"
             },

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -43,6 +43,9 @@
             "formKey": {
               "type": "long"
             },
+            "action": {
+              "type": "text"
+            },
             "elementId": {
               "type": "text"
             },

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -246,13 +246,6 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
-  public UserTaskRecord setChangedAttributes(final List<String> changedAttributes) {
-    changedAttributesProp.reset();
-    changedAttributes.forEach(
-        attribute -> changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute)));
-    return this;
-  }
-
   public UserTaskRecord setAction(final String action) {
     actionProp.setValue(action);
     return this;
@@ -260,6 +253,13 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setAction(final DirectBuffer action) {
     actionProp.setValue(action);
+    return this;
+  }
+
+  public UserTaskRecord setChangedAttributes(final List<String> changedAttributes) {
+    changedAttributesProp.reset();
+    changedAttributes.forEach(
+        attribute -> changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute)));
     return this;
   }
 
@@ -426,7 +426,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   }
 
   @JsonIgnore
-  public String getAction(final String defaultAction) {
+  public String getActionOrDefault(final String defaultAction) {
     final String action = bufferAsString(actionProp.getValue());
     return action.isEmpty() ? defaultAction : action;
   }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -68,9 +68,10 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
+  private final StringProperty actionProp = new StringProperty("action", EMPTY_STRING);
 
   public UserTaskRecord() {
-    super(16);
+    super(17);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsProp)
@@ -86,7 +87,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(changedAttributesProp);
+        .declareProperty(changedAttributesProp)
+        .declareProperty(actionProp);
   }
 
   public void wrapWithoutVariables(final UserTaskRecord record) {
@@ -105,6 +107,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     tenantIdProp.setValue(record.getTenantIdBuffer());
     setChangedAttributesProp(record.getChangedAttributesProp());
+    actionProp.setValue(record.getActionBuffer());
   }
 
   public void wrapChangedAttributes(
@@ -179,6 +182,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   }
 
   @Override
+  public String getAction() {
+    return bufferAsString(actionProp.getValue());
+  }
+
+  @Override
   public String getElementId() {
     return bufferAsString(elementIdProp.getValue());
   }
@@ -242,6 +250,16 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     changedAttributesProp.reset();
     changedAttributes.forEach(
         attribute -> changedAttributesProp.add().wrap(BufferUtil.wrapString(attribute)));
+    return this;
+  }
+
+  public UserTaskRecord setAction(final String action) {
+    actionProp.setValue(action);
+    return this;
+  }
+
+  public UserTaskRecord setAction(final DirectBuffer action) {
+    actionProp.setValue(action);
     return this;
   }
 
@@ -383,11 +401,6 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   }
 
   @JsonIgnore
-  public DirectBuffer getTenantIdBuffer() {
-    return tenantIdProp.getValue();
-  }
-
-  @JsonIgnore
   public DirectBuffer getVariablesBuffer() {
     return variableProp.getValue();
   }
@@ -395,6 +408,27 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   @JsonIgnore
   public DirectBuffer getBpmnProcessIdBuffer() {
     return bpmnProcessIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getElementIdBuffer() {
+    return elementIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getTenantIdBuffer() {
+    return tenantIdProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getActionBuffer() {
+    return actionProp.getValue();
+  }
+
+  @JsonIgnore
+  public String getAction(final String defaultAction) {
+    final String action = bufferAsString(actionProp.getValue());
+    return action.isEmpty() ? defaultAction : action;
   }
 
   @Override
@@ -405,10 +439,5 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   public UserTaskRecord setProcessInstanceKey(final long key) {
     processInstanceKeyProp.setValue(key);
     return this;
-  }
-
-  @JsonIgnore
-  public DirectBuffer getElementIdBuffer() {
-    return elementIdProp.getValue();
   }
 }

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2083,6 +2083,7 @@ final class JsonSerializableToJsonTest {
                     .setFormKey(456)
                     .setVariables(VARIABLES_MSGPACK)
                     .setChangedAttributes(List.of("foo", "bar"))
+                    .setAction("complete")
                     .setBpmnProcessId("test-process")
                     .setProcessDefinitionKey(13)
                     .setProcessDefinitionVersion(12)
@@ -2106,6 +2107,7 @@ final class JsonSerializableToJsonTest {
         "variables": {
           "foo": "bar"
         },
+        "action": "complete",
         "formKey": 456,
         "userTaskKey": 123,
         "tenantId": "<default>"
@@ -2134,6 +2136,7 @@ final class JsonSerializableToJsonTest {
         "followUpDate": "",
         "changedAttributes": [],
         "variables": {},
+        "action": "",
         "formKey": -1,
         "userTaskKey": -1,
         "tenantId": "<default>"
@@ -2167,6 +2170,7 @@ final class JsonSerializableToJsonTest {
         "variables": {
           "foo": null
         },
+        "action": "",
         "formKey": -1,
         "userTaskKey": -1,
         "tenantId": "<default>"

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -47,6 +47,8 @@ public interface UserTaskRecordValue
 
   List<String> getChangedAttributes();
 
+  String getAction();
+
   /**
    * @return the element id of the corresponding user task
    */


### PR DESCRIPTION
## Description

* Add an `action` attribute to the user task record.
* Issue default values by the different user task commands (`assign`, `claim`, `update`, `complete`) if none is provided externally in the command's record.
* Do not store the `action` in the Zeebe state.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15839

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
