### PR TITLE
fix: check state version for compatibility

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -94,24 +94,22 @@ public class DbMigratorImpl implements DbMigrator {
     LOGGER.info(
         "Starting processing of migration tasks (use LogLevel.DEBUG for more details) ... ");
     LOGGER.debug(
-        "Found "
-            + migrationTasks.size()
-            + " migration tasks: "
-            + migrationTasks.stream()
-                .map(MigrationTask::getIdentifier)
-                .collect(Collectors.joining(", ")));
+        "Found {} migration tasks: {}",
+        migrationTasks.size(),
+        migrationTasks.stream()
+            .map(MigrationTask::getIdentifier)
+            .collect(Collectors.joining(", ")));
   }
 
   private void logSummary(final List<MigrationTask> migrationTasks) {
     LOGGER.info(
         "Completed processing of migration tasks (use LogLevel.DEBUG for more details) ... ");
     LOGGER.debug(
-        "Executed "
-            + migrationTasks.size()
-            + " migration tasks: "
-            + migrationTasks.stream()
-                .map(MigrationTask::getIdentifier)
-                .collect(Collectors.joining(", ")));
+        "Executed {} migration tasks: {}",
+        migrationTasks.size(),
+        migrationTasks.stream()
+            .map(MigrationTask::getIdentifier)
+            .collect(Collectors.joining(", ")));
   }
 
   private boolean handleMigrationTask(
@@ -128,24 +126,19 @@ public class DbMigratorImpl implements DbMigrator {
   private void logMigrationSkipped(
       final MigrationTask migrationTask, final int index, final int total) {
     LOGGER.info(
-        "Skipping "
-            + migrationTask.getIdentifier()
-            + " migration ("
-            + index
-            + "/"
-            + total
-            + ").  It was determined it does not need to run right now.");
+        "Skipping {} migration ({}/{}).  It was determined it does not need to run right now.",
+        migrationTask.getIdentifier(),
+        index,
+        total);
   }
 
   private void runMigration(final MigrationTask migrationTask, final int index, final int total) {
-    LOGGER.info(
-        "Starting " + migrationTask.getIdentifier() + " migration (" + index + "/" + total + ")");
+    LOGGER.info("Starting {} migration ({}/{})", migrationTask.getIdentifier(), index, total);
     final var startTime = System.currentTimeMillis();
     migrationTask.runMigration(processingState);
     final var duration = System.currentTimeMillis() - startTime;
 
-    LOGGER.debug(migrationTask.getIdentifier() + " migration completed in " + duration + " ms.");
-    LOGGER.info(
-        "Finished " + migrationTask.getIdentifier() + " migration (" + index + "/" + total + ")");
+    LOGGER.debug("{} migration completed in {} ms.", migrationTask.getIdentifier(), duration);
+    LOGGER.info("Finished {} migration ({}/{})", migrationTask.getIdentifier(), index, total);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -128,6 +128,20 @@ public class DbMigratorImpl implements DbMigrator {
           "Snapshot from version %s is not compatible with current version %s"
               .formatted(migratedByVersion, currentVersion));
     }
+
+    if (migratedSemanticVersion.get().major() != currentSemanticVersion.get().major()) {
+      throw new IllegalStateException(
+          "Snapshot from version %s is not compatible with current version %s, upgrades between major versions are not supported"
+              .formatted(migratedByVersion, currentVersion));
+    }
+
+    if (currentSemanticVersion.get().minor() - migratedSemanticVersion.get().minor() > 1) {
+      final var requiredVersion =
+          migratedSemanticVersion.get().major() + "." + (migratedSemanticVersion.get().minor() - 1);
+      throw new IllegalStateException(
+          "Snapshot from version %s is not compatible with current version %s, must be %s or newer."
+              .formatted(migratedByVersion, currentVersion, requiredVersion));
+    }
   }
 
   private void markMigrationsAsCompleted() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -101,6 +101,9 @@ public class DbMigratorImpl implements DbMigrator {
       case final Indeterminate indeterminate ->
           LOGGER.warn(
               "Could not check compatibility of snapshot with current version: {}", indeterminate);
+      case final Incompatible.UseOfPreReleaseVersion preRelease ->
+          throw new IllegalStateException(
+              "Cannot upgrade to or from a pre-release version: %s".formatted(preRelease));
       case final Incompatible incompatible ->
           throw new IllegalStateException(
               "Snapshot is not compatible with current version: %s".formatted(incompatible));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheck.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.engine.state.migration;
 
 import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Compatible;
 import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
-import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Incompatible.UseOfPreReleaseVersion;
 import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
 import io.camunda.zeebe.util.SemanticVersion;
 
@@ -56,7 +55,7 @@ final class VersionCompatibilityCheck {
     if (previous.compareTo(current) == 0) {
       return new Compatible.SameVersion(current);
     } else if (previous.preRelease() != null || current.preRelease() != null) {
-      return new UseOfPreReleaseVersion(previous, current);
+      return new Incompatible.UseOfPreReleaseVersion(previous, current);
     } else if (previous.compareTo(current) > 0) {
       if (previous.major() > current.major()) {
         return new Incompatible.MajorDowngrade(previous, current);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheck.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheck.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import io.camunda.zeebe.util.SemanticVersion;
+
+/** Checks the compatibility of the current version with the version that ran state migrations. */
+final class VersionCompatibilityCheck {
+  private VersionCompatibilityCheck() {}
+
+  /**
+   * Checks the compatibility of the current version with the previous Version
+   *
+   * @param previousVersion a string representation of the previous version or null if unknown
+   * @param currentVersion a string representation of the current version or null if unknown
+   * @return a tri-state object indicating the compatibility of the versions:
+   *     <ul>
+   *       <li>{@link Indeterminate} if either of the versions are not available or version is not a
+   *           valid semantic version.
+   *       <li>{@link Incompatible} if the current version is not compatible with the previous
+   *           version, e.g. a downgrade or a skipped minor version.
+   *       <li>{@link Compatible} if the current version is compatible with the previous version,
+   *           e.g. upgrade to the next minor version.
+   */
+  public static CheckResult check(final String previousVersion, final String currentVersion) {
+    if (previousVersion == null) {
+      return new Indeterminate.PreviousVersionUnknown(currentVersion);
+    }
+    if (currentVersion == null) {
+      return new Indeterminate.CurrentVersionUnknown(previousVersion);
+    }
+
+    final var parsedPreviousVersion = SemanticVersion.parse(previousVersion);
+    final var parsedCurrentVersion = SemanticVersion.parse(currentVersion);
+
+    if (parsedPreviousVersion.isEmpty()) {
+      return new Indeterminate.PreviousVersionInvalid(previousVersion, currentVersion);
+    }
+
+    if (parsedCurrentVersion.isEmpty()) {
+      return new Indeterminate.CurrentVersionInvalid(previousVersion, currentVersion);
+    }
+
+    final var previous = parsedPreviousVersion.get();
+    final var current = parsedCurrentVersion.get();
+
+    if (previous.compareTo(current) == 0) {
+      return new Compatible.SameVersion(current);
+    } else if (previous.compareTo(current) > 0) {
+      if (previous.major() > current.major()) {
+        return new Incompatible.MajorDowngrade(previous, current);
+      } else if (previous.minor() > current.minor()) {
+        return new Incompatible.MinorDowngrade(previous, current);
+      } else if (previous.patch() > current.patch()) {
+        return new Incompatible.PatchDowngrade(previous, current);
+      } else {
+        return new Incompatible.PreReleaseDowngrade(previous, current);
+      }
+    } else {
+      if (previous.major() < current.major()) {
+        return new Incompatible.MajorUpgrade(previous, current);
+      } else if (previous.minor() - current.minor() < -1) {
+        return new Incompatible.SkippedMinorVersion(previous, current);
+      } else if (previous.minor() < current.minor()) {
+        return new Compatible.MinorUpgrade(previous, current);
+      } else if (previous.patch() < current.patch()) {
+        return new Compatible.PatchUpgrade(previous, current);
+      } else {
+        return new Compatible.PreReleaseUpgrade(previous, current);
+      }
+    }
+  }
+
+  sealed interface CheckResult {
+    sealed interface Indeterminate extends CheckResult {
+      record PreviousVersionUnknown(String currentVersion) implements Indeterminate {}
+
+      record CurrentVersionUnknown(String previousVersion) implements Indeterminate {}
+
+      record PreviousVersionInvalid(String previousVersion, String currentVersion)
+          implements Indeterminate {}
+
+      record CurrentVersionInvalid(String previousVersion, String currentVersion)
+          implements Indeterminate {}
+    }
+
+    sealed interface Incompatible extends CheckResult {
+      record MajorUpgrade(SemanticVersion from, SemanticVersion to) implements Incompatible {}
+
+      record SkippedMinorVersion(SemanticVersion from, SemanticVersion to)
+          implements Incompatible {}
+
+      record PreReleaseDowngrade(SemanticVersion from, SemanticVersion to)
+          implements Incompatible {}
+
+      record PatchDowngrade(SemanticVersion from, SemanticVersion to) implements Incompatible {}
+
+      record MinorDowngrade(SemanticVersion from, SemanticVersion to) implements Incompatible {}
+
+      record MajorDowngrade(SemanticVersion from, SemanticVersion to) implements Incompatible {}
+    }
+
+    sealed interface Compatible extends CheckResult {
+      record SameVersion(SemanticVersion version) implements Compatible {}
+
+      record PreReleaseUpgrade(SemanticVersion from, SemanticVersion to) implements Compatible {}
+
+      record PatchUpgrade(SemanticVersion from, SemanticVersion to) implements Compatible {}
+
+      record MinorUpgrade(SemanticVersion from, SemanticVersion to) implements Compatible {}
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
@@ -34,8 +34,11 @@ final class VersionCompatibilityCheckTest {
     @Test
     public void shouldRejectChangeOfPreRelease() {
       assertThat(check("8.0.0-alpha1", "8.0.0-alpha2")).isInstanceOf(UseOfPreReleaseVersion.class);
-      assertThat(check("8.1.0-alpha1", "8.0.0-beta1")).isInstanceOf(UseOfPreReleaseVersion.class);
-      assertThat(check("8.0.1-beta1", "8.0.2-rc1")).isInstanceOf(UseOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-alpha1", "8.0.0-beta1")).isInstanceOf(UseOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-beta1", "8.0.0-rc1")).isInstanceOf(UseOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-rc1", "8.0.0")).isInstanceOf(UseOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-alpha1", "8.1.0")).isInstanceOf(UseOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-alpha2", "8.0.1")).isInstanceOf(UseOfPreReleaseVersion.class);
     }
 
     @Test
@@ -44,6 +47,10 @@ final class VersionCompatibilityCheckTest {
       assertThat(check("8.0.0-alpha1", "8.0.1")).isInstanceOf(UseOfPreReleaseVersion.class);
       assertThat(check("8.0.0-beta1", "8.0.1")).isInstanceOf(UseOfPreReleaseVersion.class);
       assertThat(check("8.0.0-rc1", "8.1.0")).isInstanceOf(UseOfPreReleaseVersion.class);
+      assertThat(check("8.5.3", "8.5.3-alpha1"))
+          .isInstanceOf(Incompatible.UseOfPreReleaseVersion.class);
+      assertThat(check("8.1.0", "8.1.0-alpha1"))
+          .isInstanceOf(Incompatible.UseOfPreReleaseVersion.class);
     }
 
     @Test
@@ -54,20 +61,6 @@ final class VersionCompatibilityCheckTest {
       assertThat(check("8.5.0", "8.4.1")).isInstanceOf(Incompatible.MinorDowngrade.class);
       assertThat(check("8.5.3", "8.5.2")).isInstanceOf(Incompatible.PatchDowngrade.class);
       assertThat(check("8.5.3", "8.5.0")).isInstanceOf(Incompatible.PatchDowngrade.class);
-      assertThat(check("8.5.3", "8.5.3-alpha1"))
-          .isInstanceOf(Incompatible.UseOfPreReleaseVersion.class);
-      assertThat(check("8.1.0", "8.1.0-alpha1"))
-          .isInstanceOf(Incompatible.UseOfPreReleaseVersion.class);
-    }
-
-    @Test
-    public void shouldRejectChangeOfPreReleaseVersion() {
-      assertThat(check("8.0.0-alpha1", "8.0.0-alpha2")).isInstanceOf(UseOfPreReleaseVersion.class);
-      assertThat(check("8.0.0-alpha1", "8.0.0-beta1")).isInstanceOf(UseOfPreReleaseVersion.class);
-      assertThat(check("8.0.0-beta1", "8.0.0-rc1")).isInstanceOf(UseOfPreReleaseVersion.class);
-      assertThat(check("8.0.0-rc1", "8.0.0")).isInstanceOf(UseOfPreReleaseVersion.class);
-      assertThat(check("8.0.0-alpha1", "8.1.0")).isInstanceOf(UseOfPreReleaseVersion.class);
-      assertThat(check("8.0.0-alpha2", "8.0.1")).isInstanceOf(UseOfPreReleaseVersion.class);
     }
 
     @Test
@@ -105,12 +98,14 @@ final class VersionCompatibilityCheckTest {
     void shouldAcceptPatchUpgrades() {
       assertThat(check("8.0.0", "8.0.1")).isInstanceOf(Compatible.PatchUpgrade.class);
       assertThat(check("8.1.4", "8.1.5")).isInstanceOf(Compatible.PatchUpgrade.class);
+      assertThat(check("8.1.4", "8.1.8")).isInstanceOf(Compatible.PatchUpgrade.class);
     }
 
     @Test
     void shouldAcceptMinorUpgrades() {
       assertThat(check("8.0.0", "8.1.0")).isInstanceOf(Compatible.MinorUpgrade.class);
       assertThat(check("8.1.3", "8.2.0")).isInstanceOf(Compatible.MinorUpgrade.class);
+      assertThat(check("8.1.3", "8.2.5")).isInstanceOf(Compatible.MinorUpgrade.class);
     }
 
     @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.migration;
+
+import static io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.check;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Compatible;
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class VersionCompatibilityCheckTest {
+
+  @Nested
+  final class IncompatibleResults {
+
+    @Test
+    public void shouldRejectDowngrades() {
+      assertThat(check("9.0.0", "8.0.0")).isInstanceOf(Incompatible.MajorDowngrade.class);
+      assertThat(check("9.0.0", "8.1.0")).isInstanceOf(Incompatible.MajorDowngrade.class);
+      assertThat(check("8.5.0", "8.4.0")).isInstanceOf(Incompatible.MinorDowngrade.class);
+      assertThat(check("8.5.0", "8.4.1")).isInstanceOf(Incompatible.MinorDowngrade.class);
+      assertThat(check("8.5.3", "8.5.2")).isInstanceOf(Incompatible.PatchDowngrade.class);
+      assertThat(check("8.5.3", "8.5.0")).isInstanceOf(Incompatible.PatchDowngrade.class);
+      assertThat(check("8.5.3-alpha2", "8.5.3-alpha1"))
+          .isInstanceOf(Incompatible.PreReleaseDowngrade.class);
+    }
+
+    @Test
+    public void shouldRejectMajorUpgrades() {
+      assertThat(check("8.0.0", "9.0.0")).isInstanceOf(Incompatible.MajorUpgrade.class);
+      assertThat(check("8.1.0", "9.0.0")).isInstanceOf(Incompatible.MajorUpgrade.class);
+    }
+
+    @Test
+    public void shouldRejectSkippedMinorVersions() {
+      assertThat(check("8.0.0", "8.2.0")).isInstanceOf(Incompatible.SkippedMinorVersion.class);
+      assertThat(check("8.0.2", "8.3.0")).isInstanceOf(Incompatible.SkippedMinorVersion.class);
+    }
+  }
+
+  @Nested
+  final class IndeterminateResults {
+    @Test
+    void shouldDetectUnknownVersions() {
+      assertThat(check(null, "8.0.0")).isInstanceOf(Indeterminate.PreviousVersionUnknown.class);
+      assertThat(check("8.0.0", null)).isInstanceOf(Indeterminate.CurrentVersionUnknown.class);
+    }
+
+    @Test
+    void shouldDetectInvalidVersions() {
+      assertThat(check("dev", "1.2.3")).isInstanceOf(Indeterminate.PreviousVersionInvalid.class);
+      assertThat(check("1.2.3", "dev")).isInstanceOf(Indeterminate.CurrentVersionInvalid.class);
+    }
+  }
+
+  @Nested
+  final class CompatibleResults {
+    @Test
+    void shouldAcceptPreReleaseUpgrades() {
+      assertThat(check("8.0.0-alpha1", "8.0.0-alpha2"))
+          .isInstanceOf(Compatible.PreReleaseUpgrade.class);
+      assertThat(check("8.0.0-alpha1", "8.0.0-alpha4"))
+          .isInstanceOf(Compatible.PreReleaseUpgrade.class);
+      assertThat(check("8.0.0-alpha1", "8.0.0-beta1"))
+          .isInstanceOf(Compatible.PreReleaseUpgrade.class);
+    }
+
+    @Test
+    void shouldAcceptPatchUpgrades() {
+      assertThat(check("8.0.0", "8.0.1")).isInstanceOf(Compatible.PatchUpgrade.class);
+      assertThat(check("8.1.4", "8.1.5")).isInstanceOf(Compatible.PatchUpgrade.class);
+    }
+
+    @Test
+    void shouldAcceptMinorUpgrades() {
+      assertThat(check("8.0.0", "8.1.0")).isInstanceOf(Compatible.MinorUpgrade.class);
+      assertThat(check("8.1.3", "8.2.0")).isInstanceOf(Compatible.MinorUpgrade.class);
+    }
+
+    @Test
+    void shouldAcceptSameVersions() {
+      assertThat(check("8.0.0", "8.0.0")).isInstanceOf(Compatible.SameVersion.class);
+      assertThat(check("8.0.0-alpha1", "8.0.0-alpha1")).isInstanceOf(Compatible.SameVersion.class);
+      assertThat(check("8.1.0-alpha1+build123", "8.1.0-alpha1+build234"))
+          .isInstanceOf(Compatible.SameVersion.class);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/VersionCompatibilityCheckTest.java
@@ -32,8 +32,26 @@ final class VersionCompatibilityCheckTest {
       assertThat(check("8.5.0", "8.4.1")).isInstanceOf(Incompatible.MinorDowngrade.class);
       assertThat(check("8.5.3", "8.5.2")).isInstanceOf(Incompatible.PatchDowngrade.class);
       assertThat(check("8.5.3", "8.5.0")).isInstanceOf(Incompatible.PatchDowngrade.class);
-      assertThat(check("8.5.3-alpha2", "8.5.3-alpha1"))
+      assertThat(check("8.5.3", "8.5.3-alpha1"))
           .isInstanceOf(Incompatible.PreReleaseDowngrade.class);
+      assertThat(check("8.1.0", "8.1.0-alpha1"))
+          .isInstanceOf(Incompatible.PreReleaseDowngrade.class);
+    }
+
+    @Test
+    public void shouldRejectChangeOfPreReleaseVersion() {
+      assertThat(check("8.0.0-alpha1", "8.0.0-alpha2"))
+          .isInstanceOf(Incompatible.ChangeOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-alpha1", "8.0.0-beta1"))
+          .isInstanceOf(Incompatible.ChangeOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-beta1", "8.0.0-rc1"))
+          .isInstanceOf(Incompatible.ChangeOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-rc1", "8.0.0"))
+          .isInstanceOf(Incompatible.ChangeOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-alpha1", "8.1.0"))
+          .isInstanceOf(Incompatible.ChangeOfPreReleaseVersion.class);
+      assertThat(check("8.0.0-alpha2", "8.0.1"))
+          .isInstanceOf(Incompatible.ChangeOfPreReleaseVersion.class);
     }
 
     @Test
@@ -66,15 +84,6 @@ final class VersionCompatibilityCheckTest {
 
   @Nested
   final class CompatibleResults {
-    @Test
-    void shouldAcceptPreReleaseUpgrades() {
-      assertThat(check("8.0.0-alpha1", "8.0.0-alpha2"))
-          .isInstanceOf(Compatible.PreReleaseUpgrade.class);
-      assertThat(check("8.0.0-alpha1", "8.0.0-alpha4"))
-          .isInstanceOf(Compatible.PreReleaseUpgrade.class);
-      assertThat(check("8.0.0-alpha1", "8.0.0-beta1"))
-          .isInstanceOf(Compatible.PreReleaseUpgrade.class);
-    }
 
     @Test
     void shouldAcceptPatchUpgrades() {
@@ -94,6 +103,13 @@ final class VersionCompatibilityCheckTest {
       assertThat(check("8.0.0-alpha1", "8.0.0-alpha1")).isInstanceOf(Compatible.SameVersion.class);
       assertThat(check("8.1.0-alpha1+build123", "8.1.0-alpha1+build234"))
           .isInstanceOf(Compatible.SameVersion.class);
+    }
+
+    @Test
+    void shouldAcceptUpgradeToPreReleaseVersions() {
+      assertThat(check("8.0.0", "8.0.1-alpha1")).isInstanceOf(Compatible.PatchUpgrade.class);
+      assertThat(check("8.0.0", "8.1.0-beta1")).isInstanceOf(Compatible.MinorUpgrade.class);
+      assertThat(check("8.1.2", "8.2.3-rc1")).isInstanceOf(Compatible.MinorUpgrade.class);
     }
   }
 }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import static org.apache.commons.lang3.StringUtils.isNumeric;
+
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * A semantic version as specified by <a href="https://semver.org/">Semantic Versioning 2.0.0</a>.
+ *
+ * <p>Note that the implementation of {@link Comparable} is not consistent with {@link
+ * Object#equals(Object)} because SemVer does not consider build metadata when comparing versions.
+ */
+public record SemanticVersion(
+    int major, int minor, int patch, String preRelease, String buildMetadata)
+    implements Comparable<SemanticVersion> {
+  /**
+   * @see <a
+   *     href="https://semver.org/spec/v2.0.0.html#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string">
+   *     Suggested Regex to parse SemVer </a>
+   */
+  private static final Pattern PATTERN =
+      Pattern.compile(
+          """
+              ^(?<major>0|[1-9]\\d*)\
+              \\.(?<minor>0|[1-9]\\d*)\
+              \\.(?<patch>0|[1-9]\\d*)\
+              (?:-(?<preRelease>(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?\
+              (?:\\+(?<buildMetadata>[0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$""");
+
+  public SemanticVersion {
+    if (major < 0) {
+      throw new IllegalArgumentException("Major version must be non-negative");
+    }
+    if (minor < 0) {
+      throw new IllegalArgumentException("Minor version must be non-negative");
+    }
+    if (patch < 0) {
+      throw new IllegalArgumentException("Patch version must be non-negative");
+    }
+  }
+
+  public static Optional<SemanticVersion> parse(final String version) {
+    if (version == null) {
+      return Optional.empty();
+    }
+
+    final var matcher = PATTERN.matcher(version);
+    if (matcher.matches()) {
+      final var major = Integer.parseInt(matcher.group("major"));
+      final var minor = Integer.parseInt(matcher.group("minor"));
+      final var patch = Integer.parseInt(matcher.group("patch"));
+      final var preRelease = matcher.group("preRelease");
+      final var buildMetadata = matcher.group("buildMetadata");
+      return Optional.of(new SemanticVersion(major, minor, patch, preRelease, buildMetadata));
+    }
+    return Optional.empty();
+  }
+
+  @Override
+  public int compareTo(final SemanticVersion other) {
+    // Precedence is determined by the first difference when comparing each of these identifiers
+    // from left to right as follows: Major, minor, and patch versions are always compared
+    // numerically.
+    if (major != other.major) {
+      return Integer.compare(major, other.major);
+    }
+    if (minor != other.minor) {
+      return Integer.compare(minor, other.minor);
+    }
+    if (patch != other.patch) {
+      return Integer.compare(patch, other.patch);
+    }
+    return comparePreRelease(other);
+  }
+
+  private int comparePreRelease(final SemanticVersion other) {
+    if (preRelease == null && other.preRelease == null) {
+      return 0;
+    } else if (preRelease != null && other.preRelease == null) {
+      // A pre-release version has lower precedence than a normal version
+      return -1;
+    } else //noinspection ConstantValue -- makes this more readable
+    if (preRelease == null && other.preRelease != null) {
+      return 1;
+    }
+
+    final var preReleaseParts = preRelease.split("\\.");
+    final var otherPreReleaseParts = other.preRelease.split("\\.");
+
+    // Precedence for two pre-release versions with the same major, minor, and patch version MUST be
+    // determined by comparing each dot separated identifier from left to right until a difference
+    // is found.
+
+    for (int i = 0; i < Math.min(preReleaseParts.length, otherPreReleaseParts.length); i++) {
+      final var thisPart = preReleaseParts[i];
+      final var otherPart = otherPreReleaseParts[i];
+
+      if (isNumeric(thisPart) && isNumeric(otherPart)) {
+        // Identifiers consisting of only digits are compared numerically.
+        final var thisNumericPart = Integer.parseInt(thisPart);
+        final var otherNumericPart = Integer.parseInt(otherPart);
+        if (thisNumericPart != otherNumericPart) {
+          return Integer.compare(thisNumericPart, otherNumericPart);
+        }
+      } else if (isNumeric(thisPart)) {
+        // Numeric identifiers always have lower precedence than non-numeric identifiers.
+        return -1;
+      } else if (isNumeric(otherPart)) {
+        return 1;
+      } else {
+        // Identifiers with letters or hyphens are compared lexically in ASCII sort order.
+        final var comparison = thisPart.compareTo(otherPart);
+        if (comparison != 0) {
+          return comparison;
+        }
+      }
+    }
+
+    return Integer.compare(preReleaseParts.length, otherPreReleaseParts.length);
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/VersionUtil.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 import java.util.Properties;
 import org.slf4j.Logger;
 
@@ -47,6 +48,13 @@ public final class VersionUtil {
     return version;
   }
 
+  /**
+   * @return the current version if it can be parsed as a semantic version, otherwise empty.
+   */
+  public static Optional<SemanticVersion> getSemanticVersion() {
+    return SemanticVersion.parse(getVersion());
+  }
+
   public static String getVersionLowerCase() {
     if (versionLowerCase == null) {
       versionLowerCase = getVersion().toLowerCase();
@@ -66,13 +74,13 @@ public final class VersionUtil {
   }
 
   private static String readProperty(final String property) {
-    try (InputStream lastVersionFileStream =
+    try (final InputStream lastVersionFileStream =
         VersionUtil.class.getResourceAsStream(VERSION_PROPERTIES_PATH)) {
       final Properties props = new Properties();
       props.load(lastVersionFileStream);
 
       return props.getProperty(property);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOG.error(String.format("Can't read version file: %s", VERSION_PROPERTIES_PATH), e);
     }
 

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/SemanticVersionTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+final class SemanticVersionTest {
+  @Test
+  void shouldParseCurrentVersion() {
+    assertThat(SemanticVersion.parse(VersionUtil.getVersion())).isPresent();
+  }
+
+  @Test
+  void shouldParseBasicSemanticVersions() {
+    assertThat(SemanticVersion.parse("1.2.3")).contains(new SemanticVersion(1, 2, 3, null, null));
+    assertThat(SemanticVersion.parse("0.0.0")).contains(new SemanticVersion(0, 0, 0, null, null));
+    assertThat(SemanticVersion.parse("10.20.30"))
+        .contains(new SemanticVersion(10, 20, 30, null, null));
+  }
+
+  @Test
+  void shouldParseVersionsWithPreRelease() {
+    assertThat(SemanticVersion.parse("1.2.3-alpha"))
+        .contains(new SemanticVersion(1, 2, 3, "alpha", null));
+    assertThat(SemanticVersion.parse("1.2.3-beta"))
+        .contains(new SemanticVersion(1, 2, 3, "beta", null));
+    assertThat(SemanticVersion.parse("1.2.3-rc"))
+        .contains(new SemanticVersion(1, 2, 3, "rc", null));
+    assertThat(SemanticVersion.parse("1.2.3-SNAPSHOT"))
+        .contains(new SemanticVersion(1, 2, 3, "SNAPSHOT", null));
+  }
+
+  @Test
+  void shouldParseVersionsWithBuildMetadata() {
+    assertThat(SemanticVersion.parse("1.2.3+build"))
+        .contains(new SemanticVersion(1, 2, 3, null, "build"));
+    assertThat(SemanticVersion.parse("1.2.3+build.1"))
+        .contains(new SemanticVersion(1, 2, 3, null, "build.1"));
+    assertThat(SemanticVersion.parse("1.2.3+build.1.2"))
+        .contains(new SemanticVersion(1, 2, 3, null, "build.1.2"));
+  }
+
+  @Test
+  void shouldParseVersionsWithPreReleaseAndBuildMetadata() {
+    assertThat(SemanticVersion.parse("1.2.3-alpha+build"))
+        .contains(new SemanticVersion(1, 2, 3, "alpha", "build"));
+    assertThat(SemanticVersion.parse("1.2.3-alpha+build.1"))
+        .contains(new SemanticVersion(1, 2, 3, "alpha", "build.1"));
+    assertThat(SemanticVersion.parse("1.2.3-alpha+build.1.2"))
+        .contains(new SemanticVersion(1, 2, 3, "alpha", "build.1.2"));
+  }
+
+  @Test
+  void shouldCompareBasicVersions() {
+    assertThat(new SemanticVersion(1, 2, 3, null, null))
+        .isLessThan(new SemanticVersion(1, 2, 4, null, null))
+        .isLessThan(new SemanticVersion(1, 3, 7, null, null))
+        .isLessThan(new SemanticVersion(2, 4, 0, null, null));
+  }
+
+  @Test
+  void shouldCompareVersionsWithPreRelease() {
+    assertThat(new SemanticVersion(1, 2, 3, "alpha", null))
+        .isLessThan(new SemanticVersion(1, 2, 3, "alpha.1", null))
+        .isLessThan(new SemanticVersion(1, 2, 3, "alpha.beta", null))
+        .isLessThan(new SemanticVersion(1, 2, 3, "beta", null))
+        .isLessThan(new SemanticVersion(1, 2, 3, "beta.2", null))
+        .isLessThan(new SemanticVersion(1, 2, 3, "beta.11", null))
+        .isLessThan(new SemanticVersion(1, 2, 3, "rc.1", null))
+        .isLessThan(new SemanticVersion(1, 2, 3, null, null));
+  }
+
+  @Test
+  void shouldCompareVersionsWithBuildMetadata() {
+    assertThat(new SemanticVersion(1, 0, 0, "alpha", "build.1"))
+        .isEqualByComparingTo(new SemanticVersion(1, 0, 0, "alpha", "build.2"));
+  }
+}


### PR DESCRIPTION
This adds a check before running migrations to evaluate whether the current runtime state, as recovered from a snapshot, is compatible with the current broker version.

The rules are neatly contained in `VersionCompatibilityCheck` and are the following:
**Compatible**
1. Same version
3. Upgrade of patch version
4. Upgrade to the _next_ minor version

**Incompatible**
1. Upgrade of major version
2. Skipping a minor version
3. Downgrade of any version component
4. Migration to or from a pre-release version

**Indeterminate**
1. Previous or current version is not known
2. Previous or current version is not compliant with SemVer.

The result of this check is then handled here: https://github.com/camunda/zeebe/blob/0a2e5d533e78f7265224dc6341c09220be7750e5/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java#L93-L112

We obviously allow compatible results but also allow indeterminate results. This is necessary to allow the upgrade from 8.4 to 8.5 where 8.4 did not yet write a version. This also allows the check to pass during development where we might not always have a SemVer compliant broker version.

If the versions are found to be incompatible, we throw an `IllegalStateException` which breaks the transition and prevents the broker from working on this partition. To recover, we require either a different snapshot or a broker version upgrade.

To implement the version comparisons, I've included a small utility for parsing versions according to [SemVer 2.0
](https://semver.org/spec/v2.0.0.html): `SemanticVersion`. This class has some overlap with the previously existing `Version` class in Atomix. I've decided to not remove this class because it is not SemVer 2.0 compliant and we rely on it for SWIM and to detect upgrades from 8.3 to 8.4. I did not want to break this in any way so I decided that another class that has slightly different (but standard compliant!) rules would be safer.

Closes https://github.com/camunda/zeebe/issues/15885