### PR TITLE
refactor(engine): `BpmnElementProcessor` methods to return types

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn;
 
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.util.Either;
 
 /**
  * The business logic of a BPMN element.
@@ -20,6 +22,8 @@ import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlo
  */
 public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
 
+  Either<Failure, Void> SUCCESS = Either.right(null);
+
   /**
    * @return the class that represents the BPMN element
    */
@@ -28,6 +32,10 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
   /**
    * The element is about to be entered. Perform every action to initialize and activate the
    * element.
+   *
+   * <p>This method returns an Either<Failure, ?> type, indicating the outcome of the activation
+   * attempt. A right value indicates success, while a left value (Failure) indicates that an error
+   * occurred during activation.
    *
    * <p>If the element is a wait-state (i.e. it is waiting for an event or an external trigger) then
    * it is waiting after this step to continue. Otherwise, it continues directly to the next step.
@@ -50,12 +58,19 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context process instance-related data of the element that is executed
+   * @return Either<Failure, ?> indicating the outcome of the activation attempt
    */
-  default void onActivate(final T element, final BpmnElementContext context) {}
+  default Either<Failure, ?> onActivate(final T element, final BpmnElementContext context) {
+    return SUCCESS;
+  }
 
   /**
    * The element is going to be left. Perform every action to leave the element and continue with
    * the next element.
+   *
+   * <p>This method returns an Either<Failure, ?> type, indicating the outcome of the completion
+   * attempt. A right value indicates success, while a left value (Failure) indicates that an error
+   * occurred during the element's completion.
    *
    * <p>Possible actions:
    *
@@ -71,8 +86,11 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    *
    * @param element the instance of the BPMN element that is executed
    * @param context process instance-related data of the element that is executed
+   * @return Either<Failure, ?> indicating the outcome of the completion attempt
    */
-  default void onComplete(final T element, final BpmnElementContext context) {}
+  default Either<Failure, ?> onComplete(final T element, final BpmnElementContext context) {
+    return SUCCESS;
+  }
 
   /**
    * The element is going to be terminated. Perform every action to terminate the element and

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -140,13 +140,14 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         final var activatingContext = stateTransitionBehavior.transitionToActivating(context);
         stateTransitionBehavior
             .onElementActivating(element, activatingContext)
-            .ifRightOrLeft(
-                ok -> processor.onActivate(element, activatingContext),
-                failure -> incidentBehavior.createIncident(failure, activatingContext));
+            .flatMap(ok -> processor.onActivate(element, activatingContext))
+            .ifLeft(failure -> incidentBehavior.createIncident(failure, activatingContext));
         break;
       case COMPLETE_ELEMENT:
         final var completingContext = stateTransitionBehavior.transitionToCompleting(context);
-        processor.onComplete(element, completingContext);
+        processor
+            .onComplete(element, completingContext)
+            .ifLeft(failure -> incidentBehavior.createIncident(failure, completingContext));
         break;
       case TERMINATE_ELEMENT:
         final var terminatingContext = stateTransitionBehavior.transitionToTerminating(context);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
@@ -11,7 +11,9 @@ import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementProcessor;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerTask;
+import io.camunda.zeebe.util.Either;
 
 public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWorkerTask>
     implements BpmnElementProcessor<T> {
@@ -25,21 +27,17 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
   }
 
   @Override
-  public void onActivate(final T element, final BpmnElementContext context) {
-    if (isJobBehavior(element, context)) {
-      delegate.onActivate(element, context);
-    } else {
-      onActivateInternal(element, context);
-    }
+  public Either<Failure, ?> onActivate(final T element, final BpmnElementContext context) {
+    return isJobBehavior(element, context)
+        ? delegate.onActivate(element, context)
+        : onActivateInternal(element, context);
   }
 
   @Override
-  public void onComplete(final T element, final BpmnElementContext context) {
-    if (isJobBehavior(element, context)) {
-      delegate.onComplete(element, context);
-    } else {
-      onCompleteInternal(element, context);
-    }
+  public Either<Failure, ?> onComplete(final T element, final BpmnElementContext context) {
+    return isJobBehavior(element, context)
+        ? delegate.onComplete(element, context)
+        : onCompleteInternal(element, context);
   }
 
   @Override
@@ -53,9 +51,11 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
 
   protected abstract boolean isJobBehavior(final T element, final BpmnElementContext context);
 
-  protected abstract void onActivateInternal(final T element, final BpmnElementContext context);
+  protected abstract Either<Failure, ?> onActivateInternal(
+      final T element, final BpmnElementContext context);
 
-  protected abstract void onCompleteInternal(final T element, final BpmnElementContext context);
+  protected abstract Either<Failure, ?> onCompleteInternal(
+      final T element, final BpmnElementContext context);
 
   protected abstract void onTerminateInternal(final T element, final BpmnElementContext context);
 }

--- a/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -286,6 +286,41 @@ public sealed interface Either<L, R> {
   <T> Either<L, T> flatMap(Function<? super R, ? extends Either<L, T>> right);
 
   /**
+   * Executes the given action with the right value if this is a {@link Right}, otherwise does
+   * nothing. This method facilitates side-effect operations on the right value without altering the
+   * state or the type of the {@code Either}. After executing the action, the original {@code
+   * Either<L, R>} is returned, allowing for further chaining of operations in a fluent API style.
+   *
+   * <p>When the instance is a {@link Right}, the action is executed, and the original {@code
+   * Either<L, R>} is returned. This maintains the right value's type and allows the action to be
+   * performed as a side-effect without changing the outcome. When the instance is a {@link Left},
+   * no action is performed, and the {@code Left} instance is returned unchanged, preserving the
+   * error information.
+   *
+   * <p>Usage example when {@code Either} is a {@link Right}:
+   *
+   * <pre>{@code
+   * Either<Exception, String> rightEither = Either.right("Success");
+   * Either<Exception, String> result = rightEither.thenDo(value -> System.out.println("Processed value: " + value));
+   * // Output: Processed value: Success
+   * // result remains a Right<Exception, String>, with the value "Success"
+   * }</pre>
+   *
+   * <p>Usage example when {@code Either} is a {@link Left}:
+   *
+   * <pre>{@code
+   * Either<String, Integer> leftEither = Either.left("Error occurred");
+   * Either<String, Integer> result = leftEither.thenDo(value -> System.out.println("This will not be printed"));
+   * // No output as the action is not executed
+   * // result remains an unchanged Left<String, Integer>, containing the original error message
+   * }</pre>
+   *
+   * @param action the consuming function to perform with the right value, if present
+   * @return Either<L, R> the original Either instance, allowing further operations.
+   */
+  Either<L, R> thenDo(Consumer<R> action);
+
+  /**
    * Performs the given action with the value if this is a {@link Right}, otherwise does nothing.
    *
    * @param action the consuming function for the right value
@@ -359,6 +394,12 @@ public sealed interface Either<L, R> {
     }
 
     @Override
+    public Either<L, R> thenDo(final Consumer<R> action) {
+      action.accept(value);
+      return this;
+    }
+
+    @Override
     public void ifRight(final Consumer<R> right) {
       right.accept(value);
     }
@@ -423,6 +464,11 @@ public sealed interface Either<L, R> {
     @SuppressWarnings("unchecked")
     public <T> Either<L, T> flatMap(final Function<? super R, ? extends Either<L, T>> right) {
       return (Either<L, T>) this;
+    }
+
+    @Override
+    public Either<L, R> thenDo(final Consumer<R> action) {
+      return this;
     }
 
     @Override

--- a/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
@@ -270,4 +270,39 @@ class EitherTest {
               collection.stream().filter(Either::isLeft).map(Either::getLeft).toList().get(0));
     }
   }
+
+  @DisplayName("`thenDo` method tests")
+  @Nested
+  class ThenDoMethodTests {
+
+    @DisplayName(
+        "Executes the consumer action and returns the original `Either` when it is a `Right`")
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.util.EitherTest#parameters")
+    void thenDoExecutesActionAndReturnsOriginalEitherWhenRight(final Object value) {
+      final var verifiableConsumer = new VerifiableConsumer();
+      final Either<Object, Object> originalRight = Either.right(value);
+
+      final Either<Object, Object> result = originalRight.thenDo(verifiableConsumer);
+
+      assertThat(verifiableConsumer.hasBeenExecuted).isTrue();
+      assertThat(result).as("Should return the original `Either` instance").isSameAs(originalRight);
+      assertThat(result.get()).isEqualTo(value);
+    }
+
+    @DisplayName(
+        "Does not execute the consumer action and returns the original `Either` when it is a `Left`")
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.util.EitherTest#parameters")
+    void thenDoDoesNotExecuteActionAndReturnsOriginalEitherWhenLeft(final Object value) {
+      final var verifiableConsumer = new VerifiableConsumer();
+      final Either<Object, Object> originalLeft = Either.left(value);
+
+      final Either<Object, Object> result = originalLeft.thenDo(verifiableConsumer);
+
+      assertThat(verifiableConsumer.hasBeenExecuted).isFalse();
+      assertThat(result).as("Should return the original `Either` instance").isSameAs(originalLeft);
+      assertThat(result.getLeft()).isEqualTo(value);
+    }
+  }
 }


### PR DESCRIPTION
## Description

### Overview
This PR introduces enhancements to the `BpmnElementProcessor` by changing the return types of the `onActivate` and `onComplete` methods from `void` to `Either<Failure, ?>`. This alteration aims to provide a more structured approach to error handling and process management within our system. Additionally, it centralises the incident creation logic within the `BpmnStreamProcessor`, streamlining error management and improving maintainability.
### Key Changes
- Updated `onActivate` and `onComplete` methods in `BpmnElementProcessor.java` to return `Either<Failure, ?>`.
- Modified all implementations of the `BpmnElementProcessor` interface to comply with the new method signatures.
- Transferred the responsibility for incident creation from individual `BpmnElementProcessor` implementations to the `BpmnStreamProcessor`.
### Motivation
1. To enhance the system's ability to handle errors more effectively and provide clear, actionable feedback for process management.
2. To prepare the interface for the introduction of new lifecycle methods.

This work lays the groundwork for subsequent enhancements.

## Related issues
closes #16207 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
