### PR TITLE
ci: test-summary should fail if tests failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,6 +479,7 @@ jobs:
     # New test jobs must be added to the `needs` lists!
     # This name is hard-coded in the branch rules; remember to update that if this name changes
     name: Test summary
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - integration-tests
@@ -493,7 +494,7 @@ jobs:
       - go-apidiff
       - docker-checks
     steps:
-      - run: exit 0
+      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ test-summary ]


### PR DESCRIPTION
This closes #16458 by ensuring that the test-summary job is not skipped on test failure but actually propagates the failure.
A skipped check is interpreted as a successful check, leading to PRs going through the merge queue even though the tests failed.