### PR TITLE
Remove trailing slashes

### DIFF
--- a/.github/workflows/medic-benchmarks.yml
+++ b/.github/workflows/medic-benchmarks.yml
@@ -83,8 +83,8 @@ jobs:
         --set camunda-platform.operate.enabled=true
         --set camunda-platform.operate.image.repository=gcr.io/zeebe-io/operate
         --set camunda-platform.operate.image.tag=${{ needs.benchmark-data.outputs.operate }}
-        --set camunda-platform.elasticsearch.master.persistence.size=128Gi \
-        --set camunda-platform.zeebe.retention.minimumAge=1d \
+        --set camunda-platform.elasticsearch.master.persistence.size=128Gi
+        --set camunda-platform.zeebe.retention.minimumAge=1d
   setup-latency-benchmark:
     name: Latency Benchmark
     uses: ./.github/workflows/benchmark.yml


### PR DESCRIPTION
## Description

Slashes have been added by mistake when changing the settings for the mixed benchmarks


Mixed benchmarks were successfully set up with the same parameters, and just removing the slashes:

```
 helm upgrade --install medic-y-2024-cw-04-0778ec7-benchmark-mixed zeebe-benchmark/zeebe-benchmark --namespace medic-y-2024-cw-04-0778ec7-benchmark-mixed --create-namespace --reuse-values --set global.image.tag=medic-y-2024-cw-04-0778ec7-benchmark-mixed-0778ec7 --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe --set camunda-platform.zeebe.image.tag=medic-y-2024-cw-04-0778ec7-benchmark-mixed-0778ec7 --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe --set camunda-platform.zeebe-gateway.image.tag=medic-y-2024-cw-04-0778ec7-benchmark-mixed-0778ec7   --set starter.rate=5 --set worker.replicas=1 --set timer.replicas=1 --set timer.rate=5 --set publisher.replicas=1 --set publisher.rate=5 --set camunda-platform.operate.enabled=true --set camunda-platform.operate.image.repository=gcr.io/zeebe-io/operate --set camunda-platform.operate.image.tag=operate-y-2024-cw-04 --set camunda-platform.elasticsearch.master.persistence.size=128Gi --set camunda-platform.zeebe.retention.minimumAge=1d
Release "medic-y-2024-cw-04-0778ec7-benchmark-mixed" does not exist. Installing it now.
W0124 15:48:43.097477  172753 warnings.go:70] spec.template.spec.containers[0].env[16].name: duplicate name "ZEEBE_LOG_LEVEL"
W0124 15:48:43.155198  172753 warnings.go:70] spec.template.spec.containers[0].env[25].name: duplicate name "K8S_NAMESPACE"
W0124 15:48:43.155214  172753 warnings.go:70] spec.template.spec.containers[0].env[26].name: duplicate name "K8S_NAME"
W0124 15:48:43.155219  172753 warnings.go:70] spec.template.spec.containers[0].env[31].name: duplicate name "ZEEBE_LOG_LEVEL"
NAME: medic-y-2024-cw-04-0778ec7-benchmark-mixed
LAST DEPLOYED: Wed Jan 24 15:48:40 2024
NAMESPACE: medic-y-2024-cw-04-0778ec7-benchmark-mixed
STATUS: deployed
REVISION: 1
NOTES:
# Zeebe Benchmark

Installed Zeebe cluster with:

 * 3 Brokers
 * 2 Gateways

The benchmark is running with:

 * Starter replicas=1
 * Worker replicas=1
 * Publisher replicas=1
 * Timer replicas=1

```