### PR TITLE
Respond decision instance key in evaluate decision RPC

### DIFF
--- a/gateway-protocol/src/main/proto/gateway.proto
+++ b/gateway-protocol/src/main/proto/gateway.proto
@@ -229,6 +229,8 @@ message EvaluateDecisionResponse {
   string failureMessage = 10;
   // the tenant identifier of the evaluated decision
   string tenantId = 11;
+  // the unique key identifying this decision evaluation
+  int64 decisionInstanceKey = 12;
 }
 
 message EvaluatedDecision {

--- a/gateway-protocol/src/main/proto/proto.lock
+++ b/gateway-protocol/src/main/proto/proto.lock
@@ -444,6 +444,11 @@
                 "id": 11,
                 "name": "tenantId",
                 "type": "string"
+              },
+              {
+                "id": 12,
+                "name": "decisionInstanceKey",
+                "type": "int64"
               }
             ]
           },

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -201,6 +201,7 @@ public final class ResponseMapper {
 
     final EvaluateDecisionResponse.Builder responseBuilder =
         EvaluateDecisionResponse.newBuilder()
+            .setDecisionInstanceKey(key)
             .setDecisionId(brokerResponse.getDecisionId())
             .setDecisionKey(brokerResponse.getDecisionKey())
             .setDecisionName(brokerResponse.getDecisionName())

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionStub.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionStub.java
@@ -66,7 +66,9 @@ public class EvaluateDecisionStub
   @Override
   public BrokerResponse<DecisionEvaluationRecord> handle(
       final BrokerEvaluateDecisionRequest request) throws Exception {
-    return new BrokerResponse<>(DECISION_RECORD, request.getPartitionId(), request.getKey());
+    // In practise the decision instance key is generated newly by the broker
+    final long decisionInstanceKey = DECISION_RECORD.getDecisionKey() + 1;
+    return new BrokerResponse<>(DECISION_RECORD, request.getPartitionId(), decisionInstanceKey);
   }
 
   private static DirectBuffer toMessagePack(final String json) {

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
@@ -77,6 +77,7 @@ public class EvaluateDecisionTest extends GatewayTest {
     assertThat(response).isNotNull();
 
     // assert DecisionEvaluationRecord mapping
+    assertThat(response.getDecisionInstanceKey()).isGreaterThan(DECISION_RECORD.getDecisionKey());
     assertThat(response.getDecisionId()).isEqualTo(DECISION_RECORD.getDecisionId());
     assertThat(response.getDecisionKey()).isEqualTo(DECISION_RECORD.getDecisionKey());
     assertThat(response.getDecisionName()).isEqualTo(DECISION_RECORD.getDecisionName());


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When evaluating a decision, we assign a key to the decision instance (i.e. decision evaluation). This key lets users easily see and find decision instances in Operate. However, it was not responded to the client over gRPC.

This PR adds the `decisionInstanceKey` to the `EvaluateDecisionResponse`.

I choose the name `decisionInstanceKey` over `decisionEvaluationKey` to align with Operate rather than have differing namings.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15916

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
