### PR TITLE
[Backport stable/8.4] deps(maven): Update dependency org.apache.commons:commons-compress to v1.26.0 (main)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
     <version.commons-logging>1.3.0</version.commons-logging>
     <version.commons-math>3.6.1</version.commons-math>
     <version.commons-codec>1.16.1</version.commons-codec>
-    <version.commons-compress>1.25.0</version.commons-compress>
+    <version.commons-compress>1.26.0</version.commons-compress>
     <version.zstd-jni>1.5.5-11</version.zstd-jni>
     <version.commons-text>1.11.0</version.commons-text>
     <version.cron-utils>9.2.1</version.cron-utils>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1149,6 +1149,13 @@
       </dependency>
 
       <!-- Dependencies present for convergence only -->
+      <!-- between commons-compress and testcontainers-keycloak -->
+      <dependency>
+        <groupId>commons-io</groupId>
+        <artifactId>commons-io</artifactId>
+        <version>2.15.1</version>
+      </dependency>
+
       <!-- between log4j2 and commons-compress (from testcontainers) -->
       <dependency>
         <groupId>org.osgi</groupId>


### PR DESCRIPTION
# Description
Backport of #16436 to `stable/8.4`.

relates to 
original author: @renovate[bot]