### PR TITLE
[Backport stable/8.4] Fix PKCS1 support by ensuring BouncyCastle is present at runtime

### DIFF
--- a/atomix/cluster/pom.xml
+++ b/atomix/cluster/pom.xml
@@ -237,13 +237,13 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -339,13 +339,13 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -290,14 +290,14 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
-      <scope>test</scope>
+      <artifactId>bcpkix-jdk18on</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
-      <scope>test</scope>
+      <artifactId>bcprov-jdk18on</artifactId>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>
@@ -427,6 +427,10 @@
 
             <!-- Needed for configuring the Identity SDK by providing an IdentityConfiguration bean -->
             <dependency>io.camunda:identity-spring-boot-autoconfigure</dependency>
+
+            <!-- Used to parse PKCS1 certificates -->
+            <dependency>org.bouncycastle:bcprov-jdk18on</dependency>
+            <dependency>org.bouncycastle:bcpkix-jdk18on</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -291,13 +291,13 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
     <version.agrona>1.20.0</version.agrona>
     <version.assertj>3.24.2</version.assertj>
     <version.awaitility>4.2.0</version.awaitility>
-    <version.bouncycastle>1.70</version.bouncycastle>
+    <version.bouncycastle>1.77</version.bouncycastle>
     <version.camunda>7.20.0</version.camunda>
     <version.checkstyle>10.12.7</version.checkstyle>
     <version.commons-lang>3.14.0</version.commons-lang>
@@ -1025,16 +1025,14 @@
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
+        <artifactId>bcpkix-jdk18on</artifactId>
         <version>${version.bouncycastle}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
+        <artifactId>bcprov-jdk18on</artifactId>
         <version>${version.bouncycastle}</version>
-        <scope>test</scope>
       </dependency>
 
       <dependency>
@@ -1747,8 +1745,8 @@
                   <dep>io.camunda:zeebe-build-tools</dep>
                   <dep>io.camunda:zeebe-gateway-protocol</dep>
                   <dep>org.ow2.asm:asm</dep>
-                  <dep>org.bouncycastle:bcpkix-jdk15on</dep>
-                  <dep>org.bouncycastle:bcprov-jdk15on</dep>
+                  <dep>org.bouncycastle:bcpkix-jdk18on</dep>
+                  <dep>org.bouncycastle:bcprov-jdk18on</dep>
                   <dep>org.junit.jupiter:junit-jupiter-engine</dep>
                   <dep>org.junit.vintage:junit-vintage-engine</dep>
                   <dep>com.tngtech.archunit:archunit-junit5-engine</dep>

--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -386,12 +386,12 @@
 
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
@@ -23,9 +23,7 @@ import java.security.cert.CertificateException;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemWriter;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.testcontainers.utility.DockerImageName;
 import org.testcontainers.utility.MountableFile;
 
 /**

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.security;
+
+import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
+import io.camunda.zeebe.test.util.asserts.SslAssert;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.netty.handler.ssl.util.SelfSignedCertificate;
+import io.zeebe.containers.ZeebeContainer;
+import io.zeebe.containers.ZeebePort;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.nio.file.Path;
+import java.security.PrivateKey;
+import java.security.cert.CertificateException;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.util.io.pem.PemObject;
+import org.bouncycastle.util.io.pem.PemWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
+
+/**
+ * The following test uses containers, specifically because Netty's PKCS1 support relies on
+ * BouncyCastle being available on the classpath. Since it was already available in this module, the
+ * tests were passing without problem, but as the dependency was only test scoped, it would fail in
+ * production.
+ *
+ * <p>So we use containers to test the actual production classpath as well.
+ */
+final class Pkcs1SupportTest {
+  @RegressionTest("https://github.com/camunda/zeebe/issues/15977")
+  void shouldSupportPkcs1Key(final @TempDir Path tmpDir) throws IOException, CertificateException {
+    // given
+    final var certificate = new SelfSignedCertificate();
+    final var pkcs1Key = convertToPkcs1(certificate.key(), tmpDir.resolve("private.key").toFile());
+    final var containerCertPath = "/usr/local/zeebe/cert.crt";
+    final var containerKeyPath = "/usr/local/zeebe/pkcs1.key";
+    final var zeebe =
+        new ZeebeContainer(ZeebeTestContainerDefaults.defaultTestImage())
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(certificate.certificate().toPath(), 511),
+                containerCertPath)
+            .withCopyFileToContainer(
+                MountableFile.forHostPath(pkcs1Key.toPath(), 511), containerKeyPath)
+            .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_ENABLED", "true")
+            .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH", containerCertPath)
+            .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH", containerKeyPath)
+            .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_ENABLED", "true")
+            .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_CERTIFICATECHAINPATH", containerCertPath)
+            .withEnv("ZEEBE_BROKER_GATEWAY_SECURITY_PRIVATEKEYPATH", containerKeyPath)
+            .withoutTopologyCheck(); // avoid the missing TLS config by the client
+
+    // when
+    try (zeebe) {
+      zeebe.start();
+
+      // then
+      SslAssert.assertThat(
+              new InetSocketAddress(
+                  zeebe.getExternalHost(), zeebe.getMappedPort(ZeebePort.INTERNAL.getPort())))
+          .isSecuredBy(certificate);
+      SslAssert.assertThat(
+              new InetSocketAddress(
+                  zeebe.getExternalHost(), zeebe.getMappedPort(ZeebePort.COMMAND.getPort())))
+          .isSecuredBy(certificate);
+      SslAssert.assertThat(
+              new InetSocketAddress(
+                  zeebe.getExternalHost(), zeebe.getMappedPort(ZeebePort.GATEWAY.getPort())))
+          .isSecuredBy(certificate);
+    }
+  }
+
+  private File convertToPkcs1(final PrivateKey key, final File dest) throws IOException {
+    final var encoded = key.getEncoded();
+    final var pkcs1Key = PrivateKeyInfo.getInstance(encoded).parsePrivateKey().toASN1Primitive();
+    final var pkcs1Encoded = pkcs1Key.getEncoded();
+    final var pemObject = new PemObject("RSA PRIVATE KEY", pkcs1Encoded);
+    final var pemWriter = new PemWriter(new FileWriter(dest));
+
+    pemWriter.writeObject(pemObject);
+    pemWriter.close();
+
+    return dest;
+  }
+}


### PR DESCRIPTION
# Description
Backport of #15978 to `stable/8.4`.

relates to #15977
original author: @npepinpe