### PR TITLE
[Backport stable/8.2] Prevent endless error loop when processing user commands

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -489,12 +489,12 @@ public final class ProcessingStateMachine {
         switch (errorHandlingPhase) {
           case NO_ERROR -> ErrorHandlingPhase.NO_ERROR; // First switch is explicit
           case PROCESSING_FAILED -> ErrorHandlingPhase.PROCESSING_ERROR_FAILED;
-          case USER_COMMAND_PROCESSING_FAILED ->
-              ErrorHandlingPhase.USER_COMMAND_PROCESSING_ERROR_FAILED;
-          case USER_COMMAND_PROCESSING_ERROR_FAILED ->
-              ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED;
-          case ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED ->
-              ErrorHandlingPhase.USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED;
+          case USER_COMMAND_PROCESSING_FAILED -> ErrorHandlingPhase
+              .USER_COMMAND_PROCESSING_ERROR_FAILED;
+          case USER_COMMAND_PROCESSING_ERROR_FAILED -> ErrorHandlingPhase
+              .USER_COMMAND_REJECT_FAILED;
+          case USER_COMMAND_REJECT_FAILED -> ErrorHandlingPhase
+              .USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED;
           case PROCESSING_ERROR_FAILED, USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED -> {
             LOG.error(
                 "Failed to process command '{} {}' retries. Entering endless error loop.",
@@ -520,7 +520,12 @@ public final class ProcessingStateMachine {
             .rejectionType(RejectionType.PROCESSING_ERROR)
             .rejectionReason(rejectionReason);
     processingResultBuilder.appendRecord(
-        currentRecord.getKey(), typedCommand.getValue(), rejectionMetadata);
+        currentRecord.getKey(),
+        rejectionMetadata.getRecordType(),
+        rejectionMetadata.getIntent(),
+        rejectionMetadata.getRejectionType(),
+        rejectionMetadata.getRejectionReason(),
+        typedCommand.getValue());
     processingResultBuilder.withResponse(
         RecordType.COMMAND_REJECTION,
         typedCommand.getKey(),

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -116,12 +117,12 @@ public final class ProcessingStateMachine {
   private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
   private static final MetadataFilter PROCESSING_FILTER =
       recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND;
+  private static final String ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED =
+      "Expected to process command '{} {}' successfully on stream processor, but caught unexpected exception. Failed to handle the exception gracefully.";
   private final EventFilter eventFilter = new MetadataEventFilter(PROCESSING_FILTER);
-
   private final EventFilter commandFilter =
       new MetadataEventFilter(
           recordMetadata -> recordMetadata.getRecordType() != RecordType.COMMAND);
-
   private final MutableLastProcessedPositionState lastProcessedPositionState;
   private final RecordMetadata metadata = new RecordMetadata();
   private final ActorControl actor;
@@ -136,14 +137,12 @@ public final class ProcessingStateMachine {
   private final TypedRecordImpl typedCommand;
   private final StreamProcessorMetrics metrics;
   private final StreamProcessorListener streamProcessorListener;
-
   // current iteration
   private LoggedEvent currentRecord;
   private ZeebeDbTransaction zeebeDbTransaction;
   private long writtenPosition = StreamProcessor.UNSET_POSITION;
   private long lastSuccessfulProcessedRecordPosition = StreamProcessor.UNSET_POSITION;
   private long lastWrittenPosition = StreamProcessor.UNSET_POSITION;
-  private volatile boolean onErrorHandlingLoop;
   private int onErrorRetries;
   // Used for processing duration metrics
   private Histogram.Timer processingTimer;
@@ -153,7 +152,6 @@ public final class ProcessingStateMachine {
   private ProcessingResult currentProcessingResult;
   private List<LogAppendEntry> pendingWrites;
   private Collection<ProcessingResponse> pendingResponses;
-
   private RecordProcessor currentProcessor;
   private final LogStreamWriter logStreamWriter;
   private boolean inProcessing;
@@ -161,6 +159,7 @@ public final class ProcessingStateMachine {
   private int processedCommandsCount;
   private final ProcessingMetrics processingMetrics;
   private final ScheduledCommandCache scheduledCommandCache;
+  private volatile ErrorHandlingPhase errorHandlingPhase = ErrorHandlingPhase.NO_ERROR;
 
   public ProcessingStateMachine(
       final StreamProcessorContext context,
@@ -202,8 +201,8 @@ public final class ProcessingStateMachine {
 
   void readNextRecord() {
     if (onErrorRetries > 0) {
-      onErrorHandlingLoop = false;
       onErrorRetries = 0;
+      errorHandlingPhase = ErrorHandlingPhase.NO_ERROR;
     }
 
     tryToReadNextRecord();
@@ -296,9 +295,10 @@ public final class ProcessingStateMachine {
             maxCommandsInBatch,
             exceededBatchRecordSizeException);
         processingMetrics.countRetry();
-        onError(() -> processCommand(loggedEvent));
+        onError(exceededBatchRecordSizeException, () -> processCommand(loggedEvent));
       } else {
         onError(
+            exceededBatchRecordSizeException,
             () -> {
               errorHandlingInTransaction(exceededBatchRecordSizeException);
               writeRecords();
@@ -306,6 +306,7 @@ public final class ProcessingStateMachine {
       }
     } catch (final Exception e) {
       onError(
+          e,
           () -> {
             errorHandlingInTransaction(e);
             writeRecords();
@@ -420,11 +421,10 @@ public final class ProcessingStateMachine {
     return new BatchProcessingStepResult(commandsToProcess, toWriteEntries);
   }
 
-  private void onError(final NextProcessingStep nextStep) {
+  private void onError(final Throwable error, final NextProcessingStep nextStep) {
     onErrorRetries++;
-    if (onErrorRetries > 1) {
-      onErrorHandlingLoop = true;
-    }
+    switchErrorPhase();
+
     final ActorFuture<Boolean> retryFuture =
         updateStateRetryStrategy.runWithRetry(
             () -> {
@@ -432,6 +432,34 @@ public final class ProcessingStateMachine {
               return true;
             },
             abortCondition);
+
+    try {
+      // If in error loop and the processing record is a user command
+      if (errorHandlingPhase == ErrorHandlingPhase.USER_COMMAND_PROCESSING_ERROR_FAILED) {
+        // First try to reject with proper error message
+        LOG.debug(ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED, currentRecord, metadata, error);
+        tryRejectingIfUserCommand(error.getMessage());
+        return;
+      } else if (errorHandlingPhase == ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED) {
+        LOG.warn(ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED, currentRecord, metadata, error);
+        // try to reject with a generic error message
+        tryRejectingIfUserCommand(
+            String.format(
+                "Expected to process command, but caught an exception. Check broker logs (partition %s) for details.",
+                context.getPartitionId()));
+        return;
+      }
+    } catch (final Exception e) {
+      // Unexpected error, so we just fail back to endless loop
+      LOG.error(
+          "Expected to write rejection for command '{} {}', but failed with unexpected error.",
+          currentRecord,
+          metadata,
+          e);
+      pendingResponses.clear();
+      pendingWrites.clear();
+      onError(e, nextStep);
+    }
 
     actor.runOnCompletion(
         retryFuture,
@@ -442,12 +470,78 @@ public final class ProcessingStateMachine {
           try {
             nextStep.run();
           } catch (final Exception ex) {
-            onError(nextStep);
+            onError(ex, nextStep);
           }
         });
   }
 
+  private void startErrorLoop(final boolean isUserCommand) {
+    if (errorHandlingPhase == ErrorHandlingPhase.NO_ERROR) {
+      errorHandlingPhase =
+          isUserCommand
+              ? ErrorHandlingPhase.USER_COMMAND_PROCESSING_FAILED
+              : ErrorHandlingPhase.PROCESSING_FAILED;
+    }
+  }
+
+  private void switchErrorPhase() {
+    errorHandlingPhase =
+        switch (errorHandlingPhase) {
+          case NO_ERROR -> ErrorHandlingPhase.NO_ERROR; // First switch is explicit
+          case PROCESSING_FAILED -> ErrorHandlingPhase.PROCESSING_ERROR_FAILED;
+          case USER_COMMAND_PROCESSING_FAILED ->
+              ErrorHandlingPhase.USER_COMMAND_PROCESSING_ERROR_FAILED;
+          case USER_COMMAND_PROCESSING_ERROR_FAILED ->
+              ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED;
+          case ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED ->
+              ErrorHandlingPhase.USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED;
+          case PROCESSING_ERROR_FAILED, USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED -> {
+            LOG.error(
+                "Failed to process command '{} {}' retries. Entering endless error loop.",
+                currentRecord,
+                metadata);
+            yield ErrorHandlingPhase.ENDLESS_ERROR_LOOP;
+          }
+          case ENDLESS_ERROR_LOOP -> ErrorHandlingPhase.ENDLESS_ERROR_LOOP;
+        };
+  }
+
+  private void tryRejectingIfUserCommand(final String errorMessage) {
+    final var rejectionReason = errorMessage != null ? errorMessage : "";
+    final ProcessingResultBuilder processingResultBuilder =
+        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
+    // reset value to minimize any potential error loop that can be caused by writing the full
+    // record.
+    typedCommand.getValue().reset();
+    final var rejectionMetadata =
+        new RecordMetadata()
+            .recordType(RecordType.COMMAND_REJECTION)
+            .intent(typedCommand.getIntent())
+            .rejectionType(RejectionType.PROCESSING_ERROR)
+            .rejectionReason(rejectionReason);
+    processingResultBuilder.appendRecord(
+        currentRecord.getKey(), typedCommand.getValue(), rejectionMetadata);
+    processingResultBuilder.withResponse(
+        RecordType.COMMAND_REJECTION,
+        typedCommand.getKey(),
+        typedCommand.getIntent(),
+        typedCommand.getValue(),
+        typedCommand.getValueType(),
+        RejectionType.PROCESSING_ERROR,
+        rejectionReason,
+        typedCommand.getRequestId(),
+        typedCommand.getRequestStreamId());
+    currentProcessingResult = processingResultBuilder.build();
+
+    pendingWrites = currentProcessingResult.getRecordBatch().entries();
+    pendingResponses = currentProcessingResult.getProcessingResponse().stream().toList();
+
+    finalizeCommandProcessing();
+    writeRecords();
+  }
+
   private void errorHandlingInTransaction(final Throwable processingException) throws Exception {
+    startErrorLoop(typedCommand.hasRequestMetadata());
     zeebeDbTransaction = transactionContext.getCurrentTransaction();
     zeebeDbTransaction.run(
         () -> {
@@ -504,6 +598,7 @@ public final class ProcessingStateMachine {
           if (t != null) {
             LOG.error(ERROR_MESSAGE_WRITE_RECORD_ABORTED, currentRecord, metadata, t);
             onError(
+                t,
                 () -> {
                   errorHandlingInTransaction(t);
                   writeRecords();
@@ -537,6 +632,7 @@ public final class ProcessingStateMachine {
           if (throwable != null) {
             LOG.error(ERROR_MESSAGE_UPDATE_STATE_FAILED, currentRecord, metadata, throwable);
             onError(
+                throwable,
                 () -> {
                   errorHandlingInTransaction(throwable);
                   updateState();
@@ -625,7 +721,7 @@ public final class ProcessingStateMachine {
   }
 
   public boolean isMakingProgress() {
-    return !onErrorHandlingLoop;
+    return errorHandlingPhase != ErrorHandlingPhase.ENDLESS_ERROR_LOOP;
   }
 
   public void startProcessing(final LastProcessingPositions lastProcessingPositions) {
@@ -652,5 +748,23 @@ public final class ProcessingStateMachine {
   @FunctionalInterface
   private interface NextProcessingStep {
     void run() throws Exception;
+  }
+
+  private enum ErrorHandlingPhase {
+    NO_ERROR,
+    // external commands failed in processRecord
+    USER_COMMAND_PROCESSING_FAILED,
+    // internal commands and events failed in processRecord
+    PROCESSING_FAILED,
+    // internal commands and events failed when handling the error from processing failure
+    PROCESSING_ERROR_FAILED,
+    // external commands failed when handling the error from processing failure
+    USER_COMMAND_PROCESSING_ERROR_FAILED,
+    // external commands failed when trying to reject with a proper error message
+    USER_COMMAND_REJECT_FAILED,
+    // external commands failed when trying to reject with a generic error message
+    USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED,
+    // All attempted error handling failed.
+    ENDLESS_ERROR_LOOP
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -487,7 +487,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     }
 
     if (processingStateMachine != null && !processingStateMachine.isMakingProgress()) {
-      return HealthReport.unhealthy(this).withMessage("not making progress");
+      return HealthReport.unhealthy(this)
+          .withMessage("Processing not making progress. It is in an error handling loop.");
     }
 
     // If healthCheckTick was not invoked it indicates the actor is blocked in a runUntilDone loop.

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
@@ -73,8 +74,11 @@ class StreamProcessorErrorHandlingTest {
     final var successResult = new BufferedProcessingResultBuilder((c, s) -> true);
     successResult.appendRecordReturnEither(
         1,
-        Records.processInstance(1),
-        new RecordMetadata().recordType(RecordType.EVENT).intent(ELEMENT_ACTIVATED));
+        RecordType.EVENT,
+        ELEMENT_ACTIVATED,
+        RejectionType.NULL_VAL,
+        "",
+        Records.processInstance(1));
 
     when(defaultMockedRecordProcessor.process(any(), any()))
         .thenThrow(new RuntimeException())

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.util.RecordToWrite;
+import io.camunda.zeebe.stream.util.Records;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.verification.VerificationWithTimeout;
+
+@ExtendWith(StreamPlatformExtension.class)
+class StreamProcessorErrorHandlingTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  @Test
+  void shouldRejectUserCommandIfProcessingErrorHandlingFailed() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenThrow(new RuntimeException());
+    when(defaultMockedRecordProcessor.onProcessingError(any(), any(), any()))
+        .thenThrow(new RuntimeException());
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.userCommand()
+            .processInstance(ProcessInstanceIntent.ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).process(any(), any());
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).onProcessingError(any(), any(), any());
+
+    final var logStreamReader = streamPlatform.getLogStream().newLogStreamReader();
+    logStreamReader.seekToFirstEvent();
+    logStreamReader.next(); // command
+
+    // rejection
+    await("should write rejection to log")
+        .untilAsserted(() -> assertThat(logStreamReader.hasNext()).isTrue());
+    final var record = logStreamReader.next();
+    final var recordMetadata = new RecordMetadata();
+    record.readMetadata(recordMetadata);
+    assertThat(recordMetadata.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(record.getSourceEventPosition()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldContinueProcessingEvenIfErrorHandlingFailedForUserCommand() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    final var successResult = new BufferedProcessingResultBuilder((c, s) -> true);
+    successResult.appendRecordReturnEither(
+        1,
+        Records.processInstance(1),
+        new RecordMetadata().recordType(RecordType.EVENT).intent(ELEMENT_ACTIVATED));
+
+    when(defaultMockedRecordProcessor.process(any(), any()))
+        .thenThrow(new RuntimeException())
+        .thenReturn(successResult.build());
+    when(defaultMockedRecordProcessor.onProcessingError(any(), any(), any()))
+        .thenThrow(new RuntimeException());
+
+    streamPlatform.startStreamProcessor();
+
+    // Command that should fail
+    streamPlatform.writeBatch(
+        RecordToWrite.userCommand()
+            .processInstance(ProcessInstanceIntent.ACTIVATE_ELEMENT, Records.processInstance(1)));
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).onProcessingError(any(), any(), any());
+
+    // when
+    // Command that should succeed
+    final var secondCommand =
+        streamPlatform.writeBatch(
+            RecordToWrite.userCommand()
+                .processInstance(
+                    ProcessInstanceIntent.ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+    final var logStreamReader = streamPlatform.getLogStream().newLogStreamReader();
+    logStreamReader.seekToFirstEvent();
+    logStreamReader.next(); // command
+    logStreamReader.next(); // rejection
+    logStreamReader.next(); // command
+
+    await("should write follow up event of second command to log")
+        .untilAsserted(() -> assertThat(logStreamReader.hasNext()).isTrue());
+    final var record = logStreamReader.next();
+    final var recordMetadata = new RecordMetadata();
+    record.readMetadata(recordMetadata);
+    assertThat(recordMetadata.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(recordMetadata.getIntent()).isEqualTo(ELEMENT_ACTIVATED);
+    assertThat(record.getSourceEventPosition()).isEqualTo(secondCommand);
+  }
+}

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
@@ -55,6 +55,11 @@ public final class RecordToWrite implements LogAppendEntry {
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
   }
 
+  public static RecordToWrite userCommand() {
+    final RecordMetadata recordMetadata = new RecordMetadata().requestId(100).requestStreamId(10);
+    return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
+  }
+
   public static RecordToWrite event() {
     final RecordMetadata recordMetadata = new RecordMetadata();
     return new RecordToWrite(recordMetadata.recordType(RecordType.EVENT));


### PR DESCRIPTION
# Description
Backport of #16290 to `stable/8.2`.

relates to #16107
original author: @deepthidevaki