### PR TITLE
Unflake `TenantAwareTimerStartEventTest.shouldTriggerTimer`

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -69,12 +69,10 @@ public class TenantAwareTimerStartEventTest {
 
     // then
     assertThat(
-            RecordingExporter.timerRecords()
-                .withIntents(TimerIntent.TRIGGER, TimerIntent.TRIGGERED)
-                .withProcessDefinitionKey(processDefinitionKey)
-                .limit(2))
+            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+                .withProcessDefinitionKey(processDefinitionKey))
         .extracting(r -> r.getValue().getTenantId(), Record::getIntent)
-        .containsSequence(tuple(TENANT, TimerIntent.TRIGGER), tuple(TENANT, TimerIntent.TRIGGERED));
+        .containsSequence(tuple(TENANT, TimerIntent.TRIGGERED));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -105,6 +105,7 @@ public class TenantAwareTimerStartEventTest {
     // then
     assertThat(
             RecordingExporter.processInstanceRecords()
+                .onlyEvents()
                 .withProcessDefinitionKey(processDefinitionKey)
                 .withElementType(BpmnElementType.START_EVENT)
                 .withEventType(BpmnEventType.TIMER)
@@ -113,7 +114,6 @@ public class TenantAwareTimerStartEventTest {
         .containsSequence(
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(TENANT, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

See https://github.com/camunda/zeebe/issues/15834#issuecomment-1940591378 for my full analysis of the flaky test.

This PR unflakes the test by only asserting events rather than also asserting commands. See commit messages for more details.

Tests were introduced with 8.3.0.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15834

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
