### PR TITLE
feat: Introduce `jobKind` property for job type distinction

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.util.EnumSet;
@@ -159,6 +160,7 @@ public final class BpmnJobBehavior {
 
     jobRecord
         .setType(props.getType())
+        .setJobKind(JobKind.BPMN_ELEMENT)
         .setRetries(props.getRetries().intValue())
         .setCustomHeaders(encodedHeaders)
         .setBpmnProcessId(context.getBpmnProcessId())

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobWorkerElementTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -162,6 +163,7 @@ public final class JobWorkerElementTest {
 
     Assertions.assertThat(jobCreated.getValue())
         .hasType("test")
+        .hasJobKind(JobKind.BPMN_ELEMENT)
         .hasRetries(5)
         .hasElementInstanceKey(taskActivated.getKey())
         .hasElementId(taskActivated.getValue().getElementId())

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -91,6 +91,9 @@
                 },
                 "tenantId": {
                   "type": "keyword"
+                },
+                "jobKind": {
+                  "type": "keyword"
                 }
               }
             },

--- a/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -72,6 +72,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "jobKind": {
+              "type": "keyword"
             }
           }
         }

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-batch-template.json
@@ -91,6 +91,9 @@
                 },
                 "tenantId": {
                   "type": "keyword"
+                },
+                "jobKind": {
+                  "type": "keyword"
                 }
               }
             },

--- a/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -72,6 +72,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "jobKind": {
+              "type": "keyword"
             }
           }
         }

--- a/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.PackedProperty;
@@ -20,6 +21,7 @@ import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Map;
@@ -59,13 +61,15 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
       new IntegerProperty("processDefinitionVersion", -1);
   private final LongProperty processDefinitionKeyProp =
       new LongProperty("processDefinitionKey", -1L);
+  private final EnumProperty<JobKind> jobKindProp =
+      new EnumProperty<>("jobKind", JobKind.class, JobKind.BPMN_ELEMENT);
   private final StringProperty elementIdProp = new StringProperty("elementId", EMPTY_STRING);
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
   public JobRecord() {
-    super(18);
+    super(19);
     declareProperty(deadlineProp)
         .declareProperty(timeoutProp)
         .declareProperty(workerProp)
@@ -81,6 +85,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(processDefinitionVersionProp)
         .declareProperty(processDefinitionKeyProp)
         .declareProperty(processInstanceKeyProp)
+        .declareProperty(jobKindProp)
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(tenantIdProp);
@@ -102,6 +107,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     processDefinitionVersionProp.setValue(record.getProcessDefinitionVersion());
     processDefinitionKeyProp.setValue(record.getProcessDefinitionKey());
     processInstanceKeyProp.setValue(record.getProcessInstanceKey());
+    jobKindProp.setValue(record.getJobKind());
     elementIdProp.setValue(record.getElementIdBuffer());
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
@@ -209,6 +215,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
 
   public JobRecord setProcessDefinitionKey(final long processDefinitionKey) {
     processDefinitionKeyProp.setValue(processDefinitionKey);
+    return this;
+  }
+
+  @Override
+  public JobKind getJobKind() {
+    return jobKindProp.getValue();
+  }
+
+  public JobRecord setJobKind(final JobKind jobKind) {
+    jobKindProp.setValue(jobKind);
     return this;
   }
 

--- a/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -635,6 +635,7 @@ final class JsonSerializableToJsonTest {
                 "foo": "bar"
               },
               "retries": 3,
+              "jobKind": "BPMN_ELEMENT",
               "retryBackoff": 1002,
               "recurringTime": 1001,
               "errorMessage": "failed message",
@@ -732,6 +733,7 @@ final class JsonSerializableToJsonTest {
             "foo": "bar"
           },
           "retries": 12,
+          "jobKind": "BPMN_ELEMENT",
           "retryBackoff": 1003,
           "recurringTime": 1004,
           "errorMessage": "failed message",
@@ -764,6 +766,7 @@ final class JsonSerializableToJsonTest {
           "variables": {},
           "worker": "",
           "retries": -1,
+          "jobKind": "BPMN_ELEMENT",
           "retryBackoff": 0,
           "recurringTime": -1,
           "errorMessage": "",
@@ -801,6 +804,7 @@ final class JsonSerializableToJsonTest {
           "timeout": -1,
           "worker": "",
           "retries": -1,
+          "jobKind": "BPMN_ELEMENT",
           "retryBackoff": 0,
           "recurringTime": -1,
           "errorCode": "",

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobKind.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobKind.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+/** Enumerates the kinds of jobs managed by Zeebe */
+public enum JobKind {
+  /**
+   * Represents jobs associated with BPMN elements. These are typically service tasks or any other
+   * BPMN element that can be executed as part of a workflow instance. This is the default type for
+   * backward compatibility and general-purpose tasks.
+   */
+  BPMN_ELEMENT,
+
+  /**
+   * Represents jobs specifically created for execution listeners. These jobs are triggered by the
+   * workflow engine in response to execution events in the BPMN process, such as starting or
+   * completing a task or an entire process.
+   */
+  EXECUTION_LISTENER,
+
+  /**
+   * Represents jobs created for task listeners. These jobs are associated with specific lifecycle
+   * events of BPMN tasks, such as task creation, assignment, or completion. Task listeners allow
+   * for custom logic to be executed in response to these events.
+   */
+  TASK_LISTENER
+}

--- a/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -113,4 +113,9 @@ public interface JobRecordValue
    * @return the process key of the corresponding process definition
    */
   long getProcessDefinitionKey();
+
+  /**
+   * @return the job kind indicating the specific category of the job
+   */
+  JobKind getJobKind();
 }

--- a/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -150,7 +150,7 @@ public class CompactRecordLogger {
     multiPartition = isMultiPartition();
     hasTimerEvents = records.stream().anyMatch(r -> r.getValueType() == ValueType.TIMER);
 
-    final var highestPosition = this.records.get(this.records.size() - 1).getPosition();
+    final var highestPosition = this.records.getLast().getPosition();
 
     int digits = 0;
     long num = highestPosition;
@@ -423,6 +423,10 @@ public class CompactRecordLogger {
           .append(value.getType())
           .append("\"")
           .append(summarizeElementInformation(value.getElementId(), value.getElementInstanceKey()));
+    }
+
+    if (value.getJobKind() != null) {
+      result.append(" (").append(value.getJobKind()).append("),");
     }
 
     result.append(" ").append(value.getRetries()).append(" retries,");


### PR DESCRIPTION
## Description:
This PR introduces a new `jobKind` property to the `JobRecordValue` and `JobRecord` classes within the Zeebe workflow engine. The addition of the `jobKind` property, an Enum comprising `BPMN_ELEMENT`, `EXECUTION_LISTENER`, and `TASK_LISTENER`, enables the Zeebe engine to distinguish between different types of jobs.

### Key Changes:
- Added the `jobKind` property to `JobRecordValue` and `JobRecord` as an Enum.
- Updated the `BpmnJobBehavior` class to set `jobKind` to BPMN_ELEMENT by default for all jobs, ensuring backward compatibility.
- Modified Elasticsearch/OpenSearch exporter configuration files to include the new `jobKind` property.

## Related issues

closes #16208

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
