### PR TITLE
[Backport stable/8.3] fix(snapshot): ignore file not found exceptions on deletion

### DIFF
--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -366,7 +366,7 @@ public final class FileBasedSnapshotStore extends Actor
       if (!buildSnapshotsChecksumPath(parsedSnapshotId).toFile().exists()) {
         try {
           // old pending/incomplete received snapshots which we can delete
-          deleteFolder(directory);
+          FileUtil.deleteFolderIfExists(directory);
         } catch (final IOException e) {
           throw new IllegalStateException(
               "Expected to delete pending received snapshot, but failed.", e);


### PR DESCRIPTION
# Description
Backport of #15763 to `stable/8.3`.

relates to #14670
original author: @npepinpe