### PR TITLE
Reject requests from non-members during forced configuration change.

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/cluster/impl/DefaultRaftMember.java
@@ -167,6 +167,7 @@ public final class DefaultRaftMember implements RaftMember, AutoCloseable {
                 .withMembers(currentConfiguration.newMembers())
                 // Override local member with the new type.
                 .withMember(new DefaultRaftMember(id, type, updated))
+                .from(cluster.getLocalMember().memberId().id())
                 .build())
         .whenComplete(
             (response, error) -> {

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -380,8 +380,8 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         () ->
             role.shouldAcceptRequest(request)
                 .ifRightOrLeft(
-                    ignore -> // assume it is always true otherwise the response is left
-                    function
+                    ignore ->
+                        function
                             .get()
                             .whenComplete(
                                 (response, error) -> {

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/AppendRequest.java
@@ -138,4 +138,9 @@ public class AppendRequest extends AbstractRaftRequest {
         .add("commitIndex", commitIndex)
         .toString();
   }
+
+  @Override
+  public MemberId from() {
+    return leader();
+  }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ConfigureRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ConfigureRequest.java
@@ -161,6 +161,11 @@ public class ConfigureRequest extends AbstractRaftRequest {
     return oldMembers;
   }
 
+  @Override
+  public MemberId from() {
+    return leader();
+  }
+
   /** Heartbeat request builder. */
   public static class Builder extends AbstractRaftRequest.Builder<Builder, ConfigureRequest> {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallRequest.java
@@ -212,6 +212,11 @@ public class InstallRequest extends AbstractRaftRequest {
         .toString();
   }
 
+  @Override
+  public MemberId from() {
+    return leader;
+  }
+
   /** Snapshot request builder. */
   public static class Builder extends AbstractRaftRequest.Builder<Builder, InstallRequest> {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/JoinRequest.java
@@ -9,6 +9,7 @@ package io.atomix.raft.protocol;
 
 import static java.util.Objects.requireNonNull;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import java.util.Objects;
 
@@ -47,6 +48,13 @@ public final class JoinRequest extends AbstractRaftRequest {
   @Override
   public String toString() {
     return "JoinRequest{" + "joining=" + joining + '}';
+  }
+
+  @Override
+  public MemberId from() {
+    // Although it is not strictly required, in the current implementation this request is sent by
+    // the member who is joining.
+    return joining.memberId();
   }
 
   public static final class Builder

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeaveRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/LeaveRequest.java
@@ -9,6 +9,7 @@ package io.atomix.raft.protocol;
 
 import static java.util.Objects.requireNonNull;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import java.util.Objects;
 
@@ -42,6 +43,13 @@ public final class LeaveRequest extends AbstractRaftRequest {
     }
     final LeaveRequest that = (LeaveRequest) o;
     return Objects.equals(leaving, that.leaving);
+  }
+
+  @Override
+  public MemberId from() {
+    // Although it is not strictly required, in the current implementation this request is sent by
+    // the member who is leaving.
+    return leaving.memberId();
   }
 
   public static final class Builder

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/PollRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/PollRequest.java
@@ -132,6 +132,11 @@ public class PollRequest extends AbstractRaftRequest {
         .toString();
   }
 
+  @Override
+  public MemberId from() {
+    return candidate();
+  }
+
   /** Poll request builder. */
   public static class Builder extends AbstractRaftRequest.Builder<Builder, PollRequest> {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftRequest.java
@@ -16,8 +16,12 @@
  */
 package io.atomix.raft.protocol;
 
+import io.atomix.cluster.MemberId;
+
 /** Base interface for requests. */
 public interface RaftRequest extends RaftMessage {
+
+  MemberId from();
 
   /**
    * Request builder.

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReconfigureRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ReconfigureRequest.java
@@ -20,8 +20,8 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
-import io.atomix.utils.Builder;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
@@ -34,11 +34,15 @@ public class ReconfigureRequest extends AbstractRaftRequest {
   private final long term;
   private final Collection<RaftMember> members;
 
+  // The sender for this request
+  private final String from;
+
   public ReconfigureRequest(
-      final Collection<RaftMember> members, final long index, final long term) {
+      final Collection<RaftMember> members, final long index, final long term, final String from) {
     this.members = members;
     this.index = index;
     this.term = term;
+    this.from = from;
   }
 
   /**
@@ -99,12 +103,19 @@ public class ReconfigureRequest extends AbstractRaftRequest {
         .toString();
   }
 
+  @Override
+  public MemberId from() {
+    return MemberId.from(from);
+  }
+
   /** Reconfigure request builder. */
   public static class Builder extends AbstractRaftRequest.Builder<Builder, ReconfigureRequest> {
 
     private Set<RaftMember> members;
     private long index = -1;
     private long term = -1;
+
+    private String from;
 
     /**
      * Sets the request members.
@@ -157,10 +168,21 @@ public class ReconfigureRequest extends AbstractRaftRequest {
       return this;
     }
 
+    /**
+     * Sets the sender for this request.
+     *
+     * @param from Member id of the sender
+     * @return The request builder.
+     */
+    public Builder from(final String from) {
+      this.from = from;
+      return this;
+    }
+
     @Override
     public ReconfigureRequest build() {
       validate();
-      return new ReconfigureRequest(members, index, term);
+      return new ReconfigureRequest(members, index, term, from);
     }
 
     @Override
@@ -169,6 +191,7 @@ public class ReconfigureRequest extends AbstractRaftRequest {
       checkNotNull(members, "members cannot be null");
       checkArgument(index >= 0, "index must be positive");
       checkArgument(term >= 0, "term must be positive");
+      checkNotNull(from, "from cannot be null");
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/TransferRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/TransferRequest.java
@@ -71,6 +71,11 @@ public class TransferRequest extends AbstractRaftRequest {
     return toStringHelper(this).add("member", member).toString();
   }
 
+  @Override
+  public MemberId from() {
+    return member;
+  }
+
   /** Transfer request builder. */
   public static class Builder extends AbstractRaftRequest.Builder<Builder, TransferRequest> {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VersionedAppendRequest.java
@@ -183,6 +183,11 @@ public class VersionedAppendRequest extends AbstractRaftRequest {
     return version;
   }
 
+  @Override
+  public MemberId from() {
+    return leader();
+  }
+
   /** Append request builder. */
   public static class Builder extends AbstractRaftRequest.Builder<Builder, VersionedAppendRequest> {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/VoteRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/VoteRequest.java
@@ -132,6 +132,11 @@ public class VoteRequest extends AbstractRaftRequest {
         .toString();
   }
 
+  @Override
+  public MemberId from() {
+    return candidate();
+  }
+
   /** Vote request builder. */
   public static class Builder extends AbstractRaftRequest.Builder<Builder, VoteRequest> {
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
@@ -53,7 +53,7 @@ public abstract class AbstractRole implements RaftRole {
   }
 
   @Override
-  public Either<RaftError, Boolean> shouldAcceptRequest(final RaftRequest request) {
+  public Either<RaftError, Void> shouldAcceptRequest(final RaftRequest request) {
     // Reject only if we are in force configuration change and the request is not from the members
     // of forced configuration
     final boolean shouldReject =
@@ -68,7 +68,7 @@ public abstract class AbstractRole implements RaftRole {
                   "Force configuration change is in progress. Cannot accept request from %s which is not a member of the new configuration.",
                   request.from())));
     } else {
-      return Either.right(true);
+      return Either.right(null);
     }
   }
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/AbstractRole.java
@@ -19,6 +19,8 @@ package io.atomix.raft.roles;
 import static com.google.common.base.MoreObjects.toStringHelper;
 
 import io.atomix.cluster.MemberId;
+import io.atomix.raft.RaftError;
+import io.atomix.raft.RaftError.Type;
 import io.atomix.raft.RaftException;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
@@ -27,6 +29,7 @@ import io.atomix.raft.protocol.RaftRequest;
 import io.atomix.raft.protocol.RaftResponse;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
+import io.camunda.zeebe.util.Either;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.BiFunction;
 import org.slf4j.Logger;
@@ -49,13 +52,25 @@ public abstract class AbstractRole implements RaftRole {
                 .build());
   }
 
-  /**
-   * Returns the Raft state represented by this state.
-   *
-   * @return The Raft state represented by this state.
-   */
   @Override
-  public abstract RaftServer.Role role();
+  public Either<RaftError, Boolean> shouldAcceptRequest(final RaftRequest request) {
+    // Reject only if we are in force configuration change and the request is not from the members
+    // of forced configuration
+    final boolean shouldReject =
+        raft.getCluster().getConfiguration() != null
+            && raft.getCluster().getConfiguration().force()
+            && !raft.getCluster().getConfiguration().hasMember(request.from());
+    if (shouldReject) {
+      return Either.left(
+          new RaftError(
+              Type.ILLEGAL_MEMBER_STATE,
+              String.format(
+                  "Force configuration change is in progress. Cannot accept request from %s which is not a member of the new configuration.",
+                  request.from())));
+    } else {
+      return Either.right(true);
+    }
+  }
 
   /** Logs a request. */
   protected final void logRequest(final Object request) {

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -235,6 +235,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                 .withMembers(currentConfiguration.newMembers())
                 // Override local member with the new type.
                 .withMember(request.joiningMember())
+                .from(raft.getCluster().getLocalMember().memberId().id())
                 .build())
         .handle(
             (reconfigureResponse, throwable) -> {
@@ -269,6 +270,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
                 .withIndex(currentConfiguration.index())
                 .withTerm(currentConfiguration.term())
                 .withMembers(updatedMembers)
+                .from(raft.getCluster().getLocalMember().memberId().id())
                 .build())
         .handle(
             (reconfigureResponse, throwable) -> {

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -16,6 +16,7 @@
  */
 package io.atomix.raft.roles;
 
+import io.atomix.raft.RaftError;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
@@ -29,6 +30,7 @@ import io.atomix.raft.protocol.LeaveRequest;
 import io.atomix.raft.protocol.LeaveResponse;
 import io.atomix.raft.protocol.PollRequest;
 import io.atomix.raft.protocol.PollResponse;
+import io.atomix.raft.protocol.RaftRequest;
 import io.atomix.raft.protocol.ReconfigureRequest;
 import io.atomix.raft.protocol.ReconfigureResponse;
 import io.atomix.raft.protocol.TransferRequest;
@@ -36,6 +38,7 @@ import io.atomix.raft.protocol.TransferResponse;
 import io.atomix.raft.protocol.VoteRequest;
 import io.atomix.raft.protocol.VoteResponse;
 import io.atomix.utils.Managed;
+import io.camunda.zeebe.util.Either;
 import java.util.concurrent.CompletableFuture;
 
 /** Raft role interface. */
@@ -109,4 +112,6 @@ public interface RaftRole extends Managed<RaftRole> {
    * @return A completable future to be completed with the request response.
    */
   CompletableFuture<VoteResponse> onVote(VoteRequest request);
+
+  Either<RaftError, Boolean> shouldAcceptRequest(RaftRequest request);
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -113,5 +113,5 @@ public interface RaftRole extends Managed<RaftRole> {
    */
   CompletableFuture<VoteResponse> onVote(VoteRequest request);
 
-  Either<RaftError, Boolean> shouldAcceptRequest(RaftRequest request);
+  Either<RaftError, Void> shouldAcceptRequest(RaftRequest request);
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/storage/system/Configuration.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableList;
+import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import io.atomix.raft.cluster.impl.DefaultRaftMember;
 import java.util.Collection;
@@ -119,5 +120,9 @@ public record Configuration(
           new DefaultRaftMember(member.memberId(), member.getType(), member.getLastUpdated()));
     }
     return copied.build();
+  }
+
+  public boolean hasMember(final MemberId member) {
+    return allMembers().stream().anyMatch(m -> m.memberId().equals(member));
   }
 }


### PR DESCRIPTION
## Description

- Added `from()` which returns the sender memberId to the interface `RaftRequest`. Most requests has this information but uses different names for the field. Added field `from` to `ReconfigureRequest` which did not have this info before. 
- Using sender info from the requests, reject requests with a proper error type and message if the receiver is in the middle of a force reconfiguration phase. To handle this uniformly across all requests, this is added to `RaftContext` when registering the handlers. Alternate (done in POC) is to add this logic to individual request handlers in all roles (`onAppend`, `onVote` etc.). This resulted in duplicate code across all handlers.

No unit test for this behavior is added. It will be tested as part of the overall test for this feature. 

## Related issues

This PR completes the following task from #16148 

- [x] Reject any message from non-members if force reconfigure is in progress

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
