### PR TITLE
[Backport stable/8.4] Building "quickly skips the flatten plugin

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -205,6 +205,7 @@
     <spotless.checks.skip>${skipChecks}</spotless.checks.skip>
 
     <!-- disable other non-essential goals -->
+    <flatten.skip>${quickly}</flatten.skip>
     <assembly.skipAssembly>${quickly}</assembly.skipAssembly>
   </properties>
 


### PR DESCRIPTION
# Description
Backport of #15929 to `stable/8.4`.

relates to #15912 #15336
original author: @korthout