### PR TITLE
[forwardport stable/8.4] Allow decision requirements in column family 49

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_4/corrections/ColumnFamily49Corrector.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/migration/to_8_4/corrections/ColumnFamily49Corrector.java
@@ -12,8 +12,10 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.db.impl.DbBytes;
 import io.camunda.zeebe.db.impl.DbCompositeKey;
+import io.camunda.zeebe.db.impl.DbInt;
 import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbNil;
+import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.ZeebeDbConstants;
 import io.camunda.zeebe.engine.state.migration.DbMigratorImpl;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
@@ -49,6 +51,8 @@ public class ColumnFamily49Corrector {
   private final DbLong processDefinitionKey;
   private final DbLong elementInstanceKey;
 
+  private final DbCompositeKey<DbString, DbInt> decisionRequirementsIdAndVersion;
+
   public ColumnFamily49Corrector(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
     recoverColumnFamily =
@@ -65,6 +69,11 @@ public class ColumnFamily49Corrector {
             transactionContext,
             processInstanceKeyByProcessDefinitionKey,
             DbNil.INSTANCE);
+
+    final var dbDecisionRequirementsId = new DbString();
+    final var dbDecisionRequirementsVersion = new DbInt();
+    decisionRequirementsIdAndVersion =
+        new DbCompositeKey<>(dbDecisionRequirementsId, dbDecisionRequirementsVersion);
   }
 
   public void correctColumnFamilyPrefix() {
@@ -84,8 +93,7 @@ public class ColumnFamily49Corrector {
           try {
             // so it appears the key fits the expected length, let's try to read it to ensure it
             // is a decision requirement id and version
-            processInstanceKeyByProcessDefinitionKey.wrap(
-                key.getDirectBuffer(), 0, key.getLength());
+            decisionRequirementsIdAndVersion.wrap(key.getDirectBuffer(), 0, key.getLength());
           } catch (final Exception e) {
             LOG.trace(
                 "Found invalid key [{}] (unable to read key) in column family [{}] {}",

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
@@ -298,6 +298,22 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       Assertions.assertThat(
               correctPiKeyByProcDefKeyColumnFamily.exists(processInstanceKeyByProcessDefinitionKey))
           .isTrue();
+
+      decisionRequirementsId.wrapString("drg");
+      decisionRequirementsVersion.wrapInt(1);
+      Assertions.assertThat(
+              correctDecisionRequirementsKeyColumnFamily.get(decisionRequirementsIdAndVersion))
+          .isNotNull()
+          .extracting(DbLong::getValue)
+          .isEqualTo(543L);
+
+      decisionRequirementsId.wrapString("drg2");
+      decisionRequirementsVersion.wrapInt(2);
+      Assertions.assertThat(
+              correctDecisionRequirementsKeyColumnFamily.get(decisionRequirementsIdAndVersion))
+          .isNotNull()
+          .extracting(DbLong::getValue)
+          .isEqualTo(987L);
     }
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_4/ColumnFamilyPrefixCorrectionMigrationTest.java
@@ -265,7 +265,7 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
     @Test
     void shouldIgnoreProcessInstanceKeyByDefinitionKeyEntries() {
       // given
-      decisionRequirementsId.wrapString("decisionRequirements");
+      decisionRequirementsId.wrapString("drg");
       decisionRequirementsVersion.wrapInt(1);
       decisionRequirementsKey.wrapLong(543);
       correctDecisionRequirementsKeyColumnFamily.insert(
@@ -276,7 +276,7 @@ public class ColumnFamilyPrefixCorrectionMigrationTest {
       wrongPiKeyByProcDefKeyColumnFamily.insert(
           processInstanceKeyByProcessDefinitionKey, DbNil.INSTANCE);
 
-      decisionRequirementsId.wrapString("decisionRequirements2");
+      decisionRequirementsId.wrapString("drg2");
       decisionRequirementsVersion.wrapInt(2);
       decisionRequirementsKey.wrapLong(987);
       correctDecisionRequirementsKeyColumnFamily.insert(


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Backports #16411 to `stable/8.4`.

I had to resolve a few conflicts manually, but nothing major. I did not need the two commits related to the `count` method, as this already exists (and is used) on 8.4 (same as on 8.3). The main changes are exactly the same.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16406

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
