### PR TITLE
[Backport stable/8.4] Fix race condition between receiving a new snapshot and aborting previous pending one

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/NoopSnapshotStore.java
@@ -78,7 +78,7 @@ public class NoopSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ReceivedSnapshot newReceivedSnapshot(final String snapshotId) {
+  public ActorFuture<ReceivedSnapshot> newReceivedSnapshot(final String snapshotId) {
     return null;
   }
 

--- a/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotStore.java
@@ -114,17 +114,19 @@ public class TestSnapshotStore implements ReceivableSnapshotStore {
   }
 
   @Override
-  public ReceivedSnapshot newReceivedSnapshot(final String snapshotId) {
+  public ActorFuture<ReceivedSnapshot> newReceivedSnapshot(final String snapshotId) {
     if (Optional.ofNullable(currentPersistedSnapshot.get())
         .map(PersistedSnapshot::getId)
         .orElse("")
         .equals(snapshotId)) {
-      throw new SnapshotAlreadyExistsException("Snapshot with this ID is already persisted");
+      CompletableActorFuture.completedExceptionally(
+          new SnapshotAlreadyExistsException("Snapshot with this ID is already persisted"));
     }
 
     final var newSnapshot = new InMemorySnapshot(this, snapshotId);
     receivedSnapshots.add(newSnapshot);
-    return newSnapshot;
+
+    return CompletableActorFuture.completed(newSnapshot);
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/ReceivableSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/ReceivableSnapshotStore.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.snapshots;
 
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+
 public interface ReceivableSnapshotStore extends PersistedSnapshotStore {
 
   /**
@@ -16,5 +18,5 @@ public interface ReceivableSnapshotStore extends PersistedSnapshotStore {
    *     index-term-timestamp-processedposition-exportedposition}
    * @return the new volatile received snapshot
    */
-  ReceivedSnapshot newReceivedSnapshot(String snapshotId);
+  ActorFuture<? extends ReceivedSnapshot> newReceivedSnapshot(String snapshotId);
 }

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -355,20 +355,16 @@ public final class FileBasedSnapshotStore extends Actor
                         + snapshotId
                         + "'."));
 
-    final var directory = buildSnapshotDirectory(parsedSnapshotId);
-    if (directory.toFile().exists()) {
-      actor.run(
-          () -> {
-            try {
-              checkAndCleanupExistingDirectory(snapshotId, parsedSnapshotId, directory);
-              createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
-            } catch (final Exception e) {
-              newSnapshotFuture.completeExceptionally(e);
-            }
-          });
-    } else {
-      createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
-    }
+    actor.run(
+        () -> {
+          final var directory = buildSnapshotDirectory(parsedSnapshotId);
+          try {
+            checkAndCleanupExistingDirectory(snapshotId, parsedSnapshotId, directory);
+            createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
+          } catch (final Exception e) {
+            newSnapshotFuture.completeExceptionally(e);
+          }
+        });
     return newSnapshotFuture;
   }
 

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -70,7 +70,7 @@ public class PersistedSnapshotStoreTest {
     final var index = 1L;
 
     // when
-    final var transientSnapshot = persistedSnapshotStore.newReceivedSnapshot("1-0-123-121");
+    final var transientSnapshot = persistedSnapshotStore.newReceivedSnapshot("1-0-123-121").join();
 
     // then
     assertThat(transientSnapshot.index()).isEqualTo(index);

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -28,7 +28,9 @@ public class PersistedSnapshotStoreTest {
     final var partitionId = 1;
     final var root = temporaryFolder.getRoot();
 
-    persistedSnapshotStore = new FileBasedSnapshotStore(partitionId, root.toPath());
+    final var snapshotStore = new FileBasedSnapshotStore(partitionId, root.toPath());
+    scheduler.submitActor(snapshotStore).join();
+    persistedSnapshotStore = snapshotStore;
   }
 
   @Test

--- a/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -69,7 +69,7 @@ public class FileBasedReceivedSnapshotTest {
 
     // when
     final ReceivedSnapshot receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot("1-0-123-121");
+        receiverSnapshotStore.newReceivedSnapshot("1-0-123-121").join();
 
     // then
     assertThat(receivedSnapshot.getPath())
@@ -97,7 +97,7 @@ public class FileBasedReceivedSnapshotTest {
     // given
     final var persistedSnapshot = takePersistedSnapshot(1L);
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
 
     // when
     final SnapshotChunk expectedChunk;
@@ -224,7 +224,7 @@ public class FileBasedReceivedSnapshotTest {
 
     // when
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
 
     final SnapshotChunk firstChunk;
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
@@ -251,7 +251,7 @@ public class FileBasedReceivedSnapshotTest {
     // when
     final SnapshotChunk firstChunk;
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       firstChunk = snapshotChunkReader.next();
       receivedSnapshot.apply(firstChunk).join();
@@ -276,7 +276,7 @@ public class FileBasedReceivedSnapshotTest {
     // when
     final SnapshotChunk firstChunk;
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       firstChunk = snapshotChunkReader.next();
       receivedSnapshot.apply(firstChunk).join();
@@ -303,7 +303,7 @@ public class FileBasedReceivedSnapshotTest {
     // when
     final SnapshotChunk firstChunk;
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       firstChunk = snapshotChunkReader.next();
       receivedSnapshot.apply(firstChunk).join();
@@ -342,7 +342,7 @@ public class FileBasedReceivedSnapshotTest {
 
   private ReceivedSnapshot receiveSnapshot(final PersistedSnapshot persistedSnapshot) {
     final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId());
+        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
 
     try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
       while (snapshotChunkReader.hasNext()) {


### PR DESCRIPTION
# Description
Backport of #15897 to `stable/8.4`.

relates to #14670
original author: @deepthidevaki