### PR TITLE
ci: run e2e test with broker scaling once a week

### DIFF
--- a/.github/workflows/weekly-e2e.yml
+++ b/.github/workflows/weekly-e2e.yml
@@ -90,3 +90,15 @@ jobs:
       fault: \"2-region-dataloss-failover\"
       maxInstanceDuration: 40m
     secrets: inherit
+
+  e2e-scaling-brokers:
+    name: Scaling brokers
+    uses: ./.github/workflows/e2e-testbench.yaml
+    with:
+      branch: main
+      generation: Zeebe SNAPSHOT
+      maxTestDuration: PT4H
+      clusterPlan: Production - M
+      fault: \"scale-brokers\"
+      maxInstanceDuration: 40m
+    secrets: inherit


### PR DESCRIPTION
## Description

This PR adds a weekly trigger to run E2E test with scaling brokers. This is similar to other E2E tests where there is a continuous load (starters and workers) running against the test cluster. A verifier periodically checks the properties and fails the test if properties are not met. To test scaling, we specify [scaling-brokers](https://github.com/camunda/zeebe-e2e-test/blob/main/workers/src/main/resources/faults/production-m/scale-brokers.json) as the fault to be injected.

The test is only run once a week and runs for 4 hours. This duration is a random choice, we can run it longer if needed.

For testing, I have manually triggered [e2e workflow](https://github.com/camunda/zeebe/actions/runs/7567182733) with the same parameters as in this PR. You can see the process [here](https://bru-2.operate.camunda.io/eeef5734-cfd6-47a5-a2ed-5fe13269e589/processes/4503599706450628)

## Related issues

closes #15752 

