### PR TITLE
[Backport stable/8.4] Unflake `TenantAwareTimerStartEventTest.shouldTriggerTimer`

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -69,12 +69,10 @@ public class TenantAwareTimerStartEventTest {
 
     // then
     assertThat(
-            RecordingExporter.timerRecords()
-                .withIntents(TimerIntent.TRIGGER, TimerIntent.TRIGGERED)
-                .withProcessDefinitionKey(processDefinitionKey)
-                .limit(2))
+            RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+                .withProcessDefinitionKey(processDefinitionKey))
         .extracting(r -> r.getValue().getTenantId(), Record::getIntent)
-        .containsSequence(tuple(TENANT, TimerIntent.TRIGGER), tuple(TENANT, TimerIntent.TRIGGERED));
+        .containsSequence(tuple(TENANT, TimerIntent.TRIGGERED));
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/multitenancy/TenantAwareTimerStartEventTest.java
@@ -105,6 +105,7 @@ public class TenantAwareTimerStartEventTest {
     // then
     assertThat(
             RecordingExporter.processInstanceRecords()
+                .onlyEvents()
                 .withProcessDefinitionKey(processDefinitionKey)
                 .withElementType(BpmnElementType.START_EVENT)
                 .withEventType(BpmnEventType.TIMER)
@@ -113,7 +114,6 @@ public class TenantAwareTimerStartEventTest {
         .containsSequence(
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_ACTIVATING),
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(TENANT, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_COMPLETING),
             tuple(TENANT, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }


### PR DESCRIPTION
# Description
Backport of #16325 to `stable/8.4`.

relates to #15834
original author: @korthout