### PR TITLE
[Backport stable/8.2] ci: test-summary should fail if tests failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -416,6 +416,7 @@ jobs:
     # New test jobs must be added to the `needs` lists!
     # This name is hard-referenced from bors.toml; remember to update that if this name changes
     name: Test summary
+    if: always()
     runs-on: ubuntu-latest
     needs:
       - integration-tests
@@ -429,7 +430,7 @@ jobs:
       - go-apidiff
       - docker-checks
     steps:
-      - run: exit 0
+      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
   event_file:
     # We need to upload the event file as an artifact in order to support
     # publishing the results of forked repositories


### PR DESCRIPTION
Manual backport of https://github.com/camunda/zeebe/pull/16481
Relates to https://github.com/camunda/zeebe/issues/16458