### PR TITLE
[Backport stable/8.2] fix(stream-platform): do not exit out of error loop before rollback is completed

### DIFF
--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -433,13 +433,31 @@ public final class ProcessingStateMachine {
             },
             abortCondition);
 
+    actor.runOnCompletion(
+        retryFuture,
+        (bool, throwable) -> {
+          if (throwable != null) {
+            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentRecord, metadata, throwable);
+          }
+          try {
+            if (tryExitOutOfErrorLoop(error)) {
+              return;
+            }
+            nextStep.run();
+          } catch (final Exception ex) {
+            onError(ex, nextStep);
+          }
+        });
+  }
+
+  private boolean tryExitOutOfErrorLoop(final Throwable error) {
     try {
       // If in error loop and the processing record is a user command
       if (errorHandlingPhase == ErrorHandlingPhase.USER_COMMAND_PROCESSING_ERROR_FAILED) {
         // First try to reject with proper error message
         LOG.debug(ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED, currentRecord, metadata, error);
         tryRejectingIfUserCommand(error.getMessage());
-        return;
+        return true;
       } else if (errorHandlingPhase == ErrorHandlingPhase.USER_COMMAND_REJECT_FAILED) {
         LOG.warn(ERROR_MESSAGE_HANDLING_PROCESSING_ERROR_FAILED, currentRecord, metadata, error);
         // try to reject with a generic error message
@@ -447,7 +465,7 @@ public final class ProcessingStateMachine {
             String.format(
                 "Expected to process command, but caught an exception. Check broker logs (partition %s) for details.",
                 context.getPartitionId()));
-        return;
+        return true;
       }
     } catch (final Exception e) {
       // Unexpected error, so we just fail back to endless loop
@@ -458,21 +476,8 @@ public final class ProcessingStateMachine {
           e);
       pendingResponses.clear();
       pendingWrites.clear();
-      onError(e, nextStep);
     }
-
-    actor.runOnCompletion(
-        retryFuture,
-        (bool, throwable) -> {
-          if (throwable != null) {
-            LOG.error(ERROR_MESSAGE_ROLLBACK_ABORTED, currentRecord, metadata, throwable);
-          }
-          try {
-            nextStep.run();
-          } catch (final Exception ex) {
-            onError(ex, nextStep);
-          }
-        });
+    return false;
   }
 
   private void startErrorLoop(final boolean isUserCommand) {


### PR DESCRIPTION
# Description
Backport of #16343 to `stable/8.2`.

relates to #16290 #16107
original author: @deepthidevaki