### PR TITLE
[stable/8.2] Allow decision requirements in column family 49

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
@@ -272,7 +272,7 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
     @Test
     void shouldIgnoreProcessInstanceKeyByDefinitionKeyEntries() {
       // given
-      decisionRequirementsId.wrapString("decisionRequirements");
+      decisionRequirementsId.wrapString("drg");
       decisionRequirementsVersion.wrapInt(1);
       decisionRequirementsKey.wrapLong(543);
       correctDecisionRequirementsKeyColumnFamily.insert(
@@ -283,7 +283,7 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       wrongPiKeyByProcDefKeyColumnFamily.insert(
           processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
 
-      decisionRequirementsId.wrapString("decisionRequirements2");
+      decisionRequirementsId.wrapString("drg2");
       decisionRequirementsVersion.wrapInt(2);
       decisionRequirementsKey.wrapLong(987);
       correctDecisionRequirementsKeyColumnFamily.insert(

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
@@ -29,7 +29,6 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.signal.SignalSubscriptionRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.List;
-import org.agrona.collections.MutableInteger;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -41,13 +40,6 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
 
   public static final String EXAMPLE_IDENTIFIER =
       new ColumnFamilyPrefixCorrectionMigration().getIdentifier();
-
-  /** Helper method for missing count method on column family */
-  private static int count(final ColumnFamily<?, ?> columnFamily) {
-    final var count = new MutableInteger(0);
-    columnFamily.forEach((key, value) -> count.increment());
-    return count.get();
-  }
 
   /** Test correction from DMN_DECISION_KEY_BY_DECISION_ID_AND_VERSION -> MESSAGE_STATS */
   @Nested
@@ -153,7 +145,7 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       decisionKey.wrapLong(234);
       correctDecisionColumnFamily.insert(decisionIdAndVersion, decisionKey);
 
-      Assertions.assertThat(count(wrongMessageStatsColumnFamily)).isEqualTo(3);
+      Assertions.assertThat(wrongMessageStatsColumnFamily.count()).isEqualTo(3);
 
       // when
       sut.correctColumnFamilyPrefix();
@@ -161,9 +153,9 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       // then
       // we can no longer use wrongMessageStatsColumnFamily.isEmpty() as there are entries in there
       // just no longer message stats entries, but we can simply count the entries
-      Assertions.assertThat(count(wrongMessageStatsColumnFamily)).isEqualTo(2);
-      Assertions.assertThat(count(correctDecisionColumnFamily)).isEqualTo(2);
-      Assertions.assertThat(count(correctMessageStatsColumnFamily)).isEqualTo(1);
+      Assertions.assertThat(wrongMessageStatsColumnFamily.count()).isEqualTo(2);
+      Assertions.assertThat(correctDecisionColumnFamily.count()).isEqualTo(2);
+      Assertions.assertThat(correctMessageStatsColumnFamily.count()).isEqualTo(1);
 
       decisionId.wrapString("decision");
       decisionVersion.wrapInt(1);
@@ -289,7 +281,7 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       correctDecisionRequirementsKeyColumnFamily.insert(
           decisionRequirementsIdAndVersion, decisionRequirementsKey);
 
-      Assertions.assertThat(count(wrongPiKeyByProcDefKeyColumnFamily)).isEqualTo(3);
+      Assertions.assertThat(wrongPiKeyByProcDefKeyColumnFamily.count()).isEqualTo(3);
 
       // when
       sut.correctColumnFamilyPrefix();
@@ -298,9 +290,9 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       // we can no longer use wrongPiKeyByProcDefKeyColumnFamily.isEmpty() as there are entries in
       // there just no longer process instance keys by process definition key entries, but we can
       // simply count the entries
-      Assertions.assertThat(count(wrongPiKeyByProcDefKeyColumnFamily)).isEqualTo(2);
-      Assertions.assertThat(count(correctDecisionRequirementsKeyColumnFamily)).isEqualTo(2);
-      Assertions.assertThat(count(correctPiKeyByProcDefKeyColumnFamily)).isEqualTo(1);
+      Assertions.assertThat(wrongPiKeyByProcDefKeyColumnFamily.count()).isEqualTo(2);
+      Assertions.assertThat(correctDecisionRequirementsKeyColumnFamily.count()).isEqualTo(2);
+      Assertions.assertThat(correctPiKeyByProcDefKeyColumnFamily.count()).isEqualTo(1);
 
       elementInstanceKey.wrapLong(123);
       processDefinitionKey.wrapLong(456);
@@ -482,7 +474,7 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       correctSignalSubscriptionColumnFamily.insert(
           signalNameAndSubscriptionKey, signalSubscription);
 
-      Assertions.assertThat(count(wrongMigrationStateColumnFamily)).isEqualTo(3);
+      Assertions.assertThat(wrongMigrationStateColumnFamily.count()).isEqualTo(3);
 
       // when
       sut.correctColumnFamilyPrefix();
@@ -491,9 +483,9 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       // we can no longer use wrongMigrationStateColumnFamily.isEmpty() as there are entries in
       // there
       // just no longer migration state entries, but we can simply count the entries
-      Assertions.assertThat(count(wrongMigrationStateColumnFamily)).isEqualTo(2);
-      Assertions.assertThat(count(correctSignalSubscriptionColumnFamily)).isEqualTo(2);
-      Assertions.assertThat(count(correctMigrationStateColumnFamily)).isEqualTo(1);
+      Assertions.assertThat(wrongMigrationStateColumnFamily.count()).isEqualTo(2);
+      Assertions.assertThat(correctSignalSubscriptionColumnFamily.count()).isEqualTo(2);
+      Assertions.assertThat(correctMigrationStateColumnFamily.count()).isEqualTo(1);
 
       signalName.wrapString("signal");
       subscriptionKey.wrapLong(123);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
@@ -299,6 +299,22 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       Assertions.assertThat(
               correctPiKeyByProcDefKeyColumnFamily.exists(processInstanceKeyByProcessDefinitionKey))
           .isTrue();
+
+      decisionRequirementsId.wrapString("drg");
+      decisionRequirementsVersion.wrapInt(1);
+      Assertions.assertThat(
+              correctDecisionRequirementsKeyColumnFamily.get(decisionRequirementsIdAndVersion))
+          .isNotNull()
+          .extracting(DbLong::getValue)
+          .isEqualTo(543L);
+
+      decisionRequirementsId.wrapString("drg2");
+      decisionRequirementsVersion.wrapInt(2);
+      Assertions.assertThat(
+              correctDecisionRequirementsKeyColumnFamily.get(decisionRequirementsIdAndVersion))
+          .isNotNull()
+          .extracting(DbLong::getValue)
+          .isEqualTo(987L);
     }
   }
 

--- a/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/ColumnFamily.java
@@ -164,4 +164,21 @@ public interface ColumnFamily<KeyType extends DbKey, ValueType extends DbValue> 
    * @return <code>true</code> if the column family has no entry
    */
   boolean isEmpty();
+
+  /**
+   * Count the number of entries in the column family by iterating over all its entries. This is an
+   * expensive operation and should be used with care.
+   *
+   * @return the number of entries in the column family
+   */
+  long count();
+
+  /**
+   * Count the number of entries in the column family which have the same common prefix by iterating
+   * over all its entries. This is an expensive operation and should be used with care.
+   *
+   * @param prefix the prefix which should have the keys in common
+   * @return the number of entries in the column family which have the same common prefix
+   */
+  long countEqualPrefix(DbKey prefix);
 }

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/TransactionalColumnFamily.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.db.ZeebeDbInconsistentException;
 import io.camunda.zeebe.protocol.EnumValue;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
@@ -261,13 +262,23 @@ class TransactionalColumnFamily<
     return isEmpty.get();
   }
 
+  @Override
+  public long count() {
+    return countEachInPrefix(new DbNullKey());
+  }
+
+  @Override
+  public long countEqualPrefix(final DbKey prefix) {
+    return countEachInPrefix(prefix);
+  }
+
   private void assertForeignKeysExist(final ZeebeTransaction transaction, final Object... keys)
       throws Exception {
     if (!consistencyChecksSettings.enableForeignKeyChecks()) {
       return;
     }
     for (final var key : keys) {
-      if (key instanceof ContainsForeignKeys containsForeignKey) {
+      if (key instanceof final ContainsForeignKeys containsForeignKey) {
         foreignKeyChecker.assertExists(transaction, containsForeignKey);
       }
     }
@@ -331,6 +342,7 @@ class TransactionalColumnFamily<
       final DbKey prefix, final KeyValuePairVisitor<KeyType, ValueType> visitor) {
     forEachInPrefix(prefix, prefix, visitor);
   }
+
   /**
    * This is the preferred method to implement methods that iterate over a column family.
    *
@@ -377,6 +389,52 @@ class TransactionalColumnFamily<
             }
           }
         });
+  }
+
+  /**
+   * This is the preferred method to implement methods that count entries in a column family.
+   *
+   * <p>It iterates over each entry without deserializing the value. If you need a value consider
+   * using {@link #forEachInPrefix}.
+   *
+   * @param prefix of all keys that are iterated over.
+   * @return count of the number of entries in the column family with the given prefix starting from
+   *     the given startAt.
+   */
+  private long countEachInPrefix(final DbKey prefix) {
+    final var seekTarget = Objects.requireNonNull(prefix);
+
+    final var count = new AtomicLong(0);
+
+    /*
+     * NOTE: it doesn't seem possible in Java RocksDB to set a flexible prefix extractor on
+     * iterators at the moment, so using prefixes seem to be mostly related to skipping files that
+     * do not contain keys with the given prefix (which is useful anyway), but it will still iterate
+     * over all keys contained in those files, so we still need to make sure the key actually
+     * matches the prefix.
+     *
+     * <p>While iterating over subsequent keys we have to validate it.
+     */
+    columnFamilyContext.withPrefixKey(
+        prefix,
+        (prefixKey, prefixLength) -> {
+          try (final RocksIterator iterator =
+              newIterator(context, transactionDb.getPrefixReadOptions())) {
+
+            for (iterator.seek(columnFamilyContext.keyWithColumnFamily(seekTarget));
+                iterator.isValid();
+                iterator.next()) {
+              final byte[] keyBytes = iterator.key();
+              if (!startsWith(prefixKey, 0, prefixLength, keyBytes, 0, keyBytes.length)) {
+                break;
+              }
+
+              count.getAndIncrement();
+            }
+          }
+        });
+
+    return count.get();
   }
 
   private boolean visit(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Fixes a bug in `ColumnFamily49Corrector` where it falsely detected a correct DRG entry in column family 49 as an entry that should be moved to `PROCESS_INSTANCE_KEY_BY_DEFINITION_KEY`.

- 7bdbf0f648ce6a7bfc5bb42dc378cadd56a9a7b3 should surface the bug, but runs into an issue with test setup where it uses a count method that attempts to deserialize the key/value pair but fails
- a0f8adfd1fe09d657bb6395338e01a342a9381b2 and 22af24c71d1f19eda7366b843c46ab9b133f3aac fix that problem, after which the bug actually surfaces in the test case
- 7f64ab4c3f00408a05a53bfae699339d9659fdd3 fixes the bug
- 94a79c727e6cd6bee66b6a084c7a6195b1b1d562 adds extra assertions to the test case

Changes have been tested manually locally against the data folder of the affected cluster.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16406 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
