### PR TITLE
refactor(topology): reduce log level when applying operation failed

### DIFF
--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -256,7 +256,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
   private void logAndScheduleRetry(final TopologyChangeOperation operation, final Throwable error) {
     shouldRetry = true;
     final Duration delay = backoffRetry.nextDelay();
-    LOG.error(
+    LOG.warn(
         "Failed to apply topology change operation {}. Will be retried in {}.",
         operation,
         delay,


### PR DESCRIPTION
## Description

The failed operation will be retried always. So there is no need to log it as error. 

I also thought about conditionally logging it as WARN or DEBUG based on the error. But leave it as warning log. If we find it is too noisy, we can conditionally log it as debug or warning based on the error messages.

## Related issues

closes #15900 

