### PR TITLE
Pin chart release version

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -35,7 +35,6 @@ on:
         type: boolean
         required: false
         default: false
-
   workflow_call:
     inputs:
       name:
@@ -76,7 +75,6 @@ on:
         type: boolean
         required: false
         default: false
-
 jobs:
   build-zeebe-image:
     name: Build Zeebe
@@ -202,16 +200,23 @@ jobs:
         run: |
           helm repo add zeebe-benchmark https://zeebe-io.github.io/benchmark-helm
           helm repo update
+
+      - name: Find previous Helm chart release version
+        id: find-chart-release
+        run: |
+          echo "chart-release=$(helm get metadata -o json --namespace ${{ inputs.name }} ${{ inputs.name }} | jq --raw-output .version)" >> $GITHUB_OUTPUT
       - name: Helm install
         run: >
           helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
           --namespace ${{ inputs.name }}
           --create-namespace
+          --reuse-values
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}
           --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
           --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+          ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && '-f benchmarks/setup/default/values-stable.yaml' || '' }}
           ${{ inputs.benchmark-load }}
       - name: Summarize deployment


### PR DESCRIPTION
## Description

In order to avoid conflicts when updating existing benchmarks we pin the installed version and reuse this on the upgrade. If we want to migrate to a newer chart release we need to do this manually.
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/zeebe-io/benchmark-helm/pull/138
