### PR TITLE
Migrate native user task entity

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/Loggers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/Loggers.java
@@ -17,6 +17,9 @@ public final class Loggers {
   public static final Logger PROCESS_PROCESSOR_LOGGER =
       LoggerFactory.getLogger("io.camunda.zeebe.broker.process");
 
+  public static final Logger ENGINE_PROCESSING_LOGGER =
+      LoggerFactory.getLogger("io.camunda.zeebe.engine.processing");
+
   public static Logger getExporterLogger(final String exporterId) {
     final String loggerName = String.format("io.camunda.zeebe.broker.exporter.%s", exporterId);
     return LoggerFactory.getLogger(loggerName);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -159,7 +159,6 @@ public class ProcessInstanceMigrationMigrateProcessor
     final long processInstanceKey = elementInstanceRecord.getProcessInstanceKey();
 
     requireSupportedElementType(elementInstanceRecord, processInstanceKey);
-    requireNonNativeUserTask(elementInstance, processInstanceKey);
 
     final String targetElementId =
         sourceElementIdToTargetElementId.get(elementInstanceRecord.getElementId());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -206,7 +206,8 @@ public class ProcessInstanceMigrationMigrateProcessor
                 .setProcessDefinitionKey(targetProcessDefinition.getKey())
                 .setProcessDefinitionVersion(targetProcessDefinition.getVersion())
                 .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
-                .setElementId(targetElementId));
+                .setElementId(targetElementId)
+                .setVariables(NIL_VALUE));
       }
     }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
@@ -262,29 +262,6 @@ public final class ProcessInstanceMigrationPreconditionChecker {
   }
 
   /**
-   * Checks whether the given element instance is a native user task. Throws an exception if the
-   * element instance is a native user task.
-   *
-   * @param elementInstance element instance to do the check
-   * @param processInstanceKey process instance key to be logged
-   */
-  public static void requireNonNativeUserTask(
-      final ElementInstance elementInstance, final long processInstanceKey) {
-    final boolean isNativeUserTask = elementInstance.getUserTaskKey() > 0;
-    if (isNativeUserTask) {
-      final ProcessInstanceRecord elementInstanceRecord = elementInstance.getValue();
-      final String reason =
-          String.format(
-              ERROR_UNSUPPORTED_ELEMENT_TYPE,
-              processInstanceKey,
-              elementInstanceRecord.getElementId(),
-              elementInstanceRecord.getBpmnElementType());
-      throw new ProcessInstanceMigrationPreconditionFailedException(
-          reason, RejectionType.INVALID_STATE);
-    }
-  }
-
-  /**
    * Checks whether the given element instance is of a supported type. Throws an exception if the
    * element instance is of an unsupported type.
    *

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -317,6 +317,7 @@ public final class EventAppliers implements EventApplier {
     register(UserTaskIntent.ASSIGNED, new UserTaskAssignedApplier(state));
     register(UserTaskIntent.UPDATING, new UserTaskUpdatingApplier(state));
     register(UserTaskIntent.UPDATED, new UserTaskUpdatedApplier(state));
+    register(UserTaskIntent.MIGRATED, new UserTaskMigratedApplier(state));
   }
 
   private void registerCompensationSubscriptionApplier(

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskMigratedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskMigratedApplier.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+
+public final class UserTaskMigratedApplier
+    implements TypedEventApplier<UserTaskIntent, UserTaskRecord> {
+
+  private final MutableUserTaskState userTaskState;
+
+  public UserTaskMigratedApplier(final MutableProcessingState processingState) {
+    userTaskState = processingState.getUserTaskState();
+  }
+
+  @Override
+  public void applyState(final long key, final UserTaskRecord value) {
+    final UserTaskRecord task = userTaskState.getUserTask(key);
+    task.setProcessDefinitionKey(value.getProcessDefinitionKey())
+        .setProcessDefinitionVersion(value.getProcessDefinitionVersion())
+        .setBpmnProcessId(value.getBpmnProcessId())
+        .setElementId(value.getElementId());
+    userTaskState.update(task);
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceUnsupportedElementsTest.java
@@ -35,60 +35,6 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Test
-  public void shouldRejectMigrationForActiveNativeUserTask() {
-    // given
-    // method reference doesn't help readability in this builder
-    @SuppressWarnings("Convert2MethodRef")
-    final var deployment =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess(SOURCE_PROCESS)
-                    .startEvent()
-                    .userTask("A", u -> u.zeebeUserTask())
-                    .endEvent()
-                    .done())
-            .withXmlResource(
-                Bpmn.createExecutableProcess(TARGET_PROCESS)
-                    .startEvent()
-                    .userTask("A", u -> u.zeebeUserTask())
-                    .userTask("B", u -> u.zeebeUserTask())
-                    .endEvent()
-                    .done())
-            .deploy();
-    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
-
-    final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
-
-    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("A")
-        .await();
-
-    // when
-    final var rejection =
-        ENGINE
-            .processInstance()
-            .withInstanceKey(processInstanceKey)
-            .migration()
-            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-            .addMappingInstruction("A", "A")
-            .expectRejection()
-            .migrate();
-
-    // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
-    Assertions.assertThat(rejection.getRejectionReason())
-        .contains(
-            String.format(
-                """
-                Expected to migrate process instance '%s' but active element with id '%s' \
-                has an unsupported type. The migration of a %s is not supported""",
-                processInstanceKey, "A", "USER_TASK"));
-  }
-
-  @Test
   public void shouldRejectMigrationForActiveSubProcess() {
     // given
     final var deployment =

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/UserTaskIntent.java
@@ -34,7 +34,9 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
 
   UPDATE(11),
   UPDATING(12),
-  UPDATED(13);
+  UPDATED(13),
+
+  MIGRATED(14);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -82,6 +84,8 @@ public enum UserTaskIntent implements ProcessInstanceRelatedIntent {
         return UPDATING;
       case 13:
         return UPDATED;
+      case 14:
+        return MIGRATED;
       default:
         return UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Introduces a new `UserTaskIntent` `MIGRATED` that is appended when migrating the native user task entity as part of Process Instance Migration.

The following attributes of the user task can change on migration:
- `bpmnProcessId`: the BPMN ID of the target process definition
- `processDefinitionVersion`: the version of the target process definition
- `processDefinitionKey`: the key of the target process definition
- elementId: changes to the mapped element ID of the associated user task (note that the mapping may define the sourceElementId and the targetElementId as equivalent, in which case it stays the same)

Tests have been added to showcase this behavior.

Note that the `variables` attribute is unset for the `MIGRATED` event to avoid exceeding the max message size.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15963 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] ! [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
