### PR TITLE
Provide `decisionInstanceKey` for evaluated decision in java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/EvaluateDecisionResponse.java
@@ -75,4 +75,9 @@ public interface EvaluateDecisionResponse {
    * @return the tenant identifier that owns this decision evaluation result
    */
   String getTenantId();
+
+  /**
+   * @return the unique key identifying this decision evaluation
+   */
+  long getDecisionInstanceKey();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluateDecisionResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/EvaluateDecisionResponseImpl.java
@@ -37,6 +37,7 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
   private final String failedDecisionId;
   private final String failureMessage;
   private final String tenantId;
+  private final long decisionInstanceKey;
 
   public EvaluateDecisionResponseImpl(
       final JsonMapper jsonMapper, final GatewayOuterClass.EvaluateDecisionResponse response) {
@@ -52,6 +53,7 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
     failedDecisionId = response.getFailedDecisionId();
     failureMessage = response.getFailureMessage();
     tenantId = response.getTenantId();
+    decisionInstanceKey = response.getDecisionInstanceKey();
 
     response.getEvaluatedDecisionsList().stream()
         .map(evaluatedDecision -> new EvaluatedDecisionImpl(jsonMapper, evaluatedDecision))
@@ -111,5 +113,10 @@ public class EvaluateDecisionResponseImpl implements EvaluateDecisionResponse {
   @Override
   public String getTenantId() {
     return tenantId;
+  }
+
+  @Override
+  public long getDecisionInstanceKey() {
+    return decisionInstanceKey;
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/decision/StandaloneDecisionEvaluationTest.java
@@ -42,6 +42,7 @@ import org.junit.Test;
 public class StandaloneDecisionEvaluationTest extends ClientTest {
 
   private static final long DECISION_KEY = 123L;
+  private static final long DECISION_INSTANCE_KEY = 234L;
   private static final String TENANT_ID = "foo";
   private static GatewayOuterClass.EvaluatedDecisionOutput evaluatedOutput;
   private static GatewayOuterClass.MatchedDecisionRule matchedRule;
@@ -97,6 +98,7 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
             .setFailedDecisionId("my-decision")
             .setFailureMessage("decision-evaluation-failure")
             .setTenantId(TENANT_ID)
+            .setDecisionInstanceKey(DECISION_INSTANCE_KEY)
             .addEvaluatedDecisions(evaluatedDecision)
             .build();
   }
@@ -315,6 +317,8 @@ public class StandaloneDecisionEvaluationTest extends ClientTest {
     assertThat(response.getFailureMessage())
         .isEqualTo(evaluateDecisionResponse.getFailureMessage());
     assertThat(response.getTenantId()).isEqualTo(evaluateDecisionResponse.getTenantId());
+    assertThat(response.getDecisionInstanceKey())
+        .isEqualTo(evaluateDecisionResponse.getDecisionInstanceKey());
 
     // assert EvaluatedDecision
     assertThat(response.getEvaluatedDecisions()).hasSize(1);


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Now that the `decisionInstanceKey` can be responded by the gateway, we can also make this accessible in the java client.

This adds a `.getDecisionInstanceKey()` method to `EvaluateDecisionResponse` in the java client.

## Related issues

<!-- Which issues are closed by this PR or are related -->

relates to #15916

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
