### PR TITLE
Allow serializing RecordMetadata of size larger than a short

### DIFF
--- a/logstreams/pom.xml
+++ b/logstreams/pom.xml
@@ -57,6 +57,11 @@
       <artifactId>simpleclient</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-value</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>
@@ -104,6 +109,16 @@
 
   <build>
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredNonTestScopedDependencies>
+            <dependency>io.camunda:zeebe-msgpack-value</dependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.logstreams.impl.log;
 import static io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor.alignedLength;
 import static io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor.lengthOffset;
 import static io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor.messageOffset;
+import static org.agrona.BitUtil.SIZE_OF_INT;
 import static org.agrona.BitUtil.SIZE_OF_LONG;
 import static org.agrona.BitUtil.SIZE_OF_SHORT;
 
@@ -94,10 +95,7 @@ public final class LogEntryDescriptor {
     offset += SIZE_OF_LONG;
 
     METADATA_LENGTH_OFFSET = offset;
-    offset += SIZE_OF_SHORT;
-
-    // UNUSED BLOCK
-    offset += SIZE_OF_SHORT;
+    offset += SIZE_OF_INT;
 
     HEADER_BLOCK_LENGTH = offset;
 

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
@@ -38,7 +38,7 @@ import org.agrona.MutableDirectBuffer;
  *  |                           TIMESTAMP                           |
  *  |                                                               |
  *  +---------------------------------------------------------------+
- *  |        METADATA LENGTH         |       unused                 |
+ *  |                        METADATA LENGTH                        |
  *  +---------------------------------------------------------------+
  *  |                         ...METADATA...                        |
  *  +---------------------------------------------------------------+
@@ -50,23 +50,24 @@ public final class LogEntryDescriptor {
 
   public static final long KEY_NULL_VALUE = -1;
 
-  public static final int VERSION_OFFSET;
+  private static final short VERSION = 1;
+  private static final int VERSION_OFFSET;
 
   // Contains arbitrary flags, currently only the `skipProcessing` flag.
-  public static final int FLAGS_OFFSET;
-  public static final int POSITION_OFFSET;
+  private static final int FLAGS_OFFSET;
+  private static final int POSITION_OFFSET;
 
-  public static final int SOURCE_EVENT_POSITION_OFFSET;
+  private static final int SOURCE_EVENT_POSITION_OFFSET;
 
-  public static final int KEY_OFFSET;
+  private static final int KEY_OFFSET;
 
-  public static final int TIMESTAMP_OFFSET;
+  private static final int TIMESTAMP_OFFSET;
 
-  public static final int METADATA_LENGTH_OFFSET;
+  private static final int METADATA_LENGTH_OFFSET;
 
-  public static final int HEADER_BLOCK_LENGTH;
+  private static final int HEADER_BLOCK_LENGTH;
 
-  public static final int METADATA_OFFSET;
+  private static final int METADATA_OFFSET;
 
   static {
     int offset = 0;
@@ -101,6 +102,18 @@ public final class LogEntryDescriptor {
     HEADER_BLOCK_LENGTH = offset;
 
     METADATA_OFFSET = offset;
+  }
+
+  public static int versionOffset(final int offset) {
+    return VERSION_OFFSET + offset;
+  }
+
+  public static void setVersion(final MutableDirectBuffer buffer, final int offset) {
+    buffer.putShort(versionOffset(offset), VERSION, Protocol.ENDIANNESS);
+  }
+
+  public static short getVersion(final DirectBuffer buffer, final int offset) {
+    return buffer.getShort(versionOffset(offset), Protocol.ENDIANNESS);
   }
 
   public static int getFragmentLength(final DirectBuffer buffer, final int offset) {
@@ -178,13 +191,13 @@ public final class LogEntryDescriptor {
     return METADATA_LENGTH_OFFSET + offset;
   }
 
-  public static short getMetadataLength(final DirectBuffer buffer, final int offset) {
-    return buffer.getShort(metadataLengthOffset(offset), Protocol.ENDIANNESS);
+  public static int getMetadataLength(final DirectBuffer buffer, final int offset) {
+    return buffer.getInt(metadataLengthOffset(offset), Protocol.ENDIANNESS);
   }
 
   public static void setMetadataLength(
-      final MutableDirectBuffer buffer, final int offset, final short metadataLength) {
-    buffer.putShort(metadataLengthOffset(offset), metadataLength, Protocol.ENDIANNESS);
+      final MutableDirectBuffer buffer, final int offset, final int metadataLength) {
+    buffer.putInt(metadataLengthOffset(offset), metadataLength, Protocol.ENDIANNESS);
   }
 
   public static int metadataOffset(final int offset) {

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LoggedEventImpl.java
@@ -74,7 +74,7 @@ public final class LoggedEventImpl implements LoggedEvent {
   }
 
   @Override
-  public short getMetadataLength() {
+  public int getMetadataLength() {
     return LogEntryDescriptor.getMetadataLength(buffer, messageOffset);
   }
 
@@ -90,13 +90,13 @@ public final class LoggedEventImpl implements LoggedEvent {
 
   @Override
   public int getValueOffset() {
-    final short metadataLength = getMetadataLength();
+    final var metadataLength = getMetadataLength();
     return LogEntryDescriptor.valueOffset(messageOffset, metadataLength);
   }
 
   @Override
   public int getValueLength() {
-    final short metadataLength = getMetadataLength();
+    final var metadataLength = getMetadataLength();
 
     return getMessageLength() - LogEntryDescriptor.headerLength(metadataLength);
   }
@@ -104,6 +104,11 @@ public final class LoggedEventImpl implements LoggedEvent {
   @Override
   public void readValue(final BufferReader reader) {
     reader.wrap(buffer, getValueOffset(), getValueLength());
+  }
+
+  @Override
+  public short getVersion() {
+    return LogEntryDescriptor.getVersion(buffer, messageOffset);
   }
 
   @Override

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializer.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setMetadat
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setPosition;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setSourceEventPosition;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setTimestamp;
+import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.setVersion;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.skipProcessing;
 import static io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor.valueOffset;
 
@@ -23,7 +24,6 @@ import org.agrona.MutableDirectBuffer;
 
 /** Serializes {@link LogAppendEntry}, including legacy dispatcher framing. */
 final class LogAppendEntrySerializer {
-
   /**
    * Serializes an entry into the given destination buffer. Returns the length of the serialized
    * entry, framed but unaligned.
@@ -89,6 +89,7 @@ final class LogAppendEntrySerializer {
     final var entryOffset = writeBufferOffset + DataFrameDescriptor.HEADER_LENGTH;
 
     // Write the entry
+    setVersion(writeBuffer, entryOffset);
     if (entry.isProcessed()) {
       skipProcessing(writeBuffer, entryOffset);
     }
@@ -96,7 +97,7 @@ final class LogAppendEntrySerializer {
     setSourceEventPosition(writeBuffer, entryOffset, sourcePosition);
     setKey(writeBuffer, entryOffset, key);
     setTimestamp(writeBuffer, entryOffset, entryTimestamp);
-    setMetadataLength(writeBuffer, entryOffset, (short) metadataLength);
+    setMetadataLength(writeBuffer, entryOffset, metadataLength);
     metadata.write(writeBuffer, metadataOffset(entryOffset));
     value.write(writeBuffer, valueOffset(entryOffset, metadataLength));
 

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LoggedEvent.java
@@ -54,7 +54,7 @@ public interface LoggedEvent extends BufferWriter {
   /**
    * @return the length of the event's metadata
    */
-  short getMetadataLength();
+  int getMetadataLength();
 
   /**
    * Wraps the given buffer to read the event's metadata
@@ -85,4 +85,7 @@ public interface LoggedEvent extends BufferWriter {
    * @param reader the buffer to read from
    */
   void readValue(BufferReader reader);
+
+  /** Returns the version of the log entry descriptor used for serialization. */
+  short getVersion();
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
@@ -36,4 +36,6 @@ public class LogEntryDescriptorTest {
     // then
     Assertions.assertThat(LogEntryDescriptor.shouldSkipProcessing(buffer, 0)).isTrue();
   }
+
+
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
@@ -36,6 +36,4 @@ public class LogEntryDescriptorTest {
     // then
     Assertions.assertThat(LogEntryDescriptor.shouldSkipProcessing(buffer, 0)).isTrue();
   }
-
-
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
@@ -24,12 +24,11 @@ final class LogAppendEntrySerializerTest {
   @Test
   void shouldSerializeEntry() {
     // given
-    final var serializer = new LogAppendEntrySerializer();
     final var event = new LoggedEventImpl();
     final var entry = TestEntry.ofKey(1);
 
     // when
-    serializer.serialize(writeBuffer, 0, entry, 2, 3, 4);
+    LogAppendEntrySerializer.serialize(writeBuffer, 0, entry, 2, 3, 4);
 
     // then
     event.wrap(writeBuffer, 0);
@@ -44,13 +43,12 @@ final class LogAppendEntrySerializerTest {
   @Test
   void shouldMarkEntryAsProcessed() {
     // given
-    final var serializer = new LogAppendEntrySerializer();
     final var event = new LoggedEventImpl();
     final var entry = TestEntry.ofKey(1);
     final var processedEntry = LogAppendEntry.ofProcessed(entry);
 
     // when
-    serializer.serialize(writeBuffer, 0, processedEntry, 2, 3, 4);
+    LogAppendEntrySerializer.serialize(writeBuffer, 0, processedEntry, 2, 3, 4);
 
     // then
     event.wrap(writeBuffer, 0);
@@ -65,44 +63,40 @@ final class LogAppendEntrySerializerTest {
   @Test
   void shouldFailWithEmptyMetadata() {
     // given
-    final var serializer = new LogAppendEntrySerializer();
     final var entry = TestEntry.builder().withRecordMetadata(null).build();
 
     // then
-    assertThatCode(() -> serializer.serialize(writeBuffer, 0, entry, 2, 3, 4))
+    assertThatCode(() -> LogAppendEntrySerializer.serialize(writeBuffer, 0, entry, 2, 3, 4))
         .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void shouldFailWithAnEmptyValue() {
     // given
-    final var serializer = new LogAppendEntrySerializer();
     final var entry = TestEntry.builder().withRecordValue(null).build();
 
     // when - then
-    assertThatCode(() -> serializer.serialize(writeBuffer, 0, entry, 2, 3, 4))
+    assertThatCode(() -> LogAppendEntrySerializer.serialize(writeBuffer, 0, entry, 2, 3, 4))
         .isInstanceOf(NullPointerException.class);
   }
 
   @Test
   void shouldFailWithANegativeTimestamp() {
     // given
-    final var serializer = new LogAppendEntrySerializer();
     final var entry = TestEntry.ofDefaults();
 
     // when - then
-    assertThatCode(() -> serializer.serialize(writeBuffer, 0, entry, 2, 3, -1))
+    assertThatCode(() -> LogAppendEntrySerializer.serialize(writeBuffer, 0, entry, 2, 3, -1))
         .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void shouldFailWithANegativePosition() {
     // given
-    final var serializer = new LogAppendEntrySerializer();
     final var entry = TestEntry.ofDefaults();
 
     // when - then
-    assertThatCode(() -> serializer.serialize(writeBuffer, 0, entry, -1, 3, 4))
+    assertThatCode(() -> LogAppendEntrySerializer.serialize(writeBuffer, 0, entry, -1, 3, 4))
         .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/serializer/LogAppendEntrySerializerTest.java
@@ -14,6 +14,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.util.TestEntry;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.ExpandableArrayBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.junit.jupiter.api.Test;
@@ -33,6 +38,7 @@ final class LogAppendEntrySerializerTest {
     // then
     event.wrap(writeBuffer, 0);
     assertThatEntry(entry).matchesLoggedEvent(event);
+    assertThat(event.getVersion()).isEqualTo((short) 1);
     assertThat(event.getKey()).isEqualTo(1);
     assertThat(event.getPosition()).isEqualTo(2);
     assertThat(event.getSourceEventPosition()).isEqualTo(3);
@@ -98,5 +104,48 @@ final class LogAppendEntrySerializerTest {
     // when - then
     assertThatCode(() -> LogAppendEntrySerializer.serialize(writeBuffer, 0, entry, -1, 3, 4))
         .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/15989")
+  void shouldWriteLargeMetadata() {
+    // given
+    final var rejection = "foo".repeat(Short.MAX_VALUE * 2);
+    final var entry = TestEntry.builder().withRecordValue(new TestValue().setFoo("bar")).build();
+    final var event = new LoggedEventImpl();
+    final var metadata = new RecordMetadata();
+    final var value = new TestValue();
+    entry.recordMetadata().rejectionReason(rejection);
+
+    // when
+    final var serializedLength =
+        LogAppendEntrySerializer.serialize(
+            writeBuffer, 0, entry, 0, -1, System.currentTimeMillis());
+    event.wrap(writeBuffer, 0);
+    event.readMetadata(metadata);
+    event.readValue(value);
+
+    // then
+    assertThat(serializedLength).isGreaterThan(Short.MAX_VALUE);
+    assertThat(metadata.getRejectionReason()).isEqualTo(rejection);
+    assertThat(value.getFoo()).isEqualTo("bar");
+  }
+
+  private static final class TestValue extends UnifiedRecordValue {
+
+    private final StringProperty foo = new StringProperty("foo");
+
+    private TestValue() {
+      super(1);
+      declareProperty(foo);
+    }
+
+    private String getFoo() {
+      return BufferUtil.bufferAsString(foo.getValue());
+    }
+
+    private TestValue setFoo(final String value) {
+      foo.setValue(value);
+      return this;
+    }
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RejectLargeDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RejectLargeDeploymentTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.concurrent.Future;
+
+@ZeebeIntegration
+public class RejectLargeDeploymentTest {
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/15989")
+  void shouldExportLargeDeploymentRejection() {
+    // given - a deployment with a large, unparsable input expression
+    final var data = "x".repeat(Short.MAX_VALUE * 2);
+    final var process =
+        Bpmn.createExecutableProcess("test")
+            .startEvent()
+            .serviceTask(
+                "task", task -> task.zeebeInput("=<DOCTYPE!" + data, "var").zeebeJobType("test"))
+            .endEvent()
+            .done();
+
+    // when -- deploying the process
+    try (final var client = zeebe.newClientBuilder().build()) {
+      final var response =
+          client
+              .newDeployResourceCommand()
+              // .addResourceFile("/home/ole/Downloads/choisirRepas.bpmn")
+              .addProcessModel(process, "process.bpmn")
+              .send();
+      assertThat((Future<DeploymentEvent>) response).failsWithin(Duration.ofSeconds(5));
+    }
+
+    // then -- The rejection can be exported
+    assertThat(RecordingExporter.deploymentRecords().withRecordType(RecordType.COMMAND_REJECTION))
+        .isNotEmpty();
+  }
+}

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RejectLargeDeploymentTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/RejectLargeDeploymentTest.java
@@ -40,11 +40,7 @@ public class RejectLargeDeploymentTest {
     // when -- deploying the process
     try (final var client = zeebe.newClientBuilder().build()) {
       final var response =
-          client
-              .newDeployResourceCommand()
-              // .addResourceFile("/home/ole/Downloads/choisirRepas.bpmn")
-              .addProcessModel(process, "process.bpmn")
-              .send();
+          client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send();
       assertThat((Future<DeploymentEvent>) response).failsWithin(Duration.ofSeconds(5));
     }
 


### PR DESCRIPTION
## Description

This PR increases the maximum record metadata size to 2GB. This is a silly number, but silly things happen - we'll create a follow up issue to limit such things at the source. Additionally, since the metadata is counted as part of the log entry, there is still an upper bound by the `maxMessageSize` anyway.

Since the log entry descriptor has changed, we also bumped its version (for the very first time). No special handling of older versions needs to be done however, since the additional 8 bytes we now use, were previously unused. Since we write using little endian, then reading a short or an int amounts to the same thing here.

## Related issues

closes #15989 

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
