### PR TITLE
refactor(engine): minor cleanup of `DbMigrator`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrator.java
@@ -10,6 +10,4 @@ package io.camunda.zeebe.engine.state.migration;
 public interface DbMigrator {
 
   void runMigrations();
-
-  void abort();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -59,8 +59,6 @@ public class DbMigratorImpl implements DbMigrator {
   private final TransactionContext zeebeDbContext;
   private final Supplier<List<MigrationTask>> migrationSupplier;
 
-  private MigrationTask currentMigration;
-
   public DbMigratorImpl(
       final MutableProcessingState processingState, final TransactionContext zeebeDbContext) {
     this(processingState, zeebeDbContext, () -> MIGRATION_TASKS);
@@ -126,10 +124,8 @@ public class DbMigratorImpl implements DbMigrator {
       final MigrationTask migrationTask, final int index, final int total) {
     if (migrationTask.needsToRun(processingState)) {
       try {
-        currentMigration = migrationTask;
         runMigration(migrationTask, index, total);
       } finally {
-        currentMigration = null;
       }
       return true;
     } else {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -58,7 +58,6 @@ public class DbMigratorImpl implements DbMigrator {
   private final MutableProcessingState processingState;
   private final TransactionContext zeebeDbContext;
   private final Supplier<List<MigrationTask>> migrationSupplier;
-  private boolean abortRequested = false;
 
   private MigrationTask currentMigration;
 
@@ -83,7 +82,7 @@ public class DbMigratorImpl implements DbMigrator {
     logPreview(migrationTasks);
 
     final var executedMigrations = new ArrayList<MigrationTask>();
-    for (int index = 1; index <= migrationTasks.size() && !abortRequested; index++) {
+    for (int index = 1; index <= migrationTasks.size(); index++) {
       // one based index looks nicer in logs
 
       final var migration = migrationTasks.get(index - 1);
@@ -96,19 +95,7 @@ public class DbMigratorImpl implements DbMigrator {
             }
           });
     }
-    if (!abortRequested) {
-      logSummary(executedMigrations);
-    }
-  }
-
-  @Override
-  public void abort() {
-    final var message =
-        currentMigration == null
-            ? "Received abort signal (no migration running)"
-            : "Aborting " + currentMigration.getIdentifier() + " migration as requested";
-    LOGGER.info(message);
-    abortRequested = true;
+    logSummary(executedMigrations);
   }
 
   private void logPreview(final List<MigrationTask> migrationTasks) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscrip
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,26 +56,25 @@ public class DbMigratorImpl implements DbMigrator {
 
   private final MutableProcessingState processingState;
   private final TransactionContext zeebeDbContext;
-  private final Supplier<List<MigrationTask>> migrationSupplier;
+  private final List<MigrationTask> migrationTasks;
 
   public DbMigratorImpl(
       final MutableProcessingState processingState, final TransactionContext zeebeDbContext) {
-    this(processingState, zeebeDbContext, () -> MIGRATION_TASKS);
+    this(processingState, zeebeDbContext, MIGRATION_TASKS);
   }
 
   public DbMigratorImpl(
       final MutableProcessingState processingState,
       final TransactionContext zeebeDbContext,
-      final Supplier<List<MigrationTask>> migrationSupplier) {
+      final List<MigrationTask> migrationTasks) {
 
     this.processingState = processingState;
     this.zeebeDbContext = zeebeDbContext;
-    this.migrationSupplier = migrationSupplier;
+    this.migrationTasks = migrationTasks;
   }
 
   @Override
   public void runMigrations() {
-    final var migrationTasks = migrationSupplier.get();
     logPreview(migrationTasks);
 
     final var executedMigrations = new ArrayList<MigrationTask>();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -103,60 +101,6 @@ public class DbMigratorImplTest {
 
     inOrder.verify(mockMigration1).runMigration(mockProcessingState);
     inOrder.verify(mockMigration2).runMigration(mockProcessingState);
-  }
-
-  @Test
-  void shouldNotRunAnyMigrationIfAbortSignalWasReceivedInTheVeryBeginning() {
-    // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigration = mock(MigrationTask.class);
-    when(mockMigration.needsToRun(mockProcessingState)).thenReturn(false);
-
-    final var sut =
-        new DbMigratorImpl(
-            mockProcessingState,
-            transactionContext,
-            () -> Collections.singletonList(mockMigration));
-
-    // when
-    sut.abort();
-    sut.runMigrations();
-
-    // then
-    verify(mockMigration, never()).needsToRun(any());
-    verify(mockMigration, never()).runMigration(any());
-  }
-
-  @Test
-  void shouldNotRunSubsequentMigrationsAfterAbortSignalWasReceived() {
-    // given
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-    final var mockMigration1 = mock(MigrationTask.class);
-    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
-    final var mockMigration2 = mock(MigrationTask.class);
-    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
-
-    final var sut =
-        new DbMigratorImpl(
-            mockProcessingState, transactionContext, () -> List.of(mockMigration1, mockMigration2));
-
-    doAnswer(
-            (invocationOnMock) -> {
-              // send abort signal during first migration
-              sut.abort();
-              return null;
-            })
-        .when(mockMigration1)
-        .runMigration(mockProcessingState);
-
-    // when
-    sut.runMigrations();
-
-    // then
-    verify(mockMigration1).runMigration(mockProcessingState);
-    verify(mockMigration2, never()).runMigration(mockProcessingState);
   }
 
   private static final class RunInTransactionContext implements TransactionContext {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -45,9 +45,7 @@ public class DbMigratorImplTest {
 
     final var sut =
         new DbMigratorImpl(
-            mockProcessingState,
-            transactionContext,
-            () -> Collections.singletonList(mockMigration));
+            mockProcessingState, transactionContext, Collections.singletonList(mockMigration));
 
     // when
     sut.runMigrations();
@@ -67,9 +65,7 @@ public class DbMigratorImplTest {
 
     final var sut =
         new DbMigratorImpl(
-            mockProcessingState,
-            transactionContext,
-            () -> Collections.singletonList(mockMigration));
+            mockProcessingState, transactionContext, Collections.singletonList(mockMigration));
 
     // when
     sut.runMigrations();
@@ -91,7 +87,7 @@ public class DbMigratorImplTest {
 
     final var sut =
         new DbMigratorImpl(
-            mockProcessingState, transactionContext, () -> List.of(mockMigration1, mockMigration2));
+            mockProcessingState, transactionContext, List.of(mockMigration1, mockMigration2));
 
     // when
     sut.runMigrations();


### PR DESCRIPTION
3 small refactorings of `DbMigrator` as prep-work for #15885. Removes unused functionality and simplifies the code a little bit.