### PR TITLE
[Backport stable/8.4] Fix Go tool version to 1.22

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -176,6 +176,6 @@ runs:
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v5
       with:
-        go-version-file: 'clients/go/go.mod'
+        go-version: '1.22'
         cache: true
         cache-dependency-path: 'clients/go/go.sum'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -380,7 +380,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
-          version: v1.52.2
+          version: v1.55.2
           # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
           skip-pkg-cache: true
           skip-build-cache: true


### PR DESCRIPTION
# Description
Manual backport of #16461 to `stable/8.4`.

relates to https://github.com/camunda/zeebe/issues/15524
original author: @tmetzke 