### PR TITLE
Exporter can soft pause and resume

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -115,6 +115,13 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     return actor.close();
   }
 
+  /**
+   * This method enables us to pause the exporting of records. No records are exported until resume
+   * exporting is invoked.
+   *
+   * <p>If the exporter is soft paused and pauseExporting is called, the exporter will be "hard"
+   * paused.
+   */
   public ActorFuture<Void> pauseExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case pausing is a no-op.
@@ -129,6 +136,14 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         });
   }
 
+  /**
+   * When the exporter is soft paused, we keep exporting the records without updating the exporter
+   * state. Upon resuming, the exporter is updated with the position and metadata of the last
+   * exported record.
+   *
+   * <p>If the exporter is hard paused and softPauseExporting is called, the exporter will be soft
+   * paused.
+   */
   public ActorFuture<Void> softPauseExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case pausing is a no-op.
@@ -144,6 +159,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         });
   }
 
+  /**
+   * This method enables us to resume the exporting of records after it has been paused. It works
+   * both to resume the "soft pause" state and the "paused" state. Upon resuming, the exporter is
+   * updated with the position and metadata of the last exported record.
+   */
   public ActorFuture<Void> resumeExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case resuming is a no-op.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -75,7 +75,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private volatile HealthReport healthReport = HealthReport.healthy(this);
 
   private boolean inExportingPhase;
-  private boolean isPaused;
+  private boolean isHardPaused;
   private ExporterPhase exporterPhase;
   private final PartitionMessagingService partitionMessagingService;
   private final String exporterPositionsTopic;
@@ -99,7 +99,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
     recordWrapStrategy = new EndlessRetryStrategy(actor);
     zeebeDb = context.getZeebeDb();
-    isPaused = shouldPauseOnStart;
+    isHardPaused = shouldPauseOnStart;
     partitionMessagingService = context.getPartitionMessagingService();
     exporterPositionsTopic = String.format(EXPORTER_STATE_TOPIC_FORMAT, partitionId);
     exporterMode = context.getExporterMode();
@@ -124,8 +124,23 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     }
     return actor.call(
         () -> {
-          isPaused = true;
+          isHardPaused = true;
           exporterPhase = ExporterPhase.PAUSED;
+        });
+  }
+
+  public ActorFuture<Void> softPauseExporting() {
+    if (actor.isClosed()) {
+      // Actor can be closed when there are no exporters. In that case pausing is a no-op.
+      // This is safe because the pausing state is persisted and will be applied later if exporters
+      // are added.
+      return CompletableActorFuture.completed(null);
+    }
+    return actor.call(
+        () -> {
+          isHardPaused = false;
+          containers.stream().forEach(ExporterContainer::softPauseExporter);
+          exporterPhase = ExporterPhase.SOFT_PAUSED;
         });
   }
 
@@ -139,7 +154,10 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     return actor.call(
         () -> {
-          isPaused = false;
+          isHardPaused = false;
+          if (exporterPhase == ExporterPhase.SOFT_PAUSED) {
+            containers.stream().forEach(ExporterContainer::undoSoftPauseExporter);
+          }
           exporterPhase = ExporterPhase.EXPORTING;
           if (exporterMode == ExporterMode.ACTIVE) {
             actor.submit(this::readNextEvent);
@@ -338,7 +356,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         throw new IllegalStateException(
             String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
       }
-      if (!isPaused) {
+      if (!isHardPaused) {
         exporterPhase = ExporterPhase.EXPORTING;
         actor.submit(this::readNextEvent);
       } else {
@@ -403,7 +421,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   private boolean shouldExport() {
-    return isOpened.get() && logStreamReader.hasNext() && !inExportingPhase && !isPaused;
+    return isOpened.get() && logStreamReader.hasNext() && !inExportingPhase && !isHardPaused;
   }
 
   private void exportEvent(final LoggedEvent event) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
@@ -10,5 +10,6 @@ package io.camunda.zeebe.broker.exporter.stream;
 public enum ExporterPhase {
   EXPORTING,
   PAUSED,
+  SOFT_PAUSED,
   CLOSED
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
+// The PAUSED phase is when the exporter is paused, and the exporter is not exporting records.
+// The SOFT_PAUSED phase is when we keep exporting the records without updating the exporter state.
 public enum ExporterPhase {
   EXPORTING,
   PAUSED,

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -275,23 +275,25 @@ final class ExporterContainerTest {
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
+    final byte[] metadata = "metadata".getBytes();
     final var recordMetadata = new RecordMetadata().requestId(1L);
     exporterContainer.exportRecord(recordMetadata, mockedRecord);
 
-    // when
-    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition(), metadata);
     awaitPreviousCall();
 
-    // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
     assertThat(exporterContainer.getPosition()).isZero();
+    assertThat(exporterContainer.readMetadata()).isNotPresent();
 
+    // when
     exporterContainer.undoSoftPauseExporter();
     awaitPreviousCall();
 
     // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
     assertThat(exporterContainer.getPosition()).isEqualTo(1);
+    assertThat(exporterContainer.readMetadata()).isPresent().hasValue(metadata);
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -142,7 +142,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(mockedRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test
@@ -166,7 +166,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(secondRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test
@@ -211,8 +211,8 @@ final class ExporterContainerTest {
 
     // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
-    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
+    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isZero();
   }
 
   @Test
@@ -242,6 +242,59 @@ final class ExporterContainerTest {
   }
 
   @Test
+  void shouldNotUpdateExporterPositionIfSoftPaused() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    runtime.getState().setPosition(EXPORTER_ID, 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+    exporterContainer.softPauseExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isZero();
+  }
+
+  @Test
+  void shouldUpdatePositionWhenResumedAfterSoftPaused() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    runtime.getState().setPosition(EXPORTER_ID, 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+    exporterContainer.softPauseExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata().requestId(1L);
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isZero();
+
+    exporterContainer.undoSoftPauseExporter();
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(1);
+  }
+
+  @Test
   void shouldUpdatePositionsWhenRecordIsFiltered() throws Exception {
     // given
     exporterContainer.configureExporter();
@@ -258,7 +311,7 @@ final class ExporterContainerTest {
 
     // then
     assertThat(exporter.getRecord()).isNull();
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
     assertThat(exporterContainer.getPosition()).isEqualTo(1);
   }
 
@@ -310,7 +363,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(firstRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -71,6 +71,7 @@ public final class ExporterDirectorPauseTest {
 
     // then
     verify(exporter, timeout(TIMEOUT).times(1)).export(any());
+    assertThat(exporter.getController().getLastExportedRecordPosition()).isEqualTo(-1L);
   }
 
   @Test
@@ -87,6 +88,7 @@ public final class ExporterDirectorPauseTest {
 
     // then
     verify(exporter, timeout(TIMEOUT).times(1)).export(any());
+    assertThat(exporter.getController().getLastExportedRecordPosition()).isZero();
   }
 
   @Test


### PR DESCRIPTION
## Description

Exporter can soft pause and resume. This means if the exporter is soft paused, we keep exporting the records without updating the exporter state. upon resuming The exporter state is updated with the position and metadata of the last exported record.

The feature to persist the soft paused state will be implemented in this issue https://github.com/camunda/zeebe/issues/16642

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/16344

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
