### PR TITLE
[Backport stable/8.4] deps(maven): Update dependency org.codehaus.mojo:flatten-maven-plugin to v1.6.0 (main)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -42,7 +42,7 @@
     <!-- Zeebe Community License v1.1 header -->
     <license.header>${maven.multiModuleProjectDirectory}/parent/COPYING-HEADER.txt</license.header>
 
-    <plugin.version.flatten>1.5.0</plugin.version.flatten>
+    <plugin.version.flatten>1.6.0</plugin.version.flatten>
     <plugin.version.javadoc>3.6.3</plugin.version.javadoc>
     <plugin.version.license>4.3</plugin.version.license>
     <plugin.version.spotless>2.41.1</plugin.version.spotless>


### PR DESCRIPTION
# Description
Backport of #15912 to `stable/8.4`.

relates to 
original author: @renovate[bot]