### PR TITLE
fix(gateway): log when pausing or resuming exporting

### DIFF
--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -17,8 +17,11 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.agrona.collections.IntHashSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ExportingControlService implements ExportingControlApi {
+  private static final Logger LOG = LoggerFactory.getLogger(ExportingControlService.class);
   final BrokerClient brokerClient;
 
   public ExportingControlService(final BrokerClient brokerClient) {
@@ -27,12 +30,14 @@ public class ExportingControlService implements ExportingControlApi {
 
   @Override
   public CompletableFuture<Void> pauseExporting() {
+    LOG.info("Pausing exporting on all partitions.");
     final var topology = brokerClient.getTopologyManager().getTopology();
     return broadcastOnTopology(topology, BrokerAdminRequest::pauseExporting);
   }
 
   @Override
   public CompletableFuture<Void> resumeExporting() {
+    LOG.info("Resuming exporting on all partitions.");
     final var topology = brokerClient.getTopologyManager().getTopology();
     return broadcastOnTopology(topology, BrokerAdminRequest::resumeExporting);
   }


### PR DESCRIPTION
Adds the same log message that's written by the `BrokerAdminServiceImpl` to be logged by the gateway when pausing or resuming exporting. This gives at least _some_ visibility into this. Long term we should have proper metrics etc. for this.

This came up in https://app.incident.io/camunda/incidents/956