### PR TITLE
feat(engine): write current broker version to state after running migrations

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/MigrationState.java
@@ -10,4 +10,10 @@ package io.camunda.zeebe.engine.state.immutable;
 public interface MigrationState {
 
   boolean shouldRunElementInstancePopulateProcessInstanceByDefinitionKey();
+
+  /**
+   * @return a string representing the version that applied migrations or null if the version is
+   *     (not yet) set.
+   */
+  String getMigratedByVersion();
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -471,16 +471,22 @@ public class DbMigrationState implements MutableMigrationState {
   }
 
   @Override
-  public void setMigratedByVersion(final String version) {
-    migratedByVersionValue.wrapString(version);
-    migrationsState.upsert(migratedByVersionKey, migratedByVersionValue);
-  }
-
-  @Override
   public boolean shouldRunElementInstancePopulateProcessInstanceByDefinitionKey() {
     parentKey.inner().wrapLong(NO_PARENT_KEY);
     return processInstanceKeyByProcessDefinitionKeyColumnFamily.isEmpty()
         || processInstanceKeyByProcessDefinitionKeyColumnFamily.count()
             != parentChildColumnFamily.countEqualPrefix(parentKey);
+  }
+
+  @Override
+  public String getMigratedByVersion() {
+    final var value = migrationsState.get(migratedByVersionKey);
+    return value == null ? null : value.toString();
+  }
+
+  @Override
+  public void setMigratedByVersion(final String version) {
+    migratedByVersionValue.wrapString(version);
+    migrationsState.upsert(migratedByVersionKey, migratedByVersionValue);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigrationState.java
@@ -46,6 +46,7 @@ import org.agrona.DirectBuffer;
 public class DbMigrationState implements MutableMigrationState {
 
   private static final long NO_PARENT_KEY = -1L;
+  private static final String MIGRATED_BY_VERSION = "migrated-by-version";
 
   // ZbColumnFamilies.MESSAGE_SUBSCRIPTION_BY_SENT_TIME
   // (sentTime, elementInstanceKey, messageName) => \0
@@ -269,7 +270,7 @@ public class DbMigrationState implements MutableMigrationState {
     signalSubscriptionMigrationState =
         new DbSignalSubscriptionMigrationState(zeebeDb, transactionContext);
 
-    migratedByVersionKey.wrapString("migrated-by-version");
+    migratedByVersionKey.wrapString(MIGRATED_BY_VERSION);
     migrationsState =
         zeebeDb.createColumnFamily(
             ZbColumnFamilies.MIGRATIONS_STATE,

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.migration.to_8_3.MultiTenancyProcessStateMi
 import io.camunda.zeebe.engine.state.migration.to_8_3.ProcessInstanceByProcessDefinitionMigration;
 import io.camunda.zeebe.engine.state.migration.to_8_4.MultiTenancySignalSubscriptionStateMigration;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -79,7 +80,12 @@ public class DbMigratorImpl implements DbMigrator {
         executedMigrations.add(migration);
       }
     }
+    markMigrationsAsCompleted();
     logSummary(executedMigrations);
+  }
+
+  private void markMigrationsAsCompleted() {
+    processingState.getMigrationState().setMigratedByVersion(VersionUtil.getVersion());
   }
 
   private void logPreview(final List<MigrationTask> migrationTasks) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableMigrationState.java
@@ -46,4 +46,6 @@ public interface MutableMigrationState extends MigrationState {
   void migrateJobStateForMultiTenancy();
 
   void migrateSignalSubscriptionStateForMultiTenancy();
+
+  void setMigratedByVersion(String version);
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigrationStateTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class DbMigrationStateTest {
+  private MutableProcessingState processingState;
+
+  @Test
+  void shouldHaveNoVersionUntilWritten() {
+    // given
+    final var sut = processingState.getMigrationState();
+
+    // when + then
+    assertThat(sut.getMigratedByVersion()).isNull();
+  }
+
+  @Test
+  void shouldWriteVersionToState() {
+    // given
+    final var sut = processingState.getMigrationState();
+
+    // when
+    sut.setMigratedByVersion("1.2.3");
+
+    // then
+    assertThat(sut.getMigratedByVersion()).isEqualTo("1.2.3");
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -7,16 +7,17 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.db.TransactionContext;
-import io.camunda.zeebe.db.TransactionOperation;
-import io.camunda.zeebe.db.ZeebeDbTransaction;
 import io.camunda.zeebe.engine.state.mutable.MutableMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.util.VersionUtil;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -86,26 +87,79 @@ public class DbMigratorImplTest {
     inOrder.verify(mockMigration2).runMigration(mockProcessingState);
   }
 
-  private static final class RunInTransactionContext implements TransactionContext {
+  @Test
+  void shouldNotSetVersionIfMigrationsFailed() {
+    // given -- two migrations that both need to be run
+    final var mockProcessingState = mock(MutableProcessingState.class);
+    final var mockMigrationState = mock(MutableMigrationState.class);
+    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
 
-    private final ZeebeDbTransaction transaction;
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
 
-    private RunInTransactionContext(final ZeebeDbTransaction transaction) {
-      this.transaction = transaction;
-    }
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
 
-    @Override
-    public void runInTransaction(final TransactionOperation operations) {
-      try {
-        operations.run();
-      } catch (final Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
+    final var sut =
+        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
 
-    @Override
-    public ZeebeDbTransaction getCurrentTransaction() {
-      return transaction;
-    }
+    // when -- first migration fails
+    doThrow(RuntimeException.class).when(mockMigration1).runMigration(mockProcessingState);
+
+    // then -- running migrations fails
+    assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
+    // then -- second migration is not run
+    verify(mockMigration2, never()).runMigration(any());
+    // then -- version is not set
+    verify(mockMigrationState, never()).setMigratedByVersion(any());
+  }
+
+  @Test
+  void shouldSetVersionAfterRunningMigrations() {
+    // given -- two migrations that both need to be run
+    final var mockProcessingState = mock(MutableProcessingState.class);
+    final var mockMigrationState = mock(MutableMigrationState.class);
+    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
+
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
+
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
+
+    final var sut =
+        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+
+    // when -- running migrations
+    sut.runMigrations();
+
+    // then -- the version is set
+    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
+  }
+
+  @Test
+  void shouldNotSetVersionIfMigrationsFail() {
+    // given -- two migrations that both need to be run
+    final var mockProcessingState = mock(MutableProcessingState.class);
+    final var mockMigrationState = mock(MutableMigrationState.class);
+    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
+
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
+
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
+
+    final var sut =
+        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+
+    // when -- second migration fails
+    doThrow(RuntimeException.class).when(mockMigration2).runMigration(mockProcessingState);
+
+    // then -- running migrations fails
+    assertThatThrownBy(sut::runMigrations).isInstanceOf(RuntimeException.class);
+
+    // then -- the version is not set
+    verify(mockMigrationState, never()).setMigratedByVersion(any());
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -88,7 +88,7 @@ public class DbMigratorImplTest {
   }
 
   @Test
-  void shouldNotSetVersionIfMigrationsFailed() {
+  void shouldNotSetVersionIfFirstMigrationFails() {
     // given -- two migrations that both need to be run
     final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigrationState = mock(MutableMigrationState.class);
@@ -115,30 +115,7 @@ public class DbMigratorImplTest {
   }
 
   @Test
-  void shouldSetVersionAfterRunningMigrations() {
-    // given -- two migrations that both need to be run
-    final var mockProcessingState = mock(MutableProcessingState.class);
-    final var mockMigrationState = mock(MutableMigrationState.class);
-    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
-
-    final var mockMigration1 = mock(MigrationTask.class);
-    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
-
-    final var mockMigration2 = mock(MigrationTask.class);
-    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
-
-    final var sut =
-        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
-
-    // when -- running migrations
-    sut.runMigrations();
-
-    // then -- the version is set
-    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
-  }
-
-  @Test
-  void shouldNotSetVersionIfMigrationsFail() {
+  void shouldNotSetVersionIfSecondMigrationFails() {
     // given -- two migrations that both need to be run
     final var mockProcessingState = mock(MutableProcessingState.class);
     final var mockMigrationState = mock(MutableMigrationState.class);
@@ -161,5 +138,28 @@ public class DbMigratorImplTest {
 
     // then -- the version is not set
     verify(mockMigrationState, never()).setMigratedByVersion(any());
+  }
+
+  @Test
+  void shouldSetVersionAfterRunningMigrations() {
+    // given -- two migrations that both need to be run
+    final var mockProcessingState = mock(MutableProcessingState.class);
+    final var mockMigrationState = mock(MutableMigrationState.class);
+    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
+
+    final var mockMigration1 = mock(MigrationTask.class);
+    when(mockMigration1.needsToRun(mockProcessingState)).thenReturn(true);
+
+    final var mockMigration2 = mock(MigrationTask.class);
+    when(mockMigration2.needsToRun(mockProcessingState)).thenReturn(true);
+
+    final var sut =
+        new DbMigratorImpl(mockProcessingState, List.of(mockMigration1, mockMigration2));
+
+    // when -- running migrations
+    sut.runMigrations();
+
+    // then -- the version is set
+    verify(mockMigrationState).setMigratedByVersion(VersionUtil.getVersion());
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -137,9 +137,6 @@ public enum ZbColumnFamilies implements EnumValue {
 
   PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY(55),
 
-  // This was introduces in 8.3 and backported to earlier versions. As this turns out to not be safe
-  // to do we have removed the usage of this CF. We must keep it to remain backwards compatible.
-  @Deprecated
   MIGRATIONS_STATE(56),
 
   PROCESS_VERSION(57),


### PR DESCRIPTION
After running all migrations, we write the current broker version to the `MIGRATION_STATE` column family. This CF was used before, until it was deprecated with https://github.com/camunda/zeebe/pull/14574. We now use it differently, not keeping track of which migration tasks ran but only the broker version.

We don't make use of that information yet, but it will be used later on to decide if state is compatible or not and if migrations need to be run or not.

Relates to #15885 