### PR TITLE
Provide default values in DMN deployment records

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
@@ -44,6 +44,9 @@ public final class DmnDeploymentTest {
       "/dmn/decision-table-with-invalid-expression.dmn";
   private static final String DMN_WITH_TWO_DECISIONS = "/dmn/drg-force-user.dmn";
 
+  private static final String DMN_MISSING_DECISION_NAME =
+      "/dmn/decision-table-with-missing-decision-name.dmn";
+
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
   @Rule
@@ -116,6 +119,25 @@ public final class DmnDeploymentTest {
 
     assertThat(deploymentEvent.getRejectionReason())
         .contains("FEEL unary-tests: failed to parse expression");
+  }
+
+  @Test
+  public void shouldRejectDmnResourceWithMissingDecisionName() {
+    // when
+    final var deploymentEvent =
+        engine
+            .deployment()
+            .withXmlClasspathResource(DMN_MISSING_DECISION_NAME)
+            .expectRejection()
+            .deploy();
+
+    // then
+    Assertions.assertThat(deploymentEvent)
+        .hasIntent(DeploymentIntent.CREATE)
+        .hasRecordType(RecordType.COMMAND_REJECTION)
+        .hasRejectionType(RejectionType.INVALID_ARGUMENT);
+
+    assertThat(deploymentEvent.getRejectionReason()).contains("because \"value\" is null");
   }
 
   @Test

--- a/engine/src/test/resources/dmn/decision-table-with-missing-decision-name.dmn
+++ b/engine/src/test/resources/dmn/decision-table-with-missing-decision-name.dmn
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" id="_6f87b3aa-d613-4c41-93ad-832f021c8318" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="_51711_44808585-3491-42a8-87ea-3c4fcda46eff" name="">
+    <decisionTable id="_07c6fdc3-7bdf-459a-a016-2ae12e474bd2">
+      <input id="_f00d0717-d08a-4918-ad51-568788e92038" label="Percent Responsible (Loan Roles)">
+        <inputExpression id="_0b922041-84c3-47bf-b94c-1dd423c394ae" typeRef="number">
+          <text>proposedLoan.loanRoles.percentResponsible</text>
+        </inputExpression>
+      </input>
+      <output id="_b304292d-98e5-4dde-8fbd-0de1981c97ea" label="" name="out" typeRef="string">
+        <outputValues id="UnaryTests_1yu7moy">
+          <text>"Approve","Decline","Review"</text>
+        </outputValues>
+      </output>
+      <rule id="DecisionRule_1j6jzzn">
+        <inputEntry id="UnaryTests_105fhm8">
+          <text></text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_1ucr6zl">
+          <text>"Approve"</text>
+        </outputEntry>
+      </rule>
+    </decisionTable>
+  </decision>
+</definitions>

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -21,15 +21,15 @@ import org.agrona.DirectBuffer;
 
 public final class DecisionRecord extends UnifiedRecordValue implements DecisionRecordValue {
 
-  private final StringProperty decisionIdProp = new StringProperty("decisionId");
-  private final StringProperty decisionNameProp = new StringProperty("decisionName");
-  private final IntegerProperty versionProp = new IntegerProperty("version");
-  private final LongProperty decisionKeyProp = new LongProperty("decisionKey");
+  private final StringProperty decisionIdProp = new StringProperty("decisionId", "");
+  private final StringProperty decisionNameProp = new StringProperty("decisionName", "");
+  private final IntegerProperty versionProp = new IntegerProperty("version", -1);
+  private final LongProperty decisionKeyProp = new LongProperty("decisionKey", -1);
 
   private final StringProperty decisionRequirementsIdProp =
-      new StringProperty("decisionRequirementsId");
+      new StringProperty("decisionRequirementsId", "");
   private final LongProperty decisionRequirementsKeyProp =
-      new LongProperty("decisionRequirementsKey");
+      new LongProperty("decisionRequirementsKey", -1);
 
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
   private final StringProperty tenantIdProp =

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
@@ -20,22 +20,23 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
     implements DecisionRequirementsMetadataValue {
 
   private final StringProperty decisionRequirementsIdProp =
-      new StringProperty("decisionRequirementsId");
+      new StringProperty("decisionRequirementsId", "");
   private final StringProperty decisionRequirementsNameProp =
-      new StringProperty("decisionRequirementsName");
+      new StringProperty("decisionRequirementsName", "");
   private final IntegerProperty decisionRequirementsVersionProp =
-      new IntegerProperty("decisionRequirementsVersion");
+      new IntegerProperty("decisionRequirementsVersion", -1);
   private final LongProperty decisionRequirementsKeyProp =
-      new LongProperty("decisionRequirementsKey");
-  private final StringProperty namespaceProp = new StringProperty("namespace");
+      new LongProperty("decisionRequirementsKey", -1);
+  private final StringProperty namespaceProp = new StringProperty("namespace", "");
 
-  private final StringProperty resourceNameProp = new StringProperty("resourceName");
-  private final BinaryProperty checksumProp = new BinaryProperty("checksum");
+  private final StringProperty resourceNameProp = new StringProperty("resourceName", "");
+  private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
 
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
   private final StringProperty tenantIdProp =

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsRecord.java
@@ -19,23 +19,24 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsRecordValue;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public final class DecisionRequirementsRecord extends UnifiedRecordValue
     implements DecisionRequirementsRecordValue {
 
   private final StringProperty decisionRequirementsIdProp =
-      new StringProperty("decisionRequirementsId");
+      new StringProperty("decisionRequirementsId", "");
   private final StringProperty decisionRequirementsNameProp =
-      new StringProperty("decisionRequirementsName");
+      new StringProperty("decisionRequirementsName", "");
   private final IntegerProperty decisionRequirementsVersionProp =
-      new IntegerProperty("decisionRequirementsVersion");
+      new IntegerProperty("decisionRequirementsVersion", -1);
   private final LongProperty decisionRequirementsKeyProp =
-      new LongProperty("decisionRequirementsKey");
+      new LongProperty("decisionRequirementsKey", -1);
   private final StringProperty namespaceProp = new StringProperty("namespace", "");
 
-  private final StringProperty resourceNameProp = new StringProperty("resourceName");
-  private final BinaryProperty checksumProp = new BinaryProperty("checksum");
-  private final BinaryProperty resourceProp = new BinaryProperty("resource");
+  private final StringProperty resourceNameProp = new StringProperty("resourceName", "");
+  private final BinaryProperty checksumProp = new BinaryProperty("checksum", new UnsafeBuffer());
+  private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 


### PR DESCRIPTION
## Description

DMN resources that pass model validation but fail to deploy due to missing data, e.g. an empty decision name, can lead to unwritable data on the stream. A rejection for the deployment CREATE command can thus not be written due to MsgPack exceptions. This can run the message writer into an infinie loop of trying to write.

Using proper defaults in the DMN deployment records lets the writer successfully write the deployment CREATE command rejection.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16104 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
