### PR TITLE
Fix flaky clustering rule shutdown and migrate backup test

### DIFF
--- a/qa/integration-tests/pom.xml
+++ b/qa/integration-tests/pom.xml
@@ -265,12 +265,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>zeebe-backup</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>zeebe-backup-store-s3</artifactId>
       <scope>test</scope>
     </dependency>

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -81,6 +81,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -293,8 +294,9 @@ public class ClusteringRule extends ExternalResource {
     // Previously we used `Collection#parallelStream` in an attempt to achieve the same but
     // that didn't work because requesting a parallel stream does not guarantee that
     // stopping the brokers will actually run in parallel.
+    final var brokersToShutdown = new ArrayList<>(brokers.values());
     final var shutdownFutures =
-        brokers.values().stream()
+        brokersToShutdown.stream()
             .map(b -> CompletableFuture.runAsync(b::close))
             .toArray(CompletableFuture[]::new);
     CompletableFuture.allOf(shutdownFutures)

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -26,6 +26,7 @@ import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.management.backups.BackupInfo;
 import io.camunda.zeebe.management.backups.TakeBackupResponse;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator.ErrorResponse.Payload;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.zeebe.containers.ZeebeNode;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -60,6 +61,17 @@ public interface BackupActuator {
    */
   static BackupActuator ofAddress(final String address) {
     final var endpoint = String.format("http://%s/actuator/backups", address);
+    return of(endpoint);
+  }
+
+  /**
+   * Returns a {@link BackupActuator} instance using the given node as upstream.
+   *
+   * @param node the node to connect to
+   * @return a new instance of {@link BackupActuator}
+   */
+  static BackupActuator of(final TestApplication<?> node) {
+    final var endpoint = String.format("http://%s/actuator/backups", node.monitoringAddress());
     return of(endpoint);
   }
 

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -108,6 +108,15 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
 
   @Override
   public <V> V bean(final Class<V> type) {
+    if (springContext == null) {
+      return beans.values().stream()
+          .map(Bean::value)
+          .filter(type::isInstance)
+          .map(type::cast)
+          .findFirst()
+          .orElse(null);
+    }
+
     return springContext.getBean(type);
   }
 

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -11,7 +11,6 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.StandaloneBroker;
 import io.camunda.zeebe.broker.shared.BrokerConfiguration.BrokerProperties;
 import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -130,7 +129,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
   }
 
   /** Returns the broker configuration */
-  public BrokerCfg brokerConfig() {
+  public BrokerProperties brokerConfig() {
     return config;
   }
 
@@ -138,7 +137,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
    * Modifies the broker configuration. Will still mutate the configuration if the broker is
    * started, but likely has no effect until it's restarted.
    */
-  public TestStandaloneBroker withBrokerConfig(final Consumer<BrokerCfg> modifier) {
+  public TestStandaloneBroker withBrokerConfig(final Consumer<BrokerProperties> modifier) {
     modifier.accept(config);
     return this;
   }


### PR DESCRIPTION
## Description

This PR fixes a race condition in the clustering rule's `after` iff you modify the map of brokers in conjunction with a timeout extension.

At the same time, it migrates a test using `ClusteringRule` to the new testing infrastructure. Note that some things still use the `BrokerClient` bean directly because there's no API to take a backup on a specific partition.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16138 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
