### PR TITLE
[Backport stable/8.3] Prevent endless error loop when processing user commands

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -486,12 +486,12 @@ public final class ProcessingStateMachine {
         switch (errorHandlingPhase) {
           case NO_ERROR -> ErrorHandlingPhase.NO_ERROR; // First switch is explicit
           case PROCESSING_FAILED -> ErrorHandlingPhase.PROCESSING_ERROR_FAILED;
-          case USER_COMMAND_PROCESSING_FAILED ->
-              ErrorHandlingPhase.USER_COMMAND_PROCESSING_ERROR_FAILED;
-          case USER_COMMAND_PROCESSING_ERROR_FAILED ->
-              ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED;
-          case ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED ->
-              ErrorHandlingPhase.USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED;
+          case USER_COMMAND_PROCESSING_FAILED -> ErrorHandlingPhase
+              .USER_COMMAND_PROCESSING_ERROR_FAILED;
+          case USER_COMMAND_PROCESSING_ERROR_FAILED -> ErrorHandlingPhase
+              .USER_COMMAND_REJECT_FAILED;
+          case USER_COMMAND_REJECT_FAILED -> ErrorHandlingPhase
+              .USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED;
           case PROCESSING_ERROR_FAILED, USER_COMMAND_REJECT_SIMPLE_REJECT_FAILED -> {
             LOG.error(
                 "Failed to process command '{} {}' retries. Entering endless error loop.",

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -490,7 +490,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     }
 
     if (processingStateMachine != null && !processingStateMachine.isMakingProgress()) {
-      return HealthReport.unhealthy(this).withMessage("not making progress");
+      return HealthReport.unhealthy(this)
+          .withMessage("Processing not making progress. It is in an error handling loop.");
     }
 
     // If healthCheckTick was not invoked it indicates the actor is blocked in a runUntilDone loop.

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorErrorHandlingTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATED;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.stream.util.RecordToWrite;
+import io.camunda.zeebe.stream.util.Records;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.verification.VerificationWithTimeout;
+
+@ExtendWith(StreamPlatformExtension.class)
+class StreamProcessorErrorHandlingTest {
+
+  private static final long TIMEOUT_MILLIS = 2_000L;
+  private static final VerificationWithTimeout TIMEOUT = timeout(TIMEOUT_MILLIS);
+
+  @SuppressWarnings("unused") // injected by the extension
+  private StreamPlatform streamPlatform;
+
+  @Test
+  void shouldRejectUserCommandIfProcessingErrorHandlingFailed() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultMockedRecordProcessor.process(any(), any())).thenThrow(new RuntimeException());
+    when(defaultMockedRecordProcessor.onProcessingError(any(), any(), any()))
+        .thenThrow(new RuntimeException());
+
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.userCommand()
+            .processInstance(ProcessInstanceIntent.ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).process(any(), any());
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).onProcessingError(any(), any(), any());
+
+    final var logStreamReader = streamPlatform.getLogStream().newLogStreamReader();
+    logStreamReader.seekToFirstEvent();
+    logStreamReader.next(); // command
+
+    // rejection
+    await("should write rejection to log")
+        .untilAsserted(() -> assertThat(logStreamReader.hasNext()).isTrue());
+    final var record = logStreamReader.next();
+    final var recordMetadata = new RecordMetadata();
+    record.readMetadata(recordMetadata);
+    assertThat(recordMetadata.getRecordType()).isEqualTo(RecordType.COMMAND_REJECTION);
+    assertThat(record.getSourceEventPosition()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldContinueProcessingEvenIfErrorHandlingFailedForUserCommand() {
+    // given
+    final var defaultMockedRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    final var successResult = new BufferedProcessingResultBuilder((c, s) -> true);
+    successResult.appendRecordReturnEither(
+        1,
+        Records.processInstance(1),
+        new RecordMetadata().recordType(RecordType.EVENT).intent(ELEMENT_ACTIVATED));
+
+    when(defaultMockedRecordProcessor.process(any(), any()))
+        .thenThrow(new RuntimeException())
+        .thenReturn(successResult.build());
+    when(defaultMockedRecordProcessor.onProcessingError(any(), any(), any()))
+        .thenThrow(new RuntimeException());
+
+    streamPlatform.startStreamProcessor();
+
+    // Command that should fail
+    streamPlatform.writeBatch(
+        RecordToWrite.userCommand()
+            .processInstance(ProcessInstanceIntent.ACTIVATE_ELEMENT, Records.processInstance(1)));
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(1)).onProcessingError(any(), any(), any());
+
+    // when
+    // Command that should succeed
+    final var secondCommand =
+        streamPlatform.writeBatch(
+            RecordToWrite.userCommand()
+                .processInstance(
+                    ProcessInstanceIntent.ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    verify(defaultMockedRecordProcessor, TIMEOUT.times(2)).process(any(), any());
+    final var logStreamReader = streamPlatform.getLogStream().newLogStreamReader();
+    logStreamReader.seekToFirstEvent();
+    logStreamReader.next(); // command
+    logStreamReader.next(); // rejection
+    logStreamReader.next(); // command
+
+    await("should write follow up event of second command to log")
+        .untilAsserted(() -> assertThat(logStreamReader.hasNext()).isTrue());
+    final var record = logStreamReader.next();
+    final var recordMetadata = new RecordMetadata();
+    record.readMetadata(recordMetadata);
+    assertThat(recordMetadata.getRecordType()).isEqualTo(RecordType.EVENT);
+    assertThat(recordMetadata.getIntent()).isEqualTo(ELEMENT_ACTIVATED);
+    assertThat(record.getSourceEventPosition()).isEqualTo(secondCommand);
+  }
+}

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
@@ -55,6 +55,11 @@ public final class RecordToWrite implements LogAppendEntry {
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
   }
 
+  public static RecordToWrite userCommand() {
+    final RecordMetadata recordMetadata = new RecordMetadata().requestId(100).requestStreamId(10);
+    return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
+  }
+
   public static RecordToWrite event() {
     final RecordMetadata recordMetadata = new RecordMetadata();
     return new RecordToWrite(recordMetadata.recordType(RecordType.EVENT));


### PR DESCRIPTION
# Description
Backport of #16290 to `stable/8.3`.

relates to #16107
original author: @deepthidevaki