### PR TITLE
feat(engine): remove userTaskKey from instance on complete

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -38,7 +38,7 @@ import java.util.Set;
 public final class BpmnUserTaskBehavior {
 
   private static final Set<LifecycleState> CANCELABLE_LIFECYCLE_STATES =
-      EnumSet.of(LifecycleState.CREATING, LifecycleState.CREATED);
+      EnumSet.complementOf(EnumSet.of(LifecycleState.NOT_FOUND, LifecycleState.CANCELING));
   private final UserTaskRecord userTaskRecord =
       new UserTaskRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);
   private final KeyGenerator keyGenerator;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletedApplier.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/UserTaskCompletedApplier.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
@@ -18,12 +20,29 @@ public final class UserTaskCompletedApplier
 
   private final MutableUserTaskState userTaskState;
 
+  private final MutableElementInstanceState elementInstanceState;
+
   public UserTaskCompletedApplier(final MutableProcessingState processingState) {
     userTaskState = processingState.getUserTaskState();
+    elementInstanceState = processingState.getElementInstanceState();
   }
 
   @Override
   public void applyState(final long key, final UserTaskRecord value) {
     userTaskState.delete(key);
+
+    final long elementInstanceKey = value.getElementInstanceKey();
+    final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
+
+    if (elementInstance != null) {
+      final long scopeKey = elementInstance.getValue().getFlowScopeKey();
+      final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
+
+      if (scopeInstance != null && scopeInstance.isActive()) {
+
+        elementInstance.setUserTaskKey(-1);
+        elementInstanceState.updateInstance(elementInstance);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

When a user task is completed, its reference from the element instance needs to be removed. This aligns the user task completion with the job completion and consolidates how lifecycles of sub-elements of the element instance work.
This makes building features on top like migration a lot easier since no extra checks have to be considered for user tasks specifically.


## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16455 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
