### PR TITLE
[Backport stable/8.1] Fix garbage left after metrics exporter cleanup

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -21,25 +21,17 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.VisibleForTesting;
 import java.time.Duration;
-import java.util.NavigableMap;
 import java.util.Set;
-import java.util.TreeMap;
-import org.agrona.collections.Long2LongHashMap;
-import org.agrona.collections.LongArrayList;
 
 public class MetricsExporter implements Exporter {
 
   public static final Duration TIME_TO_LIVE = Duration.ofSeconds(10);
   private final ExecutionLatencyMetrics executionLatencyMetrics;
-  private final Long2LongHashMap jobKeyToCreationTimeMap;
-  private final Long2LongHashMap processInstanceKeyToCreationTimeMap;
-
-  // only used to keep track of how long the entries are existing and to clean up the corresponding
-  // maps
-  private final NavigableMap<Long, LongArrayList> creationTimeToJobKeyNavigableMap;
-  private final NavigableMap<Long, LongArrayList> creationTimeToProcessInstanceKeyNavigableMap;
+  private final TtlKeyCache processInstanceCache;
+  private final TtlKeyCache jobCache;
 
   private Controller controller;
 
@@ -48,11 +40,17 @@ public class MetricsExporter implements Exporter {
   }
 
   public MetricsExporter(final ExecutionLatencyMetrics executionLatencyMetrics) {
+    this(executionLatencyMetrics, new TtlKeyCache(), new TtlKeyCache());
+  }
+
+  @VisibleForTesting
+  MetricsExporter(
+      final ExecutionLatencyMetrics executionLatencyMetrics,
+      final TtlKeyCache processInstanceCache,
+      final TtlKeyCache jobCache) {
     this.executionLatencyMetrics = executionLatencyMetrics;
-    jobKeyToCreationTimeMap = new Long2LongHashMap(-1);
-    processInstanceKeyToCreationTimeMap = new Long2LongHashMap(-1);
-    creationTimeToJobKeyNavigableMap = new TreeMap<>();
-    creationTimeToProcessInstanceKeyNavigableMap = new TreeMap<>();
+    this.processInstanceCache = processInstanceCache;
+    this.jobCache = jobCache;
   }
 
   @Override
@@ -83,10 +81,8 @@ public class MetricsExporter implements Exporter {
 
   @Override
   public void close() {
-    jobKeyToCreationTimeMap.clear();
-    processInstanceKeyToCreationTimeMap.clear();
-    creationTimeToJobKeyNavigableMap.clear();
-    creationTimeToProcessInstanceKeyNavigableMap.clear();
+    processInstanceCache.clear();
+    jobCache.clear();
   }
 
   @Override
@@ -117,20 +113,13 @@ public class MetricsExporter implements Exporter {
 
     if (currentIntent == ProcessInstanceIntent.ELEMENT_ACTIVATING
         && isProcessInstanceRecord(record)) {
-      storeProcessInstanceCreation(record.getTimestamp(), recordKey);
+      processInstanceCache.store(recordKey, record.getTimestamp());
     } else if (currentIntent == ProcessInstanceIntent.ELEMENT_COMPLETED
         && isProcessInstanceRecord(record)) {
-      final var creationTime = processInstanceKeyToCreationTimeMap.remove(recordKey);
+      final var creationTime = processInstanceCache.remove(recordKey);
       executionLatencyMetrics.observeProcessInstanceExecutionTime(
           partitionId, creationTime, record.getTimestamp());
     }
-  }
-
-  private void storeProcessInstanceCreation(final long creationTime, final long recordKey) {
-    processInstanceKeyToCreationTimeMap.put(recordKey, creationTime);
-    creationTimeToProcessInstanceKeyNavigableMap
-        .computeIfAbsent(creationTime, ignored -> new LongArrayList())
-        .add(recordKey);
   }
 
   private void handleJobRecord(
@@ -138,9 +127,9 @@ public class MetricsExporter implements Exporter {
     final var currentIntent = record.getIntent();
 
     if (currentIntent == JobIntent.CREATED) {
-      storeJobCreation(record.getTimestamp(), recordKey);
+      jobCache.store(recordKey, record.getTimestamp());
     } else if (currentIntent == JobIntent.COMPLETED) {
-      final var creationTime = jobKeyToCreationTimeMap.remove(recordKey);
+      final var creationTime = jobCache.remove(recordKey);
       executionLatencyMetrics.observeJobLifeTime(partitionId, creationTime, record.getTimestamp());
     }
   }
@@ -151,53 +140,19 @@ public class MetricsExporter implements Exporter {
     if (currentIntent == JobBatchIntent.ACTIVATED) {
       final var value = (JobBatchRecordValue) record.getValue();
       for (final long jobKey : value.getJobKeys()) {
-        final var creationTime = jobKeyToCreationTimeMap.get(jobKey);
+        final var creationTime = jobCache.remove(jobKey);
         executionLatencyMetrics.observeJobActivationTime(
             partitionId, creationTime, record.getTimestamp());
       }
     }
   }
 
-  private void storeJobCreation(final long creationTime, final long recordKey) {
-    jobKeyToCreationTimeMap.put(recordKey, creationTime);
-    creationTimeToJobKeyNavigableMap
-        .computeIfAbsent(creationTime, ignored -> new LongArrayList())
-        .add(recordKey);
-  }
-
   private void cleanUp() {
-    final var currentTimeMillis = System.currentTimeMillis();
-
+    final var currentTimeMillis = ActorClock.currentTimeMillis();
     final var deadTime = currentTimeMillis - TIME_TO_LIVE.toMillis();
-    clearMaps(deadTime, creationTimeToJobKeyNavigableMap, jobKeyToCreationTimeMap);
-    clearMaps(
-        deadTime,
-        creationTimeToProcessInstanceKeyNavigableMap,
-        processInstanceKeyToCreationTimeMap);
-
+    processInstanceCache.cleanup(deadTime);
+    jobCache.cleanup(deadTime);
     controller.scheduleCancellableTask(TIME_TO_LIVE, this::cleanUp);
-  }
-
-  @VisibleForTesting
-  int cachedProcessInstanceCount() {
-    return processInstanceKeyToCreationTimeMap.size();
-  }
-
-  @VisibleForTesting
-  int cachedJobCount() {
-    return jobKeyToCreationTimeMap.size();
-  }
-
-  private void clearMaps(
-      final long deadTime,
-      final NavigableMap<Long, LongArrayList> timeToKeyMap,
-      final Long2LongHashMap keyToTimestampMap) {
-    final var outOfScopeInstances = timeToKeyMap.headMap(deadTime);
-
-    for (final LongArrayList keys : outOfScopeInstances.values()) {
-      keys.forEach(keyToTimestampMap::remove);
-    }
-    outOfScopeInstances.clear();
   }
 
   public static ExporterCfg defaultConfig() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -40,7 +40,10 @@ public class MetricsExporter implements Exporter {
   }
 
   public MetricsExporter(final ExecutionLatencyMetrics executionLatencyMetrics) {
-    this(executionLatencyMetrics, new TtlKeyCache(), new TtlKeyCache());
+    this(
+        executionLatencyMetrics,
+        new TtlKeyCache(TIME_TO_LIVE.toMillis()),
+        new TtlKeyCache(TIME_TO_LIVE.toMillis()));
   }
 
   @VisibleForTesting

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
@@ -14,8 +14,9 @@ import org.agrona.collections.LongArrayList;
 
 final class TtlKeyCache {
   private static final int DEFAULT_MAX_CAPACITY = 10_000;
+  private static final long DEFAULT_NULL_VALUE = -1L;
 
-  private final Long2LongHashMap keyToTimestamp = new Long2LongHashMap(-1);
+  private final Long2LongHashMap keyToTimestamp;
 
   // only used to keep track of how long the entries are existing and to clean up the
   // corresponding
@@ -28,11 +29,20 @@ final class TtlKeyCache {
     this(DEFAULT_MAX_CAPACITY);
   }
 
+  TtlKeyCache(final int maxCapacity) {
+    this(maxCapacity, DEFAULT_NULL_VALUE);
+  }
+
+  TtlKeyCache(final long nullValue) {
+    this(DEFAULT_MAX_CAPACITY, nullValue);
+  }
+
   /**
    * @param maxCapacity the maximum number of entries that can be cached, regardless of TTL
    */
-  TtlKeyCache(final int maxCapacity) {
+  TtlKeyCache(final int maxCapacity, final long nullValue) {
     this.maxCapacity = maxCapacity;
+    this.keyToTimestamp = new Long2LongHashMap(nullValue);
   }
 
   void store(final long key, final long timestamp) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.exporter.metrics;
+
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.agrona.collections.Long2LongHashMap;
+import org.agrona.collections.LongArrayList;
+
+final class TtlKeyCache {
+  private final Long2LongHashMap keyToTimestamp = new Long2LongHashMap(-1);
+
+  // only used to keep track of how long the entries are existing and to clean up the
+  // corresponding
+  // maps
+  private final NavigableMap<Long, LongArrayList> timestampToKeys = new TreeMap<>();
+
+  void store(final long key, final long timestamp) {
+    keyToTimestamp.put(key, timestamp);
+    timestampToKeys.computeIfAbsent(timestamp, ignored -> new LongArrayList()).add(key);
+  }
+
+  long remove(final long key) {
+    return keyToTimestamp.remove(key);
+  }
+
+  void cleanup(final long timestamp) {
+    final var deadTime = timestamp - MetricsExporter.TIME_TO_LIVE.toMillis();
+    final var outOfScopeInstances = timestampToKeys.headMap(deadTime);
+
+    for (final LongArrayList keys : outOfScopeInstances.values()) {
+      keys.forEach(keyToTimestamp::remove);
+    }
+
+    outOfScopeInstances.clear();
+  }
+
+  boolean isEmpty() {
+    return keyToTimestamp.isEmpty() && timestampToKeys.isEmpty();
+  }
+
+  void clear() {
+    keyToTimestamp.clear();
+    timestampToKeys.clear();
+  }
+
+  int size() {
+    return keyToTimestamp.size();
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -71,7 +71,9 @@ class MetricsExporterTest {
   @Test
   void shouldCleanupProcessInstancesWithSameStartTime() {
     // given
-    final var exporter = new MetricsExporter(new ExecutionLatencyMetrics());
+    final var processCache = new TtlKeyCache();
+    final var exporter =
+        new MetricsExporter(new ExecutionLatencyMetrics(), processCache, new TtlKeyCache());
     final var controller = new ExporterTestController();
     exporter.open(controller);
     exporter.export(
@@ -97,13 +99,15 @@ class MetricsExporterTest {
     controller.runScheduledTasks(Duration.ofHours(1));
 
     // then
-    assertThat(exporter.cachedProcessInstanceCount()).isZero();
+    assertThat(processCache.isEmpty()).isTrue();
   }
 
   @Test
   void shouldCleanupJobWithSameStartTime() {
     // given
-    final var exporter = new MetricsExporter(new ExecutionLatencyMetrics());
+    final var jobCache = new TtlKeyCache();
+    final var exporter =
+        new MetricsExporter(new ExecutionLatencyMetrics(), new TtlKeyCache(), jobCache);
     final var controller = new ExporterTestController();
     exporter.open(controller);
     exporter.export(
@@ -127,7 +131,7 @@ class MetricsExporterTest {
     controller.runScheduledTasks(Duration.ofHours(1));
 
     // then
-    assertThat(exporter.cachedJobCount()).isZero();
+    assertThat(jobCache.isEmpty()).isTrue();
   }
 
   @Nested

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
@@ -115,4 +115,17 @@ final class TtlKeyCacheTest {
     assertThat(cache.remove(3L)).isEqualTo(30L);
     assertThat(cache.remove(4L)).isEqualTo(40L);
   }
+
+  @Test
+  void shouldReturnNullValue() {
+    // given
+    final var cache = new TtlKeyCache(3L);
+    cache.store(1L, 10L);
+
+    // when
+    final var timestamp = cache.remove(2L);
+
+    // then
+    assertThat(timestamp).isEqualTo(3L);
+  }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.exporter.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import org.junit.jupiter.api.Test;
+
+final class TtlKeyCacheTest {
+
+  @Test
+  void shouldStorePair() {
+    // given
+    final var cache = new TtlKeyCache();
+
+    // when
+    cache.store(1L, 10L);
+    final var timestamp = cache.remove(1L);
+
+    // then
+    assertThat(timestamp).isEqualTo(10L);
+  }
+
+  @Test
+  void shouldStoreMultipleKeysWithSameTimestamp() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 10L);
+
+    // when - then
+    assertThat(cache.remove(1L)).isEqualTo(10L);
+    assertThat(cache.remove(2L)).isEqualTo(10L);
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/16405")
+  void shouldCleanupKeysEvenWithSameTimestamps() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 10L);
+
+    // when
+    cache.cleanup(11L);
+
+    // when - then
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldRemovePair() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+
+    // when
+    cache.remove(1L);
+
+    // then
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldCleanupExpiredEntries() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 20L);
+    cache.store(3L, 30L);
+
+    // when
+    cache.cleanup(21L);
+
+    // then - assert we can still find the non expired key, then once removed, the cache is empty
+    assertThat(cache.remove(3L)).isEqualTo(30L);
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldClearCache() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+    cache.store(2L, 20L);
+    cache.store(3L, 30L);
+
+    // when
+    cache.clear();
+
+    // then
+    assertThat(cache.isEmpty()).isTrue();
+  }
+
+  @Test
+  void shouldEvictOldestKeyOnCapacityReached() {
+    // given
+    final var cache = new TtlKeyCache(3);
+    cache.store(1L, 10L);
+    cache.store(2L, 20L);
+    cache.store(3L, 30L);
+
+    // when
+    cache.store(4L, 40L);
+
+    // then
+    assertThat(cache.size()).isEqualTo(3);
+    assertThat(cache.remove(1L)).isEqualTo(-1L);
+    assertThat(cache.remove(2L)).isEqualTo(20L);
+    assertThat(cache.remove(3L)).isEqualTo(30L);
+    assertThat(cache.remove(4L)).isEqualTo(40L);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #16417 to `stable/8.1`.

relates to #16405
original author: @npepinpe