### PR TITLE
fix(docker): Disable provenance for docker-push-action

### DIFF
--- a/.github/actions/build-docker/action.yml
+++ b/.github/actions/build-docker/action.yml
@@ -85,6 +85,7 @@ runs:
         cache-to: type=gha,mode=max,ignore-error=true
         no-cache-filters: build,distball,dist
         platforms: ${{ inputs.platforms }}
+        provenance: false
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -115,6 +115,7 @@ jobs:
           cache-from: type=gha,ignore-error=true
           cache-to: type=gha,mode=max,ignore-error=true
           build-args: DIST=build
+          provenance: false
           target: app
   build-benchmark-images:
     name: Build Starter and Worker


### PR DESCRIPTION
## Description

This fixes the same [problem](https://github.com/camunda/operate/pull/5669) that Operate had as some point, when Docker images produced by the release process have a manifest of type `application/vnd.oci.image.manifest.v1+json` (OCI) instead of `application/vnd.docker.distribution.manifest.list.v2+json`

How to check the manifest type: `docker manifest inspect camunda/zeebe:<tag> | jq '.mediaType'`
- for 8.4.0: `application/vnd.oci.image.index.v1+json` (problematic)
- for 8.3.5: `application/vnd.docker.distribution.manifest.list.v2+json` (good)

The OCI manifest is not compatible with some old registries of our customers, and they customers cannot run Zeebe 8.4.0  due to this.

Zeebe images are produced by the `docker/build-push-action` action. That action relies on the default `docker buildx` behavior, which in current version shipped with GitHub Actions runners, [adds provenance](https://github.com/docker/build-push-action/releases/tag/v4.2.1) by default (and that leads to using the OCI-type of manifests)

This PR also aligns the Zeebe image with the rest of C8 Docker images.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
