### PR TITLE
Support I/O mapping variables starting with _

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidator.java
@@ -27,7 +27,7 @@ public final class ZeebeExpressionValidator<T extends ModelElementInstance>
   private static final long NO_VARIABLE_SCOPE = -1L;
 
   private static final Pattern PATH_PATTERN =
-      Pattern.compile("[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*");
+      Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*");
 
   private static final List<String> PATH_RESERVED_WORDS =
       List.of(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeExpressionValidatorTest.java
@@ -59,7 +59,8 @@ class ZeebeExpressionValidatorTest {
           Arguments.of(" a,b "),
           Arguments.of(" a ,b "),
           Arguments.of(" a, b "),
-          Arguments.of(" a , b "));
+          Arguments.of(" a , b "),
+          Arguments.of("_variable"));
     }
 
     Stream<Arguments> notCsv() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -60,7 +60,7 @@ public final class ZeebeRuntimeValidationTest {
       "Expected path expression but not found.";
   private static final String INVALID_PATH_EXPRESSION = "a ? b";
   private static final String INVALID_PATH_EXPRESSION_MESSAGE =
-      "Expected path expression 'a ? b' but doesn't match the pattern '[a-zA-Z][a-zA-Z0-9_]*(\\.[a-zA-Z][a-zA-Z0-9_]*)*'.";
+      "Expected path expression 'a ? b' but doesn't match the pattern '[a-zA-Z_][a-zA-Z0-9_]*(\\.[a-zA-Z_][a-zA-Z0-9_]*)*'.";
   private static final String RESERVED_TASK_HEADER_KEY =
       Protocol.RESERVED_HEADER_NAME_PREFIX + "reserved-header-key";
   private static final String RESERVED_TASK_HEADER_MESSAGE =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTest.java
@@ -186,18 +186,18 @@ public final class ProcessInstanceVariableTest {
         ENGINE_RULE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariables("{'x':1, 'y':2}")
+            .withVariables("{'x':1, 'y':2, '_z':3}")
             .create();
 
     // then
     assertThat(
             RecordingExporter.variableRecords(VariableIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)
-                .limit(2))
+                .limit(3))
         .extracting(Record::getValue)
         .extracting(v -> tuple(v.getName(), v.getValue()))
-        .hasSize(2)
-        .contains(tuple("x", "1"), tuple("y", "2"));
+        .hasSize(3)
+        .contains(tuple("x", "1"), tuple("y", "2"), tuple("_z", "3"));
   }
 
   @Test
@@ -307,7 +307,7 @@ public final class ProcessInstanceVariableTest {
         ENGINE_RULE
             .processInstance()
             .ofBpmnProcessId(PROCESS_ID)
-            .withVariables("{'x':1, 'y':2, 'z':3}")
+            .withVariables("{'x':1, 'y':2, 'z':3, '_z':4}")
             .create();
 
     // when
@@ -315,7 +315,7 @@ public final class ProcessInstanceVariableTest {
         .job()
         .ofInstance(processInstanceKey)
         .withType("test")
-        .withVariables("{'x':1, 'y':4, 'z':5}")
+        .withVariables("{'x':1, 'y':4, 'z':5, '_z':7}")
         .complete();
 
     // then
@@ -327,8 +327,8 @@ public final class ProcessInstanceVariableTest {
                 .withProcessInstanceKey(processInstanceKey))
         .extracting(Record::getValue)
         .extracting(v -> tuple(v.getName(), v.getValue()))
-        .hasSize(2)
-        .contains(tuple("y", "4"), tuple("z", "5"));
+        .hasSize(3)
+        .contains(tuple("y", "4"), tuple("z", "5"), tuple("_z", "7"));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTypeTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/ProcessInstanceVariableTypeTest.java
@@ -54,6 +54,7 @@ public final class ProcessInstanceVariableTypeTest {
       {"{'x':null}", "null"},
       {"{'x':[1,2,3]}", "[1,2,3]"},
       {"{'x':{'y':123}}", "{\"y\":123}"},
+      {"{'x':{'_y':123}}", "{\"_y\":123}"},
     };
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityInputMappingTest.java
@@ -70,6 +70,11 @@ public final class ActivityInputMappingTest {
         activityVariables(variable("y", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeInputExpression("_x", "_y")),
+        activityVariables(variable("_y", "1"))
+      },
+      {
         "{'x': 1, 'y': 2}",
         mapping(b -> b.zeebeInputExpression("y", "z")),
         activityVariables(variable("z", "2"))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/ActivityOutputMappingTest.java
@@ -68,6 +68,11 @@ public final class ActivityOutputMappingTest {
         scopeVariables(variable("y", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeOutputExpression("_x", "_y")),
+        scopeVariables(variable("_y", "1"))
+      },
+      {
         "{'x': 1, 'y': 2}",
         mapping(b -> b.zeebeOutputExpression("y", "z")),
         scopeVariables(variable("z", "2"))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/JobInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/JobInputMappingTest.java
@@ -54,6 +54,7 @@ public final class JobInputMappingTest {
     return new Object[][] {
       {"{}", mapping(b -> {}), "{}"},
       {"{'x': 1, 'y': 2}", mapping(b -> {}), "{'x': 1, 'y': 2}"},
+      {"{'_x': 1, '_y': 2}", mapping(b -> {}), "{'_x': 1, '_y': 2}"},
       {"{'x': {'y': 2}}", mapping(b -> {}), "{'x': {'y': 2}}"},
       {"{'x': 1}", mapping(b -> b.zeebeInputExpression("x", "y")), "{'x': 1, 'y': 1}"},
       {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/JobOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/JobOutputMappingTest.java
@@ -76,6 +76,12 @@ public final class JobOutputMappingTest {
         scopeVariables(variable("y", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeOutputExpression("_x", "_y")),
+        activityVariables(variable("_x", "1")),
+        scopeVariables(variable("_y", "1"))
+      },
+      {
         "{'x': 1, 'y': 2}",
         mapping(b -> b.zeebeOutputExpression("y", "z")),
         activityVariables(variable("x", "1"), variable("y", "2")),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/MessageOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/MessageOutputMappingTest.java
@@ -80,6 +80,12 @@ public final class MessageOutputMappingTest {
         scopeVariables(variable("y", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeOutputExpression("_x", "_y")),
+        activityVariables(variable("_x", "1")),
+        scopeVariables(variable("_y", "1"))
+      },
+      {
         "{'x': 1, 'y': 2}",
         mapping(b -> b.zeebeOutputExpression("y", "z")),
         activityVariables(variable("x", "1"), variable("y", "2")),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/NoneEndEventOutputMappingTest.java
@@ -69,6 +69,11 @@ public final class NoneEndEventOutputMappingTest {
         scopeVariables(variable("y", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeOutputExpression("_x", "_y")),
+        scopeVariables(variable("_y", "1"))
+      },
+      {
         "{'x': 1}",
         mapping(b -> b.zeebeOutputExpression("decimal(x / 3, 2)", "y")),
         scopeVariables(variable("y", "0.33"))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventInputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventInputMappingTest.java
@@ -69,9 +69,19 @@ public final class SignalEndEventInputMappingTest {
         activityVariables(variable("x", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeInputExpression("_x", "_x")),
+        activityVariables(variable("_x", "1"))
+      },
+      {
         "{'x': 1}",
         mapping(b -> b.zeebeInputExpression("x", "y")),
         activityVariables(variable("y", "1"))
+      },
+      {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeInputExpression("_x", "_y")),
+        activityVariables(variable("_y", "1"))
       },
       {
         "{'x': 1, 'y': 2}",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/SignalEndEventOutputMappingTest.java
@@ -72,6 +72,11 @@ public final class SignalEndEventOutputMappingTest {
         scopeVariables(variable("y", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeOutputExpression("_x", "_y")),
+        scopeVariables(variable("_y", "1"))
+      },
+      {
         "{'x': 1}",
         mapping(b -> b.zeebeOutputExpression("decimal(x / 3, 2)", "y")),
         scopeVariables(variable("y", "0.33"))

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/UserTaskOutputMappingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/UserTaskOutputMappingTest.java
@@ -72,6 +72,12 @@ public final class UserTaskOutputMappingTest {
         scopeVariables(variable("y", "1"))
       },
       {
+        "{'_x': 1}",
+        mapping(b -> b.zeebeOutputExpression("_x", "_y")),
+        activityVariables(variable("_x", "1")),
+        scopeVariables(variable("_y", "1"))
+      },
+      {
         "{'x': 1, 'y': 2}",
         mapping(b -> b.zeebeOutputExpression("y", "z")),
         activityVariables(variable("x", "1"), variable("y", "2")),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -52,6 +52,7 @@ public final class VariableInputMappingTransformerTest {
       // direct mapping
       {List.of(mapping("x", "x")), Map.of("x", asMsgPack("1")), "{'x':1}"},
       {List.of(mapping("x", "a")), Map.of("x", asMsgPack("1")), "{'a':1}"},
+      {List.of(mapping("_x", "_b")), Map.of("_x", asMsgPack("1")), "{'_b':1}"},
       {
         List.of(mapping("x", "a"), mapping("y", "b")),
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -32,7 +32,8 @@ public final class VariableMappingTransformerTest {
   public void shouldCreateValidExpression() {
     // when
     final var expression =
-        transformer.transformInputMappings(List.of(mapping("x", "a")), expressionLanguage);
+        transformer.transformInputMappings(
+            List.of(mapping("x", "a"), mapping("_x", "b")), expressionLanguage);
 
     // then
     assertThat(expression.isValid())

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -39,6 +39,7 @@ public final class VariableOutputMappingTransformerTest {
       // direct mapping
       {List.of(mapping("x", "x")), Map.of("x", asMsgPack("1")), "{'x':1}"},
       {List.of(mapping("x", "a")), Map.of("x", asMsgPack("1")), "{'a':1}"},
+      {List.of(mapping("_x", "_b")), Map.of("_x", asMsgPack("1")), "{'_b':1}"},
       {
         List.of(mapping("x", "a"), mapping("y", "b")),
         Map.of("x", asMsgPack("1"), "y", asMsgPack("2")),


### PR DESCRIPTION
## Description

At the moment it is not possible to use I/O mappings where the variable name starts with an _. It is possible to create variable names like this in other ways, for example using the SetVariables RPC.

Restrictions around variable names should be consistent across the system. If we allow variables to start with an _ in one place, we should also allow it in the I/O mappings.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #11397 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.ink/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.ink/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [x] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.ink/camunda/operate/issues)
- [ ] [Tasklist](https://github.ink/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.ink/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.ink/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.ink/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.ink/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
