### PR TITLE
feat: skip processing for positions listed in `zeebe.broker.processing.skipPositions`

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -7,11 +7,14 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import java.util.Set;
+
 public final class ProcessingCfg implements ConfigurationEntry {
 
   private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
   private boolean enableAsyncScheduledTasks = true;
+  private Set<Long> skipPositions;
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
@@ -35,6 +38,14 @@ public final class ProcessingCfg implements ConfigurationEntry {
 
   public void setEnableAsyncScheduledTasks(final boolean enableAsyncScheduledTasks) {
     this.enableAsyncScheduledTasks = enableAsyncScheduledTasks;
+  }
+
+  public Set<Long> skipPositions() {
+    return skipPositions != null ? skipPositions : Set.of();
+  }
+
+  public void setSkipPositions(final Set<Long> skipPositions) {
+    this.skipPositions = skipPositions;
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
@@ -147,6 +148,8 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
             JobIntent.TIME_OUT,
             JobIntent.RECUR_AFTER_BACKOFF,
             MessageIntent.EXPIRE);
+    final var processingFilter =
+        SkipPositionsFilter.of(context.getBrokerCfg().getProcessing().skipPositions());
 
     return StreamProcessor.builder()
         .logStream(context.getLogStream())
@@ -158,6 +161,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
         .setEnableAsyncScheduledTasks(
             context.getBrokerCfg().getProcessing().isEnableAsyncScheduledTasks())
+        .processingFilter(processingFilter)
         .listener(
             new StreamProcessorListener() {
               @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfgTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Collections;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 final class ProcessingCfgTest {
@@ -129,5 +130,45 @@ final class ProcessingCfgTest {
 
     // then
     assertThat(enabled).isTrue();
+  }
+
+  @Test
+  void shouldSetSkipPositions() {
+    // given
+    final var cfg = new ProcessingCfg();
+    cfg.setSkipPositions(Set.of(1L, 2L, 3L));
+
+    // when
+    final var skipPositions = cfg.skipPositions();
+
+    // then
+    assertThat(skipPositions).containsExactlyInAnyOrder(1L, 2L, 3L);
+  }
+
+  @Test
+  void shouldSetSkipPositionsFromConfig() {
+    // given
+    final var cfg =
+        TestConfigReader.readConfig("processing-cfg", Collections.emptyMap()).getProcessing();
+
+    // when
+    final var skipPositions = cfg.skipPositions();
+
+    // then
+    assertThat(skipPositions).containsExactlyInAnyOrder(1L, 2L, 3L);
+  }
+
+  @Test
+  void shouldSetSkipPositionsFromEnvironment() {
+    // given
+    final var environment =
+        Collections.singletonMap("zeebe.broker.processing.skipPositions", "4,5,6");
+    final var cfg = TestConfigReader.readConfig("processing-cfg", environment).getProcessing();
+
+    // when
+    final var skipPositions = cfg.skipPositions();
+
+    // then
+    assertThat(skipPositions).containsExactly(4L, 5L, 6L);
   }
 }

--- a/broker/src/test/resources/system/processing-cfg.yaml
+++ b/broker/src/test/resources/system/processing-cfg.yaml
@@ -3,3 +3,4 @@ zeebe:
     processing:
       maxCommandsInBatch: 125
       enableAsyncScheduledTasks: false
+      skipPositions: 1, 2, 3

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -899,6 +899,12 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_ENABLEASYNCSCHEDULEDTASKS
       # enableAsyncScheduledTasks: true
 
+      # Allows to skip certain commands by their position. This is useful for debugging and data recovery.
+      # It is not recommended to use this in production.
+      # The value is a comma-separated list of positions to skip. Whitespace is ignored.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SKIPPOSITIONS
+      # skipPositions: ""
+
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -790,6 +790,12 @@
       #
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_ENABLEASYNCSCHEDULEDTASKS
       # enableAsyncScheduledTasks: true
+
+      # Allows to skip certain commands by their position. This is useful for debugging and data recovery.
+      # It is not recommended to use this in production.
+      # The value is a comma-separated list of positions to skip. Whitespace is ignored.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SKIPPOSITIONS
+      # skipPositions: ""
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.scheduler.retry.RecoverableRetryStrategy;
 import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
 import io.camunda.zeebe.stream.api.EventFilter;
-import io.camunda.zeebe.stream.api.MetadataFilter;
 import io.camunda.zeebe.stream.api.ProcessingResponse;
 import io.camunda.zeebe.stream.api.ProcessingResult;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
@@ -115,14 +114,17 @@ public final class ProcessingStateMachine {
   private static final String NOTIFY_SKIPPED_LISTENER_ERROR_MESSAGE =
       "Expected to invoke skipped listener for record '{} {}' successfully, but exception was thrown.";
   private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
-  private static final MetadataFilter PROCESSING_FILTER =
-      recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND;
   private static final String ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED =
       "Expected to process command '{} {}' successfully on stream processor, but caught unexpected exception. Failed to handle the exception gracefully.";
-  private final EventFilter eventFilter = new MetadataEventFilter(PROCESSING_FILTER);
-  private final EventFilter commandFilter =
+  private final EventFilter isCommand =
       new MetadataEventFilter(
-          recordMetadata -> recordMetadata.getRecordType() != RecordType.COMMAND);
+          recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND);
+  private final EventFilter isEventOrRejection =
+      new MetadataEventFilter(
+          recordMetadata -> {
+            final var recordType = recordMetadata.getRecordType();
+            return recordType == RecordType.EVENT || recordType == RecordType.COMMAND_REJECTION;
+          });
   private final MutableLastProcessedPositionState lastProcessedPositionState;
   private final RecordMetadata metadata = new RecordMetadata();
   private final ActorControl actor;
@@ -220,7 +222,7 @@ public final class ProcessingStateMachine {
       //  * and this was the last record written (records that have been written to the dispatcher
       //    might not be written to the log yet, which means they will appear shortly after this)
       reachedEnd =
-          commandFilter.applies(previousRecord)
+          isEventOrRejection.applies(previousRecord)
               && !hasNext
               && lastWrittenPosition <= previousRecord.getPosition();
     }
@@ -228,7 +230,7 @@ public final class ProcessingStateMachine {
     if (shouldProcessNext.getAsBoolean() && hasNext && !inProcessing) {
       currentRecord = logStreamReader.next();
 
-      if (eventFilter.applies(currentRecord) && !currentRecord.shouldSkipProcessing()) {
+      if (isCommand.applies(currentRecord) && !currentRecord.shouldSkipProcessing()) {
         processCommand(currentRecord);
       } else {
         skipRecord();

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -116,10 +116,7 @@ public final class ProcessingStateMachine {
   private static final Duration PROCESSING_RETRY_DELAY = Duration.ofMillis(250);
   private static final String ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED =
       "Expected to process command '{} {}' successfully on stream processor, but caught unexpected exception. Failed to handle the exception gracefully.";
-  private final EventFilter processingFilter =
-      new MetadataEventFilter(
-              recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND)
-          .and(record -> !record.shouldSkipProcessing());
+  private final EventFilter processingFilter;
   private final EventFilter isEventOrRejection =
       new MetadataEventFilter(
           recordMetadata -> {
@@ -193,6 +190,12 @@ public final class ProcessingStateMachine {
     streamProcessorListener = context.getStreamProcessorListener();
 
     processingMetrics = new ProcessingMetrics(Integer.toString(partitionId));
+
+    processingFilter =
+        new MetadataEventFilter(
+                recordMetadata -> recordMetadata.getRecordType() == RecordType.COMMAND)
+            .and(record -> !record.shouldSkipProcessing())
+            .and(context.processingFilter());
   }
 
   private void skipRecord() {

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SkipPositionsFilter.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SkipPositionsFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.stream.api.EventFilter;
+import java.util.Set;
+
+/** A filter that skips events with positions in a given set of positions. */
+public final class SkipPositionsFilter implements EventFilter {
+
+  private final Set<Long> positionsToSkip;
+
+  private SkipPositionsFilter(final Set<Long> positionsToSkip) {
+
+    this.positionsToSkip = positionsToSkip;
+  }
+
+  public static SkipPositionsFilter of(final Set<Long> positionsToSkip) {
+    return new SkipPositionsFilter(positionsToSkip);
+  }
+
+  /**
+   * @return true if the event position is not in the set of positions to skip
+   */
+  @Override
+  public boolean applies(final LoggedEvent event) {
+    return !positionsToSkip.contains(event.getPosition());
+  }
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SkipPositionsFilter.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/SkipPositionsFilter.java
@@ -10,19 +10,22 @@ package io.camunda.zeebe.stream.impl;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.stream.api.EventFilter;
 import java.util.Set;
+import org.agrona.collections.LongHashSet;
 
 /** A filter that skips events with positions in a given set of positions. */
 public final class SkipPositionsFilter implements EventFilter {
 
-  private final Set<Long> positionsToSkip;
+  private final LongHashSet positionsToSkip;
 
-  private SkipPositionsFilter(final Set<Long> positionsToSkip) {
+  private SkipPositionsFilter(final LongHashSet positionsToSkip) {
 
     this.positionsToSkip = positionsToSkip;
   }
 
   public static SkipPositionsFilter of(final Set<Long> positionsToSkip) {
-    return new SkipPositionsFilter(positionsToSkip);
+    final LongHashSet longHashSet = new LongHashSet(positionsToSkip.size());
+    longHashSet.addAll(positionsToSkip);
+    return new SkipPositionsFilter(longHashSet);
   }
 
   /**
@@ -30,6 +33,6 @@ public final class SkipPositionsFilter implements EventFilter {
    */
   @Override
   public boolean applies(final LoggedEvent event) {
-    return !positionsToSkip.contains(event.getPosition());
+    return positionsToSkip.isEmpty() || !positionsToSkip.contains(event.getPosition());
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
@@ -151,6 +152,11 @@ public final class StreamProcessorBuilder {
 
   public StreamProcessorBuilder setEnableAsyncScheduledTasks(final boolean enabled) {
     streamProcessorContext.setEnableAsyncScheduledTasks(enabled);
+    return this;
+  }
+
+  public StreamProcessorBuilder processingFilter(final EventFilter processingFilter) {
+    streamProcessorContext.processingFilter(processingFilter);
     return this;
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -57,6 +58,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private KeyGeneratorControls keyGeneratorControls;
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
   private boolean enableAsyncScheduledTasks = true;
+  private EventFilter processingFilter = e -> true;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -76,6 +78,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   @Override
   public int getPartitionId() {
     return getLogStream().getPartitionId();
+  }
+
+  @Override
+  public boolean enableAsyncScheduledTasks() {
+    return enableAsyncScheduledTasks;
   }
 
   public LogStream getLogStream() {
@@ -209,11 +216,16 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   }
 
   public StreamProcessorContext setEnableAsyncScheduledTasks(final boolean enabled) {
-    this.enableAsyncScheduledTasks = enabled;
+    enableAsyncScheduledTasks = enabled;
     return this;
   }
 
-  public boolean enableAsyncScheduledTasks() {
-    return enableAsyncScheduledTasks;
+  public EventFilter processingFilter() {
+    return processingFilter;
+  }
+
+  public StreamProcessorContext processingFilter(final EventFilter processingFilter) {
+    this.processingFilter = processingFilter;
+    return this;
   }
 }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/SkipPositionsFilterTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/SkipPositionsFilterTest.java
@@ -41,4 +41,17 @@ final class SkipPositionsFilterTest {
     // then
     assertThat(filter.applies(event)).isTrue();
   }
+
+  @Test
+  void shouldNotSkipEventWhenSetIsEmpty() {
+    // given
+    final var filter = SkipPositionsFilter.of(Set.of());
+    final var event = mock(LoggedEventImpl.class);
+
+    // when
+    when(event.getPosition()).thenReturn(4L);
+
+    // then
+    assertThat(filter.applies(event)).isTrue();
+  }
 }

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/SkipPositionsFilterTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/SkipPositionsFilterTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class SkipPositionsFilterTest {
+  @Test
+  void shouldSkipEventWithMatchingPosition() {
+    // given
+    final var filter = SkipPositionsFilter.of(Set.of(1L, 2L, 3L));
+    final var event = mock(LoggedEventImpl.class);
+
+    // when
+    when(event.getPosition()).thenReturn(2L);
+
+    // then
+    assertThat(filter.applies(event)).isFalse();
+  }
+
+  @Test
+  void shouldNotSkipEventWithNonMatchingPosition() {
+    // given
+    final var filter = SkipPositionsFilter.of(Set.of(1L, 2L, 3L));
+    final var event = mock(LoggedEventImpl.class);
+
+    // when
+    when(event.getPosition()).thenReturn(4L);
+
+    // then
+    assertThat(filter.applies(event)).isTrue();
+  }
+}

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -1366,6 +1366,23 @@ public final class StreamProcessorTest {
         .untilAsserted(() -> assertThat(commandCache.contains(ACTIVATE_ELEMENT, 1)).isFalse());
   }
 
+  @Test
+  void shouldUseProcessingFilter() {
+    // given -- filter that always skips
+    streamPlatform.buildStreamProcessor(
+        streamPlatform.getLogStream(), true, cfg -> cfg.processingFilter(event -> false));
+
+    // when -- writing any command
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then -- command is skipped and processor is not used
+    verify(streamPlatform.getMockStreamProcessorListener(), timeout(TIMEOUT_MILLIS))
+        .onSkipped(any());
+    verify(streamPlatform.getDefaultMockedRecordProcessor(), never()).accepts(any());
+    verify(streamPlatform.getDefaultMockedRecordProcessor(), never()).process(any(), any());
+  }
+
   private static final class TestProcessor implements RecordProcessor {
 
     ProcessingResult processingResult = EmptyProcessingResult.INSTANCE;


### PR DESCRIPTION
This implements the first half of #16177, allowing us to set the new configuration value `zeebe.broker.processing.skipPositions` in order to skip processing for these commands.

The config value accepts any comma-separated list of `Long`s.