### PR TITLE
Allow raft Configuration to be marked as forced

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/serializer/MetaStoreSerializer.java
@@ -52,7 +52,8 @@ public class MetaStoreSerializer {
     configurationEncoder
         .index(configuration.index())
         .term(configuration.term())
-        .timestamp(configuration.time());
+        .timestamp(configuration.time())
+        .force(configuration.force() ? BooleanType.TRUE : BooleanType.FALSE);
 
     final var newMembersEncoder =
         configurationEncoder.newMembersCount(configuration.newMembers().size());
@@ -94,6 +95,7 @@ public class MetaStoreSerializer {
     final long index = configurationDecoder.index();
     final long term = configurationDecoder.term();
     final long timestamp = configurationDecoder.timestamp();
+    final boolean force = BooleanType.TRUE.equals(configurationDecoder.force());
 
     final var newMembersDecoder = configurationDecoder.newMembers();
     final var newMembers = new ArrayList<RaftMember>(newMembersDecoder.count());
@@ -113,7 +115,7 @@ public class MetaStoreSerializer {
       oldMembers.add(new DefaultRaftMember(MemberId.from(memberId), type, updated));
     }
 
-    return new Configuration(index, term, timestamp, newMembers, oldMembers);
+    return new Configuration(index, term, timestamp, newMembers, oldMembers, force);
   }
 
   public void writeTerm(final long term, final MutableDirectBuffer buffer, final int offset) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
@@ -43,20 +43,24 @@ import java.util.stream.Stream;
  * @param time The time at which the configuration was committed.
  * @param newMembers The cluster membership for this configuration.
  * @param oldMembers The cluster membership for the previous configuration.
+ * @param force True indicates, we are skipping joint consensus and force the configuration change
+ *     without a quorum.
  */
 public record Configuration(
     long index,
     long term,
     long time,
     Collection<RaftMember> newMembers,
-    Collection<RaftMember> oldMembers) {
+    Collection<RaftMember> oldMembers,
+    boolean force) {
 
   public Configuration(
       final long index,
       final long term,
       final long time,
       final Collection<RaftMember> newMembers,
-      final Collection<RaftMember> oldMembers) {
+      final Collection<RaftMember> oldMembers,
+      final boolean force) {
     checkArgument(time > 0, "time must be positive");
     checkNotNull(newMembers, "newMembers cannot be null");
     checkNotNull(oldMembers, "oldMembers cannot be null");
@@ -66,6 +70,16 @@ public record Configuration(
     this.time = time;
     this.newMembers = copyMembers(newMembers);
     this.oldMembers = copyMembers(oldMembers);
+    this.force = force;
+  }
+
+  public Configuration(
+      final long index,
+      final long term,
+      final long time,
+      final Collection<RaftMember> newMembers,
+      final Collection<RaftMember> oldMembers) {
+    this(index, term, time, newMembers, oldMembers, false);
   }
 
   public Configuration(

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
@@ -71,6 +71,11 @@ public record Configuration(
     this.newMembers = copyMembers(newMembers);
     this.oldMembers = copyMembers(oldMembers);
     this.force = force;
+
+    if (force) {
+      checkArgument(oldMembers.isEmpty(), "oldMembers must be empty when force is true");
+      checkArgument(!newMembers.isEmpty(), "newMembers must not be empty when force is true");
+    }
   }
 
   public Configuration(

--- a/atomix/cluster/src/main/resources/raft-entry-schema.xml
+++ b/atomix/cluster/src/main/resources/raft-entry-schema.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
   xmlns:xi="http://www.w3.org/2001/XInclude"
-  package="io.atomix.raft.storage.serializer" id="8" version="2"
+  package="io.atomix.raft.storage.serializer" id="8" version="3"
   semanticVersion="0.1.0" description="Raft Entry" byteOrder="littleEndian"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://fixprotocol.io/2016/sbe http://fixprotocol.io/2016/sbe/sbe.xsd">
@@ -65,6 +65,7 @@
     <field name="index" id="0" type="uint64"/>
     <field name="term" id="1" type="uint64"/>
     <field name="timestamp" id="2" type="uint64"/>
+    <field name="force" id="5" type="BooleanType" sinceVersion="3"/>
     <group name="newMembers" id="3">
       <field name="type" id="1" type="MemberType"/>
       <field name="updated" id="2" type="int64"/>

--- a/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/storage/system/MetaStoreTest.java
@@ -23,253 +23,268 @@ import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import io.atomix.raft.storage.RaftStorage;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Set;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-public class MetaStoreTest {
-
-  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+class MetaStoreTest {
+  @TempDir Path temporaryFolder;
   private MetaStore metaStore;
   private RaftStorage storage;
 
-  @Before
+  @BeforeEach
   public void setup() throws IOException {
-    storage = RaftStorage.builder().withDirectory(temporaryFolder.newFolder("store")).build();
+    storage = RaftStorage.builder().withDirectory(temporaryFolder.toFile()).build();
     metaStore = new MetaStore(storage);
   }
 
-  @Test
-  public void shouldStoreAndLoadConfiguration() {
-    // given
-    final Configuration config = getConfiguration(1, 2);
-    metaStore.storeConfiguration(config);
-
-    // when
-    final Configuration readConfig = metaStore.loadConfiguration();
-
-    // then
-    assertThat(readConfig.index()).isEqualTo(config.index());
-    assertThat(readConfig.term()).isEqualTo(config.term());
-    assertThat(readConfig.time()).isEqualTo(config.time());
-    assertThat(readConfig.newMembers())
-        .containsExactlyInAnyOrder(config.newMembers().toArray(new RaftMember[0]));
-  }
-
-  private Configuration getConfiguration(final long index, final long term) {
-    return new Configuration(
-        index,
-        term,
-        1234L,
-        new ArrayList<>(
-            Set.of(
-                new DefaultRaftMember(MemberId.from("0"), Type.ACTIVE, Instant.ofEpochMilli(12345)),
-                new DefaultRaftMember(
-                    MemberId.from("2"), Type.PASSIVE, Instant.ofEpochMilli(12346)))));
-  }
-
-  @Test
-  public void shouldStoreAndLoadTerm() {
-    // when
-    metaStore.storeTerm(2L);
-
-    // then
-    assertThat(metaStore.loadTerm()).isEqualTo(2L);
-  }
-
-  @Test
-  public void shouldStoreAndLoadVote() {
-    // when
-    metaStore.storeVote(new MemberId("id"));
-
-    // then
-    assertThat(metaStore.loadVote().id()).isEqualTo("id");
-  }
-
-  @Test
-  public void shouldLoadExistingConfiguration() throws IOException {
-    // given
-    final Configuration config = getConfiguration(1, 2);
-    metaStore.storeConfiguration(config);
-
-    // when
+  @AfterEach
+  public void tearDown() {
     metaStore.close();
-    metaStore = new MetaStore(storage);
-
-    // then
-    final Configuration readConfig = metaStore.loadConfiguration();
-
-    assertThat(readConfig.index()).isEqualTo(config.index());
-    assertThat(readConfig.term()).isEqualTo(config.term());
-    assertThat(readConfig.time()).isEqualTo(config.time());
-    assertThat(readConfig.newMembers())
-        .containsExactlyInAnyOrder(config.newMembers().toArray(new RaftMember[0]));
   }
 
-  @Test
-  public void shouldLoadExistingTerm() throws IOException {
-    // given
-    metaStore.storeTerm(2L);
+  @Nested
+  final class MetadataTest {
 
-    // when
-    metaStore.close();
-    metaStore = new MetaStore(storage);
+    @Test
+    void shouldStoreAndLoadTerm() {
+      // when
+      metaStore.storeTerm(2L);
 
-    // then
-    assertThat(metaStore.loadTerm()).isEqualTo(2L);
+      // then
+      assertThat(metaStore.loadTerm()).isEqualTo(2L);
+    }
+
+    @Test
+    void shouldStoreAndLoadVote() {
+      // when
+      metaStore.storeVote(new MemberId("id"));
+
+      // then
+      assertThat(metaStore.loadVote().id()).isEqualTo("id");
+    }
+
+    @Test
+    void shouldLoadExistingTerm() throws IOException {
+      // given
+      metaStore.storeTerm(2L);
+
+      // when
+      metaStore.close();
+      metaStore = new MetaStore(storage);
+
+      // then
+      assertThat(metaStore.loadTerm()).isEqualTo(2L);
+    }
+
+    @Test
+    void shouldLoadExistingVote() throws IOException {
+      // given
+      metaStore.storeVote(new MemberId("id"));
+
+      // when
+      metaStore.close();
+      metaStore = new MetaStore(storage);
+
+      // then
+      assertThat(metaStore.loadVote().id()).isEqualTo("id");
+    }
+
+    @Test
+    void shouldLoadEmptyMeta() {
+      // when -then
+      assertThat(metaStore.loadVote()).isNull();
+
+      // when - then
+      assertThat(metaStore.loadTerm()).isEqualTo(0);
+    }
+
+    @Test
+    void shouldLoadEmptyVoteWhenTermExists() {
+      // given
+      metaStore.storeTerm(1);
+
+      // when - then
+      assertThat(metaStore.loadVote()).isNull();
+    }
+
+    @Test
+    void shouldLoadLatestTermAndVoteAfterRestart() throws IOException {
+      //  given
+      metaStore.storeTerm(2L);
+      metaStore.storeVote(MemberId.from("0"));
+      metaStore.storeTerm(3L);
+      metaStore.storeVote(MemberId.from("1"));
+
+      // when
+      metaStore.close();
+      metaStore = new MetaStore(storage);
+
+      // then
+      assertThat(metaStore.loadTerm()).isEqualTo(3L);
+      assertThat(metaStore.loadVote().id()).isEqualTo("1");
+    }
+
+    @Test
+    void shouldStoreAndLoadLastFlushedIndex() {
+      // given
+      metaStore.storeLastFlushedIndex(5L);
+
+      // when/then
+      assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(5L);
+    }
+
+    @Test
+    void shouldStoreAndLoadLastFlushedIndexAfterRestart() throws IOException {
+      // given
+      metaStore.storeLastFlushedIndex(5L);
+
+      // when
+      metaStore.close();
+      metaStore = new MetaStore(storage);
+
+      // then
+      assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(5L);
+    }
+
+    @Test
+    void shouldLoadLatestWrittenIndex() throws IOException {
+      // given
+      metaStore.storeLastFlushedIndex(5L);
+
+      // when
+      metaStore.storeLastFlushedIndex(7L);
+
+      // then
+      assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(7L);
+
+      // when
+      metaStore.storeLastFlushedIndex(8L);
+
+      metaStore.close();
+      metaStore = new MetaStore(storage);
+
+      // then
+      assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(8L);
+    }
+
+    @Test
+    void shouldStoreAndLoadAllMetadata() {
+      // when
+      metaStore.storeTerm(1L);
+      metaStore.storeLastFlushedIndex(2L);
+      metaStore.storeVote(MemberId.from("a"));
+
+      // then
+      assertThat(metaStore.loadTerm()).isEqualTo(1L);
+      assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(2L);
+      assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a"));
+    }
   }
 
-  @Test
-  public void shouldLoadExistingVote() throws IOException {
-    // given
-    metaStore.storeVote(new MemberId("id"));
+  @Nested
+  final class ConfigurationTest {
 
-    // when
-    metaStore.close();
-    metaStore = new MetaStore(storage);
+    @Test
+    void shouldLoadEmptyConfig() {
+      // when -then
+      assertThat(metaStore.loadConfiguration()).isNull();
+    }
 
-    // then
-    assertThat(metaStore.loadVote().id()).isEqualTo("id");
-  }
+    @Test
+    void shouldStoreAndLoadConfiguration() {
+      // given
+      final Configuration config = getConfiguration(1, 2);
+      metaStore.storeConfiguration(config);
 
-  @Test
-  public void shouldLoadEmptyMeta() {
-    // when -then
-    assertThat(metaStore.loadVote()).isNull();
+      // when
+      final Configuration readConfig = metaStore.loadConfiguration();
 
-    // when - then
-    assertThat(metaStore.loadTerm()).isEqualTo(0);
-  }
+      // then
+      assertThat(readConfig.index()).isEqualTo(config.index());
+      assertThat(readConfig.term()).isEqualTo(config.term());
+      assertThat(readConfig.time()).isEqualTo(config.time());
+      assertThat(readConfig.newMembers())
+          .containsExactlyInAnyOrder(config.newMembers().toArray(new RaftMember[0]));
+    }
 
-  @Test
-  public void shouldLoadEmptyVoteWhenTermExists() {
-    // given
-    metaStore.storeTerm(1);
+    @Test
+    void shouldLoadExistingConfiguration() throws IOException {
+      // given
+      final Configuration config = getConfiguration(1, 2);
+      metaStore.storeConfiguration(config);
 
-    // when - then
-    assertThat(metaStore.loadVote()).isNull();
-  }
+      // when
+      metaStore.close();
+      metaStore = new MetaStore(storage);
 
-  @Test
-  public void shouldLoadEmptyConfig() {
-    // when -then
-    assertThat(metaStore.loadConfiguration()).isNull();
-  }
+      // then
+      final Configuration readConfig = metaStore.loadConfiguration();
 
-  @Test
-  public void shouldLoadLatestTermAndVoteAfterRestart() throws IOException {
-    //  given
-    metaStore.storeTerm(2L);
-    metaStore.storeVote(MemberId.from("0"));
-    metaStore.storeTerm(3L);
-    metaStore.storeVote(MemberId.from("1"));
+      assertThat(readConfig.index()).isEqualTo(config.index());
+      assertThat(readConfig.term()).isEqualTo(config.term());
+      assertThat(readConfig.time()).isEqualTo(config.time());
+      assertThat(readConfig.newMembers())
+          .containsExactlyInAnyOrder(config.newMembers().toArray(new RaftMember[0]));
+    }
 
-    // when
-    metaStore.close();
-    metaStore = new MetaStore(storage);
+    @Test
+    void shouldLoadLatestConfigurationAfterRestart() throws IOException {
+      // given
+      final Configuration firstConfig = getConfiguration(1, 2);
+      metaStore.storeConfiguration(firstConfig);
+      final Configuration secondConfig = getConfiguration(3, 4);
+      metaStore.storeConfiguration(secondConfig);
 
-    // then
-    assertThat(metaStore.loadTerm()).isEqualTo(3L);
-    assertThat(metaStore.loadVote().id()).isEqualTo("1");
-  }
+      // when
+      metaStore.close();
+      metaStore = new MetaStore(storage);
+      final Configuration readConfig = metaStore.loadConfiguration();
 
-  @Test
-  public void shouldStoreConfigurationMultipleTimes() {
-    // given
-    final Configuration firstConfig = getConfiguration(1, 2);
-    metaStore.storeConfiguration(firstConfig);
-    final Configuration secondConfig = getConfiguration(3, 4);
-    metaStore.storeConfiguration(secondConfig);
+      // then
+      assertThat(readConfig.index()).isEqualTo(secondConfig.index());
+      assertThat(readConfig.term()).isEqualTo(secondConfig.term());
+      assertThat(readConfig.time()).isEqualTo(secondConfig.time());
+      assertThat(readConfig.newMembers())
+          .containsExactlyInAnyOrder(secondConfig.newMembers().toArray(new RaftMember[0]));
+    }
 
-    // when
-    final Configuration readConfig = metaStore.loadConfiguration();
+    @Test
+    void shouldStoreConfigurationMultipleTimes() {
+      // given
+      final Configuration firstConfig = getConfiguration(1, 2);
+      metaStore.storeConfiguration(firstConfig);
+      final Configuration secondConfig = getConfiguration(3, 4);
+      metaStore.storeConfiguration(secondConfig);
 
-    // then
-    assertThat(readConfig.index()).isEqualTo(secondConfig.index());
-    assertThat(readConfig.term()).isEqualTo(secondConfig.term());
-    assertThat(readConfig.time()).isEqualTo(secondConfig.time());
-    assertThat(readConfig.newMembers())
-        .containsExactlyInAnyOrder(secondConfig.newMembers().toArray(new RaftMember[0]));
-  }
+      // when
+      final Configuration readConfig = metaStore.loadConfiguration();
 
-  @Test
-  public void shouldLoadLatestConfigurationAfterRestart() throws IOException {
-    // given
-    final Configuration firstConfig = getConfiguration(1, 2);
-    metaStore.storeConfiguration(firstConfig);
-    final Configuration secondConfig = getConfiguration(3, 4);
-    metaStore.storeConfiguration(secondConfig);
+      // then
+      assertThat(readConfig.index()).isEqualTo(secondConfig.index());
+      assertThat(readConfig.term()).isEqualTo(secondConfig.term());
+      assertThat(readConfig.time()).isEqualTo(secondConfig.time());
+      assertThat(readConfig.newMembers())
+          .containsExactlyInAnyOrder(secondConfig.newMembers().toArray(new RaftMember[0]));
+    }
 
-    // when
-    metaStore.close();
-    metaStore = new MetaStore(storage);
-    final Configuration readConfig = metaStore.loadConfiguration();
-
-    // then
-    assertThat(readConfig.index()).isEqualTo(secondConfig.index());
-    assertThat(readConfig.term()).isEqualTo(secondConfig.term());
-    assertThat(readConfig.time()).isEqualTo(secondConfig.time());
-    assertThat(readConfig.newMembers())
-        .containsExactlyInAnyOrder(secondConfig.newMembers().toArray(new RaftMember[0]));
-  }
-
-  @Test
-  public void shouldStoreAndLoadLastFlushedIndex() {
-    // given
-    metaStore.storeLastFlushedIndex(5L);
-
-    // when/then
-    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(5L);
-  }
-
-  @Test
-  public void shouldStoreAndLoadLastFlushedIndexAfterRestart() throws IOException {
-    // given
-    metaStore.storeLastFlushedIndex(5L);
-
-    // when
-    metaStore.close();
-    metaStore = new MetaStore(storage);
-
-    // then
-    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(5L);
-  }
-
-  @Test
-  public void shouldLoadLatestWrittenIndex() throws IOException {
-    // given
-    metaStore.storeLastFlushedIndex(5L);
-
-    // when
-    metaStore.storeLastFlushedIndex(7L);
-
-    // then
-    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(7L);
-
-    // when
-    metaStore.storeLastFlushedIndex(8L);
-
-    metaStore.close();
-    metaStore = new MetaStore(storage);
-
-    // then
-    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(8L);
-  }
-
-  @Test
-  public void shouldStoreAndLoadAllMetadata() {
-    // when
-    metaStore.storeTerm(1L);
-    metaStore.storeLastFlushedIndex(2L);
-    metaStore.storeVote(MemberId.from("a"));
-
-    // then
-    assertThat(metaStore.loadTerm()).isEqualTo(1L);
-    assertThat(metaStore.loadLastFlushedIndex()).isEqualTo(2L);
-    assertThat(metaStore.loadVote()).isEqualTo(MemberId.from("a"));
+    private Configuration getConfiguration(final long index, final long term) {
+      return new Configuration(
+          index,
+          term,
+          1234L,
+          new ArrayList<>(
+              Set.of(
+                  new DefaultRaftMember(
+                      MemberId.from("0"), Type.ACTIVE, Instant.ofEpochMilli(12345)),
+                  new DefaultRaftMember(
+                      MemberId.from("2"), Type.PASSIVE, Instant.ofEpochMilli(12346)))));
+    }
   }
 }


### PR DESCRIPTION
## Description

- Add a field `force` in `Configuration`
- Add the field to the SBE definitions
- Move `MetaStoreTest` to junit5. 
- Add test to verify all force configuration can be stored and loaded

This PR adds new field to SBE definition of `Configuration`. I did not add an additional test for backwards compatibility because qa/update-tests should cover this.

## Related issues

This PR complets the following task from #16148 
- [x] Define Configuration with flag "force". Extend SBE definition and serialization.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
