### PR TITLE
[Backport stable/8.3] fix(engine): throw instead of ignoring events that can't be applied

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/EventApplier.java
@@ -29,6 +29,34 @@ public interface EventApplier {
    * @param intent the intent of the event
    * @param recordValue the value of the event
    * @param recordVersion the record version of the event
+   * @throws NoSuchEventApplier if no event applier is found for the given intent and record
+   *     version. The event is not applied and it is up to the caller to decide what to do.
    */
-  void applyState(long key, Intent intent, RecordValue recordValue, final int recordVersion);
+  void applyState(long key, Intent intent, RecordValue recordValue, final int recordVersion)
+      throws NoSuchEventApplier;
+
+  /** Thrown when no event applier is found for a given intent and record version. */
+  abstract sealed class NoSuchEventApplier extends RuntimeException {
+    public NoSuchEventApplier(final String message) {
+      super(message);
+    }
+
+    public static final class NoApplierForIntent extends NoSuchEventApplier {
+      public NoApplierForIntent(final Intent intent) {
+        super(
+            String.format(
+                "Expected to find an event applier for intent '%s', but none was found.", intent));
+      }
+    }
+
+    public static final class NoApplierForVersion extends NoSuchEventApplier {
+      public NoApplierForVersion(
+          final Intent intent, final int recordVersion, final int latestVersion) {
+        super(
+            String.format(
+                "Expected to find an event applier for intent '%s' and version '%d', but '%s' is the latest supported version.",
+                intent, recordVersion, latestVersion));
+      }
+    }
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
+import io.camunda.zeebe.protocol.record.intent.EscalationIntent;
 import io.camunda.zeebe.protocol.record.intent.FormIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -84,6 +85,7 @@ public final class EventAppliers implements EventApplier {
     registerSignalSubscriptionAppliers(state);
 
     registerCommandDistributionAppliers(state);
+    registerEscalationAppliers();
     return this;
   }
 
@@ -311,6 +313,11 @@ public final class EventAppliers implements EventApplier {
     register(
         CommandDistributionIntent.FINISHED,
         new CommandDistributionFinishedApplier(distributionState));
+  }
+
+  private void registerEscalationAppliers() {
+    register(EscalationIntent.ESCALATED, NOOP_EVENT_APPLIER);
+    register(EscalationIntent.NOT_ESCALATED, NOOP_EVENT_APPLIER);
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
@@ -89,6 +90,7 @@ public final class EventAppliers implements EventApplier {
 
     registerCommandDistributionAppliers(state);
     registerEscalationAppliers();
+    registerResourceDeletionAppliers();
     return this;
   }
 
@@ -327,6 +329,11 @@ public final class EventAppliers implements EventApplier {
   private void registerEscalationAppliers() {
     register(EscalationIntent.ESCALATED, NOOP_EVENT_APPLIER);
     register(EscalationIntent.NOT_ESCALATED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerResourceDeletionAppliers() {
+    register(ResourceDeletionIntent.DELETING, NOOP_EVENT_APPLIER);
+    register(ResourceDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.SignalIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
@@ -84,7 +85,7 @@ public final class EventAppliers implements EventApplier {
 
     registerFormAppliers(state);
 
-    registerSignalSubscriptionAppliers(state);
+    registerSignalAppliers(state);
 
     registerCommandDistributionAppliers(state);
     registerEscalationAppliers();
@@ -274,13 +275,14 @@ public final class EventAppliers implements EventApplier {
         new ProcessEventTriggeredApplier(state.getEventScopeInstanceState()));
   }
 
-  private void registerSignalSubscriptionAppliers(final MutableProcessingState state) {
+  private void registerSignalAppliers(final MutableProcessingState state) {
     register(
         SignalSubscriptionIntent.CREATED,
         new SignalSubscriptionCreatedApplier(state.getSignalSubscriptionState()));
     register(
         SignalSubscriptionIntent.DELETED,
         new SignalSubscriptionDeletedApplier(state.getSignalSubscriptionState()));
+    register(SignalIntent.BROADCASTED, NOOP_EVENT_APPLIER);
   }
 
   private void registerDecisionAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceModificationIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ResourceDeletionIntent;
@@ -63,6 +64,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessInstanceEventAppliers(state);
     registerProcessInstanceCreationAppliers(state);
     registerProcessInstanceModificationAppliers(state);
+    register(ProcessInstanceResultIntent.COMPLETED, NOOP_EVENT_APPLIER);
 
     registerProcessAppliers(state);
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBannedInstanceState()));

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -118,6 +119,7 @@ public final class EventAppliers implements EventApplier {
     final VariableApplier variableApplier = new VariableApplier(state.getVariableState());
     register(VariableIntent.CREATED, variableApplier);
     register(VariableIntent.UPDATED, variableApplier);
+    register(VariableDocumentIntent.UPDATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerProcessInstanceEventAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentDistributionIntent;
@@ -79,6 +80,7 @@ public final class EventAppliers implements EventApplier {
 
     registerDecisionAppliers(state);
     registerDecisionRequirementsAppliers(state);
+    registerDecisionEvaluationAppliers();
 
     registerFormAppliers(state);
 
@@ -293,6 +295,11 @@ public final class EventAppliers implements EventApplier {
     register(
         DecisionRequirementsIntent.DELETED,
         new DecisionRequirementsDeletedApplier(state.getDecisionState()));
+  }
+
+  private void registerDecisionEvaluationAppliers() {
+    register(DecisionEvaluationIntent.EVALUATED, NOOP_EVENT_APPLIER);
+    register(DecisionEvaluationIntent.FAILED, NOOP_EVENT_APPLIER);
   }
 
   private void registerFormAppliers(final MutableProcessingState state) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -47,6 +47,7 @@ import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Applies state changes from events to the {@link MutableProcessingState}.
@@ -344,7 +345,22 @@ public final class EventAppliers implements EventApplier {
 
   <I extends Intent> void register(
       final I intent, final int version, final TypedEventApplier<I, ?> applier) {
-    mapping.computeIfAbsent(intent, unused -> new HashMap<>()).put(version, applier);
+    Objects.requireNonNull(intent, "Intent must not be null");
+    Objects.requireNonNull(applier, "Applier must not be null");
+    if (version < 1) {
+      throw new IllegalArgumentException("Version must be greater than 0");
+    }
+    if (!intent.isEvent()) {
+      throw new IllegalArgumentException("Only event intents can be registered");
+    }
+
+    final var previousApplier =
+        mapping.computeIfAbsent(intent, unused -> new HashMap<>()).putIfAbsent(version, applier);
+    if (previousApplier != null) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Applier for intent '%s' and version '%d' is already registered", intent, version));
+    }
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.engine.state.appliers;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 
+import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -51,10 +53,9 @@ public class EventAppliersTest {
   void shouldNotApplyStateUsingUnregisteredApplier() {
     // given no registered appliers
 
-    // when
-    eventAppliers.applyState(1, Intent.UNKNOWN, null, 1);
-
     // then
+    assertThatExceptionOfType(NoSuchEventApplier.NoApplierForIntent.class)
+        .isThrownBy(() -> eventAppliers.applyState(1, Intent.UNKNOWN, null, 1));
     Mockito.verify(mockedApplier, Mockito.never()).applyState(anyLong(), any());
   }
 
@@ -63,10 +64,9 @@ public class EventAppliersTest {
     // given
     eventAppliers.register(Intent.UNKNOWN, 1, mockedApplier);
 
-    // when
-    eventAppliers.applyState(1, Intent.UNKNOWN, null, 2);
-
     // then
+    assertThatExceptionOfType(NoSuchEventApplier.NoApplierForVersion.class)
+        .isThrownBy(() -> eventAppliers.applyState(1, Intent.UNKNOWN, null, 2));
     Mockito.verify(mockedApplier, Mockito.never()).applyState(anyLong(), any());
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -17,7 +17,6 @@ import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.Intent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceResultIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
@@ -152,10 +151,7 @@ public class EventAppliersTest {
             // instead of the imperative used for commands.
             .filter(intent -> intent.name().endsWith("ED") || intent.name().endsWith("ING"))
             // CheckpointIntent is not handled by the engine
-            .filter(intent -> !(intent instanceof CheckpointIntent))
-            // ProcessInstanceResultIntent is only used for client responses and does not appear on
-            // the log
-            .filter(intent -> !(intent instanceof ProcessInstanceResultIntent));
+            .filter(intent -> !(intent instanceof CheckpointIntent));
 
     // when
     eventAppliers.registerEventAppliers(Mockito.mock(MutableProcessingState.class));

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -147,9 +147,7 @@ public class EventAppliersTest {
     final var events =
         Intent.INTENT_CLASSES.stream()
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
-            // Heuristic to detect event intents which are generally in past or present tense
-            // instead of the imperative used for commands.
-            .filter(intent -> intent.name().endsWith("ED") || intent.name().endsWith("ING"))
+            .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
             .filter(intent -> !(intent instanceof CheckpointIntent));
 
@@ -165,5 +163,31 @@ public class EventAppliersTest {
                         "Intent %s.%s has a registered event applier",
                         intent.getClass().getSimpleName(), intent.name())
                     .isNotEqualTo(-1));
+  }
+
+  @Test
+  void shouldOnlyRegisterAppliersForEvents() {
+    // given
+    final var intents =
+        Intent.INTENT_CLASSES.stream()
+            .flatMap(c -> Arrays.stream(c.getEnumConstants()))
+            // CheckpointIntent is not handled by the engine
+            .filter(intent -> !(intent instanceof CheckpointIntent));
+
+    // when
+    eventAppliers.registerEventAppliers(Mockito.mock(MutableProcessingState.class));
+
+    // then
+    assertThat(intents)
+        .allSatisfy(
+            intent -> {
+              if (!intent.isEvent()) {
+                assertThat(eventAppliers.getLatestVersion(intent))
+                    .describedAs(
+                        "Intent %s.%s is not an event but has a registered event applier",
+                        intent.getClass().getSimpleName(), intent.name())
+                    .isEqualTo(-1);
+              }
+            });
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/CommandDistributionIntent.java
@@ -33,6 +33,19 @@ public enum CommandDistributionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case STARTED:
+      case DISTRIBUTING:
+      case ACKNOWLEDGED:
+      case FINISHED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionEvaluationIntent.java
@@ -47,4 +47,15 @@ public enum DecisionEvaluationIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case EVALUATED:
+      case FAILED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionIntent.java
@@ -44,4 +44,9 @@ public enum DecisionIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DecisionRequirementsIntent.java
@@ -44,4 +44,9 @@ public enum DecisionRequirementsIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentDistributionIntent.java
@@ -53,4 +53,15 @@ public enum DeploymentDistributionIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case COMPLETED:
+      case DISTRIBUTING:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/DeploymentIntent.java
@@ -62,4 +62,16 @@ public enum DeploymentIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case DISTRIBUTED:
+      case FULLY_DISTRIBUTED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ErrorIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ErrorIntent.java
@@ -41,4 +41,9 @@ public enum ErrorIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/EscalationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/EscalationIntent.java
@@ -45,4 +45,9 @@ public enum EscalationIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/FormIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/FormIntent.java
@@ -41,4 +41,9 @@ public enum FormIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
@@ -56,6 +56,17 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case RESOLVED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -61,6 +61,11 @@ public interface Intent {
 
   String name();
 
+  /**
+   * @return true if this intent is used as an event, i.e. it's not a command or command rejection.
+   */
+  boolean isEvent();
+
   @SuppressWarnings("checkstyle:MissingSwitchDefault")
   static Intent fromProtocolValue(final ValueType valueType, final short intent) {
     switch (valueType) {
@@ -219,6 +224,11 @@ public interface Intent {
     @Override
     public short value() {
       return NULL_VAL;
+    }
+
+    @Override
+    public boolean isEvent() {
+      return false;
     }
   }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobBatchIntent.java
@@ -44,4 +44,14 @@ public enum JobBatchIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case ACTIVATED:
+        return true;
+      default:
+        return false;
+    }
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -109,6 +109,24 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case COMPLETED:
+      case TIMED_OUT:
+      case FAILED:
+      case RETRIES_UPDATED:
+      case CANCELED:
+      case ERROR_THROWN:
+      case RECURRED_AFTER_BACKOFF:
+      case YIELDED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageBatchIntent.java
@@ -28,6 +28,11 @@ public enum MessageBatchIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return false;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageIntent.java
@@ -33,6 +33,17 @@ public enum MessageIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case PUBLISHED:
+      case EXPIRED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageStartEventSubscriptionIntent.java
@@ -31,6 +31,11 @@ public enum MessageStartEventSubscriptionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageSubscriptionIntent.java
@@ -46,6 +46,20 @@ public enum MessageSubscriptionIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case CORRELATING:
+      case CORRELATED:
+      case REJECTED:
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessEventIntent.java
@@ -30,6 +30,11 @@ public enum ProcessEventIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
@@ -48,6 +48,11 @@ public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    return false;
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceCreationIntent.java
@@ -37,6 +37,16 @@ public enum ProcessInstanceCreationIntent implements Intent, ProcessInstanceRela
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -89,6 +89,22 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case SEQUENCE_FLOW_TAKEN:
+      case ELEMENT_ACTIVATING:
+      case ELEMENT_ACTIVATED:
+      case ELEMENT_COMPLETING:
+      case ELEMENT_COMPLETED:
+      case ELEMENT_TERMINATING:
+      case ELEMENT_TERMINATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return shouldBanInstance;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceModificationIntent.java
@@ -31,6 +31,16 @@ public enum ProcessInstanceModificationIntent implements Intent, ProcessInstance
   }
 
   @Override
+  public boolean isEvent() {
+    switch (this) {
+      case MODIFIED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  @Override
   public boolean shouldBanInstanceOnError() {
     return true;
   }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceResultIntent.java
@@ -35,6 +35,11 @@ public enum ProcessInstanceResultIntent implements Intent, ProcessInstanceRelate
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessIntent.java
@@ -47,4 +47,9 @@ public enum ProcessIntent implements Intent {
   public short value() {
     return value;
   }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
 }

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessMessageSubscriptionIntent.java
@@ -44,6 +44,20 @@ public enum ProcessMessageSubscriptionIntent implements ProcessInstanceRelatedIn
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATING:
+      case CREATED:
+      case CORRELATED:
+      case DELETING:
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ResourceDeletionIntent.java
@@ -35,6 +35,17 @@ public enum ResourceDeletionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case DELETING:
+      case DELETED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalIntent.java
@@ -30,6 +30,16 @@ public enum SignalIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case BROADCASTED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/SignalSubscriptionIntent.java
@@ -30,6 +30,11 @@ public enum SignalSubscriptionIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
@@ -46,6 +46,18 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case TRIGGERED:
+      case CANCELED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableDocumentIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableDocumentIntent.java
@@ -34,6 +34,16 @@ public enum VariableDocumentIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case UPDATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/VariableIntent.java
@@ -30,6 +30,11 @@ public enum VariableIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/management/CheckpointIntent.java
@@ -33,6 +33,17 @@ public enum CheckpointIntent implements Intent {
     return value;
   }
 
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CREATED:
+      case IGNORED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
   public static Intent from(final short value) {
     switch (value) {
       case 0:


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/16160 to 8.3

Lot's of conflicts:

1. 8.3 does not have versioned event appliers
2. 8.3 was missing some intents that were added later

relates to https://github.com/camunda/zeebe/issues/15833