### PR TITLE
[Backport stable/8.4] fix(engine): double quotes in variables should be correctly handled

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/VariableMappingTransformer.java
@@ -154,7 +154,10 @@ public final class VariableMappingTransformer {
         final String expression;
 
         if (sourceExpression instanceof StaticExpression) {
-          expression = String.format("\"%s\"", sourceExpression.getExpression());
+          // due to a regression (https://github.com/camunda/zeebe/issues/16043) all the double
+          // quotes inside the static expression must be escaped
+          expression =
+              String.format("\"%s\"", sourceExpression.getExpression().replaceAll("\"", "\\\\\""));
         } else {
           expression = sourceExpression.getExpression();
         }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -106,6 +106,7 @@ public final class VariableMappingTransformerTest {
                 mapping("Hello\tWorld", "tab"),
                 mapping("Hello\nWorld", "newline"),
                 mapping("Hello\rWorld", "carriageReturn"),
+                mapping("\"My Name is \"Zeebe\", nice to meet you\"", "doubleQoutes"),
                 mapping("My Name is &#34;Zeebe&#34;, nice to meet you", "encodedQuotes")),
             expressionLanguage);
 
@@ -115,7 +116,7 @@ public final class VariableMappingTransformerTest {
         .isTrue();
     assertThat(expression.getExpression())
         .isEqualTo(
-            "{tab:\"Hello\tWorld\",newline:\"Hello\nWorld\",carriageReturn:\"Hello\rWorld\",encodedQuotes:\"My Name is &#34;Zeebe&#34;, nice to meet you\"}");
+            "{tab:\"Hello\tWorld\",newline:\"Hello\nWorld\",carriageReturn:\"Hello\rWorld\",doubleQoutes:\"\\\"My Name is \\\"Zeebe\\\", nice to meet you\\\"\",encodedQuotes:\"My Name is &#34;Zeebe&#34;, nice to meet you\"}");
   }
 
   private static ZeebeMapping mapping(final String source, final String target) {

--- a/engine/src/test/resources/regression-variable-mapping.bpmn
+++ b/engine/src/test/resources/regression-variable-mapping.bpmn
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0" camunda:diagramRelationId="8c789d33-bba0-4505-a6f3-15904332cc2d">
+  <bpmn:process id="regressionProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_036oth8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_036oth8" sourceRef="StartEvent_1" targetRef="send-email" />
+    <bpmn:serviceTask id="send-email" name="Send mail" zeebe:modelerTemplate="io.camunda.connectors.SendGrid.v2" zeebe:modelerTemplateVersion="2" zeebe:modelerTemplateIcon="data:image/svg+xml;utf8,%3Csvg%20width%3D%2216%22%20height%3D%2216%22%20viewBox%3D%220%200%2016%2016%22%20fill%3D%22none%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%0A%3Cpath%20d%3D%22M0.285706%205.40847H5.43837V10.5611H0.285706V5.40847Z%22%20fill%3D%22white%22%2F%3E%0A%3Cpath%20d%3D%22M0.285706%205.40847H5.43837V10.5611H0.285706V5.40847Z%22%20fill%3D%22%2399E1F4%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V15.6844H5.43837V10.5611Z%22%20fill%3D%22white%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V15.6844H5.43837V10.5611Z%22%20fill%3D%22%2399E1F4%22%2F%3E%0A%3Cpath%20d%3D%22M0.285706%2015.6846L5.43837%2015.6844V15.7143H0.285706V15.6846ZM0.285706%2010.5619H5.43837V15.6844L0.285706%2015.6846V10.5619Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%200.285706H10.5611V5.40847H5.43837V0.285706ZM10.5616%205.43837H15.7143V10.5611H10.5616V5.43837Z%22%20fill%3D%22%2300B3E3%22%2F%3E%0A%3Cpath%20d%3D%22M5.43837%2010.5611L10.5611%2010.5616V5.40847H5.43837V10.5611Z%22%20fill%3D%22%23009DD9%22%2F%3E%0A%3Cpath%20d%3D%22M10.5611%200.285706H15.7143V5.40847H10.5611V0.285706Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3Cpath%20d%3D%22M10.5611%205.40847H15.7143V5.43837H10.5616L10.5611%205.40847Z%22%20fill%3D%22%231A82E2%22%2F%3E%0A%3C%2Fsvg%3E">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="io.camunda:sendgrid:1" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=key" target="apiKey" />
+          <zeebe:input source="Me" target="from.name" />
+          <zeebe:input source="me@camunda.com" target="from.email" />
+          <zeebe:input source="&#34;You&#34;" target="to.name" />
+          <zeebe:input source="you@camunda.com" target="to.email" />
+          <zeebe:input source="mail" target="unMappedFieldNotUseInModel.mailType" />
+          <zeebe:input source="Hello" target="content.subject" />
+          <zeebe:input source="text/plain" target="content.type" />
+          <zeebe:input source="This &#34;is a&#34; test." target="content.value" />
+        </zeebe:ioMapping>
+        <zeebe:taskHeaders />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_036oth8</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wxg9fx</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1pddplp">
+      <bpmn:incoming>Flow_1wxg9fx</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1wxg9fx" sourceRef="send-email" targetRef="Event_1pddplp" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="regressionProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="150" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1er7c60_di" bpmnElement="send-email">
+        <dc:Bounds x="240" y="78" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1pddplp_di" bpmnElement="Event_1pddplp">
+        <dc:Bounds x="402" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_036oth8_di" bpmnElement="Flow_036oth8">
+        <di:waypoint x="186" y="118" />
+        <di:waypoint x="240" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wxg9fx_di" bpmnElement="Flow_1wxg9fx">
+        <di:waypoint x="340" y="118" />
+        <di:waypoint x="402" y="118" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
# Description
Backport of #16065 to `stable/8.4`.

relates to #16043
original author: @nicpuppa