### PR TITLE
build: auto retry bot PRs for auto merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,10 +657,12 @@ jobs:
     #
     # The workflow is divided into multiple sequential jobs to allow giving only minimal permissions to
     # the GitHub token passed around.
-    name: Auto-merge backport and renovate PRs
+    name: Auto-merge backport, release, and renovate PRs
     runs-on: ubuntu-latest
     needs: [ test-summary ]
-    if: github.repository == 'camunda/zeebe' && (github.actor == 'backport-action' || github.actor == 'renovate[bot]')
+    if: |
+      github.repository == 'camunda/zeebe' &&
+      (github.actor == 'backport-action' || github.actor == 'renovate[bot]' || github.actor == 'camundait')
     permissions:
       checks: read
       pull-requests: write
@@ -675,3 +677,24 @@ jobs:
           gh pr review ${{ github.event.pull_request.number }} --approve
           # Call the API directly to work around https://github.com/cli/cli/issues/8352
           gh api graphql -f query='mutation PullRequestAutoMerge {enablePullRequestAutoMerge(input: {pullRequestId: "${{ github.event.pull_request.node_id }}"}) {clientMutationId}}'
+  # This job will trigger another workflow such that it will trigger a re-run of this failing workflow
+  # We can't automatically do this here, since you can only re-run a workflow iff it has finished,
+  # and while this job is running, the workflow clearly hasn't finished
+  #
+  # It will only retry if the workflow failed, the run count is < 3 (to avoid infinite loops), and
+  # the author is backport-action, renovate, or camundait (for release PRs)
+  retry-workflow:
+    name: Retry release, renovate, or backport PRs automatically
+    needs: [ test-summary ]
+    if: |
+      failure() &&
+      fromJSON(github.run_attempt) < 3 &&
+      github.repository == 'camunda/zeebe' &&
+      (github.actor == 'backport-action' || github.actor == 'renovate[bot]' || github.actor == 'camundait')
+    runs-on: ubuntu-latest
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Retry workflow run ${{ github.run_id }}
+        run: gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -678,7 +678,7 @@ jobs:
           # Call the API directly to work around https://github.com/cli/cli/issues/8352
           gh api graphql -f query='mutation PullRequestAutoMerge {enablePullRequestAutoMerge(input: {pullRequestId: "${{ github.event.pull_request.node_id }}"}) {clientMutationId}}'
   # This job will trigger another workflow such that it will trigger a re-run of this failing workflow
-  # We can't automatically do this here, since you can only re-run a workflow iff it has finished,
+  # We can't automatically do this here, since you can only re-run a workflow if it has finished,
   # and while this job is running, the workflow clearly hasn't finished
   #
   # It will only retry if the workflow failed, the run count is < 3 (to avoid infinite loops), and

--- a/.github/workflows/retry-workflow.yml
+++ b/.github/workflows/retry-workflow.yml
@@ -1,0 +1,21 @@
+# This workflow receives a run ID and triggers a retry of its failed jobs.
+# This is useful, for example, to retry dependency update PRs automatically in case of network
+# errors, flaky tests, etc.
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: The ID of the workflow run to retry
+        required: true
+
+jobs:
+  retry:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Retry workflow run ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }} > /dev/null 2>&1
+          gh run rerun ${{ inputs.run_id }} --failed


### PR DESCRIPTION
## Description

This PR auto retries (up to 3 times) PRs failed jobs for PRs opened by renovate, backport, or camundait. This will allow such PRs to bypass things like flaky tests, network issues, etc.

This also enables auto merging of PRs opened by camundait (e.g. release PRs).

I hope this cuts down on such PRs remaining opened due to flaky tests and no one feeling responsible for them.

This is done by introducing a new workflow which will re-run failed jobs of a specific run. Basically, when the CI workflow fails, the last job (after `test-summary`) will trigger a new workflow, `retry-workflow`, to run, with the CI workflow run ID as the input. That workflow has only one job, which will wait until the original CI workflow run is finished, and then re-trigger failed jobs only.

It has to be split in two like this, because a workflow run cannot re-run itself, since you can only re-run jobs of a run which finished, and it wouldn't be finished if it was still running some job.

(how many times did I write run? :smile:)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
