### PR TITLE
Track the creation timestamp of user tasks

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -117,6 +117,7 @@ public final class BpmnUserTaskBehavior {
         .setTenantId(context.getTenantId())
         .setCreationTimestamp(ActorClock.currentTimeMillis());
 
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
     return userTaskRecord;
   }
 
@@ -212,9 +213,9 @@ public final class BpmnUserTaskBehavior {
     }
   }
 
-  public void appendFollowUpEvent(
-      final long userTaskKey, final UserTaskIntent intent, final UserTaskRecord userTaskRecord) {
-    stateWriter.appendFollowUpEvent(userTaskKey, intent, userTaskRecord);
+  public void userTaskCreated(final UserTaskRecord userTaskRecord) {
+    final long userTaskKey = userTaskRecord.getUserTaskKey();
+    stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATED, userTaskRecord);
   }
 
   public static final class UserTaskProperties {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -108,6 +108,7 @@ public final class BpmnUserTaskBehavior {
         .setDueDate(userTaskProperties.getDueDate())
         .setFollowUpDate(userTaskProperties.getFollowUpDate())
         .setFormKey(userTaskProperties.getFormKey())
+        .setExternalFormReference(userTaskProperties.getExternalFormReference())
         .setBpmnProcessId(context.getBpmnProcessId())
         .setProcessDefinitionVersion(context.getProcessVersion())
         .setProcessDefinitionKey(context.getProcessDefinitionKey())

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehav
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnUserTaskBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnVariableMappingBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
-import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 
 public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<ExecutableUserTask> {
 
@@ -72,13 +71,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             userTaskProperties -> {
               final var userTaskRecord =
                   userTaskBehavior.createNewUserTask(context, element, userTaskProperties);
-
-              userTaskBehavior.appendFollowUpEvent(
-                  userTaskRecord.getUserTaskKey(), UserTaskIntent.CREATING, userTaskRecord);
-
-              userTaskBehavior.appendFollowUpEvent(
-                  userTaskRecord.getUserTaskKey(), UserTaskIntent.CREATED, userTaskRecord);
-
+              userTaskBehavior.userTaskCreated(userTaskRecord);
               stateTransitionBehavior.transitionToActivated(context, element.getEventType());
             },
             failure -> incidentBehavior.createIncident(failure, context));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
@@ -629,6 +629,23 @@ public final class NativeUserTaskTest {
   }
 
   @Test
+  public void shouldCreateUserTaskWithCreationTimestampGreaterThanZero() {
+    // given
+    ENGINE.deployment().withXmlResource(process()).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<UserTaskRecordValue> userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    assertThat(userTask.getValue().getCreationTimestamp()).isGreaterThan(0L);
+  }
+
+  @Test
   public void shouldAssignUserTask() {
     // given
     ENGINE.deployment().withXmlResource(process()).deploy();

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/UserTaskStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/UserTaskStateTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.BufferAssert;
 import io.camunda.zeebe.test.util.MsgPackUtil;
 import java.util.Arrays;
@@ -168,7 +169,8 @@ public class UserTaskStateTest {
         .setDueDate("2023-11-11T11:11:00+01:00")
         .setFollowUpDate("2023-11-12T11:11:00+01:00")
         .setFormKey(5678)
-        .setUserTaskKey(userTaskKey);
+        .setUserTaskKey(userTaskKey)
+        .setCreationTimestamp(ActorClock.currentTimeMillis());
   }
 
   private void assertUserTask(
@@ -201,7 +203,8 @@ public class UserTaskStateTest {
         .hasFollowUpDate(expectedRecord.getFollowUpDate())
         .hasFormKey(expectedRecord.getFormKey())
         .hasUserTaskKey(expectedRecord.getUserTaskKey())
-        .hasTenantId(expectedTenantId);
+        .hasTenantId(expectedTenantId)
+        .hasCreationTimestamp(expectedRecord.getCreationTimestamp());
     assertUserTaskState(expectedRecord.getUserTaskKey(), expectedLifecycleState);
   }
 

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -49,6 +49,9 @@
             "externalFormReference": {
               "type": "keyword"
             },
+            "creationTimestamp": {
+              "type": "long"
+            },
             "elementId": {
               "type": "text"
             },

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -49,6 +49,9 @@
             "externalFormReference": {
               "type": "keyword"
             },
+            "creationTimestamp": {
+              "type": "long"
+            },
             "elementId": {
               "type": "text"
             },

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -74,7 +74,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final LongProperty creationTimestampProp = new LongProperty("creationTimestamp", -1L);
 
   public UserTaskRecord() {
-    super(18);
+    super(19);
     declareProperty(userTaskKeyProp)
         .declareProperty(assigneeProp)
         .declareProperty(candidateGroupsProp)
@@ -268,16 +268,6 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     return this;
   }
 
-  public UserTaskRecord setAction(final String action) {
-    actionProp.setValue(action);
-    return this;
-  }
-
-  public UserTaskRecord setAction(final DirectBuffer action) {
-    actionProp.setValue(action);
-    return this;
-  }
-
   public UserTaskRecord setExternalFormReference(final DirectBuffer externalFormReference) {
     externalFormReferenceProp.setValue(externalFormReference);
     return this;
@@ -285,6 +275,16 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setExternalFormReference(final String externalFormReference) {
     externalFormReferenceProp.setValue(externalFormReference);
+    return this;
+  }
+
+  public UserTaskRecord setAction(final String action) {
+    actionProp.setValue(action);
+    return this;
+  }
+
+  public UserTaskRecord setAction(final DirectBuffer action) {
+    actionProp.setValue(action);
     return this;
   }
 

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/usertask/UserTaskRecord.java
@@ -71,6 +71,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   private final ArrayProperty<StringValue> changedAttributesProp =
       new ArrayProperty<>("changedAttributes", StringValue::new);
   private final StringProperty actionProp = new StringProperty("action", EMPTY_STRING);
+  private final LongProperty creationTimestampProp = new LongProperty("creationTimestamp", -1L);
 
   public UserTaskRecord() {
     super(18);
@@ -91,7 +92,8 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(tenantIdProp)
         .declareProperty(changedAttributesProp)
-        .declareProperty(actionProp);
+        .declareProperty(actionProp)
+        .declareProperty(creationTimestampProp);
   }
 
   public void wrapWithoutVariables(final UserTaskRecord record) {
@@ -110,6 +112,7 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
     elementIdProp.setValue(record.getElementIdBuffer());
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     tenantIdProp.setValue(record.getTenantIdBuffer());
+    creationTimestampProp.setValue(record.getCreationTimestamp());
     setChangedAttributesProp(record.getChangedAttributesProp());
     actionProp.setValue(record.getActionBuffer());
   }
@@ -196,6 +199,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
   }
 
   @Override
+  public long getCreationTimestamp() {
+    return creationTimestampProp.getValue();
+  }
+
+  @Override
   public String getElementId() {
     return bufferAsString(elementIdProp.getValue());
   }
@@ -252,6 +260,11 @@ public final class UserTaskRecord extends UnifiedRecordValue implements UserTask
 
   public UserTaskRecord setElementId(final DirectBuffer elementId) {
     elementIdProp.setValue(elementId);
+    return this;
+  }
+
+  public UserTaskRecord setCreationTimestamp(final long creationTimestamp) {
+    creationTimestampProp.setValue(creationTimestamp);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2078,6 +2078,7 @@ final class JsonSerializableToJsonTest {
                     .setAssignee("myAssignee")
                     .setCandidateGroups("myCandidateGroups")
                     .setCandidateUsers("myCandidateUsers")
+                    .setCreationTimestamp(1699633748000L)
                     .setDueDate("2023-11-11T11:11:00+01:00")
                     .setFollowUpDate("2023-11-12T11:11:00+01:00")
                     .setFormKey(456)
@@ -2102,6 +2103,7 @@ final class JsonSerializableToJsonTest {
         "assignee": "myAssignee",
         "candidateGroups": "myCandidateGroups",
         "candidateUsers": "myCandidateUsers",
+        "creationTimestamp": 1699633748000,
         "dueDate": "2023-11-11T11:11:00+01:00",
         "followUpDate": "2023-11-12T11:11:00+01:00",
         "changedAttributes": ["foo", "bar"],
@@ -2134,6 +2136,7 @@ final class JsonSerializableToJsonTest {
         "assignee": "",
         "candidateGroups": "",
         "candidateUsers": "",
+        "creationTimestamp": -1,
         "dueDate": "",
         "followUpDate": "",
         "changedAttributes": [],
@@ -2167,6 +2170,7 @@ final class JsonSerializableToJsonTest {
         "assignee": "",
         "candidateGroups": "",
         "candidateUsers": "",
+        "creationTimestamp": -1,
         "dueDate": "",
         "followUpDate": "",
         "changedAttributes": [],

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -51,6 +51,8 @@ public interface UserTaskRecordValue
 
   String getExternalFormReference();
 
+  long getCreationTimestamp();
+
   /**
    * @return the element id of the corresponding user task
    */


### PR DESCRIPTION
## Description

- Created a creationTimestamp property of type long in the UserTaskRecord, with a default of -1.
- Increased the number of expectedDeclaredProperties in the UserTaskRecord's constructor.
- Updated JsonSerializableToJsonTest
- Added new property it to the exporters (ES + OS).
- Set the creation date to the current time using ActorClock#currentTimeMillis when the user task record is created in the UserTaskProcessor.
- Ensured the creation date is set in NativeUserTaskTest.java

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16174

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
