### PR TITLE
[Backport stable/8.2] fix(stream-processor): throw instead of ignoring unknown records

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
@@ -110,6 +110,11 @@ public class LogStreamBatchReaderImpl implements LogStreamBatchReader {
     }
 
     @Override
+    public LoggedEvent current() {
+      return event;
+    }
+
+    @Override
     public boolean hasNext() {
       return currentIndex < offsets.size();
     }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
@@ -63,5 +63,10 @@ public interface LogStreamBatchReader extends Iterator<Batch>, CloseableSilently
      * the whole batch again.
      */
     void head();
+
+    /**
+     * @return the current head of the batch without moving to the next event.
+     */
+    LoggedEvent current();
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/NoSuchProcessorException.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/NoSuchProcessorException.java
@@ -16,7 +16,20 @@ import io.camunda.zeebe.util.exception.UnrecoverableException;
  */
 final class NoSuchProcessorException extends UnrecoverableException {
 
-  NoSuchProcessorException(final TypedRecord<?> command) {
-    super("No processor registered for command type %s".formatted(command.getValueType()));
+  private NoSuchProcessorException(final String message) {
+    super(message);
+  }
+
+  public static NoSuchProcessorException forRecord(final TypedRecord<?> record) {
+    final var message =
+        switch (record.getRecordType()) {
+          case EVENT ->
+              "No processor registered for event type %s".formatted(record.getValueType());
+          case COMMAND ->
+              "No processor registered for command type %s".formatted(record.getValueType());
+          case COMMAND_REJECTION, SBE_UNKNOWN, NULL_VAL ->
+              ("No processor registered for record type %s").formatted(record.getRecordType());
+        };
+    return new NoSuchProcessorException(message);
   }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/NoSuchProcessorException.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/NoSuchProcessorException.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
+/**
+ * Exception type thrown by the {@link ProcessingStateMachine} when encountering a command that is
+ * not accepted by any of the registered processors.
+ */
+final class NoSuchProcessorException extends UnrecoverableException {
+
+  NoSuchProcessorException(final TypedRecord<?> command) {
+    super("No processor registered for command type %s".formatted(command.getValueType()));
+  }
+}

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/NoSuchProcessorException.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/NoSuchProcessorException.java
@@ -23,12 +23,14 @@ final class NoSuchProcessorException extends UnrecoverableException {
   public static NoSuchProcessorException forRecord(final TypedRecord<?> record) {
     final var message =
         switch (record.getRecordType()) {
-          case EVENT ->
-              "No processor registered for event type %s".formatted(record.getValueType());
-          case COMMAND ->
-              "No processor registered for command type %s".formatted(record.getValueType());
-          case COMMAND_REJECTION, SBE_UNKNOWN, NULL_VAL ->
-              ("No processor registered for record type %s").formatted(record.getRecordType());
+          case EVENT -> "No processor registered for event type %s"
+              .formatted(record.getValueType());
+          case COMMAND -> "No processor registered for command type %s"
+              .formatted(record.getValueType());
+          case COMMAND_REJECTION,
+              SBE_UNKNOWN,
+              NULL_VAL -> ("No processor registered for record type %s")
+              .formatted(record.getRecordType());
         };
     return new NoSuchProcessorException(message);
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -361,7 +361,7 @@ public final class ProcessingStateMachine {
           recordProcessors.stream()
               .filter(p -> p.accepts(command.getValueType()))
               .findFirst()
-              .orElseThrow(() -> new NoSuchProcessorException(command));
+              .orElseThrow(() -> NoSuchProcessorException.forRecord(command));
 
       currentProcessingResult = currentProcessor.process(command, processingResultBuilder);
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -165,7 +165,10 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
             .onComplete(
                 (success, failure) -> {
                   if (failure != null) {
-                    throw new RuntimeException(failure);
+                    throw new RuntimeException(
+                        "Failed to replay batch at '%s %s'"
+                            .formatted(batch.current(), typedEvent.getMetadata()),
+                        failure);
                   } else {
                     // observe the replay duration
                     replayDurationTimer.close();

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ReplayStateMachine.java
@@ -225,11 +225,13 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
       readMetadata(currentEvent);
       final var currentTypedEvent = readRecordValue(currentEvent);
 
-      recordProcessors.stream()
-          .filter(p -> p.accepts(currentTypedEvent.getValueType()))
-          .findFirst()
-          .ifPresent(recordProcessor -> recordProcessor.replay(currentTypedEvent));
+      final var processor =
+          recordProcessors.stream()
+              .filter(p -> p.accepts(currentTypedEvent.getValueType()))
+              .findFirst()
+              .orElseThrow(() -> NoSuchProcessorException.forRecord(currentTypedEvent));
 
+      processor.replay(currentTypedEvent);
       lastReplayedEventPosition = currentTypedEvent.getPosition();
     }
 

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -37,6 +37,7 @@ public final class TypedRecordImpl implements TypedRecord {
     this.value = value;
   }
 
+  @JsonIgnore
   public RecordMetadata getMetadata() {
     return metadata;
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -37,6 +37,10 @@ public final class TypedRecordImpl implements TypedRecord {
     this.value = value;
   }
 
+  public RecordMetadata getMetadata() {
+    return metadata;
+  }
+
   @Override
   public long getPosition() {
     return rawEvent.getPosition();

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -205,6 +205,22 @@ public final class StreamProcessorTest {
         .untilAsserted(() -> assertThat(streamPlatform.getStreamProcessor().isFailed()).isTrue());
   }
 
+  @Test
+  void shouldFailOnEventWithoutProcessor() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultRecordProcessor.accepts(any())).thenReturn(false);
+    streamPlatform.startStreamProcessorInReplayOnlyMode();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.event().processInstance(ELEMENT_ACTIVATING, Records.processInstance(1)));
+
+    // then
+    Awaitility.await("StreamProcessor fails eventually")
+        .untilAsserted(() -> assertThat(streamPlatform.getStreamProcessor().isFailed()).isTrue());
+  }
+
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
   public void shouldUpdateLastProcessPositionEvenWhenProcessingFails() {
     // given

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorTest.java
@@ -189,6 +189,22 @@ public final class StreamProcessorTest {
     inOrder.verifyNoMoreInteractions();
   }
 
+  @Test
+  void shouldFailOnCommandWithoutProcessor() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultRecordProcessor.accepts(any())).thenReturn(false);
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    Awaitility.await("StreamProcessor fails eventually")
+        .untilAsserted(() -> assertThat(streamPlatform.getStreamProcessor().isFailed()).isTrue());
+  }
+
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
   public void shouldUpdateLastProcessPositionEvenWhenProcessingFails() {
     // given


### PR DESCRIPTION
# Description
Backport of #16377 to `stable/8.2`.

relates to #16376 #16379 #7449
original author: @oleschoenburg