### PR TITLE
Adjust mixed benchmarks set up

### DIFF
--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -45,7 +45,7 @@ jobs:
           echo "full-ref"=$(git rev-parse HEAD) >> $GITHUB_OUTPUT
           echo "benchmark=medic-y-$(date +%Y)-cw-$(date +%V)-$(git rev-parse --short HEAD)-benchmark" >> $GITHUB_OUTPUT
           echo "operate=operate-y-$(date +%Y)-cw-$(date +%V)" >> $GITHUB_OUTPUT
-          
+
 
   setup-normal-benchmark:
     name: Normal Benchmark
@@ -82,10 +82,9 @@ jobs:
         --set publisher.rate=5
         --set camunda-platform.operate.enabled=true
         --set camunda-platform.operate.image.repository=gcr.io/zeebe-io/operate
-        --set camunda-platform.operate.image.tag=${{ needs.benchmark-data.outputs.operate }}    
-        --set camunda-platform.elasticsearch.volumeClaimTemplate.resources.requests.storage=128Gi
-        --set camunda-platform.retentionPolicy.enabled=false
-        --set retentionPolicy.enabled=true
+        --set camunda-platform.operate.image.tag=${{ needs.benchmark-data.outputs.operate }}
+        --set camunda-platform.elasticsearch.master.persistence.size=128Gi \
+        --set camunda-platform.zeebe.retention.minimumAge=1d \
   setup-latency-benchmark:
     name: Latency Benchmark
     uses: ./.github/workflows/benchmark.yml


### PR DESCRIPTION
## Description

Based on [the new benchmark chart release](https://github.com/zeebe-io/benchmark-helm/pull/138) we use a new retetion configuration (ILM-based). We need to use a different notation for ES, since we use a different chart.
<!-- Please explain the changes you made here. -->