### PR TITLE
Detect inconsistent state of local member in the topology

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerShutdownHelper.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerShutdownHelper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+/**
+ * Helper class to initiate the shutdown of the broker application. This is used to trigger graceful
+ * shutdown the broker from within the application itself.
+ */
+@Component
+public class BrokerShutdownHelper {
+
+  @Autowired private ApplicationContext appContext;
+
+  public void initiateShutdown(final int returnCode) {
+    SpringApplication.exit(appContext, () -> returnCode);
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -42,7 +42,6 @@ import org.springframework.context.event.ContextClosedEvent;
 public class StandaloneBroker
     implements CommandLineRunner, ApplicationListener<ContextClosedEvent> {
   private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;
-
   private final BrokerConfiguration configuration;
   private final IdentityConfiguration identityConfiguration;
   private final SpringBrokerBridge springBrokerBridge;
@@ -50,6 +49,7 @@ public class StandaloneBroker
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
 
+  @Autowired private BrokerShutdownHelper shutdownHelper;
   private Broker broker;
 
   @Autowired
@@ -87,6 +87,9 @@ public class StandaloneBroker
     final SystemContext systemContext =
         new SystemContext(
             configuration.config(), identityConfiguration, actorScheduler, cluster, brokerClient);
+
+    springBrokerBridge.registerShutdownHelper(
+        errorCode -> shutdownHelper.initiateShutdown(errorCode));
 
     broker = new Broker(systemContext, springBrokerBridge);
     broker.start();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -7,11 +7,19 @@
  */
 package io.camunda.zeebe.broker.bootstrap;
 
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.SpringBrokerBridge;
 import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import org.slf4j.Logger;
 
 final class PartitionManagerStep extends AbstractBrokerStartupStep {
+  private static final Logger logger = Loggers.SYSTEM_LOGGER;
+  private static final int ERROR_CODE_ON_INCONSISTENT_TOPOLOGY = 3;
+
   @Override
   public String getName() {
     return "Partition Manager";
@@ -41,6 +49,15 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
     concurrencyControl.run(
         () -> {
           try {
+            brokerStartupContext
+                .getClusterTopology()
+                .registerTopologyChangeListener(
+                    (newTopology, oldTopology) ->
+                        shutdownOnInconsistentTopology(
+                            brokerStartupContext.getBrokerInfo().getNodeId(),
+                            brokerStartupContext.getSpringBrokerBridge(),
+                            newTopology,
+                            oldTopology));
             partitionManager.start();
             brokerStartupContext.setPartitionManager(partitionManager);
             brokerStartupContext
@@ -76,5 +93,25 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             shutdownFuture.complete(brokerShutdownContext);
           }
         });
+
+    brokerShutdownContext.getClusterTopology().removeTopologyChangeListener();
+  }
+
+  private void shutdownOnInconsistentTopology(
+      final int localBrokerId,
+      final SpringBrokerBridge springBrokerBridge,
+      final ClusterTopology newTopology,
+      final ClusterTopology oldTopology) {
+    final MemberId localMemberId = MemberId.from(String.valueOf(localBrokerId));
+    logger.warn(
+        """
+          Received a newer topology which has a different state for this broker.
+          State of this broker in new topology :'{}'
+          State of this broker in old topology: '{}'
+          This usually happens when the topology was changed forcefully when this broker was unreachable or this broker encountered a data loss. Shutting down the broker. Please restart the broker to use the new topology.
+        """,
+        newTopology.getMember(localMemberId),
+        oldTopology.getMember(localMemberId));
+    springBrokerBridge.initiateShutdown(ERROR_CODE_ON_INCONSISTENT_TOPOLOGY);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.topology.state.ClusterTopology;
 import org.slf4j.Logger;
 
 final class PartitionManagerStep extends AbstractBrokerStartupStep {
-  private static final Logger logger = Loggers.SYSTEM_LOGGER;
+  private static final Logger LOGGER = Loggers.SYSTEM_LOGGER;
   private static final int ERROR_CODE_ON_INCONSISTENT_TOPOLOGY = 3;
 
   @Override
@@ -103,7 +103,7 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
       final ClusterTopology newTopology,
       final ClusterTopology oldTopology) {
     final MemberId localMemberId = MemberId.from(String.valueOf(localBrokerId));
-    logger.warn(
+    LOGGER.warn(
         """
           Received a newer topology which has a different state for this broker.
           State of this broker in new topology :'{}'

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyService.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.partitioning.topology;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 
 public interface ClusterTopologyService extends AsyncClosable {
@@ -20,4 +21,8 @@ public interface ClusterTopologyService extends AsyncClosable {
   void removePartitionChangeExecutor();
 
   ActorFuture<Void> start(BrokerStartupContext brokerStartupContext);
+
+  void registerTopologyChangeListener(TopologyChangedListener listener);
+
+  void removeTopologyChangeListener();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/ClusterTopologyService.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.broker.partitioning.topology;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
+import io.camunda.zeebe.topology.ClusterTopologyManager.InconsistentTopologyListener;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 
 public interface ClusterTopologyService extends AsyncClosable {
@@ -22,7 +22,7 @@ public interface ClusterTopologyService extends AsyncClosable {
 
   ActorFuture<Void> start(BrokerStartupContext brokerStartupContext);
 
-  void registerTopologyChangeListener(TopologyChangedListener listener);
+  void registerTopologyChangeListener(InconsistentTopologyListener listener);
 
   void removeTopologyChangeListener();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
@@ -12,7 +12,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
+import io.camunda.zeebe.topology.ClusterTopologyManager.InconsistentTopologyListener;
 import io.camunda.zeebe.topology.ClusterTopologyManagerService;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
@@ -88,7 +88,7 @@ public class DynamicClusterTopologyService implements ClusterTopologyService {
   }
 
   @Override
-  public void registerTopologyChangeListener(final TopologyChangedListener listener) {
+  public void registerTopologyChangeListener(final InconsistentTopologyListener listener) {
     if (clusterTopologyManagerService != null) {
       clusterTopologyManagerService.registerTopologyChangedListener(listener);
     } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionManagerImpl;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
 import io.camunda.zeebe.topology.ClusterTopologyManagerService;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
@@ -84,6 +85,23 @@ public class DynamicClusterTopologyService implements ClusterTopologyService {
           }
         });
     return started;
+  }
+
+  @Override
+  public void registerTopologyChangeListener(final TopologyChangedListener listener) {
+    if (clusterTopologyManagerService != null) {
+      clusterTopologyManagerService.registerTopologyChangedListener(listener);
+    } else {
+      throw new IllegalStateException(
+          "Cannot register topology change listener before the topology manager is started");
+    }
+  }
+
+  @Override
+  public void removeTopologyChangeListener() {
+    if (clusterTopologyManagerService != null) {
+      clusterTopologyManagerService.removeTopologyChangedListener();
+    }
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
+import io.camunda.zeebe.topology.ClusterTopologyManager.InconsistentTopologyListener;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 
 public class StaticClusterTopologyService implements ClusterTopologyService {
@@ -56,7 +56,7 @@ public class StaticClusterTopologyService implements ClusterTopologyService {
   }
 
   @Override
-  public void registerTopologyChangeListener(final TopologyChangedListener listener) {
+  public void registerTopologyChangeListener(final InconsistentTopologyListener listener) {
     // do nothing. Static cluster topology cannot be changed.
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
 import io.camunda.zeebe.topology.changes.PartitionChangeExecutor;
 
 public class StaticClusterTopologyService implements ClusterTopologyService {
@@ -52,6 +53,16 @@ public class StaticClusterTopologyService implements ClusterTopologyService {
     }
 
     return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public void registerTopologyChangeListener(final TopologyChangedListener listener) {
+    // do nothing. Static cluster topology cannot be changed.
+  }
+
+  @Override
+  public void removeTopologyChangeListener() {
+    // do nothing. Static cluster topology cannot be changed.
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.management;
 import static org.assertj.core.api.Assertions.*;
 
 import feign.FeignException;
+import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.management.cluster.Operation;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
@@ -124,6 +125,7 @@ final class ClusterEndpointIT {
     try (final var cluster = createCluster(2)) {
       // given
       cluster.awaitCompleteTopology();
+      cluster.brokers().get(MemberId.from("1")).close();
       final var actuator = ClusterActuator.of(cluster.availableGateway());
 
       // when - force remove broker 1

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -36,6 +36,6 @@ public interface ClusterTopologyManager {
      * @param newTopology new topology received
      * @param oldTopology the local topology before receiving the new one
      */
-    void onTopologyChanged(ClusterTopology newTopology, ClusterTopology oldTopology);
+    void onLocalTopologyChanged(ClusterTopology newTopology, ClusterTopology oldTopology);
   }
 }

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -17,4 +17,25 @@ public interface ClusterTopologyManager {
 
   ActorFuture<ClusterTopology> updateClusterTopology(
       UnaryOperator<ClusterTopology> topologyUpdated);
+
+  /**
+   * A listener that is invoked, when the local member state in the local topology is older compared
+   * to the received topology. Normally, only a member can change its own state. However, if the
+   * state changes without its knowledge it means there was a request that force changed the
+   * topology. In that case the listener can decide how to react - for example by shutting down the
+   * node or restarting all partitions with the new topology.
+   */
+  @FunctionalInterface
+  interface TopologyChangedListener {
+
+    /**
+     * Invoked when the local member state in the local topology is old compared to the newer
+     * received topology. Before invoking this listener, the local topology will be updated to the
+     * newTopology.
+     *
+     * @param newTopology new topology received
+     * @param oldTopology the local topology before receiving the new one
+     */
+    void onTopologyChanged(ClusterTopology newTopology, ClusterTopology oldTopology);
+  }
 }

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManager.java
@@ -26,7 +26,7 @@ public interface ClusterTopologyManager {
    * node or restarting all partitions with the new topology.
    */
   @FunctionalInterface
-  interface TopologyChangedListener {
+  interface InconsistentTopologyListener {
 
     /**
      * Invoked when the local member state in the local topology is old compared to the newer
@@ -36,6 +36,6 @@ public interface ClusterTopologyManager {
      * @param newTopology new topology received
      * @param oldTopology the local topology before receiving the new one
      */
-    void onLocalTopologyChanged(ClusterTopology newTopology, ClusterTopology oldTopology);
+    void onInconsistentLocalTopology(ClusterTopology newTopology, ClusterTopology oldTopology);
   }
 }

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -56,7 +56,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
   private Consumer<ClusterTopology> topologyGossiper;
   private final ActorFuture<Void> startFuture;
   private TopologyChangeAppliers changeAppliers;
-  private TopologyChangedListener onInconsistentTopologyDetected;
+  private InconsistentTopologyListener onInconsistentTopologyDetected;
   private final MemberId localMemberId;
   // Indicates whether there is a topology change operation in progress on this member.
   private boolean onGoingTopologyChangeOperation = false;
@@ -200,7 +200,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
                 persistedClusterTopology.update(mergedTopology);
 
                 if (isConflictingTopology && onInconsistentTopologyDetected != null) {
-                  onInconsistentTopologyDetected.onLocalTopologyChanged(
+                  onInconsistentTopologyDetected.onInconsistentLocalTopology(
                       mergedTopology, oldTopology);
                 }
 
@@ -349,7 +349,7 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
     executor.run(() -> changeAppliers = null);
   }
 
-  void registerTopologyChangedListener(final TopologyChangedListener listener) {
+  void registerTopologyChangedListener(final InconsistentTopologyListener listener) {
     executor.run(() -> onInconsistentTopologyDetected = listener);
   }
 

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -200,7 +200,8 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
                 persistedClusterTopology.update(mergedTopology);
 
                 if (isConflictingTopology && onInconsistentTopologyDetected != null) {
-                  onInconsistentTopologyDetected.onTopologyChanged(mergedTopology, oldTopology);
+                  onInconsistentTopologyDetected.onLocalTopologyChanged(
+                      mergedTopology, oldTopology);
                 }
 
                 topologyGossiper.accept(mergedTopology);

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerImpl.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.util.ExponentialBackoffRetryDelay;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.UnaryOperator;
 import org.slf4j.Logger;
@@ -193,9 +194,9 @@ public final class ClusterTopologyManagerImpl implements ClusterTopologyManager 
 
                 final var oldTopology = persistedClusterTopology.getTopology();
                 final var isConflictingTopology =
-                    !mergedTopology
-                        .getMember(localMemberId)
-                        .equals(oldTopology.getMember(localMemberId));
+                    !Objects.equals(
+                        mergedTopology.getMember(localMemberId),
+                        oldTopology.getMember(localMemberId));
                 persistedClusterTopology.update(mergedTopology);
 
                 if (isConflictingTopology && onInconsistentTopologyDetected != null) {

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
+import io.camunda.zeebe.topology.ClusterTopologyManager.InconsistentTopologyListener;
 import io.camunda.zeebe.topology.TopologyInitializer.FileInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.GossipInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.InitializerError.PersistedTopologyIsBroken;
@@ -218,7 +218,7 @@ public final class ClusterTopologyManagerService implements TopologyUpdateNotifi
     clusterTopologyManager.removeTopologyChangeAppliers();
   }
 
-  public void registerTopologyChangedListener(final TopologyChangedListener listener) {
+  public void registerTopologyChangedListener(final InconsistentTopologyListener listener) {
     clusterTopologyManager.registerTopologyChangedListener(listener);
   }
 

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/ClusterTopologyManagerService.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.AsyncClosable;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
 import io.camunda.zeebe.topology.TopologyInitializer.FileInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.GossipInitializer;
 import io.camunda.zeebe.topology.TopologyInitializer.InitializerError.PersistedTopologyIsBroken;
@@ -215,6 +216,14 @@ public final class ClusterTopologyManagerService implements TopologyUpdateNotifi
 
   public void removePartitionChangeExecutor() {
     clusterTopologyManager.removeTopologyChangeAppliers();
+  }
+
+  public void registerTopologyChangedListener(final TopologyChangedListener listener) {
+    clusterTopologyManager.registerTopologyChangedListener(listener);
+  }
+
+  public void removeTopologyChangedListener() {
+    clusterTopologyManager.removeTopologyChangedListener();
   }
 
   @Override

--- a/zeebe/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
+++ b/zeebe/topology/src/test/java/io/camunda/zeebe/topology/ClusterTopologyManagerTest.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.camunda.zeebe.topology.ClusterTopologyManager.TopologyChangedListener;
+import io.camunda.zeebe.topology.ClusterTopologyManager.InconsistentTopologyListener;
 import io.camunda.zeebe.topology.changes.NoopTopologyChangeAppliers;
 import io.camunda.zeebe.topology.changes.TopologyChangeAppliers;
 import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
@@ -265,7 +265,7 @@ final class ClusterTopologyManagerTest {
     final AtomicReference<ClusterTopology> newTopology = new AtomicReference<>();
     final AtomicReference<ClusterTopology> oldTopology = new AtomicReference<>();
     final CompletableFuture<Void> listenerCalled = new CompletableFuture<>();
-    final TopologyChangedListener listener =
+    final InconsistentTopologyListener listener =
         (received, old) -> {
           newTopology.set(received);
           oldTopology.set(old);


### PR DESCRIPTION
## Description

Usually, a broker is force-remove when it is unreachable. However, due to intermittent network issues we may have to force fully remove a broker. In that case, that broker may try to connect back to the cluster when the network is available. The partitions which are already running in that broker will repeatedly send send poll requests to the rest of the replicas, thus spamming them. Since it is already removed, the other replicas reject the request and will never sent a heartbeat or updated configuration.  This is not a dangerous situation, but can create noisy logs and difficult to debug other related issues.

To prevent this situation, a broker shuts down gracefully when it detects an inconsistent topology. The local topology is inconsistent with the received one if the received one is of higher version and the state of this member in the topology is different. That means it has been force-fully updated by some other broker. 

When the spring application is shutdown gracefully, the kubernetes pod is also shutdown and will be restarted. This has been verified manually. When the broker is restarted, it uses the new topology in which this broker is not part of and not having any partitions. As a result it doesn't start any partitions and remain in an "unready" state. The pod has to be manually removed. This is ok because force-remove is only used when the broker has to be removed from the cluster. 

## Related issues

closes #16312 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
