### PR TITLE
Fix garbage left after metrics exporter cleanup

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -56,7 +56,10 @@ public class MetricsExporter implements Exporter {
   }
 
   public MetricsExporter(final ExecutionLatencyMetrics executionLatencyMetrics) {
-    this(executionLatencyMetrics, new TtlKeyCache(), new TtlKeyCache());
+    this(
+        executionLatencyMetrics,
+        new TtlKeyCache(TIME_TO_LIVE.toMillis()),
+        new TtlKeyCache(TIME_TO_LIVE.toMillis()));
   }
 
   @VisibleForTesting

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -21,13 +21,10 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
-import java.util.NavigableMap;
 import java.util.Set;
-import java.util.TreeMap;
-import org.agrona.collections.Long2LongHashMap;
-import org.agrona.collections.LongArrayList;
 
 public class MetricsExporter implements Exporter {
 
@@ -49,13 +46,8 @@ public class MetricsExporter implements Exporter {
   public static final Duration TIME_TO_LIVE = Duration.ofSeconds(60);
 
   private final ExecutionLatencyMetrics executionLatencyMetrics;
-  private final Long2LongHashMap jobKeyToCreationTimeMap;
-  private final Long2LongHashMap processInstanceKeyToCreationTimeMap;
-
-  // only used to keep track of how long the entries are existing and to clean up the corresponding
-  // maps
-  private final NavigableMap<Long, LongArrayList> creationTimeToJobKeyNavigableMap;
-  private final NavigableMap<Long, LongArrayList> creationTimeToProcessInstanceKeyNavigableMap;
+  private final TtlKeyCache processInstanceCache;
+  private final TtlKeyCache jobCache;
 
   private Controller controller;
 
@@ -64,11 +56,17 @@ public class MetricsExporter implements Exporter {
   }
 
   public MetricsExporter(final ExecutionLatencyMetrics executionLatencyMetrics) {
+    this(executionLatencyMetrics, new TtlKeyCache(), new TtlKeyCache());
+  }
+
+  @VisibleForTesting
+  MetricsExporter(
+      final ExecutionLatencyMetrics executionLatencyMetrics,
+      final TtlKeyCache processInstanceCache,
+      final TtlKeyCache jobCache) {
     this.executionLatencyMetrics = executionLatencyMetrics;
-    jobKeyToCreationTimeMap = new Long2LongHashMap(-1);
-    processInstanceKeyToCreationTimeMap = new Long2LongHashMap(-1);
-    creationTimeToJobKeyNavigableMap = new TreeMap<>();
-    creationTimeToProcessInstanceKeyNavigableMap = new TreeMap<>();
+    this.processInstanceCache = processInstanceCache;
+    this.jobCache = jobCache;
   }
 
   @Override
@@ -99,10 +97,8 @@ public class MetricsExporter implements Exporter {
 
   @Override
   public void close() {
-    jobKeyToCreationTimeMap.clear();
-    processInstanceKeyToCreationTimeMap.clear();
-    creationTimeToJobKeyNavigableMap.clear();
-    creationTimeToProcessInstanceKeyNavigableMap.clear();
+    processInstanceCache.clear();
+    jobCache.clear();
   }
 
   @Override
@@ -133,22 +129,15 @@ public class MetricsExporter implements Exporter {
 
     if (currentIntent == ProcessInstanceIntent.ELEMENT_ACTIVATING
         && isProcessInstanceRecord(record)) {
-      storeProcessInstanceCreation(record.getTimestamp(), recordKey);
+      processInstanceCache.store(recordKey, record.getTimestamp());
     } else if (currentIntent == ProcessInstanceIntent.ELEMENT_COMPLETED
         && isProcessInstanceRecord(record)) {
-      final var creationTime = processInstanceKeyToCreationTimeMap.remove(recordKey);
+      final var creationTime = processInstanceCache.remove(recordKey);
       executionLatencyMetrics.observeProcessInstanceExecutionTime(
           partitionId, creationTime, record.getTimestamp());
     }
     executionLatencyMetrics.setCurrentProcessInstanceCount(
-        partitionId, processInstanceKeyToCreationTimeMap.size());
-  }
-
-  private void storeProcessInstanceCreation(final long creationTime, final long recordKey) {
-    processInstanceKeyToCreationTimeMap.put(recordKey, creationTime);
-    creationTimeToProcessInstanceKeyNavigableMap
-        .computeIfAbsent(creationTime, ignored -> new LongArrayList())
-        .add(recordKey);
+        partitionId, processInstanceCache.size());
   }
 
   private void handleJobRecord(
@@ -156,12 +145,12 @@ public class MetricsExporter implements Exporter {
     final var currentIntent = record.getIntent();
 
     if (currentIntent == JobIntent.CREATED) {
-      storeJobCreation(record.getTimestamp(), recordKey);
+      jobCache.store(recordKey, record.getTimestamp());
     } else if (currentIntent == JobIntent.COMPLETED) {
-      final var creationTime = jobKeyToCreationTimeMap.remove(recordKey);
+      final var creationTime = jobCache.remove(recordKey);
       executionLatencyMetrics.observeJobLifeTime(partitionId, creationTime, record.getTimestamp());
     }
-    executionLatencyMetrics.setCurrentJobsCount(partitionId, jobKeyToCreationTimeMap.size());
+    executionLatencyMetrics.setCurrentJobsCount(partitionId, jobCache.size());
   }
 
   private void handleJobBatchRecord(final Record<?> record, final int partitionId) {
@@ -170,53 +159,19 @@ public class MetricsExporter implements Exporter {
     if (currentIntent == JobBatchIntent.ACTIVATED) {
       final var value = (JobBatchRecordValue) record.getValue();
       for (final long jobKey : value.getJobKeys()) {
-        final var creationTime = jobKeyToCreationTimeMap.get(jobKey);
+        final var creationTime = jobCache.remove(jobKey);
         executionLatencyMetrics.observeJobActivationTime(
             partitionId, creationTime, record.getTimestamp());
       }
     }
   }
 
-  private void storeJobCreation(final long creationTime, final long recordKey) {
-    jobKeyToCreationTimeMap.put(recordKey, creationTime);
-    creationTimeToJobKeyNavigableMap
-        .computeIfAbsent(creationTime, ignored -> new LongArrayList())
-        .add(recordKey);
-  }
-
   private void cleanUp() {
-    final var currentTimeMillis = System.currentTimeMillis();
-
+    final var currentTimeMillis = ActorClock.currentTimeMillis();
     final var deadTime = currentTimeMillis - TIME_TO_LIVE.toMillis();
-    clearMaps(deadTime, creationTimeToJobKeyNavigableMap, jobKeyToCreationTimeMap);
-    clearMaps(
-        deadTime,
-        creationTimeToProcessInstanceKeyNavigableMap,
-        processInstanceKeyToCreationTimeMap);
-
+    processInstanceCache.cleanup(deadTime);
+    jobCache.cleanup(deadTime);
     controller.scheduleCancellableTask(TIME_TO_LIVE, this::cleanUp);
-  }
-
-  @VisibleForTesting
-  int cachedProcessInstanceCount() {
-    return processInstanceKeyToCreationTimeMap.size();
-  }
-
-  @VisibleForTesting
-  int cachedJobCount() {
-    return jobKeyToCreationTimeMap.size();
-  }
-
-  private void clearMaps(
-      final long deadTime,
-      final NavigableMap<Long, LongArrayList> timeToKeyMap,
-      final Long2LongHashMap keyToTimestampMap) {
-    final var outOfScopeInstances = timeToKeyMap.headMap(deadTime);
-
-    for (final LongArrayList keys : outOfScopeInstances.values()) {
-      keys.forEach(keyToTimestampMap::remove);
-    }
-    outOfScopeInstances.clear();
   }
 
   public static ExporterCfg defaultConfig() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -21,11 +21,13 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
 import java.util.NavigableMap;
 import java.util.Set;
 import java.util.TreeMap;
 import org.agrona.collections.Long2LongHashMap;
+import org.agrona.collections.LongArrayList;
 
 public class MetricsExporter implements Exporter {
 
@@ -52,8 +54,8 @@ public class MetricsExporter implements Exporter {
 
   // only used to keep track of how long the entries are existing and to clean up the corresponding
   // maps
-  private final NavigableMap<Long, Long> creationTimeToJobKeyNavigableMap;
-  private final NavigableMap<Long, Long> creationTimeToProcessInstanceKeyNavigableMap;
+  private final NavigableMap<Long, LongArrayList> creationTimeToJobKeyNavigableMap;
+  private final NavigableMap<Long, LongArrayList> creationTimeToProcessInstanceKeyNavigableMap;
 
   private Controller controller;
 
@@ -144,7 +146,9 @@ public class MetricsExporter implements Exporter {
 
   private void storeProcessInstanceCreation(final long creationTime, final long recordKey) {
     processInstanceKeyToCreationTimeMap.put(recordKey, creationTime);
-    creationTimeToProcessInstanceKeyNavigableMap.put(creationTime, recordKey);
+    creationTimeToProcessInstanceKeyNavigableMap
+        .computeIfAbsent(creationTime, ignored -> new LongArrayList())
+        .add(recordKey);
   }
 
   private void handleJobRecord(
@@ -175,7 +179,9 @@ public class MetricsExporter implements Exporter {
 
   private void storeJobCreation(final long creationTime, final long recordKey) {
     jobKeyToCreationTimeMap.put(recordKey, creationTime);
-    creationTimeToJobKeyNavigableMap.put(creationTime, recordKey);
+    creationTimeToJobKeyNavigableMap
+        .computeIfAbsent(creationTime, ignored -> new LongArrayList())
+        .add(recordKey);
   }
 
   private void cleanUp() {
@@ -191,14 +197,24 @@ public class MetricsExporter implements Exporter {
     controller.scheduleCancellableTask(TIME_TO_LIVE, this::cleanUp);
   }
 
+  @VisibleForTesting
+  int cachedProcessInstanceCount() {
+    return processInstanceKeyToCreationTimeMap.size();
+  }
+
+  @VisibleForTesting
+  int cachedJobCount() {
+    return jobKeyToCreationTimeMap.size();
+  }
+
   private void clearMaps(
       final long deadTime,
-      final NavigableMap<Long, Long> timeToKeyMap,
+      final NavigableMap<Long, LongArrayList> timeToKeyMap,
       final Long2LongHashMap keyToTimestampMap) {
     final var outOfScopeInstances = timeToKeyMap.headMap(deadTime);
 
-    for (final Long key : outOfScopeInstances.values()) {
-      keyToTimestampMap.remove(key);
+    for (final LongArrayList keys : outOfScopeInstances.values()) {
+      keys.forEach(keyToTimestampMap::remove);
     }
     outOfScopeInstances.clear();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
@@ -14,8 +14,9 @@ import org.agrona.collections.LongArrayList;
 
 final class TtlKeyCache {
   private static final int DEFAULT_MAX_CAPACITY = 10_000;
+  private static final long DEFAULT_NULL_VALUE = -1L;
 
-  private final Long2LongHashMap keyToTimestamp = new Long2LongHashMap(-1);
+  private final Long2LongHashMap keyToTimestamp;
 
   // only used to keep track of how long the entries are existing and to clean up the
   // corresponding
@@ -28,11 +29,20 @@ final class TtlKeyCache {
     this(DEFAULT_MAX_CAPACITY);
   }
 
+  TtlKeyCache(final int maxCapacity) {
+    this(maxCapacity, DEFAULT_NULL_VALUE);
+  }
+
+  TtlKeyCache(final long nullValue) {
+    this(DEFAULT_MAX_CAPACITY, nullValue);
+  }
+
   /**
    * @param maxCapacity the maximum number of entries that can be cached, regardless of TTL
    */
-  TtlKeyCache(final int maxCapacity) {
+  TtlKeyCache(final int maxCapacity, final long nullValue) {
     this.maxCapacity = maxCapacity;
+    this.keyToTimestamp = new Long2LongHashMap(nullValue);
   }
 
   void store(final long key, final long timestamp) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.exporter.metrics;
+
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.agrona.collections.Long2LongHashMap;
+import org.agrona.collections.LongArrayList;
+
+final class TtlKeyCache {
+  private final Long2LongHashMap keyToTimestamp = new Long2LongHashMap(-1);
+
+  // only used to keep track of how long the entries are existing and to clean up the
+  // corresponding
+  // maps
+  private final NavigableMap<Long, LongArrayList> timestampToKeys = new TreeMap<>();
+
+  void store(final long key, final long timestamp) {
+    keyToTimestamp.put(key, timestamp);
+    timestampToKeys.computeIfAbsent(timestamp, ignored -> new LongArrayList()).add(key);
+  }
+
+  long remove(final long key) {
+    return keyToTimestamp.remove(key);
+  }
+
+  void cleanup(final long timestamp) {
+    final var deadTime = timestamp - MetricsExporter.TIME_TO_LIVE.toMillis();
+    final var outOfScopeInstances = timestampToKeys.headMap(deadTime);
+
+    for (final LongArrayList keys : outOfScopeInstances.values()) {
+      keys.forEach(keyToTimestamp::remove);
+    }
+
+    outOfScopeInstances.clear();
+  }
+
+  boolean isEmpty() {
+    return keyToTimestamp.isEmpty() && timestampToKeys.isEmpty();
+  }
+
+  void clear() {
+    keyToTimestamp.clear();
+    timestampToKeys.clear();
+  }
+
+  int size() {
+    return keyToTimestamp.size();
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -71,7 +71,9 @@ class MetricsExporterTest {
   @Test
   void shouldCleanupProcessInstancesWithSameStartTime() {
     // given
-    final var exporter = new MetricsExporter(new ExecutionLatencyMetrics());
+    final var processCache = new TtlKeyCache();
+    final var exporter =
+        new MetricsExporter(new ExecutionLatencyMetrics(), processCache, new TtlKeyCache());
     final var controller = new ExporterTestController();
     exporter.open(controller);
     exporter.export(
@@ -97,13 +99,15 @@ class MetricsExporterTest {
     controller.runScheduledTasks(Duration.ofHours(1));
 
     // then
-    assertThat(exporter.cachedProcessInstanceCount()).isZero();
+    assertThat(processCache.isEmpty()).isTrue();
   }
 
   @Test
   void shouldCleanupJobWithSameStartTime() {
     // given
-    final var exporter = new MetricsExporter(new ExecutionLatencyMetrics());
+    final var jobCache = new TtlKeyCache();
+    final var exporter =
+        new MetricsExporter(new ExecutionLatencyMetrics(), new TtlKeyCache(), jobCache);
     final var controller = new ExporterTestController();
     exporter.open(controller);
     exporter.export(
@@ -127,7 +131,7 @@ class MetricsExporterTest {
     controller.runScheduledTasks(Duration.ofHours(1));
 
     // then
-    assertThat(exporter.cachedJobCount()).isZero();
+    assertThat(jobCache.isEmpty()).isTrue();
   }
 
   @Nested

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
@@ -115,4 +115,17 @@ final class TtlKeyCacheTest {
     assertThat(cache.remove(3L)).isEqualTo(30L);
     assertThat(cache.remove(4L)).isEqualTo(40L);
   }
+
+  @Test
+  void shouldReturnNullValue() {
+    // given
+    final var cache = new TtlKeyCache(3L);
+    cache.store(1L, 10L);
+
+    // when
+    final var timestamp = cache.remove(2L);
+
+    // then
+    assertThat(timestamp).isEqualTo(3L);
+  }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.exporter.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import org.junit.jupiter.api.Test;
+
+final class TtlKeyCacheTest {
+
+  @Test
+  void shouldStorePair() {
+    // given
+    final var cache = new TtlKeyCache();
+
+    // when
+    cache.store(1L, 10L);
+    final var timestamp = cache.remove(1L);
+
+    // then
+    assertThat(timestamp).isEqualTo(10L);
+  }
+
+  @Test
+  void shouldStoreMultipleKeysWithSameTimestamp() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 10L);
+
+    // when - then
+    assertThat(cache.remove(1L)).isEqualTo(10L);
+    assertThat(cache.remove(2L)).isEqualTo(10L);
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/16405")
+  void shouldCleanupKeysEvenWithSameTimestamps() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 10L);
+
+    // when
+    cache.cleanup(11L);
+
+    // when - then
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldRemovePair() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+
+    // when
+    cache.remove(1L);
+
+    // then
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldCleanupExpiredEntries() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 20L);
+    cache.store(3L, 30L);
+
+    // when
+    cache.cleanup(21L);
+
+    // then - assert we can still find the non expired key, then once removed, the cache is empty
+    assertThat(cache.remove(3L)).isEqualTo(30L);
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldClearCache() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 20L);
+    cache.store(3L, 30L);
+
+    // when
+    cache.clear();
+
+    // then
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldEvictOldestKeyOnCapacityReached() {
+    // given
+    final var cache = new TtlKeyCache(3);
+    cache.store(1L, 10L);
+    cache.store(2L, 20L);
+    cache.store(3L, 30L);
+
+    // when
+    cache.store(4L, 40L);
+
+    // then
+    assertThat(cache.size()).isEqualTo(3);
+    assertThat(cache.remove(1L)).isEqualTo(-1L);
+    assertThat(cache.remove(2L)).isEqualTo(20L);
+    assertThat(cache.remove(3L)).isEqualTo(30L);
+    assertThat(cache.remove(4L)).isEqualTo(40L);
+  }
+}


### PR DESCRIPTION
## Description

It's possible to build state in the metrics exporter if we have process instances or jobs which have the same timestamp creation. This is possible if you create more instances in the same milliseconds, which is possible thanks to call activities and batch processing :)

This PR fixes the issue by keeping track of a list of keys per timestamp, instead of a single value. It also adds a max capacity to the cache as a failsafe, defaulting to 10_000 for now (completely arbitrary number).

## Related issues

closes #16405 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
