### PR TITLE
Exporter: expose partitionId on Context and LastExportedRecordPosition on Controller

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -20,12 +20,15 @@ public final class ExporterContext implements Context {
 
   private final Logger logger;
   private final Configuration configuration;
+  private final int partitionId;
 
   private RecordFilter filter = DEFAULT_FILTER;
 
-  public ExporterContext(final Logger logger, final Configuration configuration) {
+  public ExporterContext(
+      final Logger logger, final Configuration configuration, final int partitionId) {
     this.logger = logger;
     this.configuration = configuration;
+    this.partitionId = partitionId;
   }
 
   @Override
@@ -36,6 +39,11 @@ public final class ExporterContext implements Context {
   @Override
   public Configuration getConfiguration() {
     return configuration;
+  }
+
+  @Override
+  public int getPartitionId() {
+    return partitionId;
   }
 
   public RecordFilter getFilter() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -88,7 +88,7 @@ public final class ExporterRepository {
   private void validate(final ExporterDescriptor descriptor) throws ExporterLoadException {
     try {
       final Exporter instance = descriptor.newInstance();
-      final ExporterContext context = new ExporterContext(LOG, descriptor.getConfiguration());
+      final ExporterContext context = new ExporterContext(LOG, descriptor.getConfiguration(), 0);
 
       ThreadContextUtil.runCheckedWithClassLoader(
           () -> instance.configure(context), instance.getClass().getClassLoader());

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -21,6 +21,7 @@ import org.slf4j.Logger;
 
 public final class ExporterRepository {
   private static final Logger LOG = Loggers.EXPORTER_LOGGER;
+  private static final int NULL_PARTITION_ID = Integer.MIN_VALUE;
   private final ExternalJarRepository jarRepository;
   private final Map<String, ExporterDescriptor> exporters;
 
@@ -88,7 +89,8 @@ public final class ExporterRepository {
   private void validate(final ExporterDescriptor descriptor) throws ExporterLoadException {
     try {
       final Exporter instance = descriptor.newInstance();
-      final ExporterContext context = new ExporterContext(LOG, descriptor.getConfiguration(), 0);
+      final ExporterContext context =
+          new ExporterContext(LOG, descriptor.getConfiguration(), NULL_PARTITION_ID);
 
       ThreadContextUtil.runCheckedWithClassLoader(
           () -> instance.configure(context), instance.getClass().getClassLoader());

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -41,10 +41,12 @@ final class ExporterContainer implements Controller {
   private ExporterMetrics metrics;
   private ActorControl actor;
 
-  ExporterContainer(final ExporterDescriptor descriptor) {
+  ExporterContainer(final ExporterDescriptor descriptor, final int partitionId) {
     context =
         new ExporterContext(
-            Loggers.getExporterLogger(descriptor.getId()), descriptor.getConfiguration());
+            Loggers.getExporterLogger(descriptor.getId()),
+            descriptor.getConfiguration(),
+            partitionId);
 
     exporter = descriptor.newInstance();
   }
@@ -129,6 +131,11 @@ final class ExporterContainer implements Controller {
   @Override
   public void updateLastExportedRecordPosition(final long position, final byte[] metadata) {
     actor.run(() -> updateExporterState(position, metadata));
+  }
+
+  @Override
+  public long getLastExportedRecordPosition() {
+    return getPosition();
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -86,11 +86,13 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   public ExporterDirector(final ExporterDirectorContext context, final boolean shouldPauseOnStart) {
     name = context.getName();
-    containers =
-        context.getDescriptors().stream().map(ExporterContainer::new).collect(Collectors.toList());
 
     logStream = Objects.requireNonNull(context.getLogStream());
     partitionId = logStream.getPartitionId();
+    containers =
+        context.getDescriptors().stream()
+            .map(descriptor -> new ExporterContainer(descriptor, partitionId))
+            .collect(Collectors.toList());
     metrics = new ExporterMetrics(partitionId);
     recordExporter = new RecordExporter(metrics, containers, partitionId);
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -63,8 +63,9 @@ public final class ExporterContainerRuntime implements CloseableSilently {
     return repository.load("external", exporterCfg);
   }
 
-  public ExporterContainer newContainer(final ExporterDescriptor descriptor) {
-    final var container = new ExporterContainer(descriptor);
+  public ExporterContainer newContainer(
+      final ExporterDescriptor descriptor, final int partitionId) {
+    final var container = new ExporterContainer(descriptor, partitionId);
     container.initContainer(actor.getActorControl(), metrics, state);
 
     return container;

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode;
 final class ExporterContainerTest {
 
   private static final String EXPORTER_ID = "fakeExporter";
+  private static final int PARTITION_ID = 123;
 
   private ExporterContainerRuntime runtime;
   private FakeExporter exporter;
@@ -44,7 +45,7 @@ final class ExporterContainerTest {
 
     final var descriptor =
         runtime.getRepository().load(EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
-    exporterContainer = runtime.newContainer(descriptor);
+    exporterContainer = runtime.newContainer(descriptor, PARTITION_ID);
     exporter = (FakeExporter) exporterContainer.getExporter();
   }
 
@@ -60,6 +61,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getContext().getLogger()).isNotNull();
     assertThat(exporter.getContext().getConfiguration()).isNotNull();
     assertThat(exporter.getContext().getConfiguration().getId()).isEqualTo(EXPORTER_ID);
+    assertThat(exporter.getContext().getPartitionId()).isEqualTo(PARTITION_ID);
     assertThat(exporter.getContext().getConfiguration().getArguments())
         .isEqualTo(Map.of("key", "value"));
   }

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -64,7 +64,7 @@ final class ExternalExporterContainerTest {
     final var exporterClass = createUnloadedExporter();
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
-    final var container = runtime.newContainer(descriptor);
+    final var container = runtime.newContainer(descriptor, 0);
 
     // when
     container.configureExporter();
@@ -86,7 +86,7 @@ final class ExternalExporterContainerTest {
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
-    final var container = runtime.newContainer(descriptor);
+    final var container = runtime.newContainer(descriptor, 0);
 
     // when
     container.openExporter();
@@ -106,7 +106,7 @@ final class ExternalExporterContainerTest {
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
-    final var container = runtime.newContainer(descriptor);
+    final var container = runtime.newContainer(descriptor, 0);
 
     // when
     final var record = mock(TypedRecord.class);
@@ -129,7 +129,7 @@ final class ExternalExporterContainerTest {
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
-    final var container = new ExporterContainer(descriptor);
+    final var container = new ExporterContainer(descriptor, 0);
 
     // when
     container.close();

--- a/exporter-api/revapi.json
+++ b/exporter-api/revapi.json
@@ -20,6 +20,11 @@
           "justification": "The controller is used by the exporters. Extending the controller interface is not a breaking change.",
           "code": "java.method.addedToInterface",
           "classQualifiedName": "io.camunda.zeebe.exporter.api.context.Controller"
+        },
+        {
+          "justification": "The Context is used by the exporters. Extending the controller interface is not a breaking change.",
+          "code": "java.method.addedToInterface",
+          "classQualifiedName": "io.camunda.zeebe.exporter.api.context.Context"
         }
       ]
     }

--- a/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -33,6 +33,11 @@ public interface Context {
   Configuration getConfiguration();
 
   /**
+   * @return the partition id for this exporter
+   */
+  int getPartitionId();
+
+  /**
    * Apply the given filter to limit the records which are exported.
    *
    * @param filter the filter to apply.

--- a/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -33,7 +33,12 @@ public interface Context {
   Configuration getConfiguration();
 
   /**
-   * @return the partition id for this exporter
+   * Gets the partition id of the exporter context. During the loading phase, while the
+   * configuration for each exporter is being validated, this method will return a null value since
+   * on instantiating the Exporter Context, we pass a null partition id, which will get replaced by
+   * a valid one at runtime.
+   *
+   * <p>* @return the partition id for this exporter.
    */
   int getPartitionId();
 

--- a/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
+++ b/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
@@ -39,6 +39,9 @@ public interface Controller {
    */
   void updateLastExportedRecordPosition(long position, byte[] metadata);
 
+  /** Gets the last acknowledged exported record position. */
+  long getLastExportedRecordPosition();
+
   /**
    * Schedules a cancellable {@param task} to be ran after {@param delay} has expired.
    *

--- a/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
+++ b/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
@@ -36,14 +36,19 @@ public final class ExporterTestContext implements Context {
     return configuration;
   }
 
-  public ExporterTestContext setConfiguration(final Configuration configuration) {
-    this.configuration = Objects.requireNonNull(configuration, "must specify a configuration");
-    return this;
+  @Override
+  public int getPartitionId() {
+    return 0;
   }
 
   @Override
   public void setFilter(final RecordFilter filter) {
     recordFilter = filter;
+  }
+
+  public ExporterTestContext setConfiguration(final Configuration configuration) {
+    this.configuration = Objects.requireNonNull(configuration, "must specify a configuration");
+    return this;
   }
 
   public RecordFilter getRecordFilter() {

--- a/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
+++ b/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
@@ -58,6 +58,11 @@ public final class ExporterTestController implements Controller {
   }
 
   @Override
+  public long getLastExportedRecordPosition() {
+    return getPosition();
+  }
+
+  @Override
   public synchronized ScheduledTask scheduleCancellableTask(
       final Duration delay, final Runnable task) {
     final var scheduledTask =

--- a/exporter-test/src/test/java/io/camunda/zeebe/exporter/test/ExporterTestControllerTest.java
+++ b/exporter-test/src/test/java/io/camunda/zeebe/exporter/test/ExporterTestControllerTest.java
@@ -30,6 +30,7 @@ final class ExporterTestControllerTest {
 
     // then
     assertThat(controller.getPosition()).isEqualTo(1);
+    assertThat(controller.getLastExportedRecordPosition()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
## Description

Expose partitionId on Context and LastExportedRecordPosition on Controller.

## Related issues

<!-- Which issues are closed by this PR or are related -->

Relates to #15418

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
