### PR TITLE
[Backport stable/8.4] fix(engine): backed-off jobs are not activatable

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -195,6 +195,7 @@ public final class DbJobState implements JobState, MutableJobState {
       if (updatedValue.getRetryBackoff() > 0) {
         addJobBackoff(key, updatedValue.getRecurringTime());
         updateJob(key, updatedValue, State.FAILED);
+        makeJobNotActivatable(updatedValue.getTypeBuffer(), updatedValue.getTenantId());
       } else {
         updateJob(key, updatedValue, State.ACTIVATABLE);
       }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/FailJobTest.java
@@ -205,6 +205,32 @@ public final class FailJobTest {
   }
 
   @Test
+  public void shouldFailJobWithBackOffAndRemainFailed() {
+    // given
+    final Record<JobRecordValue> job = ENGINE.createJob(jobType, PROCESS_ID);
+    final long jobKey = job.getKey();
+    final Duration backOff = Duration.ofDays(1);
+    final Record<JobRecordValue> failRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .ofInstance(job.getValue().getProcessInstanceKey())
+            .withRetries(3)
+            .withBackOff(backOff)
+            .fail();
+    Assertions.assertThat(failRecord)
+        .hasRecordType(RecordType.EVENT)
+        .hasIntent(FAILED)
+        .hasKey(jobKey);
+
+    // when
+    final var reactivatedJobs = ENGINE.jobs().withType(jobType).activate();
+
+    // then
+    assertThat(reactivatedJobs.getValue().getJobKeys()).doesNotContain(jobKey).isEmpty();
+  }
+
+  @Test
   public void shouldFailIfJobCreated() {
     // given
     final Record<JobRecordValue> job = ENGINE.createJob(jobType, PROCESS_ID);


### PR DESCRIPTION
# Description
Backport of #16085 to `stable/8.4`.

relates to #16084
original author: @koevskinikola