### PR TITLE
Allow any broker to become the coordinator to handle cluster topology requests

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/TopologyServices.java
@@ -9,11 +9,11 @@ package io.camunda.zeebe.broker;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.ClusterMembershipService;
-import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.topology.api.TopologyCoordinatorSupplier.ClusterTopologyAwareCoordinatorSupplier;
 import io.camunda.zeebe.topology.api.TopologyManagementRequestSender;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,8 +44,11 @@ public class TopologyServices {
   }
 
   @Bean
-  TopologyManagementRequestSender topologyManagementRequestSender() {
+  TopologyManagementRequestSender topologyManagementRequestSender(
+      final BrokerTopologyManager brokerTopologyManager) {
     return new TopologyManagementRequestSender(
-        clusterCommunicationService, MemberId.from("0"), new ProtoBufSerializer());
+        clusterCommunicationService,
+        new ClusterTopologyAwareCoordinatorSupplier(brokerTopologyManager::getClusterTopology),
+        new ProtoBufSerializer());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/TopologyServices.java
@@ -9,12 +9,12 @@ package io.camunda.zeebe.gateway;
 
 import io.atomix.cluster.AtomixCluster;
 import io.atomix.cluster.ClusterMembershipService;
-import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.topology.GatewayClusterTopologyService;
+import io.camunda.zeebe.topology.api.TopologyCoordinatorSupplier.ClusterTopologyAwareCoordinatorSupplier;
 import io.camunda.zeebe.topology.api.TopologyManagementRequestSender;
 import io.camunda.zeebe.topology.gossip.ClusterTopologyGossiperConfig;
 import io.camunda.zeebe.topology.serializer.ProtoBufSerializer;
@@ -61,8 +61,11 @@ public class TopologyServices {
   }
 
   @Bean
-  TopologyManagementRequestSender topologyManagementRequestSender() {
+  TopologyManagementRequestSender topologyManagementRequestSender(
+      final BrokerTopologyManager brokerTopologyManager) {
     return new TopologyManagementRequestSender(
-        clusterCommunicationService, MemberId.from("0"), new ProtoBufSerializer());
+        clusterCommunicationService,
+        new ClusterTopologyAwareCoordinatorSupplier(brokerTopologyManager::getClusterTopology),
+        new ProtoBufSerializer());
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManager.java
@@ -9,10 +9,22 @@ package io.camunda.zeebe.broker.client.api;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.TopologyUpdateNotifier.TopologyUpdateListener;
+import io.camunda.zeebe.topology.state.ClusterTopology;
 
 public interface BrokerTopologyManager extends TopologyUpdateListener {
 
+  /**
+   * Returns live topology that includes which brokers are available, who is leader for each
+   * partition, etc.
+   */
   BrokerClusterState getTopology();
+
+  /**
+   * Returns the current cluster topology. The topology contains the information about brokers which
+   * are part of the cluster, and the partition distribution. Unlike {@link BrokerClusterState} this
+   * also includes information about brokers which are currently unreachable.
+   */
+  ClusterTopology getClusterTopology();
 
   /**
    * Adds the topology listener. For each existing brokers, the listener will be notified via {@link

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -31,6 +31,7 @@ public final class BrokerTopologyManagerImpl extends Actor
 
   private static final Logger LOG = LoggerFactory.getLogger(BrokerTopologyManagerImpl.class);
   private volatile BrokerClusterStateImpl topology = new BrokerClusterStateImpl();
+  private volatile ClusterTopology clusterTopology = ClusterTopology.uninitialized();
   private final Supplier<Set<Member>> membersSupplier;
   private final BrokerClientTopologyMetrics topologyMetrics = new BrokerClientTopologyMetrics();
 
@@ -46,6 +47,11 @@ public final class BrokerTopologyManagerImpl extends Actor
   @Override
   public BrokerClusterState getTopology() {
     return topology;
+  }
+
+  @Override
+  public ClusterTopology getClusterTopology() {
+    return clusterTopology;
   }
 
   @Override
@@ -204,6 +210,7 @@ public final class BrokerTopologyManagerImpl extends Actor
     if (clusterTopology.isUninitialized()) {
       return;
     }
+    this.clusterTopology = clusterTopology;
     LOG.debug("Received new cluster topology with clusterSize {}", clusterTopology.clusterSize());
     updateTopology(
         topology -> {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -40,6 +40,11 @@ final class TestTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
+  public ClusterTopology getClusterTopology() {
+    throw new UnsupportedOperationException("not implemented");
+  }
+
+  @Override
   public void addTopologyListener(final BrokerTopologyListener listener) {
     throw new UnsupportedOperationException();
   }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -40,6 +40,11 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
   }
 
   @Override
+  public ClusterTopology getClusterTopology() {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
   public void addTopologyListener(final BrokerTopologyListener listener) {
     throw new UnsupportedOperationException("Not yet implemented; implement if need be");
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertChangeIsPlanned;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@ZeebeIntegration
+@AutoCloseResources
+@Timeout(2 * 60)
+final class TopologyCoordinatorTest {
+  private static final int PARTITIONS_COUNT = 3;
+  private static final int CLUSTER_SIZE = 3;
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          // Use standalone gateway because we will be shutting down some of the brokers
+          // during the test
+          .withGatewaysCount(1)
+          .withEmbeddedGateway(false)
+          .withBrokersCount(CLUSTER_SIZE)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(1)
+          .withGatewayConfig(
+              g ->
+                  g.gatewayConfig()
+                      .getCluster()
+                      .getMembership()
+                      // Decrease the timeouts for fast convergence of gateway topology. When the
+                      // broker is shutdown, the topology update takes at least 10 seconds with the
+                      // default values.
+                      .setSyncInterval(Duration.ofSeconds(1))
+                      .setFailureTimeout(Duration.ofSeconds(2)))
+          .build();
+
+  @Test
+  void canHandleTopologyRequestsWhenBroker0IsRemoved() {
+    // given
+    final var broker0 = cluster.brokers().get(MemberId.from("0"));
+    final var actuator = ClusterActuator.of(cluster.anyGateway());
+    final var newBrokerSet = List.of(1, 2);
+    final var response = actuator.scaleBrokers(newBrokerSet);
+    assertChangeIsPlanned(response);
+
+    Awaitility.await()
+        .timeout(Duration.ofMinutes(2))
+        .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
+    // broker 0 is removed from cluster topology
+    broker0.close();
+
+    // when - then
+    // No exception because the query will be forwarded to broker 1
+    ClusterActuatorAssert.assertThat(cluster)
+        .hasActiveBroker(1)
+        .hasActiveBroker(2)
+        .doesNotHaveBroker(0);
+    // can also start a new topology change
+    assertChangeIsPlanned(actuator.scaleBrokers(List.of(1, 2, 3)));
+  }
+}

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/ForceScaleDownRequestTransformer.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/ForceScaleDownRequestTransformer.java
@@ -84,6 +84,11 @@ public class ForceScaleDownRequestTransformer implements TopologyChangeRequest {
     return generateOperations(partitionsWithNewMembers, memberToRemove);
   }
 
+  @Override
+  public boolean isForced() {
+    return true;
+  }
+
   private Either<Exception, List<TopologyChangeOperation>> generateOperations(
       final Map<Integer, ArrayList<MemberId>> partitionsWithNewMembers,
       final List<MemberId> memberToRemove) {

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyCoordinatorSupplier.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyCoordinatorSupplier.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.api;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.topology.state.ClusterTopology;
+import java.util.Collection;
+import java.util.function.Supplier;
+
+public interface TopologyCoordinatorSupplier {
+  MemberId getDefaultCoordinator();
+
+  MemberId getNextCoordinator(Collection<MemberId> members);
+
+  class ClusterTopologyAwareCoordinatorSupplier implements TopologyCoordinatorSupplier {
+    private final Supplier<ClusterTopology> clusterTopologySupplier;
+
+    public ClusterTopologyAwareCoordinatorSupplier(
+        final Supplier<ClusterTopology> clusterTopologySupplier) {
+      this.clusterTopologySupplier = clusterTopologySupplier;
+    }
+
+    private MemberId lowestMemberId(final Collection<MemberId> members) {
+      if (members.isEmpty()) {
+        // if cluster topology is not initialized, fall back to member 0
+        return MemberId.from("0");
+      }
+      return members.stream().min(MemberId::compareTo).orElseThrow();
+    }
+
+    @Override
+    public MemberId getDefaultCoordinator() {
+      final var clusterTopology = clusterTopologySupplier.get();
+      return lowestMemberId(clusterTopology.members().keySet());
+    }
+
+    @Override
+    public MemberId getNextCoordinator(final Collection<MemberId> members) {
+      return lowestMemberId(members);
+    }
+  }
+}

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestSender.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.topology.api;
 
-import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.topology.api.TopologyManagementRequest.JoinPartitionRequest;
@@ -26,15 +25,15 @@ import java.util.function.Function;
 public final class TopologyManagementRequestSender {
   private static final Duration TIMEOUT = Duration.ofSeconds(10);
   private final ClusterCommunicationService communicationService;
-  private final MemberId coordinator;
+  private final TopologyCoordinatorSupplier coordinatorSupplier;
   private final TopologyRequestsSerializer serializer;
 
   public TopologyManagementRequestSender(
       final ClusterCommunicationService communicationService,
-      final MemberId coordinator,
+      final TopologyCoordinatorSupplier coordinatorSupplier,
       final TopologyRequestsSerializer serializer) {
     this.communicationService = communicationService;
-    this.coordinator = coordinator;
+    this.coordinatorSupplier = coordinatorSupplier;
     this.serializer = serializer;
   }
 
@@ -45,7 +44,7 @@ public final class TopologyManagementRequestSender {
         addMembersRequest,
         serializer::encodeAddMembersRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 
@@ -56,7 +55,7 @@ public final class TopologyManagementRequestSender {
         removeMembersRequest,
         serializer::encodeRemoveMembersRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 
@@ -67,7 +66,7 @@ public final class TopologyManagementRequestSender {
         joinPartitionRequest,
         serializer::encodeJoinPartitionRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 
@@ -78,7 +77,7 @@ public final class TopologyManagementRequestSender {
         leavePartitionRequest,
         serializer::encodeLeavePartitionRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 
@@ -89,7 +88,7 @@ public final class TopologyManagementRequestSender {
         reassignPartitionsRequest,
         serializer::encodeReassignPartitionsRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 
@@ -100,7 +99,7 @@ public final class TopologyManagementRequestSender {
         scaleRequest,
         serializer::encodeScaleRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 
@@ -111,7 +110,7 @@ public final class TopologyManagementRequestSender {
         forceScaleDownRequest,
         serializer::encodeScaleRequest,
         serializer::decodeTopologyChangeResponse,
-        coordinator,
+        coordinatorSupplier.getNextCoordinator(forceScaleDownRequest.members()),
         TIMEOUT);
   }
 
@@ -121,7 +120,7 @@ public final class TopologyManagementRequestSender {
         new byte[0],
         Function.identity(),
         serializer::decodeClusterTopologyResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 
@@ -132,7 +131,7 @@ public final class TopologyManagementRequestSender {
         request,
         serializer::encodeCancelChangeRequest,
         serializer::decodeClusterTopologyResponse,
-        coordinator,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 }

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinator.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/changes/TopologyChangeCoordinator.java
@@ -73,5 +73,9 @@ public interface TopologyChangeCoordinator {
      */
     Either<Exception, List<TopologyChangeOperation>> operations(
         final ClusterTopology currentTopology);
+
+    default boolean isForced() {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
## Description

By default broker 0 was the coordinator. This was ok until now because broker ids starts with 0, thus a cluster with atlease one broker will always have a broker 0. Now, with force removing brokers we want to allow any brokers to be removed from the cluster. This means that when broker 0 is removed, some other broker should be able to take over the coordinator role. 

The selection of the coordinator is as follows:
1. For any normal requests, the broker with the lowest id will be chosen as the coordinator
2. For any "force" requests, the lowest id among the surviving brokers would be chosen. 

There is no election process. The gateway looks at its known cluster topology to figure out the coordinator. This is not fool proof, as an outdated local cluster topology can chose a wrong coordinator. To improve the safety, the broker receiving the request also verifies if it is supposed to be the coordinator. This would be enough for most cases, because for normal scale down or scale up operation, we do not expect that broker 0 is removed. The only reason to remove broker 0 is when it has to be forcefully removed. Such force operations are not expected to be called back-to-back frequently, so the chances of using an outdated cluster topology is very less. Besides, we are also planning to improve the conflict detection and prevention due to concurrent coordinators requesting conflicting operations. Until then, this solution although not perfect will be sufficient.

## Related issues

closes #16315 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
