### PR TITLE
[Backport stable/8.1] fix(stream-processor): throw instead of ignoring unknown records

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.streamprocessor;
 import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 
-public class NoSuchProcessorException extends UnrecoverableException {
+final class NoSuchProcessorException extends UnrecoverableException {
   private NoSuchProcessorException(final String message) {
     super(message);
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
@@ -18,12 +18,14 @@ public class NoSuchProcessorException extends UnrecoverableException {
   public static NoSuchProcessorException forRecord(final TypedRecord<?> record) {
     final var message =
         switch (record.getRecordType()) {
-          case EVENT ->
-              "No processor registered for event type %s".formatted(record.getValueType());
-          case COMMAND ->
-              "No processor registered for command type %s".formatted(record.getValueType());
-          case COMMAND_REJECTION, SBE_UNKNOWN, NULL_VAL ->
-              ("No processor registered for record type %s").formatted(record.getRecordType());
+          case EVENT -> "No processor registered for event type %s"
+              .formatted(record.getValueType());
+          case COMMAND -> "No processor registered for command type %s"
+              .formatted(record.getValueType());
+          case COMMAND_REJECTION,
+              SBE_UNKNOWN,
+              NULL_VAL -> ("No processor registered for record type %s")
+              .formatted(record.getRecordType());
         };
     return new NoSuchProcessorException(message);
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.streamprocessor;
+
+import io.camunda.zeebe.engine.api.TypedRecord;
+import io.camunda.zeebe.util.exception.UnrecoverableException;
+
+public class NoSuchProcessorException extends UnrecoverableException {
+
+  public NoSuchProcessorException(final TypedRecord<?> command) {
+    super("No processor found for command with key " + command.getKey());
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/NoSuchProcessorException.java
@@ -11,8 +11,20 @@ import io.camunda.zeebe.engine.api.TypedRecord;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 
 public class NoSuchProcessorException extends UnrecoverableException {
+  private NoSuchProcessorException(final String message) {
+    super(message);
+  }
 
-  public NoSuchProcessorException(final TypedRecord<?> command) {
-    super("No processor found for command with key " + command.getKey());
+  public static NoSuchProcessorException forRecord(final TypedRecord<?> record) {
+    final var message =
+        switch (record.getRecordType()) {
+          case EVENT ->
+              "No processor registered for event type %s".formatted(record.getValueType());
+          case COMMAND ->
+              "No processor registered for command type %s".formatted(record.getValueType());
+          case COMMAND_REJECTION, SBE_UNKNOWN, NULL_VAL ->
+              ("No processor registered for record type %s").formatted(record.getRecordType());
+        };
+    return new NoSuchProcessorException(message);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -357,7 +357,7 @@ public final class ProcessingStateMachine {
           recordProcessors.stream()
               .filter(p -> p.accepts(command.getValueType()))
               .findFirst()
-              .orElseThrow(() -> new NoSuchProcessorException(command));
+              .orElseThrow(() -> NoSuchProcessorException.forRecord(command));
 
       currentProcessingResult = currentProcessor.process(command, processingResultBuilder);
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingStateMachine.java
@@ -357,21 +357,20 @@ public final class ProcessingStateMachine {
           recordProcessors.stream()
               .filter(p -> p.accepts(command.getValueType()))
               .findFirst()
-              .orElse(null);
-      if (currentProcessor != null) {
-        currentProcessingResult = currentProcessor.process(command, processingResultBuilder);
+              .orElseThrow(() -> new NoSuchProcessorException(command));
 
-        final var nextToProcessCommands =
-            collectBatchProcessingStepResult(
-                currentProcessingResult,
-                lastProcessingResultSize,
-                // +1 since we already need include the current command in the calculation
-                pendingCommands.size() + processedCommandsCount + 1,
-                currentProcessingBatchLimit);
+      currentProcessingResult = currentProcessor.process(command, processingResultBuilder);
 
-        pendingCommands.addAll(nextToProcessCommands);
-        currentProcessingResult.getProcessingResponse().ifPresent(pendingResponses::add);
-      }
+      final var nextToProcessCommands =
+          collectBatchProcessingStepResult(
+              currentProcessingResult,
+              lastProcessingResultSize,
+              // +1 since we already need include the current command in the calculation
+              pendingCommands.size() + processedCommandsCount + 1,
+              currentProcessingBatchLimit);
+
+      pendingCommands.addAll(nextToProcessCommands);
+      currentProcessingResult.getProcessingResponse().ifPresent(pendingResponses::add);
 
       lastProcessingResultSize = currentProcessingResult.getRecordBatch().entries().size();
       processedCommandsCount++;

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ReplayStateMachine.java
@@ -223,11 +223,13 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
       readMetadata(currentEvent);
       final var currentTypedEvent = readRecordValue(currentEvent);
 
-      recordProcessors.stream()
-          .filter(p -> p.accepts(currentTypedEvent.getValueType()))
-          .findFirst()
-          .ifPresent(recordProcessor -> recordProcessor.replay(currentTypedEvent));
+      final var processor =
+          recordProcessors.stream()
+              .filter(p -> p.accepts(currentTypedEvent.getValueType()))
+              .findFirst()
+              .orElseThrow(() -> NoSuchProcessorException.forRecord(currentTypedEvent));
 
+      processor.replay(currentTypedEvent);
       lastReplayedEventPosition = currentTypedEvent.getPosition();
     }
 

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ReplayStateMachine.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ReplayStateMachine.java
@@ -163,7 +163,10 @@ public final class ReplayStateMachine implements LogRecordAwaiter {
             .onComplete(
                 (success, failure) -> {
                   if (failure != null) {
-                    throw new RuntimeException(failure);
+                    throw new RuntimeException(
+                        "Failed to replay batch at '%s %s'"
+                            .formatted(batch.current(), typedEvent.getMetadata()),
+                        failure);
                   } else {
                     // observe the replay duration
                     replayDurationTimer.close();

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/TypedRecordImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/TypedRecordImpl.java
@@ -38,6 +38,7 @@ public final class TypedRecordImpl implements TypedRecord {
     this.value = value;
   }
 
+  @JsonIgnore
   public RecordMetadata getMetadata() {
     return metadata;
   }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/TypedRecordImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/TypedRecordImpl.java
@@ -38,6 +38,10 @@ public final class TypedRecordImpl implements TypedRecord {
     this.value = value;
   }
 
+  public RecordMetadata getMetadata() {
+    return metadata;
+  }
+
   @Override
   public long getPosition() {
     return rawEvent.getPosition();

--- a/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/StreamPlatform.java
@@ -206,12 +206,17 @@ public final class StreamPlatform {
 
   public StreamProcessor startStreamProcessor() {
     final SynchronousLogStream stream = getLogStream();
-    return buildStreamProcessor(stream, true);
+    return buildStreamProcessor(stream, true, StreamProcessorMode.PROCESSING);
+  }
+
+  public StreamProcessor startStreamProcessorInReplayOnlyMode() {
+    final SynchronousLogStream stream = getLogStream();
+    return buildStreamProcessor(stream, false, StreamProcessorMode.REPLAY);
   }
 
   public StreamProcessor startStreamProcessorNotAwaitOpening() {
     final SynchronousLogStream stream = getLogStream();
-    return buildStreamProcessor(stream, false);
+    return buildStreamProcessor(stream, false, StreamProcessorMode.PROCESSING);
   }
 
   public StreamProcessorLifecycleAware getMockProcessorLifecycleAware() {
@@ -223,7 +228,9 @@ public final class StreamPlatform {
   }
 
   public StreamProcessor buildStreamProcessor(
-      final SynchronousLogStream stream, final boolean awaitOpening) {
+      final SynchronousLogStream stream,
+      final boolean awaitOpening,
+      final StreamProcessorMode processorMode) {
     final var storage = createRuntimeFolder(stream);
     final var snapshot = storage.getParent().resolve(SNAPSHOT_FOLDER);
     scheduledCommandCache = new TestCommandCache();
@@ -243,7 +250,7 @@ public final class StreamPlatform {
             .commandResponseWriter(mockCommandResponseWriter)
             .recordProcessors(recordProcessors)
             .eventApplierFactory(EventAppliers::new) // todo remove this soon
-            .streamProcessorMode(streamProcessorMode)
+            .streamProcessorMode(processorMode)
             .listener(mockStreamProcessorListener)
             .maxCommandsInBatch(maxCommandsInBatch)
             .scheduledCommandCache(scheduledCommandCache)

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -170,6 +170,22 @@ public final class StreamProcessorTest {
     inOrder.verifyNoMoreInteractions();
   }
 
+  @Test
+  void shouldFailOnCommandWithoutProcessor() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultRecordProcessor.accepts(any())).thenReturn(false);
+    streamPlatform.startStreamProcessor();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+
+    // then
+    Awaitility.await("StreamProcessor fails eventually")
+        .untilAsserted(() -> assertThat(streamPlatform.getStreamProcessor().isFailed()).isTrue());
+  }
+
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
   public void shouldUpdateLastProcessPositionEvenWhenProcessingFails() {
     // given

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/StreamProcessorTest.java
@@ -186,6 +186,22 @@ public final class StreamProcessorTest {
         .untilAsserted(() -> assertThat(streamPlatform.getStreamProcessor().isFailed()).isTrue());
   }
 
+  @Test
+  void shouldFailOnEventWithoutProcessor() {
+    // given
+    final var defaultRecordProcessor = streamPlatform.getDefaultMockedRecordProcessor();
+    when(defaultRecordProcessor.accepts(any())).thenReturn(false);
+    streamPlatform.startStreamProcessorInReplayOnlyMode();
+
+    // when
+    streamPlatform.writeBatch(
+        RecordToWrite.event().processInstance(ELEMENT_ACTIVATING, Records.processInstance(1)));
+
+    // then
+    Awaitility.await("StreamProcessor fails eventually")
+        .untilAsserted(() -> assertThat(streamPlatform.getStreamProcessor().isFailed()).isTrue());
+  }
+
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
   public void shouldUpdateLastProcessPositionEvenWhenProcessingFails() {
     // given

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderImpl.java
@@ -110,6 +110,11 @@ public class LogStreamBatchReaderImpl implements LogStreamBatchReader {
     }
 
     @Override
+    public LoggedEvent current() {
+      return event;
+    }
+
+    @Override
     public boolean hasNext() {
       return currentIndex < offsets.size();
     }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBatchReader.java
@@ -63,5 +63,10 @@ public interface LogStreamBatchReader extends Iterator<Batch>, CloseableSilently
      * the whole batch again.
      */
     void head();
+
+    /**
+     * @return the current head of the batch without moving to the next event.
+     */
+    LoggedEvent current();
   }
 }


### PR DESCRIPTION
# Description
Backport of #16377 to `stable/8.4`.

relates to #16376 #16379 #7449
original author: @oleschoenburg