### PR TITLE
refactor(raft): input member type when force configuring

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/RaftServer.java
@@ -23,6 +23,7 @@ import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
 import io.atomix.raft.cluster.RaftCluster;
 import io.atomix.raft.cluster.RaftMember;
+import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.impl.DefaultRaftServer;
 import io.atomix.raft.impl.RaftContext;
 import io.atomix.raft.partition.RaftElectionConfig;
@@ -38,6 +39,7 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
@@ -332,7 +334,7 @@ public interface RaftServer {
    * @param membersToRetain The members to retain in the partition
    * @return a future to be completed once the server has been force configured
    */
-  CompletableFuture<RaftServer> forceConfigure(Collection<MemberId> membersToRetain);
+  CompletableFuture<RaftServer> forceConfigure(Map<MemberId, Type> membersToRetain);
 
   /**
    * Update priority of this server used for priority election. If priority election is not enabled,

--- a/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/impl/DefaultRaftServer.java
@@ -24,12 +24,14 @@ import io.atomix.raft.RaftRoleChangeListener;
 import io.atomix.raft.RaftServer;
 import io.atomix.raft.RaftThreadContextFactory;
 import io.atomix.raft.cluster.RaftCluster;
+import io.atomix.raft.cluster.RaftMember.Type;
 import io.atomix.raft.impl.RaftContext.State;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import io.camunda.zeebe.util.health.FailureListener;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicReference;
@@ -116,7 +118,7 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
-  public CompletableFuture<RaftServer> forceConfigure(final Collection<MemberId> membersToRetain) {
+  public CompletableFuture<RaftServer> forceConfigure(final Map<MemberId, Type> membersToRetain) {
     return new ReconfigurationHelper(context).forceConfigure(membersToRetain).thenApply(v -> this);
   }
 


### PR DESCRIPTION
## Description

In future, we may want to support PASSIVE members as well. To allow that take the type of the member as input.

## Related issues

related to #16148 
follow up of #16295 
