### PR TITLE
Migrate user task instances with job worker implementation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -52,7 +52,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     implements TypedRecordProcessor<ProcessInstanceMigrationRecord> {
 
   private static final EnumSet<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
-      EnumSet.of(BpmnElementType.PROCESS, BpmnElementType.SERVICE_TASK);
+      EnumSet.of(BpmnElementType.PROCESS, BpmnElementType.SERVICE_TASK, BpmnElementType.USER_TASK);
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -405,6 +405,13 @@ public class ProcessInstanceMigrationMigrateProcessor
       }
     }
 
+    if (elementInstance.getUserTaskKey() > 0) {
+      throw new UnsupportedElementMigrationException(
+          processInstanceKey,
+          elementInstanceRecord.getElementId(),
+          elementInstanceRecord.getBpmnElementType());
+    }
+
     variableState
         .getVariablesLocal(elementInstance.getKey())
         .forEach(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/CancelProcessInstanceTest.java
@@ -369,7 +369,11 @@ public final class CancelProcessInstanceTest {
         .withElementId("task")
         .getFirst();
 
-    assertThat(RecordingExporter.userTaskRecords().withProcessInstanceKey(processInstanceKey))
+    assertThat(
+            RecordingExporter.records()
+                .limitToProcessInstance(processInstanceKey)
+                .userTaskRecords()
+                .withProcessInstanceKey(processInstanceKey))
         .extracting(Record::getValueType, Record::getIntent)
         .containsSubsequence(
             tuple(ValueType.USER_TASK, UserTaskIntent.CANCELING),

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -314,6 +314,63 @@ public class MigrateProcessInstanceTest {
   }
 
   @Test
+  public void shouldWriteElementMigratedEventForUserTaskWithJobWorkerImplementation() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("A")
+                    .userTask()
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementType(BpmnElementType.USER_TASK)
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "A")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.USER_TASK)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasVersion(1)
+        .describedAs("Expect that element id is left unchanged")
+        .hasElementId("A");
+  }
+
+  @Test
   public void shouldWriteMigratedEventForJob() {
     // given
     final String processId = helper.getBpmnProcessId();

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java
@@ -331,7 +331,7 @@ public class MigrateProcessInstanceTest {
             .withXmlResource(
                 Bpmn.createExecutableProcess(targetProcessId)
                     .startEvent()
-                    .userTask("A")
+                    .userTask("B")
                     .userTask()
                     .endEvent()
                     .done())
@@ -352,7 +352,7 @@ public class MigrateProcessInstanceTest {
         .withInstanceKey(processInstanceKey)
         .migration()
         .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A")
+        .addMappingInstruction("A", "B")
         .migrate();
 
     // then
@@ -366,8 +366,7 @@ public class MigrateProcessInstanceTest {
         .hasProcessDefinitionKey(targetProcessDefinitionKey)
         .hasBpmnProcessId(targetProcessId)
         .hasVersion(1)
-        .describedAs("Expect that element id is left unchanged")
-        .hasElementId("A");
+        .hasElementId("B");
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
@@ -35,22 +35,24 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Test
-  public void shouldRejectMigrationForActiveUserTask() {
+  public void shouldRejectMigrationForActiveNativeUserTask() {
     // given
+    // method reference doesn't help readability in this builder
+    @SuppressWarnings("Convert2MethodRef")
     final var deployment =
         ENGINE
             .deployment()
             .withXmlResource(
                 Bpmn.createExecutableProcess(SOURCE_PROCESS)
                     .startEvent()
-                    .userTask("A")
+                    .userTask("A", u -> u.zeebeUserTask())
                     .endEvent()
                     .done())
             .withXmlResource(
                 Bpmn.createExecutableProcess(TARGET_PROCESS)
                     .startEvent()
-                    .userTask("A")
-                    .userTask("B")
+                    .userTask("A", u -> u.zeebeUserTask())
+                    .userTask("B", u -> u.zeebeUserTask())
                     .endEvent()
                     .done())
             .deploy();

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordStream.java
@@ -118,4 +118,9 @@ public final class RecordStream extends ExporterRecordStream<RecordValue, Record
     return new SignalSubscriptionRecordStream(
         filter(r -> r.getValueType() == ValueType.SIGNAL_SUBSCRIPTION).map(Record.class::cast));
   }
+
+  public UserTaskRecordStream userTaskRecords() {
+    return new UserTaskRecordStream(
+        filter(r -> r.getValueType() == ValueType.USER_TASK).map(Record.class::cast));
+  }
 }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds support for migrating active User Task element instances with a Job Worker implementation. This explicitly does not yet support migrating active native User Tasks, which will be added later.

Additionally, I've taken the liberty to speed up a slow test in the same package.

> [!NOTE]
> I haven't added a test case showing that the element ID of a User Task can be changed through migration. This uses the same logic as that for Service Tasks. Perhaps we can eventually move [`shouldWriteElementMigratedEventForServiceTask`](https://github.com/camunda/zeebe/blob/69aea926773796f05e5914f3ad68d15a389df7a3/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java#L204), [`shouldWriteElementMigratedEventForServiceTaskWithNewId`](https://github.com/camunda/zeebe/blob/69aea926773796f05e5914f3ad68d15a389df7a3/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java#L261C15-L261C69), and the new [`shouldWriteElementMigratedEventForUserTaskWithJobWorkerImplementation`](https://github.com/camunda/zeebe/blob/69aea926773796f05e5914f3ad68d15a389df7a3/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceTest.java#L317) test cases to a parameterized test using the [`JobWorkerElementBuilderProvider`](https://github.com/camunda/zeebe/blob/main/engine/src/test/java/io/camunda/zeebe/engine/util/JobWorkerElementBuilderProvider.java). But, I didn't want to take that step now since not all job worker elements are supported yet.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15962 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
