### PR TITLE
Forms Linked to User Tasks Are Sometimes Wrong

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbFormState.java
@@ -137,8 +137,9 @@ public class DbFormState implements MutableFormState {
       return Optional.empty();
     }
 
-    formByTenantAndIdCache.put(new TenantIdAndFormId(tenantId, formId), persistedForm);
-    return Optional.of(persistedForm).map(PersistedForm::copy);
+    final PersistedForm copiedForm = persistedForm.copy();
+    formByTenantAndIdCache.put(new TenantIdAndFormId(tenantId, formId), copiedForm);
+    return Optional.of(copiedForm);
   }
 
   @Override

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/FormLinkingIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/FormLinkingIT.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.processing;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.Optional;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@AutoCloseResources
+@ZeebeIntegration
+final class FormLinkingIT {
+
+  @TestZeebe private final TestStandaloneBroker zeebe = new TestStandaloneBroker();
+  private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
+  @AutoCloseResource private ZeebeClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = zeebe.newClientBuilder().build();
+  }
+
+  @Test
+  public void shouldActivateUserTaskWithCorrectFormKey() {
+    // given
+    final String form1Path = "form/form-linking-test-form-1.form";
+
+    final DeploymentEvent deployment =
+        client
+            .newDeployResourceCommand()
+            .addProcessModel(
+                Bpmn.createExecutableProcess("form_linking_test")
+                    .startEvent()
+                    .userTask()
+                    .zeebeFormId("formId1")
+                    .endEvent()
+                    .done(),
+                "form_linking_test.bpmn")
+            .addResourceFromClasspath(form1Path)
+            .send()
+            .join();
+
+    final Long formKey = deployment.getForm().getFirst().getFormKey();
+
+    // take snapshot and start the engine from snapshot
+    partitions.takeSnapshot();
+    Awaitility.await("Snapshot is taken")
+        .atMost(Duration.ofSeconds(60))
+        .until(
+            () ->
+                Optional.ofNullable(partitions.query().get(1).snapshotId())
+                    .flatMap(FileBasedSnapshotId::ofFileName),
+            Optional::isPresent)
+        .orElseThrow();
+    zeebe.stop();
+
+    // when
+    zeebe.withRecordingExporter(true).start().awaitCompleteTopology();
+
+    // create a process instance to trigger form linking where the actual caching issue exists
+    final long processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("form_linking_test")
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue()
+                .getCustomHeaders())
+        .containsValue(formKey.toString());
+
+    // deploy another form to update form object referenced by formId1 in the cache (the wrong
+    // behaviour)
+    final String form2Path = "form/form-linking-test-form-2.form";
+    client.newDeployResourceCommand().addResourceFromClasspath(form2Path).send().join();
+    RecordingExporter.formRecords().withIntent(FormIntent.CREATED).withFormId("formId2").await();
+
+    // create another process instance to verify it works as expected (e.g. cache data is not
+    // changed)
+    final long processInstanceKey2 =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("form_linking_test")
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    assertThat(
+            RecordingExporter.jobRecords(JobIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey2)
+                .getFirst()
+                .getValue()
+                .getCustomHeaders())
+        .containsValue(formKey.toString());
+  }
+}

--- a/qa/integration-tests/src/test/resources/form/form-linking-test-form-1.form
+++ b/qa/integration-tests/src/test/resources/form/form-linking-test-form-1.form
@@ -1,0 +1,23 @@
+{
+  "components": [
+    {
+      "label": "Text field",
+      "type": "textfield",
+      "layout": {
+        "row": "Row_0hpohpx",
+        "columns": null
+      },
+      "id": "Field_19qoinx",
+      "key": "textfield_3c2arb"
+    }
+  ],
+  "type": "default",
+  "id": "formId1",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.3.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.17.0"
+  },
+  "schemaVersion": 12
+}

--- a/qa/integration-tests/src/test/resources/form/form-linking-test-form-2.form
+++ b/qa/integration-tests/src/test/resources/form/form-linking-test-form-2.form
@@ -1,0 +1,29 @@
+{
+  "components": [
+    {
+      "values": [
+        {
+          "label": "Value",
+          "value": "value"
+        }
+      ],
+      "label": "Radio",
+      "type": "radio",
+      "layout": {
+        "row": "Row_0th2vqr",
+        "columns": null
+      },
+      "id": "Field_1fslkgq",
+      "key": "radio_8tm2d7"
+    }
+  ],
+  "type": "default",
+  "id": "formId2",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.3.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.17.0"
+  },
+  "schemaVersion": 12
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
While putting the form to the cache during the retrieval for linking, we skip copying a re-used form record object. Then, when we insert another form, we modify that object. That means, we modify the object that we put to the cache. Afterwards, when we query formId1 from the cache, it returns the wrong form object (formId2's object in our case).
It happens only after broker restart because the cache is cleaned up during restart. Therefore, the correct form we put to the cache during the creation of form is gone.

The PR now copies the form before putting it to the cache on retrieval. Also, a test case is added to verify the behaviour. 

**Note:** We chose to add a test case to integration tests because it is easier to manipulate snapshot behaviour with the integration test setup

**Steps to Reproduce**

- Deploy a form with id formId1
- Deploy a process (id=process1) that contains a user task which has a link to form formId1
- Restart the broker
    - Take a snapshot
    - Stop the broker
    - Start broker from the last snapshot
- Create a process instance of process1 (the form linking is correct)
- Deploy another form with id formId2
- Create a process instance of process1 (the form linking is wrong) => it will retrieve the key for formId2

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16311 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
