### PR TITLE
Reject migration that attempts to change user task implementation

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -178,6 +178,8 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNoIncident(incidentState, elementInstance);
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstanceRecord, processInstanceKey);
+    requireSameUserTaskType(
+        targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
     requireUnchangedFlowScope(
         elementInstanceState, elementInstanceRecord, targetProcessDefinition, targetElementId);
     requireNoBoundaryEventInSource(sourceProcessDefinition, elementInstanceRecord);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -178,7 +178,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     requireNoIncident(incidentState, elementInstance);
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstanceRecord, processInstanceKey);
-    requireSameUserTaskType(
+    requireSameUserTaskImplementation(
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
     requireUnchangedFlowScope(
         elementInstanceState, elementInstanceRecord, targetProcessDefinition, targetElementId);

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
@@ -1004,9 +1004,9 @@ public class MigrateProcessInstanceRejectionTest {
             String.format(
                 """
               Expected to migrate process instance '%s' \
-              but active element with id 'A' and type 'ZEEBE_USER_TASK' is mapped to \
-              an element with id 'B' and different type 'USER_TASK'. \
-              Elements must be mapped to elements of the same type.""",
+              but active user task with id 'A' and implementation 'zeebe user task' is mapped to \
+              an user task with id 'B' and different implementation 'job worker'. \
+              Elements must be mapped to elements of the same implementation.""",
                 processInstanceKey))
         .hasKey(processInstanceKey);
   }
@@ -1057,9 +1057,9 @@ public class MigrateProcessInstanceRejectionTest {
             String.format(
                 """
               Expected to migrate process instance '%s' \
-              but active element with id 'A' and type 'USER_TASK' is mapped to \
-              an element with id 'B' and different type 'ZEEBE_USER_TASK'. \
-              Elements must be mapped to elements of the same type.""",
+              but active user task with id 'A' and implementation 'job worker' is mapped to \
+              an user task with id 'B' and different implementation 'zeebe user task'. \
+              Elements must be mapped to elements of the same implementation.""",
                 processInstanceKey))
         .hasKey(processInstanceKey);
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

We do not (yet) support migration job worker based user tasks to zeebe (native) user tasks and vice versa. We need to reject migration when user tries to migrate elements that have different user task implementations.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16013 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
