### PR TITLE
Invoke a compensation handler the same amount as executed 

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/MultiInstanceBodyProcessor.java
@@ -106,8 +106,7 @@ public final class MultiInstanceBodyProcessor
         .getOutputCollection()
         .ifPresent(variableName -> stateBehavior.propagateVariable(context, variableName));
 
-    compensationSubscriptionBehaviour.createCompensationSubscriptionForMultiInstance(
-        element, context);
+    compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
 
     return stateTransitionBehavior
         .transitionToCompleted(element, context)
@@ -398,11 +397,11 @@ public final class MultiInstanceBodyProcessor
 
       case "numberOfActiveInstances" -> getNumberOfActiveInstancesVariable(elementInstanceKey);
 
-      case "numberOfCompletedInstances" -> getNumberOfCompletedInstancesVariable(
-          elementInstanceKey);
+      case "numberOfCompletedInstances" ->
+          getNumberOfCompletedInstancesVariable(elementInstanceKey);
 
-      case "numberOfTerminatedInstances" -> getNumberOfTerminatedInstancesVariable(
-          elementInstanceKey);
+      case "numberOfTerminatedInstances" ->
+          getNumberOfTerminatedInstancesVariable(elementInstanceKey);
 
       default -> null;
     };

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -69,7 +69,7 @@ public final class ProcessProcessor
       final ExecutableFlowElementContainer element, final BpmnElementContext context) {
 
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
-    compensationSubscriptionBehaviour.deleteSubscriptions(context);
+    compensationSubscriptionBehaviour.deleteSubscriptionsOfProcessInstance(context);
 
     // we need to send the result before we transition to completed, since the
     // event applier will delete the element instance
@@ -87,7 +87,7 @@ public final class ProcessProcessor
 
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
     incidentBehavior.resolveIncidents(context);
-    compensationSubscriptionBehaviour.deleteSubscriptions(context);
+    compensationSubscriptionBehaviour.deleteSubscriptionsOfProcessInstance(context);
 
     final var noActiveChildInstances = stateTransitionBehavior.terminateChildInstances(context);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -77,8 +77,7 @@ public final class SubProcessProcessor
         .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(completing);
-              compensationSubscriptionBehaviour.createCompensationSubscriptionForSubprocess(
-                  element, completing);
+              compensationSubscriptionBehaviour.createCompensationSubscription(element, completing);
               return stateTransitionBehavior.transitionToCompleted(element, completing);
             })
         .thenDo(completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -338,7 +338,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
           stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
 
       final var isCompensationTriggered =
-          compensationSubscriptionBehaviour.triggerCompensation(element, activating);
+          compensationSubscriptionBehaviour.triggerCompensation(activating);
 
       if (isCompensationTriggered) {
         return SUCCESS;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -315,7 +315,7 @@ public class IntermediateThrowEventProcessor
           stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
 
       final var isCompensationTriggered =
-          compensationSubscriptionBehaviour.triggerCompensation(element, activating);
+          compensationSubscriptionBehaviour.triggerCompensation(activating);
 
       if (isCompensationTriggered) {
         return SUCCESS;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -78,7 +78,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
             })
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
@@ -97,7 +97,7 @@ public final class ScriptTaskProcessor
             })
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
@@ -53,7 +53,7 @@ public class UndefinedTaskProcessor implements BpmnElementProcessor<ExecutableAc
         .transitionToCompleted(element, context)
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -91,7 +91,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             })
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(context, element);
+              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -39,7 +39,10 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     copy.recordProp.getValue().setThrowEventId(getRecord().getThrowEventId());
     copy.recordProp.getValue().setThrowEventInstanceKey(getRecord().getThrowEventInstanceKey());
     copy.recordProp.getValue().setCompensationHandlerId(getRecord().getCompensationHandlerId());
-    copy.recordProp.getValue().setScopeInstanceKey(getRecord().getScopeInstanceKey());
+    copy.recordProp
+        .getValue()
+        .setCompensableActivityScopeKey(getRecord().getCompensableActivityScopeKey());
+    copy.recordProp.getValue().setCompensableParentKey(getRecord().getCompensableParentKey());
     copy.recordProp
         .getValue()
         .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -45,6 +45,7 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     copy.recordProp
         .getValue()
         .setCompensableActivityInstanceKey(getRecord().getCompensableActivityInstanceKey());
+    copy.recordProp.getValue().setMultiInstance(getRecord().isMultiInstance());
     copy.recordProp
         .getValue()
         .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -42,7 +42,9 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     copy.recordProp
         .getValue()
         .setCompensableActivityScopeKey(getRecord().getCompensableActivityScopeKey());
-    copy.recordProp.getValue().setCompensableParentKey(getRecord().getCompensableParentKey());
+    copy.recordProp
+        .getValue()
+        .setCompensableActivityInstanceKey(getRecord().getCompensableActivityInstanceKey());
     copy.recordProp
         .getValue()
         .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -39,6 +39,7 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     copy.recordProp.getValue().setThrowEventId(getRecord().getThrowEventId());
     copy.recordProp.getValue().setThrowEventInstanceKey(getRecord().getThrowEventInstanceKey());
     copy.recordProp.getValue().setCompensationHandlerId(getRecord().getCompensationHandlerId());
+    copy.recordProp.getValue().setScopeInstanceKey(getRecord().getScopeInstanceKey());
     copy.recordProp
         .getValue()
         .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -45,7 +45,6 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     copy.recordProp
         .getValue()
         .setCompensableActivityInstanceKey(getRecord().getCompensableActivityInstanceKey());
-    copy.recordProp.getValue().setMultiInstance(getRecord().isMultiInstance());
     copy.recordProp
         .getValue()
         .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -870,6 +870,14 @@ public class CompensationEventExecutionTest {
         .containsSubsequence(
             tuple(CompensationSubscriptionIntent.TRIGGERED, "CompensationHandler"),
             tuple(CompensationSubscriptionIntent.COMPLETED, "CompensationHandler"));
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -802,11 +802,11 @@ public class CompensationEventExecutionTest {
             tuple(
                 ValueType.COMPENSATION_SUBSCRIPTION,
                 CompensationSubscriptionIntent.DELETED,
-                "ActivityToCompensate"),
+                "embedded-subprocess"),
             tuple(
                 ValueType.COMPENSATION_SUBSCRIPTION,
                 CompensationSubscriptionIntent.DELETED,
-                "embedded-subprocess"));
+                "ActivityToCompensate"));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -115,6 +116,12 @@ public final class JobActivationClient {
     final long position =
         writer.writeCommandOnPartition(partitionId, JobBatchIntent.ACTIVATE, jobBatchRecord);
 
+    return expectation.apply(partitionId, position);
+  }
+
+  public Record<JobBatchRecordValue> complete() {
+    final long position =
+        writer.writeCommandOnPartition(partitionId, JobIntent.COMPLETE, jobBatchRecord);
     return expectation.apply(partitionId, position);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobActivationClient.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -116,12 +115,6 @@ public final class JobActivationClient {
     final long position =
         writer.writeCommandOnPartition(partitionId, JobBatchIntent.ACTIVATE, jobBatchRecord);
 
-    return expectation.apply(partitionId, position);
-  }
-
-  public Record<JobBatchRecordValue> complete() {
-    final long position =
-        writer.writeCommandOnPartition(partitionId, JobIntent.COMPLETE, jobBatchRecord);
     return expectation.apply(partitionId, position);
   }
 }

--- a/zeebe/engine/src/test/resources/compensation/compensation-multi-instance-activity.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-multi-instance-activity.bpmn
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1705lk6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1lqxsls</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1lqxsls" sourceRef="StartEvent_1" targetRef="CompensableActivity" />
+    <bpmn:serviceTask id="CompensableActivity" name="A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="compensableActivity" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1lqxsls</bpmn:incoming>
+      <bpmn:outgoing>Flow_0epiml1</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=for i in 1..3 return i" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="Event_0jurki8" attachedToRef="CompensableActivity">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1sdgn4g" />
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="compensationHandler" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0epiml1" sourceRef="CompensableActivity" targetRef="Event_0apk6a4" />
+    <bpmn:intermediateThrowEvent id="Event_0apk6a4">
+      <bpmn:incoming>Flow_0epiml1</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rqy95l</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0req0f1" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:endEvent id="Event_17vtu0h">
+      <bpmn:incoming>Flow_0rqy95l</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rqy95l" sourceRef="Event_0apk6a4" targetRef="Event_17vtu0h" />
+    <bpmn:association id="Association_05vn9eq" associationDirection="One" sourceRef="Event_0jurki8" targetRef="CompensationHandler" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sifzcx_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ykci7s_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="440" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1e76xi0_di" bpmnElement="Event_0apk6a4">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17vtu0h_di" bpmnElement="Event_17vtu0h">
+        <dc:Bounds x="532" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_05vn9eq_di" bpmnElement="Association_05vn9eq">
+        <di:waypoint x="370" y="175" />
+        <di:waypoint x="370" y="240" />
+        <di:waypoint x="440" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_111hsdn_di" bpmnElement="Event_0jurki8">
+        <dc:Bounds x="352" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1lqxsls_di" bpmnElement="Flow_1lqxsls">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0epiml1_di" bpmnElement="Flow_0epiml1">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rqy95l_di" bpmnElement="Flow_0rqy95l">
+        <di:waypoint x="468" y="117" />
+        <di:waypoint x="532" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-multi-instance.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-multi-instance.bpmn
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1g33wbg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1sx0i5y</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="multi-instance">
+      <bpmn:incoming>Flow_1sx0i5y</bpmn:incoming>
+      <bpmn:outgoing>Flow_0et9le0</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=for i in 1..3 return i" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_05yrhtq">
+        <bpmn:outgoing>Flow_10a7n7b</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_10a7n7b" sourceRef="Event_05yrhtq" targetRef="CompensableActivity" />
+      <bpmn:serviceTask id="CompensableActivity" name="A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensableActivity" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_10a7n7b</bpmn:incoming>
+        <bpmn:outgoing>Flow_158w0cn</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_1xnhu6k" attachedToRef="CompensableActivity">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_0ant20m" />
+      </bpmn:boundaryEvent>
+      <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="Event_0titp86">
+        <bpmn:incoming>Flow_158w0cn</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_158w0cn" sourceRef="CompensableActivity" targetRef="Event_0titp86" />
+      <bpmn:association id="Association_1shifcw" associationDirection="One" sourceRef="Event_1xnhu6k" targetRef="CompensationHandler" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_1sx0i5y" sourceRef="StartEvent_1" targetRef="multi-instance" />
+    <bpmn:endEvent id="Event_1r5h4l7">
+      <bpmn:incoming>Flow_0jcqqwu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0et9le0" sourceRef="multi-instance" targetRef="Event_04lb4oo" />
+    <bpmn:sequenceFlow id="Flow_0jcqqwu" sourceRef="Event_04lb4oo" targetRef="Event_1r5h4l7" />
+    <bpmn:intermediateThrowEvent id="Event_04lb4oo">
+      <bpmn:incoming>Flow_0et9le0</bpmn:incoming>
+      <bpmn:outgoing>Flow_0jcqqwu</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0bbegpq" />
+    </bpmn:intermediateThrowEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nu57aq_di" bpmnElement="Event_04lb4oo">
+        <dc:Bounds x="792" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1r5h4l7_di" bpmnElement="Event_1r5h4l7">
+        <dc:Bounds x="882" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02piju3_di" bpmnElement="multi-instance" isExpanded="true">
+        <dc:Bounds x="330" y="77" width="410" height="353" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05yrhtq_di" bpmnElement="Event_05yrhtq">
+        <dc:Bounds x="370" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0thn7tl_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="460" y="137" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0titp86_di" bpmnElement="Event_0titp86">
+        <dc:Bounds x="622" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kh81wq_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="540" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_1shifcw_di" bpmnElement="Association_1shifcw">
+        <di:waypoint x="500" y="235" />
+        <di:waypoint x="500" y="300" />
+        <di:waypoint x="540" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ktcqwv_di" bpmnElement="Event_1xnhu6k">
+        <dc:Bounds x="482" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_10a7n7b_di" bpmnElement="Flow_10a7n7b">
+        <di:waypoint x="406" y="177" />
+        <di:waypoint x="460" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_158w0cn_di" bpmnElement="Flow_158w0cn">
+        <di:waypoint x="560" y="177" />
+        <di:waypoint x="622" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sx0i5y_di" bpmnElement="Flow_1sx0i5y">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="330" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0et9le0_di" bpmnElement="Flow_0et9le0">
+        <di:waypoint x="740" y="177" />
+        <di:waypoint x="792" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0jcqqwu_di" bpmnElement="Flow_0jcqqwu">
+        <di:waypoint x="828" y="177" />
+        <di:waypoint x="882" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-multi-subprocess.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-multi-subprocess.bpmn
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ooqdwl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_09xy41x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="subprocess">
+      <bpmn:incoming>Flow_0e18s63</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rj1jj3</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0tx7iii">
+        <bpmn:outgoing>Flow_0sposdy</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:subProcess id="subprocess2">
+        <bpmn:incoming>Flow_0sposdy</bpmn:incoming>
+        <bpmn:outgoing>Flow_1nhtn4w</bpmn:outgoing>
+        <bpmn:startEvent id="Event_0o7zu5i">
+          <bpmn:outgoing>Flow_0sp9eyb</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_0sp9eyb" sourceRef="Event_0o7zu5i" targetRef="CompensableActivity" />
+        <bpmn:boundaryEvent id="Event_0zxqmkj" attachedToRef="CompensableActivity">
+          <bpmn:compensateEventDefinition id="CompensateEventDefinition_05q4r2x" />
+        </bpmn:boundaryEvent>
+        <bpmn:endEvent id="Event_0brggx9">
+          <bpmn:incoming>Flow_034ls0z</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_034ls0z" sourceRef="CompensableActivity" targetRef="Event_0brggx9" />
+        <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="compensationHandler" />
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+        <bpmn:serviceTask id="CompensableActivity" name="A">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="compensableActivity" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_0sp9eyb</bpmn:incoming>
+          <bpmn:outgoing>Flow_034ls0z</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:association id="Association_1gut1kg" associationDirection="One" sourceRef="Event_0zxqmkj" targetRef="CompensationHandler" />
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="Flow_1nhtn4w" sourceRef="subprocess2" targetRef="Activity" />
+      <bpmn:serviceTask id="Activity" name="B">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="activity" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1nhtn4w</bpmn:incoming>
+        <bpmn:outgoing>Flow_0ekizp5</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:endEvent id="Event_1rehk03">
+        <bpmn:incoming>Flow_0ekizp5</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0ekizp5" sourceRef="Activity" targetRef="Event_1rehk03" />
+      <bpmn:sequenceFlow id="Flow_0sposdy" sourceRef="Event_0tx7iii" targetRef="subprocess2" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_09xy41x" sourceRef="StartEvent_1" targetRef="Gateway_0zisueq" />
+    <bpmn:sequenceFlow id="Flow_1rj1jj3" sourceRef="subprocess" targetRef="Gateway_0muzrsh" />
+    <bpmn:sequenceFlow id="Flow_0e18s63" sourceRef="Gateway_0zisueq" targetRef="subprocess" />
+    <bpmn:sequenceFlow id="Flow_1mhc63d" sourceRef="Gateway_0zisueq" targetRef="Activity2" />
+    <bpmn:serviceTask id="Activity2" name="C">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="activity2" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1mhc63d</bpmn:incoming>
+      <bpmn:outgoing>Flow_0p2km4d</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0p2km4d" sourceRef="Activity2" targetRef="Event_12pt29g" />
+    <bpmn:intermediateThrowEvent id="Event_12pt29g">
+      <bpmn:incoming>Flow_0p2km4d</bpmn:incoming>
+      <bpmn:outgoing>Flow_0t4oxgl</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1hj6kom" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:parallelGateway id="Gateway_0zisueq">
+      <bpmn:incoming>Flow_09xy41x</bpmn:incoming>
+      <bpmn:outgoing>Flow_0e18s63</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1mhc63d</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_1shx5oq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1shx5oq" sourceRef="Gateway_0muzrsh" targetRef="end" />
+    <bpmn:parallelGateway id="Gateway_0muzrsh">
+      <bpmn:incoming>Flow_1rj1jj3</bpmn:incoming>
+      <bpmn:incoming>Flow_0t4oxgl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1shx5oq</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0t4oxgl" sourceRef="Event_12pt29g" targetRef="Gateway_0muzrsh" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="209" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hx27gq_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="430" y="80" width="930" height="440" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tx7iii_di" bpmnElement="Event_0tx7iii">
+        <dc:Bounds x="470" y="209" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1sq756b_di" bpmnElement="subprocess2" isExpanded="true">
+        <dc:Bounds x="570" y="127" width="450" height="330" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0o7zu5i_di" bpmnElement="Event_0o7zu5i">
+        <dc:Bounds x="610" y="209" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0brggx9_di" bpmnElement="Event_0brggx9">
+        <dc:Bounds x="942" y="209" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lyv3cj_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="870" y="310" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_065y779_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="700" y="187" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0o2jrqh_di" bpmnElement="Event_0zxqmkj">
+        <dc:Bounds x="782" y="249" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0sp9eyb_di" bpmnElement="Flow_0sp9eyb">
+        <di:waypoint x="646" y="227" />
+        <di:waypoint x="700" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_034ls0z_di" bpmnElement="Flow_034ls0z">
+        <di:waypoint x="800" y="227" />
+        <di:waypoint x="942" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1gut1kg_di" bpmnElement="Association_1gut1kg">
+        <di:waypoint x="800" y="285" />
+        <di:waypoint x="800" y="350" />
+        <di:waypoint x="870" y="350" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_1tle95n_di" bpmnElement="Activity">
+        <dc:Bounds x="1070" y="187" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rehk03_di" bpmnElement="Event_1rehk03">
+        <dc:Bounds x="1252" y="209" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1nhtn4w_di" bpmnElement="Flow_1nhtn4w">
+        <di:waypoint x="1020" y="227" />
+        <di:waypoint x="1070" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ekizp5_di" bpmnElement="Flow_0ekizp5">
+        <di:waypoint x="1170" y="227" />
+        <di:waypoint x="1252" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0sposdy_di" bpmnElement="Flow_0sposdy">
+        <di:waypoint x="506" y="227" />
+        <di:waypoint x="570" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0jxzvj3_di" bpmnElement="Activity2">
+        <dc:Bounds x="690" y="560" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1kag4u9_di" bpmnElement="Event_12pt29g">
+        <dc:Bounds x="842" y="582" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1p3qfk9_di" bpmnElement="Gateway_0zisueq">
+        <dc:Bounds x="275" y="202" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1wptou0_di" bpmnElement="end">
+        <dc:Bounds x="1652" y="209" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1j4yzru_di" bpmnElement="Gateway_0muzrsh">
+        <dc:Bounds x="1495" y="202" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09xy41x_di" bpmnElement="Flow_09xy41x">
+        <di:waypoint x="188" y="227" />
+        <di:waypoint x="275" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rj1jj3_di" bpmnElement="Flow_1rj1jj3">
+        <di:waypoint x="1360" y="227" />
+        <di:waypoint x="1495" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0e18s63_di" bpmnElement="Flow_0e18s63">
+        <di:waypoint x="325" y="227" />
+        <di:waypoint x="430" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mhc63d_di" bpmnElement="Flow_1mhc63d">
+        <di:waypoint x="300" y="252" />
+        <di:waypoint x="300" y="600" />
+        <di:waypoint x="690" y="600" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0p2km4d_di" bpmnElement="Flow_0p2km4d">
+        <di:waypoint x="790" y="600" />
+        <di:waypoint x="842" y="600" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1shx5oq_di" bpmnElement="Flow_1shx5oq">
+        <di:waypoint x="1545" y="227" />
+        <di:waypoint x="1652" y="227" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0t4oxgl_di" bpmnElement="Flow_0t4oxgl">
+        <di:waypoint x="878" y="600" />
+        <di:waypoint x="1520" y="600" />
+        <di:waypoint x="1520" y="252" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-multi-throw-event.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-multi-throw-event.bpmn
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pz12bc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" name="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1aio93t</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="embedded-subprocess">
+      <bpmn:incoming>Flow_1aio93t</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ol2z69</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0dalpr8">
+        <bpmn:outgoing>Flow_1d0mxws</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_1d0mxws" sourceRef="Event_0dalpr8" targetRef="CompensableActivity" />
+      <bpmn:endEvent id="Event_14yri0u">
+        <bpmn:incoming>Flow_1d578j1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1d578j1" sourceRef="CompensableActivity" targetRef="Event_14yri0u" />
+      <bpmn:boundaryEvent id="Event_1gsh13f" attachedToRef="CompensableActivity">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_05mmvno" />
+      </bpmn:boundaryEvent>
+      <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="CompensableActivity" name="A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensableActivity" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1d0mxws</bpmn:incoming>
+        <bpmn:outgoing>Flow_1d578j1</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:association id="Association_04jmv68" associationDirection="One" sourceRef="Event_1gsh13f" targetRef="CompensationHandler" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_1aio93t" sourceRef="StartEvent_1" targetRef="embedded-subprocess" />
+    <bpmn:sequenceFlow id="Flow_1ol2z69" sourceRef="embedded-subprocess" targetRef="Gateway_13nx77l" />
+    <bpmn:parallelGateway id="Gateway_13nx77l">
+      <bpmn:incoming>Flow_1ol2z69</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h304a5</bpmn:outgoing>
+      <bpmn:outgoing>Flow_06h724z</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_0h304a5" sourceRef="Gateway_13nx77l" targetRef="Event_0q9b6gp" />
+    <bpmn:intermediateThrowEvent id="Event_0q9b6gp">
+      <bpmn:incoming>Flow_0h304a5</bpmn:incoming>
+      <bpmn:outgoing>Flow_1are0jz</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1jqfdmj" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_1are0jz" sourceRef="Event_0q9b6gp" targetRef="Gateway_100du1t" />
+    <bpmn:parallelGateway id="Gateway_100du1t">
+      <bpmn:incoming>Flow_1are0jz</bpmn:incoming>
+      <bpmn:incoming>Flow_0613fme</bpmn:incoming>
+      <bpmn:outgoing>Flow_08jt10a</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:endEvent id="Event_133p0id">
+      <bpmn:incoming>Flow_08jt10a</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_08jt10a" sourceRef="Gateway_100du1t" targetRef="Event_133p0id" />
+    <bpmn:sequenceFlow id="Flow_06h724z" sourceRef="Gateway_13nx77l" targetRef="Event_10duyc2" />
+    <bpmn:intermediateThrowEvent id="Event_10duyc2">
+      <bpmn:incoming>Flow_06h724z</bpmn:incoming>
+      <bpmn:outgoing>Flow_0613fme</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1a85vry" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0613fme" sourceRef="Event_10duyc2" targetRef="Gateway_100du1t" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0wfeh4b_di" bpmnElement="Gateway_13nx77l">
+        <dc:Bounds x="715" y="155" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0paweqb_di" bpmnElement="Event_0q9b6gp">
+        <dc:Bounds x="822" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1i1fe7o_di" bpmnElement="Gateway_100du1t">
+        <dc:Bounds x="915" y="155" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_133p0id_di" bpmnElement="Event_133p0id">
+        <dc:Bounds x="1022" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rvr39a_di" bpmnElement="Event_10duyc2">
+        <dc:Bounds x="822" y="272" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0rblt17_di" bpmnElement="embedded-subprocess" isExpanded="true">
+        <dc:Bounds x="250" y="77" width="410" height="293" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0dalpr8_di" bpmnElement="Event_0dalpr8">
+        <dc:Bounds x="290" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14yri0u_di" bpmnElement="Event_14yri0u">
+        <dc:Bounds x="542" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x0z6p5_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="520" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1b9e13a_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="380" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_04jmv68_di" bpmnElement="Association_04jmv68">
+        <di:waypoint x="450" y="235" />
+        <di:waypoint x="450" y="300" />
+        <di:waypoint x="520" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1ddlv7q_di" bpmnElement="Event_1gsh13f">
+        <dc:Bounds x="432" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1d0mxws_di" bpmnElement="Flow_1d0mxws">
+        <di:waypoint x="326" y="177" />
+        <di:waypoint x="380" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d578j1_di" bpmnElement="Flow_1d578j1">
+        <di:waypoint x="480" y="177" />
+        <di:waypoint x="542" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1aio93t_di" bpmnElement="Flow_1aio93t">
+        <di:waypoint x="188" y="177" />
+        <di:waypoint x="250" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ol2z69_di" bpmnElement="Flow_1ol2z69">
+        <di:waypoint x="660" y="180" />
+        <di:waypoint x="715" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h304a5_di" bpmnElement="Flow_0h304a5">
+        <di:waypoint x="765" y="180" />
+        <di:waypoint x="822" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06h724z_di" bpmnElement="Flow_06h724z">
+        <di:waypoint x="740" y="205" />
+        <di:waypoint x="740" y="290" />
+        <di:waypoint x="822" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1are0jz_di" bpmnElement="Flow_1are0jz">
+        <di:waypoint x="858" y="180" />
+        <di:waypoint x="915" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0613fme_di" bpmnElement="Flow_0613fme">
+        <di:waypoint x="858" y="290" />
+        <di:waypoint x="940" y="290" />
+        <di:waypoint x="940" y="205" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08jt10a_di" bpmnElement="Flow_08jt10a">
+        <di:waypoint x="965" y="180" />
+        <di:waypoint x="1022" y="180" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-subprocess-multi-handler.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-subprocess-multi-handler.bpmn
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ooqdwl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_09xy41x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="multi-instance">
+      <bpmn:incoming>Flow_09xy41x</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rj1jj3</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0tx7iii">
+        <bpmn:outgoing>Flow_02s4q60</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_02s4q60" sourceRef="Event_0tx7iii" targetRef="CompensableActivity" />
+      <bpmn:sequenceFlow id="Flow_1vvcwbh" sourceRef="CompensableActivity" targetRef="CompensableActivity2" />
+      <bpmn:serviceTask id="CompensableActivity" name="A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensableActivity" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_02s4q60</bpmn:incoming>
+        <bpmn:outgoing>Flow_1vvcwbh</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="CompensableActivity2" name="B">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensableActivity2" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1vvcwbh</bpmn:incoming>
+        <bpmn:outgoing>Flow_1nqqcn9</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_1wtb45q" attachedToRef="CompensableActivity">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1vrx9w9" />
+      </bpmn:boundaryEvent>
+      <bpmn:endEvent id="Event_0loo0x6">
+        <bpmn:incoming>Flow_1nqqcn9</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1nqqcn9" sourceRef="CompensableActivity2" targetRef="Event_0loo0x6" />
+      <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_11k055y" attachedToRef="CompensableActivity2">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1s9mqk1" />
+      </bpmn:boundaryEvent>
+      <bpmn:serviceTask id="CompensationHandler2" name="undo B" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensationHandler2" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:association id="Association_0x6ydnr" associationDirection="One" sourceRef="Event_1wtb45q" targetRef="CompensationHandler" />
+      <bpmn:association id="Association_0j02zpk" associationDirection="One" sourceRef="Event_11k055y" targetRef="CompensationHandler2" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_09xy41x" sourceRef="StartEvent_1" targetRef="multi-instance" />
+    <bpmn:sequenceFlow id="Flow_1rj1jj3" sourceRef="multi-instance" targetRef="end" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_1rj1jj3</bpmn:incoming>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1n5o6da" />
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1an7v7d_di" bpmnElement="end">
+        <dc:Bounds x="1142" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hx27gq_di" bpmnElement="multi-instance" isExpanded="true">
+        <dc:Bounds x="310" y="77" width="750" height="313" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tx7iii_di" bpmnElement="Event_0tx7iii">
+        <dc:Bounds x="350" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hsnw7f_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="440" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hcx97u_di" bpmnElement="CompensableActivity2">
+        <dc:Bounds x="710" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0m18tth_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="580" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0loo0x6_di" bpmnElement="Event_0loo0x6">
+        <dc:Bounds x="952" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0gpo0dj_di" bpmnElement="CompensationHandler2">
+        <dc:Bounds x="860" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0j02zpk_di" bpmnElement="Association_0j02zpk">
+        <di:waypoint x="790" y="235" />
+        <di:waypoint x="790" y="300" />
+        <di:waypoint x="860" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1xe0s1s_di" bpmnElement="Event_1wtb45q">
+        <dc:Bounds x="492" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0djx6jx_di" bpmnElement="Event_11k055y">
+        <dc:Bounds x="772" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02s4q60_di" bpmnElement="Flow_02s4q60">
+        <di:waypoint x="386" y="177" />
+        <di:waypoint x="440" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vvcwbh_di" bpmnElement="Flow_1vvcwbh">
+        <di:waypoint x="540" y="177" />
+        <di:waypoint x="710" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nqqcn9_di" bpmnElement="Flow_1nqqcn9">
+        <di:waypoint x="810" y="177" />
+        <di:waypoint x="952" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0x6ydnr_di" bpmnElement="Association_0x6ydnr">
+        <di:waypoint x="510" y="235" />
+        <di:waypoint x="510" y="300" />
+        <di:waypoint x="580" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09xy41x_di" bpmnElement="Flow_09xy41x">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="310" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rj1jj3_di" bpmnElement="Flow_1rj1jj3">
+        <di:waypoint x="1060" y="177" />
+        <di:waypoint x="1142" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-throw-error.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-throw-error.bpmn
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ooqdwl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_09xy41x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="multi-instance">
+      <bpmn:incoming>Flow_09xy41x</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rj1jj3</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=for i in 1..3 return i" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_0tx7iii">
+        <bpmn:outgoing>Flow_02s4q60</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_02s4q60" sourceRef="Event_0tx7iii" targetRef="CompensableActivity" />
+      <bpmn:sequenceFlow id="Flow_1vvcwbh" sourceRef="CompensableActivity" targetRef="Activity" />
+      <bpmn:serviceTask id="CompensableActivity" name="A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensableActivity" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_02s4q60</bpmn:incoming>
+        <bpmn:outgoing>Flow_1vvcwbh</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="Activity" name="B">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="activity" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1vvcwbh</bpmn:incoming>
+        <bpmn:outgoing>Flow_1nqqcn9</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_1wtb45q" attachedToRef="CompensableActivity">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1vrx9w9" />
+      </bpmn:boundaryEvent>
+      <bpmn:boundaryEvent id="Event_11k055y" attachedToRef="Activity">
+        <bpmn:outgoing>Flow_0uyhkdp</bpmn:outgoing>
+        <bpmn:errorEventDefinition id="ErrorEventDefinition_0gqga3b" />
+      </bpmn:boundaryEvent>
+      <bpmn:sequenceFlow id="Flow_0uyhkdp" sourceRef="Event_11k055y" targetRef="Event_1vnn3sh" />
+      <bpmn:endEvent id="Event_1vnn3sh">
+        <bpmn:incoming>Flow_0uyhkdp</bpmn:incoming>
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_076dgsr" />
+      </bpmn:endEvent>
+      <bpmn:endEvent id="Event_0loo0x6">
+        <bpmn:incoming>Flow_1nqqcn9</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1nqqcn9" sourceRef="Activity" targetRef="Event_0loo0x6" />
+      <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:association id="Association_0x6ydnr" associationDirection="One" sourceRef="Event_1wtb45q" targetRef="CompensationHandler" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_09xy41x" sourceRef="StartEvent_1" targetRef="multi-instance" />
+    <bpmn:endEvent id="end">
+      <bpmn:incoming>Flow_1rj1jj3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1rj1jj3" sourceRef="multi-instance" targetRef="end" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hx27gq_di" bpmnElement="multi-instance" isExpanded="true">
+        <dc:Bounds x="310" y="77" width="660" height="313" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tx7iii_di" bpmnElement="Event_0tx7iii">
+        <dc:Bounds x="350" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hsnw7f_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="440" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hcx97u_di" bpmnElement="Activity">
+        <dc:Bounds x="710" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_147z359_di" bpmnElement="Event_1vnn3sh">
+        <dc:Bounds x="822" y="282" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0loo0x6_di" bpmnElement="Event_0loo0x6">
+        <dc:Bounds x="882" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0m18tth_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="580" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ru8e73_di" bpmnElement="Event_11k055y">
+        <dc:Bounds x="772" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xe0s1s_di" bpmnElement="Event_1wtb45q">
+        <dc:Bounds x="492" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02s4q60_di" bpmnElement="Flow_02s4q60">
+        <di:waypoint x="386" y="177" />
+        <di:waypoint x="440" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vvcwbh_di" bpmnElement="Flow_1vvcwbh">
+        <di:waypoint x="540" y="177" />
+        <di:waypoint x="710" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uyhkdp_di" bpmnElement="Flow_0uyhkdp">
+        <di:waypoint x="790" y="235" />
+        <di:waypoint x="790" y="300" />
+        <di:waypoint x="822" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nqqcn9_di" bpmnElement="Flow_1nqqcn9">
+        <di:waypoint x="810" y="177" />
+        <di:waypoint x="882" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0x6ydnr_di" bpmnElement="Association_0x6ydnr">
+        <di:waypoint x="510" y="235" />
+        <di:waypoint x="510" y="300" />
+        <di:waypoint x="580" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0i2s3zb_di" bpmnElement="end">
+        <dc:Bounds x="1022" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09xy41x_di" bpmnElement="Flow_09xy41x">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="310" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rj1jj3_di" bpmnElement="Flow_1rj1jj3">
+        <di:waypoint x="970" y="177" />
+        <di:waypoint x="1022" y="177" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -43,7 +43,10 @@
             "compensationHandlerId": {
               "type": "keyword"
             },
-            "scopeInstanceKey":{
+            "compensableActivityScopeKey":{
+              "type": "long"
+            },
+            "compensableParentKey":{
               "type": "long"
             },
             "variables": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -46,7 +46,7 @@
             "compensableActivityScopeKey":{
               "type": "long"
             },
-            "compensableParentKey":{
+            "compensableActivityInstanceKey":{
               "type": "long"
             },
             "variables": {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -43,6 +43,9 @@
             "compensationHandlerId": {
               "type": "keyword"
             },
+            "scopeInstanceKey":{
+              "type": "long"
+            },
             "variables": {
               "enabled": false
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -43,7 +43,10 @@
             "compensationHandlerId": {
               "type": "keyword"
             },
-            "scopeInstanceKey":{
+            "compensableActivityScopeKey":{
+              "type": "long"
+            },
+            "compensableParentKey":{
               "type": "long"
             },
             "variables": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -46,7 +46,7 @@
             "compensableActivityScopeKey":{
               "type": "long"
             },
-            "compensableParentKey":{
+            "compensableActivityInstanceKey":{
               "type": "long"
             },
             "variables": {

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -43,6 +43,9 @@
             "compensationHandlerId": {
               "type": "keyword"
             },
+            "scopeInstanceKey":{
+              "type": "long"
+            },
             "variables": {
               "enabled": false
             }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.record.value.compensation;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -44,12 +45,15 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   private final LongProperty compensableActivityScopeKeyProperty =
       new LongProperty("compensableActivityScopeKey", -1);
 
+  private final BooleanProperty isMultiInstanceProperty =
+      new BooleanProperty("isMultiInstance", false);
+
   private final LongProperty compensableActivityInstanceKeyProperty =
       new LongProperty("compensableActivityInstanceKey", -1);
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
-    super(11);
+    super(12);
     declareProperty(tenantIdProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
@@ -60,6 +64,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(compensationHandlerIdProperty)
         .declareProperty(compensableActivityScopeKeyProperty)
         .declareProperty(compensableActivityInstanceKeyProperty)
+        .declareProperty(isMultiInstanceProperty)
         .declareProperty(variablesProperty);
   }
 
@@ -74,6 +79,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
     compensableActivityScopeKeyProperty.setValue(record.getCompensableActivityScopeKey());
     compensableActivityInstanceKeyProperty.setValue(record.getCompensableActivityInstanceKey());
+    isMultiInstanceProperty.setValue(record.isMultiInstance());
     variablesProperty.setValue(record.getVariablesBuffer());
   }
 
@@ -143,12 +149,22 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
+  public boolean isMultiInstance() {
+    return isMultiInstanceProperty.getValue();
+  }
+
+  @Override
   public Map<String, Object> getVariables() {
     return MsgPackConverter.convertToMap(variablesProperty.getValue());
   }
 
   public CompensationSubscriptionRecord setVariables(final DirectBuffer variables) {
     variablesProperty.setValue(variables);
+    return this;
+  }
+
+  public CompensationSubscriptionRecord setMultiInstance(final boolean isMultiInstance) {
+    isMultiInstanceProperty.setValue(isMultiInstance);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -40,6 +40,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
       new LongProperty("throwEventInstanceKey", -1);
   private final StringProperty compensationHandlerIdProperty =
       new StringProperty("compensationHandlerId", EMPTY_STRING);
+
+  private final LongProperty scopeInstanceKeyProperty = new LongProperty("scopeInstanceKey", -1);
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
@@ -52,6 +54,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(throwEventIdProperty)
         .declareProperty(throwEventInstanceKeyProperty)
         .declareProperty(compensationHandlerIdProperty)
+        .declareProperty(scopeInstanceKeyProperty)
         .declareProperty(variablesProperty);
   }
 
@@ -64,6 +67,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     throwEventIdProperty.setValue(record.getThrowEventId());
     throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
     compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
+    scopeInstanceKeyProperty.setValue(record.getScopeInstanceKey());
     variablesProperty.setValue(record.getVariablesBuffer());
   }
 
@@ -123,12 +127,22 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
+  public long getScopeInstanceKey() {
+    return scopeInstanceKeyProperty.getValue();
+  }
+
+  @Override
   public Map<String, Object> getVariables() {
     return MsgPackConverter.convertToMap(variablesProperty.getValue());
   }
 
   public CompensationSubscriptionRecord setVariables(final DirectBuffer variables) {
     variablesProperty.setValue(variables);
+    return this;
+  }
+
+  public CompensationSubscriptionRecord setScopeInstanceKey(final long scopeInstanceKey) {
+    scopeInstanceKeyProperty.setValue(scopeInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -41,7 +41,11 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty compensationHandlerIdProperty =
       new StringProperty("compensationHandlerId", EMPTY_STRING);
 
-  private final LongProperty scopeInstanceKeyProperty = new LongProperty("scopeInstanceKey", -1);
+  private final LongProperty compensableActivityScopeKeyProperty =
+      new LongProperty("compensableActivityScopeKey", -1);
+
+  private final LongProperty compensableParentKeyProperty =
+      new LongProperty("compensableParentKey", -1);
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
@@ -54,7 +58,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(throwEventIdProperty)
         .declareProperty(throwEventInstanceKeyProperty)
         .declareProperty(compensationHandlerIdProperty)
-        .declareProperty(scopeInstanceKeyProperty)
+        .declareProperty(compensableActivityScopeKeyProperty)
+        .declareProperty(compensableParentKeyProperty)
         .declareProperty(variablesProperty);
   }
 
@@ -67,7 +72,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     throwEventIdProperty.setValue(record.getThrowEventId());
     throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
     compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
-    scopeInstanceKeyProperty.setValue(record.getScopeInstanceKey());
+    compensableActivityScopeKeyProperty.setValue(record.getCompensableActivityScopeKey());
+    compensableParentKeyProperty.setValue(record.getCompensableParentKey());
     variablesProperty.setValue(record.getVariablesBuffer());
   }
 
@@ -127,8 +133,13 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getScopeInstanceKey() {
-    return scopeInstanceKeyProperty.getValue();
+  public long getCompensableActivityScopeKey() {
+    return compensableActivityScopeKeyProperty.getValue();
+  }
+
+  @Override
+  public long getCompensableParentKey() {
+    return compensableParentKeyProperty.getValue();
   }
 
   @Override
@@ -141,8 +152,14 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public CompensationSubscriptionRecord setScopeInstanceKey(final long scopeInstanceKey) {
-    scopeInstanceKeyProperty.setValue(scopeInstanceKey);
+  public CompensationSubscriptionRecord setCompensableParentKey(final long compensableParentKey) {
+    compensableParentKeyProperty.setValue(compensableParentKey);
+    return this;
+  }
+
+  public CompensationSubscriptionRecord setCompensableActivityScopeKey(
+      final long scopeInstanceKey) {
+    compensableActivityScopeKeyProperty.setValue(scopeInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.protocol.impl.record.value.compensation;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -45,15 +44,12 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   private final LongProperty compensableActivityScopeKeyProperty =
       new LongProperty("compensableActivityScopeKey", -1);
 
-  private final BooleanProperty isMultiInstanceProperty =
-      new BooleanProperty("isMultiInstance", false);
-
   private final LongProperty compensableActivityInstanceKeyProperty =
       new LongProperty("compensableActivityInstanceKey", -1);
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
-    super(12);
+    super(11);
     declareProperty(tenantIdProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
@@ -64,7 +60,6 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(compensationHandlerIdProperty)
         .declareProperty(compensableActivityScopeKeyProperty)
         .declareProperty(compensableActivityInstanceKeyProperty)
-        .declareProperty(isMultiInstanceProperty)
         .declareProperty(variablesProperty);
   }
 
@@ -79,7 +74,6 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
     compensableActivityScopeKeyProperty.setValue(record.getCompensableActivityScopeKey());
     compensableActivityInstanceKeyProperty.setValue(record.getCompensableActivityInstanceKey());
-    isMultiInstanceProperty.setValue(record.isMultiInstance());
     variablesProperty.setValue(record.getVariablesBuffer());
   }
 
@@ -149,22 +143,12 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public boolean isMultiInstance() {
-    return isMultiInstanceProperty.getValue();
-  }
-
-  @Override
   public Map<String, Object> getVariables() {
     return MsgPackConverter.convertToMap(variablesProperty.getValue());
   }
 
   public CompensationSubscriptionRecord setVariables(final DirectBuffer variables) {
     variablesProperty.setValue(variables);
-    return this;
-  }
-
-  public CompensationSubscriptionRecord setMultiInstance(final boolean isMultiInstance) {
-    isMultiInstanceProperty.setValue(isMultiInstance);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -44,12 +44,12 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   private final LongProperty compensableActivityScopeKeyProperty =
       new LongProperty("compensableActivityScopeKey", -1);
 
-  private final LongProperty compensableParentKeyProperty =
-      new LongProperty("compensableParentKey", -1);
+  private final LongProperty compensableActivityInstanceKeyProperty =
+      new LongProperty("compensableActivityInstanceKey", -1);
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
-    super(8);
+    super(11);
     declareProperty(tenantIdProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
@@ -59,7 +59,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(throwEventInstanceKeyProperty)
         .declareProperty(compensationHandlerIdProperty)
         .declareProperty(compensableActivityScopeKeyProperty)
-        .declareProperty(compensableParentKeyProperty)
+        .declareProperty(compensableActivityInstanceKeyProperty)
         .declareProperty(variablesProperty);
   }
 
@@ -73,7 +73,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
     compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
     compensableActivityScopeKeyProperty.setValue(record.getCompensableActivityScopeKey());
-    compensableParentKeyProperty.setValue(record.getCompensableParentKey());
+    compensableActivityInstanceKeyProperty.setValue(record.getCompensableActivityInstanceKey());
     variablesProperty.setValue(record.getVariablesBuffer());
   }
 
@@ -138,8 +138,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
-  public long getCompensableParentKey() {
-    return compensableParentKeyProperty.getValue();
+  public long getCompensableActivityInstanceKey() {
+    return compensableActivityInstanceKeyProperty.getValue();
   }
 
   @Override
@@ -152,8 +152,9 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public CompensationSubscriptionRecord setCompensableParentKey(final long compensableParentKey) {
-    compensableParentKeyProperty.setValue(compensableParentKey);
+  public CompensationSubscriptionRecord setCompensableActivityInstanceKey(
+      final long compensableActivityInstanceKey) {
+    compensableActivityInstanceKeyProperty.setValue(compensableActivityInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2271,7 +2271,7 @@ final class JsonSerializableToJsonTest {
                     .setThrowEventInstanceKey(123L)
                     .setCompensationHandlerId("compensationActivityElementId")
                     .setCompensableActivityScopeKey(789L)
-                    .setCompensableParentKey(123L)
+                    .setCompensableActivityInstanceKey(123L)
                     .setVariables(VARIABLES_MSGPACK),
         """
         {
@@ -2284,7 +2284,7 @@ final class JsonSerializableToJsonTest {
           "throwEventInstanceKey": 123,
           "compensationHandlerId": "compensationActivityElementId",
           "compensableActivityScopeKey": 789,
-          "compensableParentKey": 123,
+          "compensableActivityInstanceKey": 123,
           "variables": {
             "foo": "bar"
           }
@@ -2309,7 +2309,7 @@ final class JsonSerializableToJsonTest {
           "throwEventInstanceKey": -1,
           "compensationHandlerId": "",
           "compensableActivityScopeKey": -1,
-          "compensableParentKey": -1,
+          "compensableActivityInstanceKey": -1,
           "variables": {}
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2270,6 +2270,7 @@ final class JsonSerializableToJsonTest {
                     .setThrowEventId("elementThrowEventId")
                     .setThrowEventInstanceKey(123L)
                     .setCompensationHandlerId("compensationActivityElementId")
+                    .setScopeInstanceKey(789L)
                     .setVariables(VARIABLES_MSGPACK),
         """
         {
@@ -2281,6 +2282,7 @@ final class JsonSerializableToJsonTest {
           "throwEventId": "elementThrowEventId",
           "throwEventInstanceKey": 123,
           "compensationHandlerId": "compensationActivityElementId",
+          "scopeInstanceKey": 789,
           "variables": {
             "foo": "bar"
           }
@@ -2304,6 +2306,7 @@ final class JsonSerializableToJsonTest {
           "throwEventId": "",
           "throwEventInstanceKey": -1,
           "compensationHandlerId": "",
+          "scopeInstanceKey": -1,
           "variables": {}
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2272,7 +2272,6 @@ final class JsonSerializableToJsonTest {
                     .setCompensationHandlerId("compensationActivityElementId")
                     .setCompensableActivityScopeKey(789L)
                     .setCompensableActivityInstanceKey(123L)
-                    .setMultiInstance(true)
                     .setVariables(VARIABLES_MSGPACK),
         """
         {
@@ -2286,7 +2285,6 @@ final class JsonSerializableToJsonTest {
           "compensationHandlerId": "compensationActivityElementId",
           "compensableActivityScopeKey": 789,
           "compensableActivityInstanceKey": 123,
-          "multiInstance": true,
           "variables": {
             "foo": "bar"
           }
@@ -2312,7 +2310,6 @@ final class JsonSerializableToJsonTest {
           "compensationHandlerId": "",
           "compensableActivityScopeKey": -1,
           "compensableActivityInstanceKey": -1,
-          "multiInstance": false,
           "variables": {}
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2270,7 +2270,8 @@ final class JsonSerializableToJsonTest {
                     .setThrowEventId("elementThrowEventId")
                     .setThrowEventInstanceKey(123L)
                     .setCompensationHandlerId("compensationActivityElementId")
-                    .setScopeInstanceKey(789L)
+                    .setCompensableActivityScopeKey(789L)
+                    .setCompensableParentKey(123L)
                     .setVariables(VARIABLES_MSGPACK),
         """
         {
@@ -2282,7 +2283,8 @@ final class JsonSerializableToJsonTest {
           "throwEventId": "elementThrowEventId",
           "throwEventInstanceKey": 123,
           "compensationHandlerId": "compensationActivityElementId",
-          "scopeInstanceKey": 789,
+          "compensableActivityScopeKey": 789,
+          "compensableParentKey": 123,
           "variables": {
             "foo": "bar"
           }
@@ -2306,7 +2308,8 @@ final class JsonSerializableToJsonTest {
           "throwEventId": "",
           "throwEventInstanceKey": -1,
           "compensationHandlerId": "",
-          "scopeInstanceKey": -1,
+          "compensableActivityScopeKey": -1,
+          "compensableParentKey": -1,
           "variables": {}
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2272,6 +2272,7 @@ final class JsonSerializableToJsonTest {
                     .setCompensationHandlerId("compensationActivityElementId")
                     .setCompensableActivityScopeKey(789L)
                     .setCompensableActivityInstanceKey(123L)
+                    .setMultiInstance(true)
                     .setVariables(VARIABLES_MSGPACK),
         """
         {
@@ -2285,6 +2286,7 @@ final class JsonSerializableToJsonTest {
           "compensationHandlerId": "compensationActivityElementId",
           "compensableActivityScopeKey": 789,
           "compensableActivityInstanceKey": 123,
+          "multiInstance": true,
           "variables": {
             "foo": "bar"
           }
@@ -2310,6 +2312,7 @@ final class JsonSerializableToJsonTest {
           "compensationHandlerId": "",
           "compensableActivityScopeKey": -1,
           "compensableActivityInstanceKey": -1,
+          "multiInstance": false,
           "variables": {}
         }
         """

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -66,9 +66,15 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   String getCompensationHandlerId();
 
   /**
-   * @return the instance key of the process containing the element
+   * @return the instance key of the flow scope that contains the activity with the compensation
+   *     handler
    */
-  long getScopeInstanceKey();
+  long getCompensableActivityScopeKey();
+
+  /**
+   * @return the parent element key of the current element
+   */
+  long getCompensableParentKey();
 
   /**
    * @return the local variables of activity with compensation handler

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -72,7 +72,7 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   long getCompensableActivityScopeKey();
 
   /**
-   * @return the parent element key of the current element
+   * @return the instance key of the activity with the compensation handler
    */
   long getCompensableActivityInstanceKey();
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -66,6 +66,11 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   String getCompensationHandlerId();
 
   /**
+   * @return the instance key of the process containing the element
+   */
+  long getScopeInstanceKey();
+
+  /**
    * @return the local variables of activity with compensation handler
    */
   Map<String, Object> getVariables();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -77,6 +77,11 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   long getCompensableActivityInstanceKey();
 
   /**
+   * @return true if the subscription is related to a multi instance
+   */
+  boolean isMultiInstance();
+
+  /**
    * @return the local variables of activity with compensation handler
    */
   Map<String, Object> getVariables();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -77,11 +77,6 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   long getCompensableActivityInstanceKey();
 
   /**
-   * @return true if the subscription is related to a multi instance
-   */
-  boolean isMultiInstance();
-
-  /**
    * @return the local variables of activity with compensation handler
    */
   Map<String, Object> getVariables();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -74,7 +74,7 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   /**
    * @return the parent element key of the current element
    */
-  long getCompensableParentKey();
+  long getCompensableActivityInstanceKey();
 
   /**
    * @return the local variables of activity with compensation handler


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Compensation handlers should be invoked the same amount of compensable activities are executed

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15141 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
