### PR TITLE
A follower can start force configuration to remove a set of nodes

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -323,6 +323,18 @@ public interface RaftServer {
   CompletableFuture<RaftServer> promote();
 
   /**
+   * Force configure the partition to remove all members which are not part of the given
+   * membersToRetain.
+   *
+   * <p>This method is typically called to remove a set of unreachable members when there is no
+   * leader.
+   *
+   * @param membersToRetain The members to retain in the partition
+   * @return a future to be completed once the server has been force configured
+   */
+  CompletableFuture<RaftServer> forceConfigure(Collection<MemberId> membersToRetain);
+
+  /**
    * Update priority of this server used for priority election. If priority election is not enabled,
    * this method has no effect. To get the desired result, priority of all replicas must be updated
    * accordingly. This method only updates the local server's priority.

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -116,6 +116,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public CompletableFuture<RaftServer> forceConfigure(final Collection<MemberId> membersToRetain) {
+    return new ReconfigurationHelper(context).forceConfigure(membersToRetain).thenApply(v -> this);
+  }
+
+  @Override
   public CompletableFuture<Void> reconfigurePriority(final int newPriority) {
     return context.reconfigurePriority(newPriority);
   }

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -42,6 +42,7 @@ import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureResponse;
+import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.JoinResponse;
 import io.atomix.raft.protocol.LeaveResponse;
@@ -324,6 +325,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
         request ->
             handleRequestOnContext(
                 request, () -> role.onReconfigure(request), ReconfigureResponse::builder));
+    protocol.registerForceConfigureHandler(
+        request ->
+            handleRequestOnContext(
+                request, () -> role.onForceConfigure(request), ForceConfigureResponse::builder));
     protocol.registerJoinHandler(
         request ->
             handleRequestOnContext(request, () -> role.onJoin(request), JoinResponse::builder));
@@ -821,6 +826,7 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
     protocol.unregisterConfigureHandler();
     protocol.unregisterInstallHandler();
     protocol.unregisterReconfigureHandler();
+    protocol.unregisterForceConfigureHandler();
     protocol.unregisterJoinHandler();
     protocol.unregisterLeaveHandler();
     protocol.unregisterTransferHandler();

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -314,7 +314,7 @@ public final class ReconfigurationHelper {
     raftContext
         .getProtocol()
         .forceConfigure(memberId, request)
-        .whenComplete(
+        .whenCompleteAsync(
             (response, error) -> {
               if (error != null) {
                 logger.warn(
@@ -330,7 +330,8 @@ public final class ReconfigurationHelper {
                     response.error());
                 quorum.fail(memberId);
               }
-            });
+            },
+            threadContext);
   }
 
   /** Attempts to become the leader. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -233,7 +233,7 @@ public final class ReconfigurationHelper {
             .map(m -> new DefaultRaftMember(m, Type.ACTIVE, Instant.now()))
             .collect(Collectors.toSet());
 
-    if (!currentConfiguration.force()) {
+    if (currentConfiguration == null || !currentConfiguration.force()) {
       // No need to overwrite if it is already in force configure and this is a retry
       if (raftContext.getRaftRole().role() == Role.LEADER) {
         // Optimization: If the current configuration is already the same as new forced, we
@@ -248,7 +248,7 @@ public final class ReconfigurationHelper {
           newMembers);
       final var newConfiguration =
           new Configuration(
-              currentConfiguration.index() + 1,
+              raftContext.getCurrentConfigurationIndex() + 1,
               raftContext.getTerm(),
               Instant.now().toEpochMilli(),
               newMembers,

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -298,7 +298,7 @@ public final class ReconfigurationHelper {
             .withTerm(configuration.term())
             .withIndex(configuration.index())
             .withTime(configuration.time())
-            .withNewMembers(configuration.newMembers())
+            .withNewMembers(Set.copyOf(configuration.newMembers()))
             .from(raftContext.getCluster().getLocalMember().memberId())
             .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -226,7 +226,7 @@ public final class ReconfigurationHelper {
   private void triggerForceConfigure(
       final Collection<MemberId> newMembersIds, final CompletableFuture<Void> future) {
     final var currentConfiguration = raftContext.getCluster().getConfiguration();
-    final Collection<RaftMember> newMembers =
+    final Set<RaftMember> newMembers =
         newMembersIds.stream()
             // We can also take the type of the member as input. But so far we do not support
             // PASSIVE members yet. So we can safely assume they are all ACTIVE.
@@ -256,8 +256,7 @@ public final class ReconfigurationHelper {
               true);
 
       raftContext.getCluster().configure(newConfiguration);
-    } else if (!(currentConfiguration.allMembers().containsAll(newMembers)
-        && newMembers.containsAll(currentConfiguration.allMembers()))) {
+    } else if (!(currentConfiguration.allMembers().equals(newMembers))) {
       // This is not expected. When force configuration is retried, we expect that they are
       // retried with the same state. If this is not the case, it is likely that there are two
       // force configuration requested at the same time.

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftMessageContext.java
@@ -28,6 +28,7 @@ class RaftMessageContext {
   final String metadataSubject;
   final String configureSubject;
   final String reconfigureSubject;
+  final String forceConfigureSubject;
   final String joinSubject;
   final String leaveSubject;
   final String installSubject;
@@ -48,6 +49,7 @@ class RaftMessageContext {
     metadataSubject = getSubject(prefix, "metadata");
     configureSubject = getSubject(prefix, "configure");
     reconfigureSubject = getSubject(prefix, "reconfigure");
+    forceConfigureSubject = getSubject(prefix, "force-configure");
     joinSubject = getSubject(prefix, "join");
     leaveSubject = getSubject(prefix, "leave");
     installSubject = getSubject(prefix, "install");

--- a/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/partition/impl/RaftNamespaces.java
@@ -25,6 +25,8 @@ import io.atomix.raft.protocol.AppendRequest;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
+import io.atomix.raft.protocol.ForceConfigureRequest;
+import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.JoinRequest;
@@ -94,6 +96,8 @@ public final class RaftNamespaces {
           .register(JoinResponse.class)
           .register(LeaveRequest.class)
           .register(LeaveResponse.class)
+          .register(ForceConfigureRequest.class)
+          .register(ForceConfigureResponse.class)
           .name("RaftProtocol")
           .build();
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureRequest.java
@@ -23,6 +23,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftMember;
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Request to change configuration forcefully without going through the joint consensus.
@@ -36,14 +37,14 @@ public class ForceConfigureRequest extends AbstractRaftRequest {
   private final long term;
   private final long index;
   private final long timestamp;
-  private final Collection<RaftMember> members;
+  private final Set<RaftMember> members;
   private final String from;
 
   public ForceConfigureRequest(
       final long term,
       final long index,
       final long timestamp,
-      final Collection<RaftMember> newMembers,
+      final Set<RaftMember> newMembers,
       final String from) {
     this.term = term;
     this.index = index;
@@ -146,7 +147,7 @@ public class ForceConfigureRequest extends AbstractRaftRequest {
     private long term;
     private long index;
     private long timestamp;
-    private Collection<RaftMember> newMembers;
+    private Set<RaftMember> newMembers;
     private String from;
 
     /**
@@ -193,7 +194,7 @@ public class ForceConfigureRequest extends AbstractRaftRequest {
      * @return The request builder.
      * @throws NullPointerException if {@code member} is null
      */
-    public Builder withNewMembers(final Collection<RaftMember> newMembers) {
+    public Builder withNewMembers(final Set<RaftMember> newMembers) {
       this.newMembers = checkNotNull(newMembers, "members cannot be null");
       return this;
     }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureRequest.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureRequest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.raft.protocol;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.raft.cluster.RaftMember;
+import java.util.Collection;
+import java.util.Objects;
+
+/**
+ * Request to change configuration forcefully without going through the joint consensus.
+ *
+ * <p>Unlike the {@link ConfigureRequest}, this request is not sent from a leader. A force
+ * configuration is requested typically to remove a set of (unavailable) members when a quorum is
+ * not possible without them.
+ */
+public class ForceConfigureRequest extends AbstractRaftRequest {
+
+  private final long term;
+  private final long index;
+  private final long timestamp;
+  private final Collection<RaftMember> members;
+  private final String from;
+
+  public ForceConfigureRequest(
+      final long term,
+      final long index,
+      final long timestamp,
+      final Collection<RaftMember> newMembers,
+      final String from) {
+    this.term = term;
+    this.index = index;
+    this.timestamp = timestamp;
+    members = newMembers;
+    this.from = from;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(term, index, timestamp, members, from);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ForceConfigureRequest that = (ForceConfigureRequest) o;
+    return term == that.term
+        && index == that.index
+        && timestamp == that.timestamp
+        && Objects.equals(members, that.members)
+        && Objects.equals(from, that.from);
+  }
+
+  @Override
+  public String toString() {
+    return "ForceConfigureRequest{"
+        + "term="
+        + term
+        + ", index="
+        + index
+        + ", timestamp="
+        + timestamp
+        + ", members="
+        + members
+        + ", from='"
+        + from
+        + '\''
+        + '}';
+  }
+
+  /**
+   * Returns a new configuration request builder.
+   *
+   * @return A new configuration request builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns the requesting node's current term.
+   *
+   * @return The requesting node's current term.
+   */
+  public long term() {
+    return term;
+  }
+
+  /**
+   * Returns the configuration index.
+   *
+   * @return The configuration index.
+   */
+  public long index() {
+    return index;
+  }
+
+  /**
+   * Returns the configuration timestamp.
+   *
+   * @return The configuration timestamp.
+   */
+  public long timestamp() {
+    return timestamp;
+  }
+
+  /**
+   * Returns the configuration members.
+   *
+   * @return The configuration members.
+   */
+  public Collection<RaftMember> newMembers() {
+    return members;
+  }
+
+  @Override
+  public MemberId from() {
+    return MemberId.from(from);
+  }
+
+  /** Heartbeat request builder. */
+  public static class Builder extends AbstractRaftRequest.Builder<Builder, ForceConfigureRequest> {
+
+    private long term;
+    private long index;
+    private long timestamp;
+    private Collection<RaftMember> newMembers;
+    private String from;
+
+    /**
+     * Sets the request term.
+     *
+     * @param term The request term.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code term} is not positive
+     */
+    public Builder withTerm(final long term) {
+      checkArgument(term > 0, "term must be positive");
+      this.term = term;
+      return this;
+    }
+
+    /**
+     * Sets the request index.
+     *
+     * @param index The request index.
+     * @return The request builder.
+     */
+    public Builder withIndex(final long index) {
+      checkArgument(index >= 0, "index must be positive");
+      this.index = index;
+      return this;
+    }
+
+    /**
+     * Sets the request timestamp.
+     *
+     * @param timestamp The request timestamp.
+     * @return The request builder.
+     */
+    public Builder withTime(final long timestamp) {
+      checkArgument(timestamp > 0, "timestamp must be positive");
+      this.timestamp = timestamp;
+      return this;
+    }
+
+    /**
+     * Sets the members that will be part of the new configuration
+     *
+     * @param newMembers members in the new configuration.
+     * @return The request builder.
+     * @throws NullPointerException if {@code member} is null
+     */
+    public Builder withNewMembers(final Collection<RaftMember> newMembers) {
+      this.newMembers = checkNotNull(newMembers, "members cannot be null");
+      return this;
+    }
+
+    public Builder from(final MemberId from) {
+      this.from = from.id();
+      return this;
+    }
+
+    /**
+     * @throws IllegalStateException if member is null
+     */
+    @Override
+    public ForceConfigureRequest build() {
+      validate();
+      return new ForceConfigureRequest(term, index, timestamp, newMembers, from);
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkArgument(term > 0, "term must be positive");
+      checkArgument(index >= 0, "index must be positive");
+      checkArgument(timestamp > 0, "timestamp must be positive");
+      checkNotNull(newMembers, "newMembers cannot be null");
+      checkNotNull(from, "sender id cannot be null");
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureResponse.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureResponse.java
@@ -21,11 +21,25 @@ import io.atomix.raft.RaftError;
 /** Force Configuration response. */
 public class ForceConfigureResponse extends AbstractRaftResponse {
 
-  // TODO: To check if we have to do reject request to ensure that receiver do not overwrite it's
-  // latest configuration with an outdated configuration from the requests. May be respond with the
-  // current the configuration if the requester has an older configuration.
-  public ForceConfigureResponse(final Status status, final RaftError error) {
+  /** Updated configuration index of this member */
+  private final long index;
+
+  /** Current term of this member */
+  private final long term;
+
+  public ForceConfigureResponse(
+      final Status status, final RaftError error, final long index, final long term) {
     super(status, error);
+    this.index = index;
+    this.term = term;
+  }
+
+  public long index() {
+    return index;
+  }
+
+  public long term() {
+    return term;
   }
 
   /**
@@ -40,9 +54,34 @@ public class ForceConfigureResponse extends AbstractRaftResponse {
   public static class Builder
       extends AbstractRaftResponse.Builder<Builder, ForceConfigureResponse> {
 
+    private long index;
+    private long term;
+
+    /**
+     * Sets the response index.
+     *
+     * @param index updated configuration index
+     * @return The response builder.
+     */
+    public Builder withIndex(final long index) {
+      this.index = index;
+      return this;
+    }
+
+    /**
+     * Sets the response term.
+     *
+     * @param term current term of this member
+     * @return The response builder.
+     */
+    public Builder withTerm(final long term) {
+      this.term = term;
+      return this;
+    }
+
     @Override
     public ForceConfigureResponse build() {
-      return new ForceConfigureResponse(status, error);
+      return new ForceConfigureResponse(status, error, index, term);
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureResponse.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/ForceConfigureResponse.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.raft.protocol;
+
+import io.atomix.raft.RaftError;
+
+/** Force Configuration response. */
+public class ForceConfigureResponse extends AbstractRaftResponse {
+
+  // TODO: To check if we have to do reject request to ensure that receiver do not overwrite it's
+  // latest configuration with an outdated configuration from the requests. May be respond with the
+  // current the configuration if the requester has an older configuration.
+  public ForceConfigureResponse(final Status status, final RaftError error) {
+    super(status, error);
+  }
+
+  /**
+   * Returns a new configure response builder.
+   *
+   * @return A new configure response builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  public static class Builder
+      extends AbstractRaftResponse.Builder<Builder, ForceConfigureResponse> {
+
+    @Override
+    public ForceConfigureResponse build() {
+      return new ForceConfigureResponse(status, error);
+    }
+  }
+}

--- a/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/protocol/RaftServerProtocol.java
@@ -42,6 +42,16 @@ public interface RaftServerProtocol {
   CompletableFuture<ReconfigureResponse> reconfigure(MemberId memberId, ReconfigureRequest request);
 
   /**
+   * Sends a force configure request to the given node.
+   *
+   * @param memberId the node to which to send the request
+   * @param request the request to send
+   * @return a future to be completed with the response
+   */
+  CompletableFuture<ForceConfigureResponse> forceConfigure(
+      MemberId memberId, ForceConfigureRequest request);
+
+  /**
    * Sends a join request to the given node.
    *
    * @param memberId the node to which to send the request
@@ -138,6 +148,11 @@ public interface RaftServerProtocol {
 
   /** Unregisters the reconfigure request handler. */
   void unregisterReconfigureHandler();
+
+  void registerForceConfigureHandler(
+      Function<ForceConfigureRequest, CompletableFuture<ForceConfigureResponse>> handler);
+
+  void unregisterForceConfigureHandler();
 
   void registerJoinHandler(Function<JoinRequest, CompletableFuture<JoinResponse>> handler);
 

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/InactiveRole.java
@@ -23,6 +23,8 @@ import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
+import io.atomix.raft.protocol.ForceConfigureRequest;
+import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
@@ -103,6 +105,19 @@ public class InactiveRole extends AbstractRole {
     final var result =
         logResponse(
             ReconfigureResponse.builder()
+                .withStatus(Status.ERROR)
+                .withError(RaftError.Type.UNAVAILABLE)
+                .build());
+    return CompletableFuture.completedFuture(result);
+  }
+
+  @Override
+  public CompletableFuture<ForceConfigureResponse> onForceConfigure(
+      final ForceConfigureRequest request) {
+    logRequest(request);
+    final var result =
+        logResponse(
+            ForceConfigureResponse.builder()
                 .withStatus(Status.ERROR)
                 .withError(RaftError.Type.UNAVAILABLE)
                 .build());

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -99,7 +99,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
     commitInitialEntriesFuture = commitInitialEntries();
     lastZbEntry = findLastZeebeEntry();
 
-    if (jointConsensus()) {
+    if (jointConsensus() || forcedConfiguration()) {
+      // Come out of joint consensus or forced configuration
       raft.getThreadContext()
           .execute(
               () -> {
@@ -449,6 +450,10 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
 
   private boolean jointConsensus() {
     return raft.getCluster().inJointConsensus();
+  }
+
+  private boolean forcedConfiguration() {
+    return raft.getCluster().getConfiguration().force();
   }
 
   /** Commits the given configuration. */

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -232,8 +232,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       final ForceConfigureRequest request) {
     final Configuration currentConfiguration = raft.getCluster().getConfiguration();
     if (currentConfiguration != null // this is not expected in a leader
-        && request.newMembers().containsAll(currentConfiguration.allMembers())
-        && currentConfiguration.allMembers().containsAll(request.newMembers())) {
+        && request.newMembers().equals(currentConfiguration.allMembers())) {
       // It is likely that the previous force configure was successfully completed, and this is a
       // retry. So just respond success.
       return CompletableFuture.completedFuture(

--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/RaftRole.java
@@ -21,6 +21,8 @@ import io.atomix.raft.RaftServer;
 import io.atomix.raft.protocol.AppendResponse;
 import io.atomix.raft.protocol.ConfigureRequest;
 import io.atomix.raft.protocol.ConfigureResponse;
+import io.atomix.raft.protocol.ForceConfigureRequest;
+import io.atomix.raft.protocol.ForceConfigureResponse;
 import io.atomix.raft.protocol.InstallRequest;
 import io.atomix.raft.protocol.InstallResponse;
 import io.atomix.raft.protocol.InternalAppendRequest;
@@ -74,6 +76,12 @@ public interface RaftRole extends Managed<RaftRole> {
    * @return A completable future to be completed with the request response.
    */
   CompletableFuture<ReconfigureResponse> onReconfigure(ReconfigureRequest request);
+
+  /**
+   * Handles a force configure request. The request is never received from a leader. This is
+   * typically requested to remove a set of (unavailable) members when a quorum is not possible.
+   */
+  CompletableFuture<ForceConfigureResponse> onForceConfigure(ForceConfigureRequest request);
 
   /** Handles a request to join the cluster. */
   CompletableFuture<JoinResponse> onJoin(JoinRequest request);

--- a/atomix/cluster/src/main/java/io/atomix/raft/utils/ForceConfigureQuorum.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/utils/ForceConfigureQuorum.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.utils;
+
+import io.atomix.cluster.MemberId;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Consumer;
+
+public final class ForceConfigureQuorum {
+  private Consumer<Boolean> callback;
+  private boolean complete;
+  private final Set<MemberId> members;
+  private int succeeded;
+  private int failed;
+  private final int quorum;
+  private final int acceptedFailures;
+
+  /**
+   * @param callback will be called when all members have acknowledged success to this request or
+   *     when atleast one failed.
+   * @param members All members excluding the local member
+   */
+  public ForceConfigureQuorum(
+      final Consumer<Boolean> callback, final Collection<MemberId> members) {
+    this.callback = callback;
+    this.members = new HashSet<>(members);
+    // Need to include all members to ensure that the member with up-to-date log is included
+    quorum = members.size();
+    acceptedFailures = 0;
+  }
+
+  public void succeed(final MemberId member) {
+    if (members.remove(member)) {
+      succeeded++;
+      checkComplete();
+    }
+  }
+
+  public void fail(final MemberId member) {
+    if (members.remove(member)) {
+      failed++;
+      checkComplete();
+    }
+  }
+
+  /**
+   * Cancels the quorum. Once this method has been called, the quorum will be marked complete and
+   * the handler will never be called.
+   */
+  public void cancel() {
+    callback = null;
+    complete = true;
+  }
+
+  private void checkComplete() {
+    if (!complete && callback != null) {
+      if (succeeded >= quorum) {
+        complete = true;
+        callback.accept(true);
+      } else if (failed > acceptedFailures) {
+        complete = true;
+        callback.accept(false);
+      }
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -32,6 +32,8 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
 
   private Function<ConfigureRequest, CompletableFuture<ConfigureResponse>> configureHandler;
   private Function<ReconfigureRequest, CompletableFuture<ReconfigureResponse>> reconfigureHandler;
+  private Function<ForceConfigureRequest, CompletableFuture<ForceConfigureResponse>>
+      forceConfigureHandler;
   private Function<JoinRequest, CompletableFuture<JoinResponse>> joinHandler;
   private Function<LeaveRequest, CompletableFuture<LeaveResponse>> leaveHandler;
   private Function<InstallRequest, CompletableFuture<InstallResponse>> installHandler;
@@ -78,6 +80,13 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
       final MemberId memberId, final ReconfigureRequest request) {
     return scheduleTimeout(
         getServer(memberId).thenCompose(listener -> listener.reconfigure(request)));
+  }
+
+  @Override
+  public CompletableFuture<ForceConfigureResponse> forceConfigure(
+      final MemberId memberId, final ForceConfigureRequest request) {
+    return scheduleTimeout(
+        getServer(memberId).thenCompose(listener -> listener.forceConfigure(request)));
   }
 
   @Override
@@ -156,6 +165,17 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public void unregisterReconfigureHandler() {
     reconfigureHandler = null;
+  }
+
+  @Override
+  public void registerForceConfigureHandler(
+      final Function<ForceConfigureRequest, CompletableFuture<ForceConfigureResponse>> handler) {
+    forceConfigureHandler = handler;
+  }
+
+  @Override
+  public void unregisterForceConfigureHandler() {
+    forceConfigureHandler = null;
   }
 
   @Override
@@ -295,6 +315,14 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   CompletableFuture<ReconfigureResponse> reconfigure(final ReconfigureRequest request) {
     if (reconfigureHandler != null) {
       return reconfigureHandler.apply(request);
+    } else {
+      return CompletableFuture.failedFuture(new ConnectException());
+    }
+  }
+
+  CompletableFuture<ForceConfigureResponse> forceConfigure(final ForceConfigureRequest request) {
+    if (forceConfigureHandler != null) {
+      return forceConfigureHandler.apply(request);
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }

--- a/atomix/cluster/src/test/java/io/atomix/raft/utils/ForceConfigureQuorumTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/utils/ForceConfigureQuorumTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.atomix.raft.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.atomix.cluster.MemberId;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class ForceConfigureQuorumTest {
+
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final MemberId id2 = MemberId.from("2");
+  private final Set<MemberId> members = Set.of(id0, id1, id2);
+
+  @Test
+  void shouldSucceedWhenAllAck() {
+    // given
+    final AtomicBoolean success = new AtomicBoolean();
+    final ForceConfigureQuorum quorum = new ForceConfigureQuorum(success::set, members);
+
+    // when
+    members.forEach(quorum::succeed);
+
+    // then
+    assertThat(success).isTrue();
+  }
+
+  @Test
+  void shouldFailWhenOneFails() {
+    // given
+    final AtomicBoolean success = new AtomicBoolean();
+    final ForceConfigureQuorum quorum = new ForceConfigureQuorum(success::set, members);
+
+    // when
+    quorum.succeed(id0);
+    quorum.succeed(id1);
+    quorum.fail(id2);
+
+    // then
+    assertThat(success).isFalse();
+  }
+
+  @Test
+  void shouldCallbackImmediatelyIfOneFailed() {
+    // given
+    final CompletableFuture<Boolean> quorumFuture = new CompletableFuture<>();
+    final ForceConfigureQuorum quorum = new ForceConfigureQuorum(quorumFuture::complete, members);
+
+    // when
+    quorum.fail(id2);
+
+    // then
+    assertThat(quorumFuture.join()).isFalse();
+  }
+}


### PR DESCRIPTION
## Description

Implement the protocol for force reconfiguring a raft partition. The input to `RaftServer#forceConfigure` is the set of members that will be part of the new configuration. Force configuration is done in two phases - first writing a configuration with "force = true". This process doesn't go through the usual replicate+commit flow. Instead it is directly overwrites the local configuration. Then once a leader among the new configuration members is elected, the leader comes out of the force configuration and writes a new configuration following the usual raft configure protocol.

If `RaftServer#forceConfigure` fails (because of timeout, or packet loss) some members might be already in "force configuration phase", while other are not. This is ok because we can assume that `forceConfigure` will be retried, eventually moving all members to the force configure. In that case, this protocol is resilient to node restarts and network issues. 

Randomized tests to cover more edge cases will be added in a follow up PR. 

## Related issues

related #16148 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
