### PR TITLE
[Backport stable/8.1] fix(engine): throw instead of ignoring events that can't be applied

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
@@ -19,6 +19,23 @@ public interface EventApplier {
    * @param key the key of the event
    * @param intent the intent of the event
    * @param recordValue the value of the event
+   * @throws NoSuchEventApplier if no event applier is found for the given intent. The event is not
+   *     applied and it is up to the caller to decide what to do.
    */
-  void applyState(long key, Intent intent, RecordValue recordValue);
+  void applyState(long key, Intent intent, RecordValue recordValue) throws NoSuchEventApplier;
+
+  /** Thrown when no event applier is found for a given intent and record version. */
+  abstract sealed class NoSuchEventApplier extends RuntimeException {
+    public NoSuchEventApplier(final String message) {
+      super(message);
+    }
+
+    public static final class NoApplierForIntent extends NoSuchEventApplier {
+      public NoApplierForIntent(final Intent intent) {
+        super(
+            String.format(
+                "Expected to find an event applier for intent '%s', but none was found.", intent));
+      }
+    }
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.util.HashMap;
 import java.util.Map;
+
 /**
  * Applies state changes from events to the {@link MutableProcessingState}.
  *
@@ -268,5 +269,9 @@ public final class EventAppliers implements EventApplier {
       throw new NoApplierForIntent(intent);
     }
     applierForIntent.applyState(key, value);
+  }
+
+  public TypedEventApplier getApplierForIntent(final Intent intent) {
+    return mapping.get(intent);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -54,6 +55,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
     registerProcessInstanceModificationAppliers(state);
+    register(ProcessInstanceResultIntent.COMPLETED, NOOP_EVENT_APPLIER);
 
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBannedInstanceState()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -32,11 +32,10 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
-
 /**
  * Applies state changes from events to the {@link MutableProcessingState}.
  *
@@ -101,6 +100,7 @@ public final class EventAppliers implements EventApplier {
     final VariableApplier variableApplier = new VariableApplier(state.getVariableState());
     register(VariableIntent.CREATED, variableApplier);
     register(VariableIntent.UPDATED, variableApplier);
+    register(VariableDocumentIntent.UPDATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerProcessInstanceEventAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -73,6 +74,7 @@ public final class EventAppliers implements EventApplier {
     register(
         DecisionRequirementsIntent.CREATED,
         new DecisionRequirementsCreatedApplier(state.getDecisionState()));
+    registerDecisionEvaluationAppliers();
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {
@@ -248,6 +250,11 @@ public final class EventAppliers implements EventApplier {
     register(
         ProcessEventIntent.TRIGGERED,
         new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
+  }
+
+  private void registerDecisionEvaluationAppliers() {
+    register(DecisionEvaluationIntent.EVALUATED, NOOP_EVENT_APPLIER);
+    register(DecisionEvaluationIntent.FAILED, NOOP_EVENT_APPLIER);
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -11,7 +11,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,10 +39,7 @@ public class EventAppliersTest {
             // instead of the imperative used for commands.
             .filter(intent -> intent.name().endsWith("ED") || intent.name().endsWith("ING"))
             // CheckpointIntent is not handled by the engine
-            .filter(intent -> !(intent instanceof CheckpointIntent))
-            // ProcessInstanceResultIntent is only used for client responses and does not appear on
-            // the log
-            .filter(intent -> !(intent instanceof ProcessInstanceResultIntent));
+            .filter(intent -> !(intent instanceof CheckpointIntent));
 
     // then
     assertThat(events)

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EventAppliersTest {
+
+  private EventAppliers eventAppliers;
+
+  @BeforeEach
+  void setup() {
+    eventAppliers = new EventAppliers(Mockito.mock(MutableProcessingState.class));
+  }
+
+  @Test
+  void shouldRegisterApplierForAllIntents() {
+    // given
+    final var events =
+        Intent.INTENT_CLASSES.stream()
+            .flatMap(c -> Arrays.stream(c.getEnumConstants()))
+            // Heuristic to detect event intents which are generally in past or present tense
+            // instead of the imperative used for commands.
+            .filter(intent -> intent.name().endsWith("ED") || intent.name().endsWith("ING"))
+            // CheckpointIntent is not handled by the engine
+            .filter(intent -> !(intent instanceof CheckpointIntent))
+            // ProcessInstanceResultIntent is only used for client responses and does not appear on
+            // the log
+            .filter(intent -> !(intent instanceof ProcessInstanceResultIntent));
+
+    // then
+    assertThat(events)
+        .allSatisfy(
+            intent ->
+                assertThat(eventAppliers.getApplierForIntent(intent))
+                    .describedAs(
+                        "Intent %s.%s has a registered event applier",
+                        intent.getClass().getSimpleName(), intent.name())
+                    .isNotNull());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -8,25 +8,32 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class EventAppliersTest {
 
   private EventAppliers eventAppliers;
+  @Mock private TypedEventApplier<Intent, ? extends RecordValue> mockedApplier;
+  @Mock private TypedEventApplier<Intent, ? extends RecordValue> anotherMockedApplier;
 
   @BeforeEach
   void setup() {
-    eventAppliers = new EventAppliers(Mockito.mock(MutableProcessingState.class));
+    eventAppliers = new EventAppliers(mock(MutableProcessingState.class));
   }
 
   @Test
@@ -51,6 +58,59 @@ public class EventAppliersTest {
   }
 
   @Test
+  void cannotRegisterNullApplier() {
+    // given
+    final var intent = mock(Intent.class);
+
+    // then
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> eventAppliers.register(intent, null));
+  }
+
+  @Test
+  void cannotRegisterApplierForNullIntent() {
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> eventAppliers.register(null, mockedApplier));
+  }
+
+  @Test
+  void cannotRegisterApplierForNegativeVersion() {
+    // given
+    final var intent = mock(Intent.class);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> eventAppliers.register(intent, mockedApplier));
+  }
+
+  @Test
+  void cannotRegisterApplierForNonEvent() {
+    // given
+    final var nonEvent = mock(Intent.class);
+
+    // when
+    when(nonEvent.isEvent()).thenReturn(false);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> eventAppliers.register(nonEvent, mockedApplier));
+  }
+
+  @Test
+  void cannotOverrideApplierForSameIntent() {
+    // given
+    final var intent = mock(Intent.class);
+    when(intent.isEvent()).thenReturn(true);
+
+    // when
+    eventAppliers.register(intent, mockedApplier);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> eventAppliers.register(intent, anotherMockedApplier));
+  }
+
+  @Test
   void shouldOnlyRegisterAppliersForEvents() {
     // given
     final var intents =
@@ -59,19 +119,16 @@ public class EventAppliersTest {
             // CheckpointIntent is not handled by the engine
             .filter(intent -> !(intent instanceof CheckpointIntent));
 
-    // when
-    eventAppliers.registerEventAppliers(Mockito.mock(MutableProcessingState.class));
-
     // then
     assertThat(intents)
         .allSatisfy(
             intent -> {
               if (!intent.isEvent()) {
-                assertThat(eventAppliers.getLatestVersion(intent))
+                assertThat(eventAppliers.getApplierForIntent(intent))
                     .describedAs(
                         "Intent %s.%s is not an event but has a registered event applier",
                         intent.getClass().getSimpleName(), intent.name())
-                    .isEqualTo(-1);
+                    .isNull();
               }
             });
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
@@ -44,4 +44,15 @@ public enum DecisionEvaluationIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case EVALUATED:
+      case FAILED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
@@ -41,4 +41,9 @@ public enum DecisionIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
@@ -41,4 +41,9 @@ public enum DecisionRequirementsIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
@@ -47,4 +47,15 @@ public enum DeploymentDistributionIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case COMPLETED:
+      case DISTRIBUTING:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
@@ -55,4 +55,16 @@ public enum DeploymentIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case DISTRIBUTED:
+      case FULLY_DISTRIBUTED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ErrorIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ErrorIntent.java
@@ -41,4 +41,9 @@ public enum ErrorIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
@@ -56,6 +56,17 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case RESOLVED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -59,11 +59,21 @@ public interface Intent {
         public String name() {
           return "UNKNOWN";
         }
+
+        @Override
+        public boolean isEvent() {
+          return false;
+        }
       };
 
   short value();
 
   String name();
+
+  /**
+   * @return true if this intent is used as an event, i.e. it's not a command or command rejection.
+   */
+  boolean isEvent();
 
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   static Intent fromProtocolValue(final ValueType valueType, final short intent) {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
@@ -44,4 +44,14 @@ public enum JobBatchIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case ACTIVATED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -102,6 +102,23 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case COMPLETED:
+      case TIMED_OUT:
+      case FAILED:
+      case RETRIES_UPDATED:
+      case CANCELED:
+      case ERROR_THROWN:
+      case RECURRED_AFTER_BACKOFF:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageIntent.java
@@ -33,6 +33,17 @@ public enum MessageIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case PUBLISHED:
+      case EXPIRED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
@@ -31,6 +31,11 @@ public enum MessageStartEventSubscriptionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -46,6 +46,20 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case CORRELATING:
+      case CORRELATED:
+      case REJECTED:
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
@@ -30,6 +30,11 @@ public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
@@ -48,6 +48,11 @@ public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    return false;
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
@@ -37,6 +37,16 @@ public enum ProcessInstanceCreationIntent implements Intent, ProcessInstanceRela
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -89,6 +89,22 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case SEQUENCE_FLOW_TAKEN:
+      case ELEMENT_ACTIVATING:
+      case ELEMENT_ACTIVATED:
+      case ELEMENT_COMPLETING:
+      case ELEMENT_COMPLETED:
+      case ELEMENT_TERMINATING:
+      case ELEMENT_TERMINATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
@@ -31,6 +31,16 @@ public enum ProcessInstanceModificationIntent implements Intent, ProcessInstance
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case MODIFIED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return true;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
@@ -35,6 +35,11 @@ public enum ProcessInstanceResultIntent implements Intent, ProcessInstanceRelate
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
@@ -41,4 +41,9 @@ public enum ProcessIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
@@ -44,6 +44,20 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATING:
+      case CREATED:
+      case CORRELATED:
+      case DELETING:
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
@@ -46,6 +46,18 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case TRIGGERED:
+      case CANCELED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableDocumentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableDocumentIntent.java
@@ -34,6 +34,16 @@ public enum VariableDocumentIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case UPDATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableIntent.java
@@ -30,6 +30,11 @@ public enum VariableIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
@@ -33,6 +33,17 @@ public enum CheckpointIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case IGNORED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/16160 to 8.1

Lot's of conflicts:
1. 8.1 does not have versioned event appliers
2. 8.1 was missing some intents that were added later

relates to https://github.com/camunda/zeebe/issues/15833