### PR TITLE
test(qa): retry deadline exceeded

### DIFF
--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import org.agrona.CloseHelper;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -80,7 +81,6 @@ final class DiskSpaceRecoveryIT {
         .correlationKey(String.valueOf(1))
         .variables(Map.of("key", "abc".repeat(4096)))
         .timeToLive(Duration.ZERO)
-        .requestTimeout(Duration.ofSeconds(30))
         .send()
         .join();
   }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
@@ -7,14 +7,18 @@
  */
 package io.camunda.zeebe.it.health;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ClientStatusException;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
+import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.grpc.Status.Code;
 import io.zeebe.containers.ZeebeContainer;
 import io.zeebe.containers.ZeebeVolume;
 import io.zeebe.containers.engine.ContainerEngine;
@@ -27,6 +31,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
@@ -51,6 +56,11 @@ final class DiskSpaceRecoveryIT {
           .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING", "8MB")
           .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION", "1MB");
 
+  @SuppressWarnings("JUnitMalformedDeclaration")
+  @RegisterExtension
+  private final ContainerLogsDumper logsDumper =
+      new ContainerLogsDumper(() -> Map.of("broker", container));
+
   private ZeebeClient client;
 
   @AfterEach
@@ -70,6 +80,7 @@ final class DiskSpaceRecoveryIT {
         .correlationKey(String.valueOf(1))
         .variables(Map.of("key", "abc".repeat(4096)))
         .timeToLive(Duration.ZERO)
+        .requestTimeout(Duration.ofSeconds(30))
         .send()
         .join();
   }
@@ -142,10 +153,32 @@ final class DiskSpaceRecoveryIT {
 
     @Test
     void shouldNotProcessWhenOutOfDiskSpaceOnStart() {
-      // when - then
-      assertThatThrownBy(DiskSpaceRecoveryIT.this::publishMessage)
-          .hasRootCauseMessage(
-              "RESOURCE_EXHAUSTED: Cannot accept requests for partition 1. Broker is out of disk space");
+      // given
+      var retryCount = 0;
+
+      // when
+      while (retryCount < 3) {
+        try {
+          publishMessage();
+        } catch (final ClientStatusException e) {
+          retryCount++;
+
+          if (e.getStatusCode() == Code.DEADLINE_EXCEEDED) {
+            continue;
+          }
+
+          // then
+          assertThat(e.getStatusCode()).isEqualTo(Code.RESOURCE_EXHAUSTED);
+          assertThat(e)
+              .hasRootCauseMessage(
+                  "RESOURCE_EXHAUSTED: Cannot accept requests for partition 1. Broker is out of disk space");
+        }
+      }
+
+      assertThat(retryCount)
+          .as(
+              "Expected at least one out of three requests to not timeout; the container may be broken")
+          .isLessThan(4);
     }
   }
 }


### PR DESCRIPTION
## Description

This PR increases the timeout of the request, and also retries up to 3 times deadline exceeded. The idea is that this only happens in CI, and this may just be a case of resource contention where the container is slower for a little while.

## Related issues

closes #11538 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
