### PR TITLE
Handle request to force remove brokers in the coordinator broker

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -40,6 +40,7 @@ import io.camunda.zeebe.topology.state.PartitionState.State;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -368,6 +369,11 @@ public class ClusterEndpoint {
                       .map(MemberId::id)
                       .map(Integer::parseInt)
                       .collect(Collectors.toList()));
+      case final TopologyChangeOperation.MemberRemoveOperation memberRemoveOperation ->
+          new Operation()
+              .operation(OperationEnum.BROKER_REMOVE)
+              .brokerId(Integer.parseInt(memberRemoveOperation.memberId().id()))
+              .brokers(List.of(Integer.parseInt(memberRemoveOperation.memberToRemove().id())));
     };
   }
 
@@ -511,6 +517,11 @@ public class ClusterEndpoint {
                           .map(MemberId::id)
                           .map(Integer::parseInt)
                           .collect(Collectors.toList()));
+          case final MemberRemoveOperation memberRemoveOperation ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.BROKER_REMOVE)
+                  .brokerId(Integer.parseInt(memberRemoveOperation.memberId().id()))
+                  .brokers(List.of(Integer.parseInt(memberRemoveOperation.memberToRemove().id())));
         };
 
     mappedOperation.completedAt(mapInstantToDateTime(operation.completedAt()));

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -334,6 +334,7 @@ components:
             - PARTITION_LEAVE
             - PARTITION_RECONFIGURE_PRIORITY
             - PARTITION_FORCE_RECONFIGURE
+            - BROKER_FORCE_REMOVE
         brokerId:
           $ref: "#/components/schemas/BrokerId"
         partitionId:

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -91,7 +91,8 @@ public final class ClusterTopologyManagerService implements TopologyUpdateNotifi
           new TopologyRequestServer(
               communicationService,
               new ProtoBufSerializer(),
-              new TopologyManagementRequestsHandler(topologyChangeCoordinator, managerActor));
+              new TopologyManagementRequestsHandler(
+                  topologyChangeCoordinator, localMemberId, managerActor));
     }
     clusterTopologyManager.setTopologyGossiper(clusterTopologyGossiper::updateClusterTopology);
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -91,8 +91,7 @@ public final class ClusterTopologyManagerService implements TopologyUpdateNotifi
           new TopologyRequestServer(
               communicationService,
               new ProtoBufSerializer(),
-              new TopologyManagementRequestsHandler(topologyChangeCoordinator, managerActor),
-              managerActor);
+              new TopologyManagementRequestsHandler(topologyChangeCoordinator, managerActor));
     }
     clusterTopologyManager.setTopologyGossiper(clusterTopologyGossiper::updateClusterTopology);
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/ForceScaleDownRequestTransformer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/ForceScaleDownRequestTransformer.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.api.TopologyRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator.TopologyChangeRequest;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class ForceScaleDownRequestTransformer implements TopologyChangeRequest {
+
+  private final Set<MemberId> membersToRetain;
+
+  private final MemberId coordinator;
+
+  public ForceScaleDownRequestTransformer(
+      final Set<MemberId> membersToRetain, final MemberId coordinator) {
+    this.membersToRetain = membersToRetain;
+    this.coordinator = coordinator;
+  }
+
+  @Override
+  public Either<Exception, List<TopologyChangeOperation>> operations(
+      final ClusterTopology currentTopology) {
+    for (final var member : membersToRetain) {
+      if (!currentTopology.hasMember(member)) {
+        return Either.left(
+            new InvalidRequest(
+                String.format(
+                    "Expected to force configure while retaining broker '%s', but broker '%s' is not in the current cluster. Current members are '%s'",
+                    member, member, currentTopology.members().keySet())));
+      }
+    }
+
+    final List<Integer> partitions =
+        currentTopology.members().values().stream()
+            .map(MemberState::partitions)
+            .flatMap(p -> p.keySet().stream())
+            .distinct()
+            .toList();
+
+    final Map<Integer, ArrayList<MemberId>> partitionsWithNewMembers =
+        calculateNewConfiguration(currentTopology, membersToRetain, partitions);
+
+    final var partitionsWithNoReplicas =
+        partitions.stream()
+            .filter(
+                p ->
+                    !partitionsWithNewMembers.containsKey(p)
+                        || partitionsWithNewMembers.get(p).isEmpty())
+            .toList();
+
+    final var hasReplicasForAllPartitions = partitionsWithNoReplicas.isEmpty();
+
+    if (!hasReplicasForAllPartitions) {
+      return Either.left(
+          new InvalidRequest(
+              String.format(
+                  "Expected to force configure and retain members '%s', but this will result in partitions '%s' having no replicas",
+                  membersToRetain, partitionsWithNoReplicas)));
+    }
+
+    // members that are not in membersToRetain
+    final var memberToRemove =
+        currentTopology.members().keySet().stream()
+            .filter(m -> !membersToRetain.contains(m))
+            .toList();
+
+    return generateOperations(partitionsWithNewMembers, memberToRemove);
+  }
+
+  private Either<Exception, List<TopologyChangeOperation>> generateOperations(
+      final Map<Integer, ArrayList<MemberId>> partitionsWithNewMembers,
+      final List<MemberId> memberToRemove) {
+
+    final var partitionForceConfigureOperations = reconfigurePartitions(partitionsWithNewMembers);
+    final List<TopologyChangeOperation> operations =
+        new ArrayList<>(partitionForceConfigureOperations);
+
+    final var memberRemoveOperations = forceRemoveMembers(memberToRemove);
+    operations.addAll(memberRemoveOperations);
+
+    return Either.right(operations);
+  }
+
+  private List<TopologyChangeOperation> reconfigurePartitions(
+      final Map<Integer, ArrayList<MemberId>> partitionsWithNewMembers) {
+    return partitionsWithNewMembers.entrySet().stream()
+        .map(
+            partition ->
+                new PartitionForceReconfigureOperation(
+                    partition.getValue().stream().findFirst().orElseThrow(),
+                    partition.getKey(),
+                    partition.getValue()))
+        .map(TopologyChangeOperation.class::cast)
+        .toList();
+  }
+
+  private List<TopologyChangeOperation> forceRemoveMembers(final List<MemberId> membersToRemove) {
+    return membersToRemove.stream()
+        .map(member -> new MemberRemoveOperation(coordinator, member))
+        .map(TopologyChangeOperation.class::cast)
+        .toList();
+  }
+
+  private Map<Integer, ArrayList<MemberId>> calculateNewConfiguration(
+      final ClusterTopology currentTopology,
+      final Set<MemberId> membersToRetain,
+      final List<Integer> partitions) {
+
+    final Map<Integer, ArrayList<MemberId>> partitionToMembersMap = new HashMap<>();
+    for (final var partitionId : partitions) {
+      partitionToMembersMap.put(partitionId, new ArrayList<>());
+      for (final var member : membersToRetain) {
+        if (currentTopology.getMember(member).hasPartition(partitionId)) {
+          partitionToMembersMap.computeIfPresent(
+              partitionId,
+              (ignore, members) -> {
+                members.add(member);
+                return members;
+              });
+        }
+      }
+    }
+
+    return partitionToMembersMap;
+  }
+}

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementApi.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementApi.java
@@ -32,6 +32,15 @@ public interface TopologyManagementApi {
 
   ActorFuture<TopologyChangeResponse> scaleMembers(ScaleRequest scaleRequest);
 
+  /**
+   * Forces a scale down of the cluster. The members that are not specified in the request will be
+   * removed forcefully. The replicas of partitions on the removed members won't be re-assigned. As
+   * a result the number of replicas for those partitions will be reduced.
+   *
+   * <p>This is expected to be used to force remove a set of brokers when they are unreachable.
+   */
+  ActorFuture<TopologyChangeResponse> forceScaleDown(ScaleRequest forceScaleDownRequest);
+
   ActorFuture<ClusterTopology> cancelTopologyChange(
       TopologyManagementRequest.CancelChangeRequest cancelChangeRequest);
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -104,6 +104,17 @@ public final class TopologyManagementRequestSender {
         TIMEOUT);
   }
 
+  public CompletableFuture<Either<ErrorResponse, TopologyChangeResponse>> forceScaleDown(
+      final ScaleRequest forceScaleDownRequest) {
+    return communicationService.send(
+        TopologyRequestTopics.FORCE_SCALE_DOWN.topic(),
+        forceScaleDownRequest,
+        serializer::encodeScaleRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinator,
+        TIMEOUT);
+  }
+
   public CompletableFuture<Either<ErrorResponse, ClusterTopology>> getTopology() {
     return communicationService.send(
         TopologyRequestTopics.QUERY_TOPOLOGY.topic(),

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.topology.api;
 
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.AddMembersRequest;
@@ -34,11 +35,15 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
 
   private final TopologyChangeCoordinator coordinator;
   private final ConcurrencyControl executor;
+  private final MemberId localMemberId;
 
   public TopologyManagementRequestsHandler(
-      final TopologyChangeCoordinator coordinator, final ConcurrencyControl executor) {
+      final TopologyChangeCoordinator coordinator,
+      final MemberId localMemberId,
+      final ConcurrencyControl executor) {
     this.coordinator = coordinator;
     this.executor = executor;
+    this.localMemberId = localMemberId;
   }
 
   @Override
@@ -94,6 +99,14 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
   public ActorFuture<TopologyChangeResponse> scaleMembers(final ScaleRequest scaleRequest) {
     return handleRequest(
         scaleRequest.dryRun(), new ScaleRequestTransformer(scaleRequest.members()));
+  }
+
+  @Override
+  public ActorFuture<TopologyChangeResponse> forceScaleDown(
+      final ScaleRequest forceScaleDownRequest) {
+    return handleRequest(
+        forceScaleDownRequest.dryRun(),
+        new ForceScaleDownRequestTransformer(forceScaleDownRequest.members(), localMemberId));
   }
 
   @Override

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.topology.api;
 
 import io.atomix.cluster.messaging.ClusterCommunicationService;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.topology.api.ErrorResponse.ErrorCode;
 import io.camunda.zeebe.topology.api.TopologyRequestFailedException.ConcurrentModificationException;
@@ -24,18 +23,15 @@ public final class TopologyRequestServer implements AutoCloseable {
 
   private final TopologyManagementApi topologyManagementApi;
   private final ClusterCommunicationService communicationService;
-  private final ConcurrencyControl executor;
   private final TopologyRequestsSerializer serializer;
 
   public TopologyRequestServer(
       final ClusterCommunicationService communicationService,
       final TopologyRequestsSerializer serializer,
-      final TopologyManagementApi topologyManagementApi,
-      final ConcurrencyControl executor) {
+      final TopologyManagementApi topologyManagementApi) {
     this.topologyManagementApi = topologyManagementApi;
     this.communicationService = communicationService;
     this.serializer = serializer;
-    this.executor = executor;
   }
 
   public void start() {

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestServer.java
@@ -43,6 +43,7 @@ public final class TopologyRequestServer implements AutoCloseable {
     registerScaleRequestHandler();
     registerGetTopologyQueryHandler();
     registerTopologyCancelHandler();
+    registerForceScaleDownHandler();
   }
 
   @Override
@@ -113,6 +114,14 @@ public final class TopologyRequestServer implements AutoCloseable {
         TopologyRequestTopics.SCALE_MEMBERS.topic(),
         serializer::decodeScaleRequest,
         request -> mapResponse(topologyManagementApi.scaleMembers(request)),
+        this::encodeResponse);
+  }
+
+  private void registerForceScaleDownHandler() {
+    communicationService.replyTo(
+        TopologyRequestTopics.FORCE_SCALE_DOWN.topic(),
+        serializer::decodeScaleRequest,
+        request -> mapResponse(topologyManagementApi.forceScaleDown(request)),
         this::encodeResponse);
   }
 

--- a/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyRequestTopics.java
@@ -15,8 +15,8 @@ public enum TopologyRequestTopics {
   REASSIGN_PARTITIONS("topology-partition-reassign"),
   SCALE_MEMBERS("topology-member-scale"),
   QUERY_TOPOLOGY("topology-query"),
-  CANCEL_CHANGE("topology-change-cancel");
-
+  CANCEL_CHANGE("topology-change-cancel"),
+  FORCE_SCALE_DOWN("topology-force-scale-down");
   private final String topic;
 
   TopologyRequestTopics(final String topic) {

--- a/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeAppliersImpl.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.topology.state.MemberState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -62,6 +63,11 @@ public class TopologyChangeAppliersImpl implements TopologyChangeAppliers {
               forceReconfigureOperation.memberId(),
               forceReconfigureOperation.members(),
               partitionChangeExecutor);
+      case final MemberRemoveOperation memberRemoveOperation ->
+          // Reuse MemberLeaveApplier, only difference is that the member applying the operation is
+          // not the member that is leaving
+          new MemberLeaveApplier(
+              memberRemoveOperation.memberToRemove(), topologyMembershipChangeExecutor);
       case null, default -> new FailingApplier(operation);
     };
   }

--- a/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
+++ b/topology/src/main/java/io/camunda/zeebe/topology/state/TopologyChangeOperation.java
@@ -32,6 +32,16 @@ public sealed interface TopologyChangeOperation {
    */
   record MemberLeaveOperation(MemberId memberId) implements TopologyChangeOperation {}
 
+  /**
+   * Operation to remove a member from the ClusterTopology. This operation is used to force remove a
+   * (unreachable) member.
+   *
+   * @param memberId the id of the member that applies this operations
+   * @param memberToRemove the id of the member to remove
+   */
+  record MemberRemoveOperation(MemberId memberId, MemberId memberToRemove)
+      implements TopologyChangeOperation {}
+
   sealed interface PartitionChangeOperation extends TopologyChangeOperation {
     int partitionId();
 

--- a/topology/src/main/resources/proto/proto.lock
+++ b/topology/src/main/resources/proto/proto.lock
@@ -469,6 +469,11 @@
                 "id": 7,
                 "name": "partitionForceReconfigure",
                 "type": "PartitionForceReconfigureOperation"
+              },
+              {
+                "id": 8,
+                "name": "memberRemove",
+                "type": "MemberRemoveOperation"
               }
             ]
           },
@@ -548,6 +553,16 @@
           },
           {
             "name": "MemberLeaveOperation"
+          },
+          {
+            "name": "MemberRemoveOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "memberToRemove",
+                "type": "string"
+              }
+            ]
           }
         ],
         "imports": [

--- a/topology/src/main/resources/proto/topology.proto
+++ b/topology/src/main/resources/proto/topology.proto
@@ -54,6 +54,7 @@ message TopologyChangeOperation {
     MemberLeaveOperation memberLeave = 5;
     PartitionReconfigurePriorityOperation partitionReconfigurePriority = 6;
     PartitionForceReconfigureOperation partitionForceReconfigure = 7;
+    MemberRemoveOperation memberRemove = 8;
   }
 }
 
@@ -84,6 +85,10 @@ message PartitionForceReconfigureOperation {
 message MemberJoinOperation {}
 
 message MemberLeaveOperation {}
+
+message MemberRemoveOperation {
+  string memberToRemove = 1;
+}
 
 enum State {
   UNKNOWN = 0;

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/ForceScaleDownRequestTransformerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/ForceScaleDownRequestTransformerTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import io.camunda.zeebe.topology.api.TopologyRequestFailedException.InvalidRequest;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.PartitionState;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ForceScaleDownRequestTransformerTest {
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final MemberId id2 = MemberId.from("2");
+  private final MemberId id3 = MemberId.from("3");
+
+  private final ClusterTopology currentTopology =
+      ClusterTopology.init()
+          .addMember(id0, MemberState.initializeAsActive(Map.of()))
+          .addMember(id1, MemberState.initializeAsActive(Map.of()))
+          .addMember(id2, MemberState.initializeAsActive(Map.of()))
+          .addMember(id3, MemberState.initializeAsActive(Map.of()))
+          .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1)))
+          .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2)))
+          .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1)))
+          .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2)));
+
+  @Test
+  void shouldGenerateForceConfigureOperations() {
+    // given
+    final var membersToRetain = Set.of(MemberId.from("0"), MemberId.from("2"));
+    final var forceConfigureTransformer =
+        new ForceScaleDownRequestTransformer(membersToRetain, id0);
+
+    // when
+    final var result = forceConfigureTransformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .hasSize(4)
+        .containsExactlyInAnyOrder(
+            new PartitionForceReconfigureOperation(id0, 1, List.of(id0)),
+            new PartitionForceReconfigureOperation(id2, 2, List.of(id2)),
+            new MemberRemoveOperation(id0, id1),
+            new MemberRemoveOperation(id0, id3));
+  }
+
+  @Test
+  void shouldFailWhenRetainingNonExistingMember() {
+    // given
+    final var membersToRetain = Set.of(MemberId.from("0"), MemberId.from("4"));
+    final var forceConfigureTransformer =
+        new ForceScaleDownRequestTransformer(membersToRetain, id0);
+
+    // when
+    final var result = forceConfigureTransformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class);
+  }
+
+  @Test
+  void shouldFailWhenRetainingMemberWithNoPartitions() {
+    // given
+    final var membersToRetain = Set.of(MemberId.from("0"), MemberId.from("1"));
+    final var forceConfigureTransformer =
+        new ForceScaleDownRequestTransformer(membersToRetain, id0);
+
+    // when
+    final var result = forceConfigureTransformer.operations(currentTopology);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft()).isInstanceOf(InvalidRequest.class);
+  }
+}

--- a/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
@@ -72,8 +72,7 @@ final class TopologyManagementApiTest {
             coordinator.getCommunicationService(),
             new ProtoBufSerializer(),
             new TopologyManagementRequestsHandler(
-                recordingCoordinator, new TestConcurrencyControl()),
-            new TestConcurrencyControl());
+                recordingCoordinator, new TestConcurrencyControl()));
 
     requestServer.start();
   }

--- a/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/serializer/ProtoBufSerializerTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.topology.state.PartitionState;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -247,7 +248,8 @@ final class ProtoBufSerializerTest {
             new PartitionJoinOperation(MemberId.from("2"), 2, 5),
             new PartitionReconfigurePriorityOperation(MemberId.from("3"), 4, 3),
             new PartitionForceReconfigureOperation(
-                MemberId.from("4"), 5, List.of(MemberId.from("1"), MemberId.from("3"))));
+                MemberId.from("4"), 5, List.of(MemberId.from("1"), MemberId.from("3"))),
+            new MemberRemoveOperation(MemberId.from("5"), MemberId.from("6")));
     return ClusterTopology.init()
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
         .startTopologyChange(changes);


### PR DESCRIPTION
## Description

- `TopologyManagementRequestSender` can send a request to force scale down to the coordinator. Gateway can use this to send the request. Right now the coordinator is always 0. In a later PR, we will add support to send this request to another broker if 0 is being force removed. 
- `TopologyRequestServer` receives this request and delegates to `TopologyManagementRequestsHandler`.
- `TopologyManagementRequestsHandler` generates a list of operations to apply using `ForceScaleDownRequestTransformer` and applies the operations similar to other topology change requests.

To support force scale down, this PR also added operation for force removing a member. This is different from MemberLeaveOperation, because the latter is always applied by the member that is being removed, while force remove must be applied by a member that is still in the cluster topology.


## Related issues

closes #16313 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
