### PR TITLE
[Backport stable/8.1] fix(engine): backed-off jobs are not activatable

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -189,7 +189,7 @@ public final class DbJobState implements JobState, MutableJobState {
       if (updatedValue.getRetryBackoff() > 0) {
         addJobBackoff(key, updatedValue.getRecurringTime());
         updateJob(key, updatedValue, State.FAILED);
-        makeJobNotActivatable(updatedValue.getTypeBuffer(), updatedValue.getTenantId());
+        makeJobNotActivatable(updatedValue.getTypeBuffer());
       } else {
         updateJob(key, updatedValue, State.ACTIVATABLE);
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -189,6 +189,7 @@ public final class DbJobState implements JobState, MutableJobState {
       if (updatedValue.getRetryBackoff() > 0) {
         addJobBackoff(key, updatedValue.getRecurringTime());
         updateJob(key, updatedValue, State.FAILED);
+        makeJobNotActivatable(updatedValue.getTypeBuffer(), updatedValue.getTenantId());
       } else {
         updateJob(key, updatedValue, State.ACTIVATABLE);
       }


### PR DESCRIPTION
# Description
Backport of #16085 to `stable/8.1`.

relates to #16084
original author: @koevskinikola