### PR TITLE
[Backport stable/8.2] fix(engine): throw instead of ignoring events that can't be applied

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
@@ -19,6 +19,23 @@ public interface EventApplier {
    * @param key the key of the event
    * @param intent the intent of the event
    * @param recordValue the value of the event
+   * @throws NoSuchEventApplier if no event applier is found for the given intent. The event is not
+   *     applied and it is up to the caller to decide what to do.
    */
-  void applyState(long key, Intent intent, RecordValue recordValue);
+  void applyState(long key, Intent intent, RecordValue recordValue) throws NoSuchEventApplier;
+
+  /** Thrown when no event applier is found for a given intent and record version. */
+  abstract sealed class NoSuchEventApplier extends RuntimeException {
+    public NoSuchEventApplier(final String message) {
+      super(message);
+    }
+
+    public static final class NoApplierForIntent extends NoSuchEventApplier {
+      public NoApplierForIntent(final Intent intent) {
+        super(
+            String.format(
+                "Expected to find an event applier for intent '%s', but none was found.", intent));
+      }
+    }
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
@@ -78,6 +79,7 @@ public final class EventAppliers implements EventApplier {
     registerSignalSubscriptionAppliers(state);
 
     registerCommandDistributionAppliers(state);
+    registerEscalationAppliers();
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {
@@ -292,6 +294,11 @@ public final class EventAppliers implements EventApplier {
     register(
         CommandDistributionIntent.FINISHED,
         new CommandDistributionFinishedApplier(distributionState));
+  }
+
+  private void registerEscalationAppliers() {
+    register(EscalationIntent.ESCALATED, NOOP_EVENT_APPLIER);
+    register(EscalationIntent.NOT_ESCALATED, NOOP_EVENT_APPLIER);
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -78,7 +79,7 @@ public final class EventAppliers implements EventApplier {
     registerDecisionRequirementsAppliers(state);
     registerDecisionEvaluationAppliers();
 
-    registerSignalSubscriptionAppliers(state);
+    registerSignalAppliers(state);
 
     registerCommandDistributionAppliers(state);
     registerEscalationAppliers();
@@ -259,13 +260,14 @@ public final class EventAppliers implements EventApplier {
         new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
   }
 
-  private void registerSignalSubscriptionAppliers(final MutableProcessingState state) {
+  private void registerSignalAppliers(final MutableProcessingState state) {
     register(
         SignalSubscriptionIntent.CREATED,
         new SignalSubscriptionCreatedApplier(state.getSignalSubscriptionState()));
     register(
         SignalSubscriptionIntent.DELETED,
         new SignalSubscriptionDeletedApplier(state.getSignalSubscriptionState()));
+    register(SignalIntent.BROADCASTED, NOOP_EVENT_APPLIER);
   }
 
   private void registerDecisionAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.EventApplier;
+import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier.NoApplierForIntent;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -36,7 +37,6 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * Applies state changes from events to the {@link MutableProcessingState}.
@@ -45,8 +45,8 @@ import java.util.function.Function;
  */
 public final class EventAppliers implements EventApplier {
 
-  private static final Function<Intent, TypedEventApplier<?, ?>> UNIMPLEMENTED_EVENT_APPLIER =
-      intent -> (key, value) -> {};
+  public static final TypedEventApplier<Intent, RecordValue> NOOP_EVENT_APPLIER =
+      (key, value) -> {};
 
   private final Map<Intent, TypedEventApplier> mapping = new HashMap<>();
 
@@ -298,8 +298,11 @@ public final class EventAppliers implements EventApplier {
 
   @Override
   public void applyState(final long key, final Intent intent, final RecordValue value) {
-    final var eventApplier =
-        mapping.getOrDefault(intent, UNIMPLEMENTED_EVENT_APPLIER.apply(intent));
-    eventApplier.applyState(key, value);
+    final var applierForIntent = mapping.get(intent);
+    if (applierForIntent == null) {
+      throw new NoApplierForIntent(intent);
+    }
+
+    applierForIntent.applyState(key, value);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionSt
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -75,6 +76,7 @@ public final class EventAppliers implements EventApplier {
 
     registerDecisionAppliers(state);
     registerDecisionRequirementsAppliers(state);
+    registerDecisionEvaluationAppliers();
 
     registerSignalSubscriptionAppliers(state);
 
@@ -278,6 +280,11 @@ public final class EventAppliers implements EventApplier {
     register(
         DecisionRequirementsIntent.DELETED,
         new DecisionRequirementsDeletedApplier(state.getDecisionState()));
+  }
+
+  private void registerDecisionEvaluationAppliers() {
+    register(DecisionEvaluationIntent.EVALUATED, NOOP_EVENT_APPLIER);
+    register(DecisionEvaluationIntent.FAILED, NOOP_EVENT_APPLIER);
   }
 
   private void registerCommandDistributionAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -329,4 +329,8 @@ public final class EventAppliers implements EventApplier {
 
     applierForIntent.applyState(key, value);
   }
+
+  public TypedEventApplier getApplierForIntent(final Intent intent) {
+    return mapping.get(intent);
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.util.HashMap;
 import java.util.Map;
@@ -104,6 +105,7 @@ public final class EventAppliers implements EventApplier {
     final VariableApplier variableApplier = new VariableApplier(state.getVariableState());
     register(VariableIntent.CREATED, variableApplier);
     register(VariableIntent.UPDATED, variableApplier);
+    register(VariableDocumentIntent.UPDATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerProcessInstanceEventAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -83,6 +84,7 @@ public final class EventAppliers implements EventApplier {
 
     registerCommandDistributionAppliers(state);
     registerEscalationAppliers();
+    registerResourceDeletionAppliers();
   }
 
   private void registerTimeEventAppliers(final MutableProcessingState state) {
@@ -310,7 +312,11 @@ public final class EventAppliers implements EventApplier {
     register(EscalationIntent.NOT_ESCALATED, NOOP_EVENT_APPLIER);
   }
 
-  private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {
+  private void registerResourceDeletionAppliers() {
+    register(ResourceDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
+  }
+
+  <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {
     mapping.put(intent, applier);
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
@@ -59,6 +60,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
     registerProcessInstanceModificationAppliers(state);
+    register(ProcessInstanceResultIntent.COMPLETED, NOOP_EVENT_APPLIER);
 
     register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBannedInstanceState()));

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -8,21 +8,29 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 public class EventAppliersTest {
 
   private EventAppliers eventAppliers;
+
+  @Mock private TypedEventApplier<Intent, ? extends RecordValue> mockedApplier;
+  @Mock private TypedEventApplier<Intent, ? extends RecordValue> anotherMockedApplier;
 
   @BeforeEach
   void setup() {
@@ -51,6 +59,59 @@ public class EventAppliersTest {
   }
 
   @Test
+  void cannotRegisterNullApplier() {
+    // given
+    final var intent = mock(Intent.class);
+
+    // then
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> eventAppliers.register(intent, null));
+  }
+
+  @Test
+  void cannotRegisterApplierForNullIntent() {
+    assertThatExceptionOfType(NullPointerException.class)
+        .isThrownBy(() -> eventAppliers.register(null, mockedApplier));
+  }
+
+  @Test
+  void cannotRegisterApplierForNegativeVersion() {
+    // given
+    final var intent = mock(Intent.class);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> eventAppliers.register(intent, mockedApplier));
+  }
+
+  @Test
+  void cannotRegisterApplierForNonEvent() {
+    // given
+    final var nonEvent = mock(Intent.class);
+
+    // when
+    when(nonEvent.isEvent()).thenReturn(false);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> eventAppliers.register(nonEvent, mockedApplier));
+  }
+
+  @Test
+  void cannotOverrideApplierForSameIntentAndVersion() {
+    // given
+    final var intent = mock(Intent.class);
+    when(intent.isEvent()).thenReturn(true);
+
+    // when
+    eventAppliers.register(intent, mockedApplier);
+
+    // then
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> eventAppliers.register(intent, anotherMockedApplier));
+  }
+
+  @Test
   void shouldOnlyRegisterAppliersForEvents() {
     // given
     final var intents =
@@ -59,19 +120,16 @@ public class EventAppliersTest {
             // CheckpointIntent is not handled by the engine
             .filter(intent -> !(intent instanceof CheckpointIntent));
 
-    // when
-    eventAppliers.registerEventAppliers(Mockito.mock(MutableProcessingState.class));
-
     // then
     assertThat(intents)
         .allSatisfy(
             intent -> {
               if (!intent.isEvent()) {
-                assertThat(eventAppliers.getLatestVersion(intent))
+                assertThat(eventAppliers.getApplierForIntent(intent))
                     .describedAs(
                         "Intent %s.%s is not an event but has a registered event applier",
                         intent.getClass().getSimpleName(), intent.name())
-                    .isEqualTo(-1);
+                    .isNull();
               }
             });
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,10 +39,7 @@ public class EventAppliersTest {
             // instead of the imperative used for commands.
             .filter(intent -> intent.name().endsWith("ED") || intent.name().endsWith("ING"))
             // CheckpointIntent is not handled by the engine
-            .filter(intent -> !(intent instanceof CheckpointIntent))
-            // ProcessInstanceResultIntent is only used for client responses and does not appear on
-            // the log
-            .filter(intent -> !(intent instanceof ProcessInstanceResultIntent));
+            .filter(intent -> !(intent instanceof CheckpointIntent));
 
     // then
     assertThat(events)

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
+import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import java.util.Arrays;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class EventAppliersTest {
+
+  private EventAppliers eventAppliers;
+
+  @BeforeEach
+  void setup() {
+    eventAppliers = new EventAppliers(mock(MutableProcessingState.class));
+  }
+
+  @Test
+  void shouldRegisterApplierForAllIntents() {
+    // given
+    final var events =
+        Intent.INTENT_CLASSES.stream()
+            .flatMap(c -> Arrays.stream(c.getEnumConstants()))
+            // Heuristic to detect event intents which are generally in past or present tense
+            // instead of the imperative used for commands.
+            .filter(intent -> intent.name().endsWith("ED") || intent.name().endsWith("ING"))
+            // CheckpointIntent is not handled by the engine
+            .filter(intent -> !(intent instanceof CheckpointIntent))
+            // ProcessInstanceResultIntent is only used for client responses and does not appear on
+            // the log
+            .filter(intent -> !(intent instanceof ProcessInstanceResultIntent));
+
+    // then
+    assertThat(events)
+        .allSatisfy(
+            intent ->
+                assertThat(eventAppliers.getApplierForIntent(intent))
+                    .describedAs(
+                        "Intent %s.%s has a registered event applier",
+                        intent.getClass().getSimpleName(), intent.name())
+                    .isNotNull());
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,9 @@ public class EventAppliersTest {
         Intent.INTENT_CLASSES.stream()
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
+            // `ProcessIntent.DELETED` exists but isn't implemented yet, so we can't have a
+            // registered applier yet.
+            .filter(intent -> intent != ProcessIntent.DELETED)
             // CheckpointIntent is not handled by the engine
             .filter(intent -> !(intent instanceof CheckpointIntent));
 

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -33,6 +33,19 @@ public enum CommandDistributionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case STARTED:
+      case DISTRIBUTING:
+      case ACKNOWLEDGED:
+      case FINISHED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
@@ -47,4 +47,15 @@ public enum DecisionEvaluationIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case EVALUATED:
+      case FAILED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
@@ -44,4 +44,9 @@ public enum DecisionIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
@@ -44,4 +44,9 @@ public enum DecisionRequirementsIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
@@ -47,4 +47,15 @@ public enum DeploymentDistributionIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case COMPLETED:
+      case DISTRIBUTING:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
@@ -55,4 +55,16 @@ public enum DeploymentIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case DISTRIBUTED:
+      case FULLY_DISTRIBUTED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ErrorIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ErrorIntent.java
@@ -41,4 +41,9 @@ public enum ErrorIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/EscalationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/EscalationIntent.java
@@ -45,4 +45,9 @@ public enum EscalationIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
@@ -56,6 +56,17 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case RESOLVED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -64,11 +64,21 @@ public interface Intent {
         public String name() {
           return "UNKNOWN";
         }
+
+        @Override
+        public boolean isEvent() {
+          return false;
+        }
       };
 
   short value();
 
   String name();
+
+  /**
+   * @return true if this intent is used as an event, i.e. it's not a command or command rejection.
+   */
+  boolean isEvent();
 
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   static Intent fromProtocolValue(final ValueType valueType, final short intent) {

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
@@ -44,4 +44,14 @@ public enum JobBatchIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case ACTIVATED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -102,6 +102,23 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case COMPLETED:
+      case TIMED_OUT:
+      case FAILED:
+      case RETRIES_UPDATED:
+      case CANCELED:
+      case ERROR_THROWN:
+      case RECURRED_AFTER_BACKOFF:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageIntent.java
@@ -33,6 +33,17 @@ public enum MessageIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case PUBLISHED:
+      case EXPIRED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
@@ -31,6 +31,11 @@ public enum MessageStartEventSubscriptionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -46,6 +46,20 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case CORRELATING:
+      case CORRELATED:
+      case REJECTED:
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
@@ -30,6 +30,11 @@ public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
@@ -48,6 +48,11 @@ public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    return false;
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
@@ -37,6 +37,16 @@ public enum ProcessInstanceCreationIntent implements Intent, ProcessInstanceRela
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -89,6 +89,22 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case SEQUENCE_FLOW_TAKEN:
+      case ELEMENT_ACTIVATING:
+      case ELEMENT_ACTIVATED:
+      case ELEMENT_COMPLETING:
+      case ELEMENT_COMPLETED:
+      case ELEMENT_TERMINATING:
+      case ELEMENT_TERMINATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
@@ -31,6 +31,16 @@ public enum ProcessInstanceModificationIntent implements Intent, ProcessInstance
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case MODIFIED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return true;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
@@ -35,6 +35,11 @@ public enum ProcessInstanceResultIntent implements Intent, ProcessInstanceRelate
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
@@ -44,4 +44,9 @@ public enum ProcessIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
@@ -44,6 +44,20 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATING:
+      case CREATED:
+      case CORRELATED:
+      case DELETING:
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
@@ -34,6 +34,16 @@ public enum ResourceDeletionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalIntent.java
@@ -30,6 +30,16 @@ public enum SignalIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case BROADCASTED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
@@ -30,6 +30,11 @@ public enum SignalSubscriptionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
@@ -46,6 +46,18 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case TRIGGERED:
+      case CANCELED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableDocumentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableDocumentIntent.java
@@ -34,6 +34,16 @@ public enum VariableDocumentIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case UPDATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableIntent.java
@@ -30,6 +30,11 @@ public enum VariableIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
@@ -33,6 +33,17 @@ public enum CheckpointIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case IGNORED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/16160 to 8.2

Lot's of conflicts:
1. 8.2 does not have versioned event appliers
2. 8.2 was missing some intents that were added later

I added another commit to register a noop applier for `ProcessIntent.DELETED`. This event seems to be unimplemented in 8.2: ce0764d8191f3672b4260f03c3904de884ffca1f

relates to https://github.com/camunda/zeebe/issues/15833