### PR TITLE
Allow to configure ES index suffix

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -749,6 +749,8 @@
         #   index:
         #     prefix: zeebe-record
         #     createTemplate: true
+        #
+        #     # Pattern based on https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html
         #     indexSuffixDatePattern = "yyyy-MM-dd"
         #
         #     numberOfShards: 3

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -749,6 +749,7 @@
         #   index:
         #     prefix: zeebe-record
         #     createTemplate: true
+        #     indexSuffixDatePattern = "yyyy-MM-dd"
         #
         #     numberOfShards: 3
         #     numberOfReplicas: 0

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -721,6 +721,9 @@
         #     prefix: zeebe-record
         #     createTemplate: true
         #
+        #     # Pattern based on https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html
+        #     indexSuffixDatePattern = "yyyy-MM-dd"
+        #
         #     numberOfShards: 3
         #     numberOfReplicas: 0
         #

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.slf4j.Logger;
@@ -159,6 +161,17 @@ public class ElasticsearchExporter implements Exporter {
           String.format(
               "Elasticsearch minimumAge '%s' must match pattern '%s', but didn't.",
               minimumAge, PATTERN_MIN_AGE_FORMAT));
+    }
+
+    final String indexSuffixDatePattern = configuration.index.indexSuffixDatePattern;
+    try {
+      DateTimeFormatter.ofPattern(indexSuffixDatePattern).withZone(ZoneOffset.UTC);
+    } catch (final IllegalArgumentException iae) {
+      throw new ExporterException(
+          String.format(
+              "Expected a valid date format pattern for the given elasticsearch indexSuffixDatePattern, but '%s' was not. Examples are: 'yyyy-MM-dd' or 'yyyy-MM-dd_HH'",
+              indexSuffixDatePattern),
+          iae);
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -148,6 +148,14 @@ public class ElasticsearchExporterConfiguration {
     // prefix for index and templates
     public String prefix = "zeebe-record";
 
+    /**
+     * Suffix for indices. Pattern is used together with the current date, to create a suffix for
+     * the index. Useful to define whether an index should be created per month, day or even hour.
+     *
+     * <p>Example: yyyy-MM-dd -> 2023-12-03
+     */
+    public String indexSuffixDatePattern = "yyyy-MM-dd";
+
     // update index template on startup
     public boolean createTemplate = true;
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -153,6 +153,8 @@ public class ElasticsearchExporterConfiguration {
      * the index. Useful to define whether an index should be created per month, day or even hour.
      *
      * <p>Example: yyyy-MM-dd -> 2023-12-03
+     *
+     * @see java.time.format.DateTimeFormatter
      */
     public String indexSuffixDatePattern = "yyyy-MM-dd";
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RecordIndexRouter.java
@@ -17,8 +17,6 @@ import java.time.format.DateTimeFormatter;
 
 /** Computes the name of the index, alias, or search pattern for a record or its value type. */
 final class RecordIndexRouter {
-  private static final DateTimeFormatter DEFAULT_FORMATTER =
-      DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(ZoneOffset.UTC);
   private static final String INDEX_DELIMITER = "_";
   private static final String ALIAS_DELIMITER = "-";
 
@@ -26,7 +24,9 @@ final class RecordIndexRouter {
   private final IndexConfiguration config;
 
   RecordIndexRouter(final IndexConfiguration config) {
-    this(config, DEFAULT_FORMATTER);
+    this(
+        config,
+        DateTimeFormatter.ofPattern(config.indexSuffixDatePattern).withZone(ZoneOffset.UTC));
   }
 
   RecordIndexRouter(final IndexConfiguration config, final DateTimeFormatter formatter) {

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterTest.java
@@ -348,6 +348,19 @@ final class ElasticsearchExporterTest {
     }
 
     @Test
+    void shouldNotAllowInvalidIndexSuffixDatePattern() {
+      // given
+      config.index.indexSuffixDatePattern = "l";
+
+      // when - then
+      assertThatCode(() -> exporter.configure(context))
+          .isInstanceOf(ExporterException.class)
+          .hasMessageContaining(
+              "Expected a valid date format pattern for the given elasticsearch indexSuffixDatePattern, but 'l' was not.")
+          .hasMessageContaining("Examples are: 'yyyy-MM-dd' or 'yyyy-MM-dd_HH'");
+    }
+
+    @Test
     void shouldForbidNegativeNumberOfReplicas() {
       // given
       config.index.setNumberOfReplicas(-1);


### PR DESCRIPTION
## Description

Previously we always wrote the `yyyy-MM-dd` as suffix to every index. This was hard-coded and not possible to configure/overwrite, which can be seen as a limitation. This makes it hard to delete indices via ILM, especially on higherload. We have run into this problem with our benchmarks.

This PR makes it possible to configure the default suffix format 'yyyy-MM-dd' and overwrite it with something like: 'yyyy-MM-dd_HH' which allows the creation of indices based on hours.

But it is also possible to create indices per day, if necessary when not much data is expected.

This configuration makes it possible to better leverage the ILM settings provided by ES.

Yesterday, I ran it to see it in action.

![es-indices](https://github.com/camunda/zeebe/assets/2758593/c222dc02-5e05-4112-8820-87cf44017b0e)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to https://github.com/zeebe-io/benchmark-helm/issues/127
relates to https://github.com/zeebe-io/benchmark-helm/issues/126