### PR TITLE
[Backport stable/8.4] fix(topology): throw detailed exception if decoding fails

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/DecodingFailed.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/DecodingFailed.java
@@ -16,4 +16,8 @@ public final class DecodingFailed extends RuntimeException {
   public DecodingFailed(final String message) {
     super(message);
   }
+
+  public DecodingFailed(final String message, final Exception e) {
+    super(message, e);
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializer.java
@@ -74,8 +74,15 @@ public class ProtoBufSerializer implements ClusterTopologySerializer, TopologyRe
     final ClusterTopologyGossipState clusterTopologyGossipState = new ClusterTopologyGossipState();
 
     if (gossipState.hasClusterTopology()) {
-      clusterTopologyGossipState.setClusterTopology(
-          decodeClusterTopology(gossipState.getClusterTopology()));
+      try {
+        clusterTopologyGossipState.setClusterTopology(
+            decodeClusterTopology(gossipState.getClusterTopology()));
+      } catch (final Exception e) {
+        throw new DecodingFailed(
+            "Cluster topology could not be deserialized from gossiped state: %s"
+                .formatted(gossipState),
+            e);
+      }
     }
     return clusterTopologyGossipState;
   }


### PR DESCRIPTION
# Description
Backport of #15818 to `stable/8.4`.

relates to #15645
original author: @oleschoenburg