### PR TITLE
Add topology operation for force reconfiguring a partition

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -359,7 +359,15 @@ public class ClusterEndpoint {
               .partitionId(reconfigure.partitionId())
               .priority(reconfigure.priority());
       case final PartitionForceReconfigureOperation partitionForceReconfigureOperation ->
-          throw new UnsupportedOperationException("Not implemented yet");
+          new Operation()
+              .operation(OperationEnum.PARTITION_FORCE_RECONFIGURE)
+              .brokerId(Integer.parseInt(partitionForceReconfigureOperation.memberId().id()))
+              .partitionId(partitionForceReconfigureOperation.partitionId())
+              .brokers(
+                  partitionForceReconfigureOperation.members().stream()
+                      .map(MemberId::id)
+                      .map(Integer::parseInt)
+                      .collect(Collectors.toList()));
     };
   }
 
@@ -494,7 +502,15 @@ public class ClusterEndpoint {
                   .partitionId(reconfigure.partitionId())
                   .priority(reconfigure.priority());
           case final PartitionForceReconfigureOperation partitionForceReconfigureOperation ->
-              throw new UnsupportedOperationException("Not implemented yet");
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.PARTITION_FORCE_RECONFIGURE)
+                  .brokerId(Integer.parseInt(partitionForceReconfigureOperation.memberId().id()))
+                  .partitionId(partitionForceReconfigureOperation.partitionId())
+                  .brokers(
+                      partitionForceReconfigureOperation.members().stream()
+                          .map(MemberId::id)
+                          .map(Integer::parseInt)
+                          .collect(Collectors.toList()));
         };
 
     mappedOperation.completedAt(mapInstantToDateTime(operation.completedAt()));

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.shared.management;
 
 import io.atomix.cluster.MemberId;
-import io.atomix.cluster.messaging.MessagingException;
+import io.atomix.cluster.messaging.MessagingException.NoSuchMemberException;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.BrokerStateCode;
 import io.camunda.zeebe.management.cluster.Error;
@@ -40,6 +40,7 @@ import io.camunda.zeebe.topology.state.PartitionState.State;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
@@ -95,7 +96,7 @@ public class ClusterEndpoint {
     final int status =
         switch (error) {
           case final ConnectException ignore -> 502;
-          case final MessagingException.NoSuchMemberException ignore -> 502;
+          case final NoSuchMemberException ignore -> 502;
           case final TimeoutException ignore -> 504;
           default -> 500;
         };
@@ -357,6 +358,8 @@ public class ClusterEndpoint {
               .brokerId(Integer.parseInt(reconfigure.memberId().id()))
               .partitionId(reconfigure.partitionId())
               .priority(reconfigure.priority());
+      case final PartitionForceReconfigureOperation partitionForceReconfigureOperation ->
+          throw new UnsupportedOperationException("Not implemented yet");
     };
   }
 
@@ -490,6 +493,8 @@ public class ClusterEndpoint {
                   .brokerId(Integer.parseInt(reconfigure.memberId().id()))
                   .partitionId(reconfigure.partitionId())
                   .priority(reconfigure.priority());
+          case final PartitionForceReconfigureOperation partitionForceReconfigureOperation ->
+              throw new UnsupportedOperationException("Not implemented yet");
         };
 
     mappedOperation.completedAt(mapInstantToDateTime(operation.completedAt()));

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -333,6 +333,7 @@ components:
             - PARTITION_JOIN
             - PARTITION_LEAVE
             - PARTITION_RECONFIGURE_PRIORITY
+            - PARTITION_FORCE_RECONFIGURE
         brokerId:
           $ref: "#/components/schemas/BrokerId"
         partitionId:
@@ -342,6 +343,10 @@ components:
           format: int32
           description: The priority of the partition
           example: 3
+        brokers:
+          type: array
+          items:
+            $ref: "#/components/schemas/BrokerId"
 
     BrokerState:
       title: BrokerState

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -232,7 +232,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     final var operationApplier = changeAppliers.getApplier(operation);
     final var initialized =
         operationApplier
-            .init(mergedTopology)
+            .initMemberState(mergedTopology)
             .map(transformer -> mergedTopology.updateMember(localMemberId, transformer))
             .flatMap(this::updateLocalTopology);
 
@@ -247,7 +247,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
 
     final var initializedTopology = initialized.get();
     operationApplier
-        .apply()
+        .applyOperation()
         .onComplete(
             (transformer, error) ->
                 onOperationApplied(initializedTopology, operation, transformer, error, observer));

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.topology.changes.TopologyChangeAppliers;
 import io.camunda.zeebe.topology.metrics.TopologyMetrics;
 import io.camunda.zeebe.topology.metrics.TopologyMetrics.OperationObserver;
 import io.camunda.zeebe.topology.state.ClusterTopology;
-import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
@@ -230,24 +229,26 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     final var observer = TopologyMetrics.observeOperation(operation);
     LOG.info("Applying topology change operation {}", operation);
     final var operationApplier = changeAppliers.getApplier(operation);
-    final var initialized =
+    final var operationInitialized =
         operationApplier
-            .initMemberState(mergedTopology)
-            .map(transformer -> mergedTopology.updateMember(localMemberId, transformer))
+            .init(mergedTopology)
+            .map(transformer -> transformer.apply(mergedTopology))
             .flatMap(this::updateLocalTopology);
 
-    if (initialized.isLeft()) {
-      // TODO: What should we do here? Retry?
+    if (operationInitialized.isLeft()) {
+      // TODO: Mark ClusterChangePlan as failed
       observer.failed();
       onGoingTopologyChangeOperation = false;
       LOG.error(
-          "Failed to initialize topology change operation {}", operation, initialized.getLeft());
+          "Failed to initialize topology change operation {}",
+          operation,
+          operationInitialized.getLeft());
       return;
     }
 
-    final var initializedTopology = initialized.get();
+    final var initializedTopology = operationInitialized.get();
     operationApplier
-        .applyOperation()
+        .apply()
         .onComplete(
             (transformer, error) ->
                 onOperationApplied(initializedTopology, operation, transformer, error, observer));
@@ -272,7 +273,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
   private void onOperationApplied(
       final ClusterTopology topologyOnWhichOperationIsApplied,
       final TopologyChangeOperation operation,
-      final UnaryOperator<MemberState> transformer,
+      final UnaryOperator<ClusterTopology> transformer,
       final Throwable error,
       final OperationObserver observer) {
     onGoingTopologyChangeOperation = false;
@@ -289,7 +290,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
         return;
       }
       updateLocalTopology(
-          persistedClusterTopology.getTopology().advanceTopologyChange(localMemberId, transformer));
+          persistedClusterTopology.getTopology().advanceTopologyChange(transformer));
       LOG.info(
           "Operation {} applied. Updated local topology to {}",
           operation,

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberJoinApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberJoinApplier.java
@@ -10,14 +10,14 @@ package io.camunda.zeebe.topology.changes;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
 
 /** A Member join operation is applied when the member is not already part of the topology. */
-final class MemberJoinApplier implements OperationApplier {
+final class MemberJoinApplier implements MemberOperationApplier {
 
   private final MemberId memberId;
   private final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor;
@@ -30,7 +30,12 @@ final class MemberJoinApplier implements OperationApplier {
   }
 
   @Override
-  public Either<Exception, UnaryOperator<MemberState>> init(
+  public MemberId memberId() {
+    return memberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterTopology currentClusterTopology) {
     if (currentClusterTopology.hasMember(memberId)) {
       return Either.left(
@@ -47,7 +52,7 @@ final class MemberJoinApplier implements OperationApplier {
   }
 
   @Override
-  public ActorFuture<UnaryOperator<MemberState>> apply() {
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final var future = new CompletableActorFuture<UnaryOperator<MemberState>>();
     topologyMembershipChangeExecutor
         .addBroker(memberId)

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberLeaveApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberLeaveApplier.java
@@ -10,13 +10,13 @@ package io.camunda.zeebe.topology.changes;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
 
-public class MemberLeaveApplier implements OperationApplier {
+public class MemberLeaveApplier implements MemberOperationApplier {
 
   private final MemberId memberId;
   private final TopologyMembershipChangeExecutor topologyMembershipChangeExecutor;
@@ -29,7 +29,12 @@ public class MemberLeaveApplier implements OperationApplier {
   }
 
   @Override
-  public Either<Exception, UnaryOperator<MemberState>> init(
+  public MemberId memberId() {
+    return memberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterTopology currentClusterTopology) {
     if (!currentClusterTopology.hasMember(memberId)) {
       return Either.left(
@@ -53,7 +58,7 @@ public class MemberLeaveApplier implements OperationApplier {
   }
 
   @Override
-  public ActorFuture<UnaryOperator<MemberState>> apply() {
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final var future = new CompletableActorFuture<UnaryOperator<MemberState>>();
     topologyMembershipChangeExecutor
         .removeBroker(memberId)

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/NoopTopologyChangeAppliers.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.topology.changes;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.topology.state.ClusterTopology;
@@ -22,20 +23,31 @@ import java.util.function.UnaryOperator;
 public class NoopTopologyChangeAppliers implements TopologyChangeAppliers {
 
   @Override
-  public OperationApplier getApplier(final TopologyChangeOperation operation) {
-    return new NoopApplier();
+  public MemberOperationApplier getApplier(final TopologyChangeOperation operation) {
+    return new NoopApplier(operation.memberId());
   }
 
-  public static class NoopApplier implements OperationApplier {
+  public static class NoopApplier implements MemberOperationApplier {
+
+    private final MemberId memberId;
+
+    public NoopApplier(final MemberId memberId) {
+      this.memberId = memberId;
+    }
 
     @Override
-    public Either<Exception, UnaryOperator<MemberState>> init(
+    public MemberId memberId() {
+      return memberId;
+    }
+
+    @Override
+    public Either<Exception, UnaryOperator<MemberState>> initMemberState(
         final ClusterTopology currentClusterTopology) {
       return Either.right(memberState -> memberState);
     }
 
     @Override
-    public ActorFuture<UnaryOperator<MemberState>> apply() {
+    public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
       return CompletableActorFuture.completed(memberState -> memberState);
     }
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionChangeExecutor.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionChangeExecutor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.topology.changes;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -44,9 +45,21 @@ public interface PartitionChangeExecutor {
   /**
    * Updates the priority of the member used for raft priority election for the given partition.
    *
-   * @param partitionId id of hte partition
+   * @param partitionId id of the partition
    * @param newPriority new priority value
    * @return a future that completes when the priority is updated
    */
   ActorFuture<Void> reconfigurePriority(int partitionId, int newPriority);
+
+  /**
+   * Force reconfigure a partition to include only the given members in the replication group.
+   *
+   * @param partitionId id of the partition
+   * @param members members that will be part of the replication group after reconfiguring
+   * @return a future that completes when the partition is reconfigured
+   */
+  default ActorFuture<Void> forceReconfigure(
+      final int partitionId, final Collection<MemberId> members) {
+    throw new UnsupportedOperationException("Not implemented");
+  }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionForceReconfigureApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionForceReconfigureApplier.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.ClusterOperationApplier;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState.State;
+import io.camunda.zeebe.util.Either;
+import java.util.Collection;
+import java.util.function.UnaryOperator;
+
+/** Force configure a partition to include only the given members in the replication group. */
+final class PartitionForceReconfigureApplier implements ClusterOperationApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final Collection<MemberId> members;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionForceReconfigureApplier(
+      final int partitionId,
+      final MemberId memberId,
+      final Collection<MemberId> members,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.members = members;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<ClusterTopology>> init(
+      final ClusterTopology currentClusterTopology) {
+
+    if (members.isEmpty()) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to reconfigure partition '%d' via member '%s', but the new configuration is empty",
+                  partitionId, memberId)));
+    }
+
+    if (!members.contains(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to reconfigure partition '%d' via member '%s', but the member is not part of the new configuration '%s'",
+                  partitionId, memberId, members)));
+    }
+
+    for (final MemberId member : members) {
+      final boolean memberIsActive =
+          currentClusterTopology.hasMember(member)
+              && currentClusterTopology.getMember(member).state() == State.ACTIVE;
+      if (!memberIsActive) {
+        return Either.left(
+            new IllegalStateException(
+                String.format(
+                    "Expected to reconfigure partition '%d' with members '%s', but member '%s' is not active.",
+                    partitionId, members, memberId)));
+      }
+
+      final var memberState = currentClusterTopology.getMember(member);
+      if (!memberState.hasPartition(partitionId)) {
+        return Either.left(
+            new IllegalStateException(
+                String.format(
+                    "Expected to reconfigure partition '%d' with members '%s', but member '%s' does not have the partition.",
+                    partitionId, members, memberId)));
+      }
+    }
+    // No need to change the state yet
+    return Either.right(UnaryOperator.identity());
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<ClusterTopology>> apply() {
+    final var future = new CompletableActorFuture<UnaryOperator<ClusterTopology>>();
+    partitionChangeExecutor
+        .forceReconfigure(partitionId, members)
+        .onComplete(
+            (ignore, error) -> {
+              if (error != null) {
+                future.completeExceptionally(error);
+              } else {
+                future.complete(this::removePartitionFromNonMembers);
+              }
+            });
+
+    return future;
+  }
+
+  private ClusterTopology removePartitionFromNonMembers(final ClusterTopology clusterTopology) {
+    // remove this partition from the state of non-members
+    ClusterTopology updatedTopology = clusterTopology;
+    for (final var member : clusterTopology.members().keySet()) {
+      if (!members.contains(member)
+          && clusterTopology.getMember(member).hasPartition(partitionId)) {
+        updatedTopology = updatedTopology.updateMember(member, m -> m.removePartition(partitionId));
+      }
+    }
+    return updatedTopology;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionJoinApplier.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.topology.changes;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.MemberState.State;
@@ -25,7 +25,7 @@ import java.util.function.UnaryOperator;
  * A Partition Join operation is executed when a member wants to start replicating a partition. This
  * is allowed only when the member is active, and the partition is not already active.
  */
-final class PartitionJoinApplier implements OperationApplier {
+final class PartitionJoinApplier implements MemberOperationApplier {
   private final int partitionId;
   private final int priority;
   private final PartitionChangeExecutor partitionChangeExecutor;
@@ -44,7 +44,12 @@ final class PartitionJoinApplier implements OperationApplier {
   }
 
   @Override
-  public Either<Exception, UnaryOperator<MemberState>> init(
+  public MemberId memberId() {
+    return localMemberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterTopology currentClusterTopology) {
 
     final boolean localMemberIsActive =
@@ -100,7 +105,7 @@ final class PartitionJoinApplier implements OperationApplier {
   }
 
   @Override
-  public ActorFuture<UnaryOperator<MemberState>> apply() {
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionLeaveApplier.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.topology.changes;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.PartitionState;
@@ -23,10 +23,15 @@ import java.util.function.UnaryOperator;
  */
 record PartitionLeaveApplier(
     int partitionId, MemberId localMemberId, PartitionChangeExecutor partitionChangeExecutor)
-    implements OperationApplier {
+    implements MemberOperationApplier {
 
   @Override
-  public Either<Exception, UnaryOperator<MemberState>> init(
+  public MemberId memberId() {
+    return localMemberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterTopology currentClusterTopology) {
 
     if (!currentClusterTopology.hasMember(localMemberId)) {
@@ -72,7 +77,7 @@ record PartitionLeaveApplier(
   }
 
   @Override
-  public ActorFuture<UnaryOperator<MemberState>> apply() {
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionReconfigurePriorityApplier.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/PartitionReconfigurePriorityApplier.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.topology.changes;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.MemberState.State;
@@ -18,7 +18,7 @@ import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
 
-public class PartitionReconfigurePriorityApplier implements OperationApplier {
+public class PartitionReconfigurePriorityApplier implements MemberOperationApplier {
 
   private final int partitionId;
   private final int newPriority;
@@ -37,7 +37,12 @@ public class PartitionReconfigurePriorityApplier implements OperationApplier {
   }
 
   @Override
-  public Either<Exception, UnaryOperator<MemberState>> init(
+  public MemberId memberId() {
+    return localMemberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterTopology currentClusterTopology) {
     final boolean localMemberIsActive =
         currentClusterTopology.hasMember(localMemberId)
@@ -71,7 +76,7 @@ public class PartitionReconfigurePriorityApplier implements OperationApplier {
   }
 
   @Override
-  public ActorFuture<UnaryOperator<MemberState>> apply() {
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
     final CompletableActorFuture<UnaryOperator<MemberState>> result =
         new CompletableActorFuture<>();
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.topology.changes;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
@@ -20,19 +22,21 @@ public interface TopologyChangeAppliers {
   /**
    * @return the operation applier for the given operation
    */
-  OperationApplier getApplier(TopologyChangeOperation operation);
+  MemberOperationApplier getApplier(TopologyChangeOperation operation);
 
-  interface OperationApplier {
+  /** An operation applier that can apply and operation and changes the ClusterTopology. */
+  interface ClusterOperationApplier {
 
     /**
-     * This method will be called before invoking {@link OperationApplier#apply()}. This method can
-     * be used to validate the operation and to update the ClusterTopology to mark the start of the
-     * operation. For example, an operation for joining a partition can mark the state as JOINING.
+     * This method will be called before invoking {@link ClusterOperationApplier#apply()}. This
+     * method can be used to validate the operation and to update the ClusterTopology to mark the
+     * start of the operation. For example, an operation for joining a partition can mark the state
+     * as JOINING.
      *
      * @return an either which contains an exception if the operation is not valid, or a function to
      *     update the cluster topology
      */
-    Either<Exception, UnaryOperator<MemberState>> init(
+    Either<Exception, UnaryOperator<ClusterTopology>> init(
         final ClusterTopology currentClusterTopology);
 
     /**
@@ -42,11 +46,69 @@ public interface TopologyChangeAppliers {
      * partition should mark the state of the partition as ACTIVE.
      *
      * <p>It is expected that no other operation is applied until this operation is completed. It is
-     * guaranteed that the MemberState updated by {@link OperationApplier#init()} remains the same
-     * until this operation is completed.
+     * guaranteed that the ClusterTopology updated by {@link ClusterTopology#init()} remains the
+     * same until this operation is completed.
      *
      * @return the future which is completed when the operation is completed successfully or failed.
      */
-    ActorFuture<UnaryOperator<MemberState>> apply();
+    ActorFuture<UnaryOperator<ClusterTopology>> apply();
+  }
+
+  /**
+   * An operation applier that can apply an operation and changes the MemberState of the member that
+   * is applying the operation.
+   */
+  interface MemberOperationApplier extends ClusterOperationApplier {
+
+    @Override
+    default Either<Exception, UnaryOperator<ClusterTopology>> init(
+        final ClusterTopology currentClusterTopology) {
+      return initMemberState(currentClusterTopology)
+          .map(transformer -> cluster -> cluster.updateMember(memberId(), transformer));
+    }
+
+    @Override
+    default ActorFuture<UnaryOperator<ClusterTopology>> apply() {
+      final var future = new CompletableActorFuture<UnaryOperator<ClusterTopology>>();
+      applyOperation()
+          .onComplete(
+              (transformer, error) -> {
+                if (error == null) {
+                  future.complete(cluster -> cluster.updateMember(memberId(), transformer));
+                } else {
+                  future.completeExceptionally(error);
+                }
+              });
+      return future;
+    }
+
+    MemberId memberId();
+
+    /**
+     * This method will be called before invoking {@link MemberOperationApplier#applyOperation()}.
+     * This method can be used to validate the operation and to update the ClusterTopology to mark
+     * the start of the operation. For example, an operation for joining a partition can mark the
+     * state as JOINING.
+     *
+     * @return an either which contains an exception if the operation is not valid, or a function to
+     *     update the cluster topology
+     */
+    Either<Exception, UnaryOperator<MemberState>> initMemberState(
+        final ClusterTopology currentClusterTopology);
+
+    /**
+     * Applies the operation. This can be run asynchronously and should complete the future when the
+     * operation is completed. The future should be completed with a function that can update the
+     * ClusterTopology to mark the operation as completed. For example, an operation for joining a
+     * partition should mark the state of the partition as ACTIVE.
+     *
+     * <p>It is expected that no other operation is applied until this operation is completed. It is
+     * guaranteed that the MemberState updated by {@link
+     * MemberOperationApplier#initMemberState(ClusterTopology)} remains the same until this
+     * operation is completed.
+     *
+     * @return the future which is completed when the operation is completed successfully or failed.
+     */
+    ActorFuture<UnaryOperator<MemberState>> applyOperation();
   }
 }

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliers.java
@@ -22,7 +22,7 @@ public interface TopologyChangeAppliers {
   /**
    * @return the operation applier for the given operation
    */
-  MemberOperationApplier getApplier(TopologyChangeOperation operation);
+  ClusterOperationApplier getApplier(TopologyChangeOperation operation);
 
   /** An operation applier that can apply and operation and changes the ClusterTopology. */
   interface ClusterOperationApplier {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
@@ -34,32 +35,35 @@ public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
   }
 
   @Override
-  public MemberOperationApplier getApplier(final TopologyChangeOperation operation) {
-    if (operation instanceof final PartitionJoinOperation joinOperation) {
-      return new PartitionJoinApplier(
-          joinOperation.partitionId(),
-          joinOperation.priority(),
-          joinOperation.memberId(),
-          partitionChangeExecutor);
-    } else if (operation instanceof final PartitionLeaveOperation leaveOperation) {
-      return new PartitionLeaveApplier(
-          leaveOperation.partitionId(), leaveOperation.memberId(), partitionChangeExecutor);
-    } else if (operation instanceof final MemberJoinOperation memberJoinOperation) {
-      return new MemberJoinApplier(
-          memberJoinOperation.memberId(), topologyMembershipChangeExecutor);
-    } else if (operation instanceof final MemberLeaveOperation memberLeaveOperation) {
-      return new MemberLeaveApplier(
-          memberLeaveOperation.memberId(), topologyMembershipChangeExecutor);
-    } else if (operation
-        instanceof final PartitionReconfigurePriorityOperation reconfigurePriorityOperation) {
-      return new PartitionReconfigurePriorityApplier(
-          reconfigurePriorityOperation.partitionId(),
-          reconfigurePriorityOperation.priority(),
-          reconfigurePriorityOperation.memberId(),
-          partitionChangeExecutor);
-    } else {
-      return new FailingApplier(operation);
-    }
+  public ClusterOperationApplier getApplier(final TopologyChangeOperation operation) {
+    return switch (operation) {
+      case final PartitionJoinOperation joinOperation ->
+          new PartitionJoinApplier(
+              joinOperation.partitionId(),
+              joinOperation.priority(),
+              joinOperation.memberId(),
+              partitionChangeExecutor);
+      case final PartitionLeaveOperation leaveOperation ->
+          new PartitionLeaveApplier(
+              leaveOperation.partitionId(), leaveOperation.memberId(), partitionChangeExecutor);
+      case final MemberJoinOperation memberJoinOperation ->
+          new MemberJoinApplier(memberJoinOperation.memberId(), topologyMembershipChangeExecutor);
+      case final MemberLeaveOperation memberLeaveOperation ->
+          new MemberLeaveApplier(memberLeaveOperation.memberId(), topologyMembershipChangeExecutor);
+      case final PartitionReconfigurePriorityOperation reconfigurePriorityOperation ->
+          new PartitionReconfigurePriorityApplier(
+              reconfigurePriorityOperation.partitionId(),
+              reconfigurePriorityOperation.priority(),
+              reconfigurePriorityOperation.memberId(),
+              partitionChangeExecutor);
+      case final PartitionForceReconfigureOperation forceReconfigureOperation ->
+          new PartitionForceReconfigureApplier(
+              forceReconfigureOperation.partitionId(),
+              forceReconfigureOperation.memberId(),
+              forceReconfigureOperation.members(),
+              partitionChangeExecutor);
+      case null, default -> new FailingApplier(operation);
+    };
   }
 
   static class FailingApplier implements MemberOperationApplier {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.topology.api.TopologyRequestFailedException;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.OperationNotAllowed;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.OperationApplier;
+import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.CompletedChange;
@@ -235,8 +235,8 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
     }
 
     final var operation = updatedTopology.nextPendingOperation();
-    final OperationApplier applier = topologyChangeSimulator.getApplier(operation);
-    final var result = applier.init(updatedTopology);
+    final MemberOperationApplier applier = topologyChangeSimulator.getApplier(operation);
+    final var result = applier.initMemberState(updatedTopology);
     if (result.isLeft()) {
       failFuture(simulationCompleted, new InvalidRequest(result.getLeft()));
       return;
@@ -245,7 +245,7 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
     final var initializedChanges = updatedTopology.updateMember(operation.memberId(), result.get());
 
     applier
-        .apply()
+        .applyOperation()
         .onComplete(
             (stateUpdater, error) -> {
               if (error != null) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinatorImpl.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.topology.api.TopologyRequestFailedException;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.ConcurrentModificationException;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.InvalidRequest;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.OperationNotAllowed;
-import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterChangePlan;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.CompletedChange;
@@ -235,25 +234,24 @@ public class TopologyChangeCoordinatorImpl implements TopologyChangeCoordinator 
     }
 
     final var operation = updatedTopology.nextPendingOperation();
-    final MemberOperationApplier applier = topologyChangeSimulator.getApplier(operation);
-    final var result = applier.initMemberState(updatedTopology);
+    final var applier = topologyChangeSimulator.getApplier(operation);
+    final var result = applier.init(updatedTopology);
     if (result.isLeft()) {
       failFuture(simulationCompleted, new InvalidRequest(result.getLeft()));
       return;
     }
 
-    final var initializedChanges = updatedTopology.updateMember(operation.memberId(), result.get());
+    final var initializedChanges = result.get().apply(updatedTopology);
 
     applier
-        .applyOperation()
+        .apply()
         .onComplete(
-            (stateUpdater, error) -> {
+            (topologyUpdater, error) -> {
               if (error != null) {
                 failFuture(simulationCompleted, new InvalidRequest(error));
                 return;
               }
-              final var newTopology =
-                  initializedChanges.advanceTopologyChange(operation.memberId(), stateUpdater);
+              final var newTopology = initializedChanges.advanceTopologyChange(topologyUpdater);
 
               simulateTopologyChange(newTopology, topologyChangeSimulator, simulationCompleted);
             });

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -182,13 +182,12 @@ public record ClusterTopology(
    * should be reflected in ClusterTopology by invoking this method. This removes the completed
    * operation from the pending changes and update the member state using the given updater.
    *
-   * @param memberId id of the member which completed the operation
-   * @param memberStateUpdater the method to update the member state
+   * @param topologyUpdater the method to update the topology
    * @return the updated ClusterTopology
    */
   public ClusterTopology advanceTopologyChange(
-      final MemberId memberId, final UnaryOperator<MemberState> memberStateUpdater) {
-    return updateMember(memberId, memberStateUpdater).advance();
+      final UnaryOperator<ClusterTopology> topologyUpdater) {
+    return topologyUpdater.apply(this).advance();
   }
 
   private ClusterTopology advance() {

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.topology.state;
 
 import io.atomix.cluster.MemberId;
+import java.util.Collection;
 
 /**
  * An operation that changes the topology. The operation could be a member join or leave a cluster,
@@ -17,20 +18,61 @@ public sealed interface TopologyChangeOperation {
 
   MemberId memberId();
 
+  /**
+   * Operation to add a member to the ClusterTopology.
+   *
+   * @param memberId the member id of the member that joined the cluster
+   */
   record MemberJoinOperation(MemberId memberId) implements TopologyChangeOperation {}
 
+  /**
+   * Operation to remove a member from the ClusterTopology.
+   *
+   * @param memberId the member id of the member that is leaving the cluster
+   */
   record MemberLeaveOperation(MemberId memberId) implements TopologyChangeOperation {}
 
   sealed interface PartitionChangeOperation extends TopologyChangeOperation {
     int partitionId();
 
+    /**
+     * Operation to add a member to a partition's replication group.
+     *
+     * @param memberId the member id of the member that will start replicating the partition
+     * @param partitionId id of the partition to join
+     * @param priority priority of the member in the partition used for Raft's priority election
+     */
     record PartitionJoinOperation(MemberId memberId, int partitionId, int priority)
         implements PartitionChangeOperation {}
 
+    /**
+     * Operation to remove a member from a partition's replication group.
+     *
+     * @param memberId the member id of the member that will stop replicating the partition
+     * @param partitionId id of the partition to leave
+     */
     record PartitionLeaveOperation(MemberId memberId, int partitionId)
         implements PartitionChangeOperation {}
 
+    /**
+     * Operation to reconfigure the priority of a member used for Raft's priority election.
+     *
+     * @param memberId the member id of the member that will change its priority
+     * @param partitionId id of the partition to reconfigure
+     * @param priority new priority of the member in the partition
+     */
     record PartitionReconfigurePriorityOperation(MemberId memberId, int partitionId, int priority)
+        implements PartitionChangeOperation {}
+
+    /**
+     * Operation to force reconfigure the replication group of a partition.
+     *
+     * @param memberId the member id of the member that will apply this operation
+     * @param partitionId id of the partition to reconfigure
+     * @param members the members of the partition's replication group after the reconfiguration
+     */
+    record PartitionForceReconfigureOperation(
+        MemberId memberId, int partitionId, Collection<MemberId> members)
         implements PartitionChangeOperation {}
   }
 }

--- a/topology/src/main/resources/proto/proto.lock
+++ b/topology/src/main/resources/proto/proto.lock
@@ -464,6 +464,11 @@
                 "id": 6,
                 "name": "partitionReconfigurePriority",
                 "type": "PartitionReconfigurePriorityOperation"
+              },
+              {
+                "id": 7,
+                "name": "partitionForceReconfigure",
+                "type": "PartitionForceReconfigureOperation"
               }
             ]
           },
@@ -519,6 +524,22 @@
                 "id": 2,
                 "name": "priority",
                 "type": "int32"
+              }
+            ]
+          },
+          {
+            "name": "PartitionForceReconfigureOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitionId",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "members",
+                "type": "string",
+                "is_repeated": true
               }
             ]
           },

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -53,6 +53,7 @@ message TopologyChangeOperation {
     MemberJoinOperation memberJoin = 4;
     MemberLeaveOperation memberLeave = 5;
     PartitionReconfigurePriorityOperation partitionReconfigurePriority = 6;
+    PartitionForceReconfigureOperation partitionForceReconfigure = 7;
   }
 }
 
@@ -74,6 +75,12 @@ message PartitionReconfigurePriorityOperation {
   int32 partitionId = 1;
   int32 priority = 2;
 }
+
+message PartitionForceReconfigureOperation {
+  int32 partitionId = 1;
+  repeated string members = 2;
+}
+
 message MemberJoinOperation {}
 
 message MemberLeaveOperation {}

--- a/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyRandomizedPropertyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/PersistedClusterTopologyRandomizedPropertyTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.topology;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import io.atomix.cluster.MemberId;
@@ -48,9 +49,10 @@ final class PersistedClusterTopologyRandomizedPropertyTest {
     persistedClusterTopology.update(updatedTopology);
 
     // then
-    assertEquals(updatedTopology, persistedClusterTopology.getTopology());
-    assertEquals(
-        updatedTopology, PersistedClusterTopology.ofFile(topologyFile, serializer).getTopology());
+    assertThat(updatedTopology).isEqualTo(persistedClusterTopology.getTopology());
+    assertThat(PersistedClusterTopology.ofFile(topologyFile, serializer).getTopology())
+        .usingRecursiveComparison()
+        .isEqualTo(updatedTopology);
   }
 
   /**

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TestTopologyChangeSimulator.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TestTopologyChangeSimulator.java
@@ -33,12 +33,12 @@ final class TestTopologyChangeSimulator {
     while (newTopology.hasPendingChanges()) {
       final var operation = newTopology.nextPendingOperation();
       final var applier = topologyChangeSimulator.getApplier(operation);
-      final Either<Exception, UnaryOperator<MemberState>> init = applier.init(newTopology);
+      final Either<Exception, UnaryOperator<MemberState>> init = applier.initMemberState(newTopology);
       if (init.isLeft()) {
         fail("Failed to init operation ", init.getLeft());
       }
       newTopology = newTopology.updateMember(operation.memberId(), init.get());
-      newTopology = newTopology.advanceTopologyChange(operation.memberId(), applier.apply().join());
+      newTopology = newTopology.advanceTopologyChange(operation.memberId(), applier.applyOperation().join());
     }
     return newTopology;
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TestTopologyChangeSimulator.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TestTopologyChangeSimulator.java
@@ -13,11 +13,8 @@ import io.camunda.zeebe.topology.changes.NoopPartitionChangeExecutor;
 import io.camunda.zeebe.topology.changes.NoopTopologyMembershipChangeExecutor;
 import io.camunda.zeebe.topology.changes.TopologyChangeAppliersImpl;
 import io.camunda.zeebe.topology.state.ClusterTopology;
-import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
-import io.camunda.zeebe.util.Either;
 import java.util.List;
-import java.util.function.UnaryOperator;
 
 final class TestTopologyChangeSimulator {
 
@@ -33,12 +30,12 @@ final class TestTopologyChangeSimulator {
     while (newTopology.hasPendingChanges()) {
       final var operation = newTopology.nextPendingOperation();
       final var applier = topologyChangeSimulator.getApplier(operation);
-      final Either<Exception, UnaryOperator<MemberState>> init = applier.initMemberState(newTopology);
+      final var init = applier.init(newTopology);
       if (init.isLeft()) {
         fail("Failed to init operation ", init.getLeft());
       }
-      newTopology = newTopology.updateMember(operation.memberId(), init.get());
-      newTopology = newTopology.advanceTopologyChange(operation.memberId(), applier.applyOperation().join());
+      newTopology = init.get().apply(newTopology);
+      newTopology = newTopology.advanceTopologyChange(applier.apply().join());
     }
     return newTopology;
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
@@ -73,7 +73,8 @@ final class MemberJoinApplierTest {
     // then
     EitherAssert.assertThat(result).isRight();
     assertThat(result.get()).isNotNull();
-    assertThat(result.get().apply(null).state()).isEqualTo(JOINING);
+    assertThat(result.get().apply(clusterTopologyWithMember).getMember(memberId).state())
+        .isEqualTo(JOINING);
   }
 
   @Test
@@ -85,14 +86,14 @@ final class MemberJoinApplierTest {
 
     final ClusterTopology clusterTopologyWithMember = ClusterTopology.init();
     final var updater = memberJoinApplier.init(clusterTopologyWithMember).get();
-    final var topologyWithJoining = clusterTopologyWithMember.updateMember(memberId, updater);
+    final var topologyWithJoining = updater.apply(clusterTopologyWithMember);
 
     // when
     final var result = memberJoinApplier.apply();
 
     // then
     assertThat(result).succeedsWithin(Duration.ofMillis(100));
-    final var finalTopology = topologyWithJoining.updateMember(memberId, result.join());
+    final var finalTopology = result.join().apply(topologyWithJoining);
     assertThat(finalTopology.getMember(memberId).state()).isEqualTo(ACTIVE);
   }
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberLeaveApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberLeaveApplierTest.java
@@ -70,8 +70,7 @@ final class MemberLeaveApplierTest {
 
     // when
     final var result = memberLeaveApplier.init(clusterTopologyWithMember);
-    final var updateTopologyAfterInit =
-        clusterTopologyWithMember.updateMember(memberId, result.get());
+    final var updateTopologyAfterInit = result.get().apply(clusterTopologyWithMember);
 
     // then
     ClusterTopologyAssert.assertThatClusterTopology(updateTopologyAfterInit)
@@ -88,11 +87,11 @@ final class MemberLeaveApplierTest {
     final ClusterTopology clusterTopologyWithMember =
         ClusterTopology.init().addMember(memberId, MemberState.initializeAsActive(Map.of()));
     final var updater = memberLeaveApplier.init(clusterTopologyWithMember).get();
-    final var topologyWithLeaving = clusterTopologyWithMember.updateMember(memberId, updater);
+    final var topologyWithLeaving = updater.apply(clusterTopologyWithMember);
 
     // when
-    final var result = memberLeaveApplier.apply().join();
-    final var updateTopologyAfterApply = topologyWithLeaving.updateMember(memberId, result);
+    final var updateTopologyAfterApply =
+        memberLeaveApplier.apply().join().apply(topologyWithLeaving);
 
     // then
     ClusterTopologyAssert.assertThatClusterTopology(updateTopologyAfterApply)

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionForceReconfigureApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionForceReconfigureApplierTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.changes;
+
+import static io.camunda.zeebe.test.util.asserts.EitherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.scheduler.testing.TestActorFuture;
+import io.camunda.zeebe.topology.ClusterTopologyAssert;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+final class PartitionForceReconfigureApplierTest {
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+  private final MemberId localMemberId = MemberId.from("1");
+  private final MemberId otherMember = MemberId.from("2");
+  private final ClusterTopology validTopology =
+      ClusterTopology.init()
+          .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
+          .updateMember(localMemberId, m -> m.addPartition(1, PartitionState.active(1)))
+          .addMember(otherMember, MemberState.initializeAsActive(Map.of()))
+          .updateMember(otherMember, m -> m.addPartition(1, PartitionState.active(1)));
+
+  @Test
+  void shouldRejectIfLocalMemberNotPartOfNewConfiguration() {
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(
+                1, localMemberId, Set.of(otherMember), partitionChangeExecutor)
+            .init(validTopology);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("member is not part of the new configuration");
+  }
+
+  @Test
+  void shouldRejectIfNewConfigurationIsEmpty() {
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(1, localMemberId, Set.of(), partitionChangeExecutor)
+            .init(validTopology);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the new configuration is empty");
+  }
+
+  @Test
+  void shouldRejectIfMembersDoNotHavePartitionsAlready() {
+    // given
+    final var topologyWithMembersWithoutPartition =
+        validTopology.updateMember(localMemberId, m -> m.removePartition(1));
+
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(
+                1, localMemberId, Set.of(localMemberId), partitionChangeExecutor)
+            .init(topologyWithMembersWithoutPartition);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("member '1' does not have the partition");
+  }
+
+  @Test
+  void shouldRejectIfMembersAreNotActive() {
+    // given
+    final var topologyWithMembersNotActive =
+        validTopology.updateMember(localMemberId, MemberState::toLeaving);
+
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(
+                1, localMemberId, Set.of(localMemberId), partitionChangeExecutor)
+            .init(topologyWithMembersNotActive);
+
+    // then
+    assertThat(result).isLeft();
+    Assertions.assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("member '1' is not active");
+  }
+
+  @Test
+  void shouldInitSuccessfullyWithoutChangingTopology() {
+    // when
+    final var result =
+        new PartitionForceReconfigureApplier(
+                1, localMemberId, Set.of(localMemberId), partitionChangeExecutor)
+            .init(validTopology);
+
+    // then
+    assertThat(result).isRight();
+    Assertions.assertThat(result.get().apply(validTopology)).isEqualTo(validTopology);
+  }
+
+  @Test
+  void shouldFailFutureIfApplyFailed() {
+    // given
+    when(partitionChangeExecutor.forceReconfigure(anyInt(), any()))
+        .thenReturn(TestActorFuture.failedFuture(new RuntimeException("force fail")));
+
+    // when
+    final PartitionForceReconfigureApplier partitionForceReconfigureApplier =
+        new PartitionForceReconfigureApplier(
+            1, localMemberId, Set.of(localMemberId), partitionChangeExecutor);
+    partitionForceReconfigureApplier.init(validTopology);
+    final var applyFuture = partitionForceReconfigureApplier.apply();
+
+    // then
+    Assertions.assertThat(applyFuture)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("force fail");
+  }
+
+  @Test
+  void shouldRemovePartitionFromNonMembersIfApplySucceeded() {
+    // given
+    when(partitionChangeExecutor.forceReconfigure(anyInt(), any()))
+        .thenReturn(TestActorFuture.completedFuture(null));
+
+    final PartitionForceReconfigureApplier partitionForceReconfigureApplier =
+        new PartitionForceReconfigureApplier(
+            1, localMemberId, Set.of(localMemberId), partitionChangeExecutor);
+    partitionForceReconfigureApplier.init(validTopology);
+
+    // when
+    final var updater = partitionForceReconfigureApplier.apply().join();
+
+    // then
+    final var resultingTopology = updater.apply(validTopology);
+    ClusterTopologyAssert.assertThatClusterTopology(resultingTopology)
+        .member(otherMember)
+        .doesNotContainPartition(1);
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionReconfigurePriorityApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/PartitionReconfigurePriorityApplierTest.java
@@ -99,7 +99,7 @@ class PartitionReconfigurePriorityApplierTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get().apply(initialClusterTopology.getMember(memberId)))
+    assertThat(result.get().apply(initialClusterTopology).getMember(memberId))
         .isEqualTo(initialClusterTopology.getMember(memberId));
   }
 
@@ -122,7 +122,8 @@ class PartitionReconfigurePriorityApplierTest {
         partitionReconfigurePriorityApplier
             .apply()
             .join()
-            .apply(initialClusterTopology.getMember(memberId));
+            .apply(initialClusterTopology)
+            .getMember(memberId);
 
     // then
     assertThat(newMemberState.getPartition(partitionId).priority()).isEqualTo(3);

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImplTest.java
@@ -13,9 +13,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -47,6 +49,9 @@ final class TopologyChangeAppliersImplTest {
         Arguments.of(new MemberLeaveOperation(localMemberId), MemberLeaveApplier.class),
         Arguments.of(
             new PartitionReconfigurePriorityOperation(localMemberId, 1, 1),
-            PartitionReconfigurePriorityApplier.class));
+            PartitionReconfigurePriorityApplier.class),
+        Arguments.of(
+            new PartitionForceReconfigureOperation(localMemberId, 1, List.of()),
+            PartitionForceReconfigureApplier.class));
   }
 }

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
@@ -244,7 +245,9 @@ final class ProtoBufSerializerTest {
         List.of(
             new PartitionLeaveOperation(MemberId.from("1"), 1),
             new PartitionJoinOperation(MemberId.from("2"), 2, 5),
-            new PartitionReconfigurePriorityOperation(MemberId.from("3"), 4, 3));
+            new PartitionReconfigurePriorityOperation(MemberId.from("3"), 4, 3),
+            new PartitionForceReconfigureOperation(
+                MemberId.from("4"), 5, List.of(MemberId.from("1"), MemberId.from("3"))));
     return ClusterTopology.init()
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
         .startTopologyChange(changes);

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -259,7 +259,7 @@ final class ProtoBufSerializerTest {
     return ClusterTopology.init()
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
         .startTopologyChange(changes)
-        .advanceTopologyChange(MemberId.from("1"), m -> m);
+        .advanceTopologyChange(topology -> topology);
   }
 
   private static ClusterTopology topologyWithClusterChangePlanWithMemberOperations() {

--- a/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -127,7 +127,8 @@ class ClusterTopologyTest {
 
     // when
     final var updatedTopology =
-        initialTopology.advanceTopologyChange(member(1), MemberState::toActive);
+        initialTopology.advanceTopologyChange(
+            t -> t.updateMember(member(1), MemberState::toActive));
 
     // then
     ClusterTopologyAssert.assertThatClusterTopology(updatedTopology)
@@ -145,7 +146,7 @@ class ClusterTopologyTest {
 
     // when
     final var updatedTopology =
-        initialTopology.advanceTopologyChange(member(1), MemberState::toLeft);
+        initialTopology.advanceTopologyChange(t -> t.updateMember(member(1), MemberState::toLeft));
 
     // then
     ClusterTopologyAssert.assertThatClusterTopology(updatedTopology)
@@ -166,7 +167,8 @@ class ClusterTopologyTest {
 
     // when
     final var updatedTopology =
-        initialTopology.advanceTopologyChange(member(1), MemberState::toActive);
+        initialTopology.advanceTopologyChange(
+            t -> t.updateMember(member(1), MemberState::toActive));
 
     final var mergedTopology = initialTopology.merge(updatedTopology);
 
@@ -186,7 +188,7 @@ class ClusterTopologyTest {
     // when
     final var finalTopology =
         initialTopology.advanceTopologyChange(
-            member(1), m -> m.addPartition(1, PartitionState.active(1)));
+            t -> t.updateMember(member(1), m -> m.addPartition(1, PartitionState.active(1))));
 
     // then
     final var expected =


### PR DESCRIPTION
## Description

To support orchestrating force removal of members from a partition, in this PR we add a new `PartitionForceReconfigureOperation`.  This operation takes the members of the new configuration as the input. After applying this operation, the members which are not in the configuration should not be part of the partition anymore. To reflect that, their state in the topology is updated by removing the partition. 

Unlike other operations, the member that applies this operation can update the state of another member because this is a "force" operation. This was not possible before because `TopologyChangeApplier` interface restricts that the member that applies the change can update only its own state. To allow updating states of other members, this interface is refactored to add two different types of applier - `ClusterOperationApplier` and `MemberOperationApplier`. All old operations implements `MemberOperationApplier`. 

## Related issues

closes #16226 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
