### PR TITLE
feat: Support ELs definition

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -219,6 +219,8 @@ import io.camunda.zeebe.model.bpmn.impl.instance.di.WaypointImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeAssignmentDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledDecisionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeCalledElementImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeExecutionListenerImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeExecutionListenersImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeFormDefinitionImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeHeaderImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeInputImpl;
@@ -660,6 +662,8 @@ public class Bpmn {
     ZeebeScriptImpl.registerType(bpmnModelBuilder);
     ZeebePublishMessageImpl.registerType(bpmnModelBuilder);
     ZeebeUserTaskImpl.registerType(bpmnModelBuilder);
+    ZeebeExecutionListenersImpl.registerType(bpmnModelBuilder);
+    ZeebeExecutionListenerImpl.registerType(bpmnModelBuilder);
   }
 
   /**

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
@@ -23,11 +23,15 @@ import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
  * @author Sebastian Menski
  */
 public abstract class AbstractServiceTaskBuilder<B extends AbstractServiceTaskBuilder<B>>
-    extends AbstractJobWorkerTaskBuilder<B, ServiceTask> {
+    extends AbstractJobWorkerTaskBuilder<B, ServiceTask>
+    implements ZeebeExecutionListenersBuilder<B> {
+
+  private final ZeebeExecutionListenersBuilder<B> zeebeExecutionListenersBuilder;
 
   protected AbstractServiceTaskBuilder(
       final BpmnModelInstance modelInstance, final ServiceTask element, final Class<?> selfType) {
     super(modelInstance, element, selfType);
+    zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
   }
 
   /**
@@ -39,5 +43,25 @@ public abstract class AbstractServiceTaskBuilder<B extends AbstractServiceTaskBu
   public B implementation(final String implementation) {
     element.setImplementation(implementation);
     return myself;
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type);
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+/** A fluent builder for elements with execution listeners. */
+public interface ZeebeExecutionListenersBuilder<B> {
+
+  B zeebeStartExecutionListener(String type, String retries);
+
+  B zeebeStartExecutionListener(String type);
+
+  B zeebeEndExecutionListener(String type, String retries);
+
+  B zeebeEndExecutionListener(String type);
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+
+public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBuilder<?, ?>>
+    implements ZeebeExecutionListenersBuilder<B> {
+
+  private final B elementBuilder;
+
+  public ZeebeExecutionListenersBuilderImpl(final B elementBuilder) {
+    this.elementBuilder = elementBuilder;
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type, final String retries) {
+    final ZeebeExecutionListeners executionListeners =
+        elementBuilder.getCreateSingleExtensionElement(ZeebeExecutionListeners.class);
+    final ZeebeExecutionListener listener =
+        elementBuilder.createChild(executionListeners, ZeebeExecutionListener.class);
+    listener.setEventType(ZeebeExecutionListenerEventType.start);
+    listener.setType(type);
+    listener.setRetries(retries);
+
+    return elementBuilder;
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type) {
+    return zeebeStartExecutionListener(type, ZeebeExecutionListener.DEFAULT_RETRIES);
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type, final String retries) {
+    final ZeebeExecutionListeners executionListeners =
+        elementBuilder.getCreateSingleExtensionElement(ZeebeExecutionListeners.class);
+    final ZeebeExecutionListener listener =
+        elementBuilder.createChild(executionListeners, ZeebeExecutionListener.class);
+    listener.setEventType(ZeebeExecutionListenerEventType.end);
+    listener.setType(type);
+    listener.setRetries(retries);
+
+    return elementBuilder;
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type) {
+    return zeebeEndExecutionListener(type, ZeebeExecutionListener.DEFAULT_RETRIES);
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -19,6 +19,7 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_RETRIES = "retries";
   public static final String ATTRIBUTE_TYPE = "type";
+  public static final String ATTRIBUTE_EVENT_TYPE = "eventType";
 
   public static final String ATTRIBUTE_KEY = "key";
   public static final String ATTRIBUTE_NAME = "name";
@@ -88,6 +89,9 @@ public class ZeebeConstants {
   public static final String ELEMENT_PROPERTY = "property";
 
   public static final String ELEMENT_USER_TASK = "userTask";
+
+  public static final String ELEMENT_EXECUTION_LISTENERS = "executionListeners";
+  public static final String ELEMENT_EXECUTION_LISTENER = "executionListener";
 
   /** Form key format used for camunda-forms format */
   public static final String USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT = "camunda-forms";

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeExecutionListenerImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeExecutionListenerImpl.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeExecutionListenerImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeExecutionListener {
+
+  protected static Attribute<ZeebeExecutionListenerEventType> eventTypeAttribute;
+  protected static Attribute<String> typeAttribute;
+  protected static Attribute<String> retriesAttribute;
+
+  public ZeebeExecutionListenerImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public ZeebeExecutionListenerEventType getEventType() {
+    return eventTypeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setEventType(final ZeebeExecutionListenerEventType eventType) {
+    eventTypeAttribute.setValue(this, eventType);
+  }
+
+  @Override
+  public String getType() {
+    return typeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setType(final String type) {
+    typeAttribute.setValue(this, type);
+  }
+
+  @Override
+  public String getRetries() {
+    return retriesAttribute.getValue(this);
+  }
+
+  @Override
+  public void setRetries(final String retries) {
+    retriesAttribute.setValue(this, retries);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeExecutionListener.class, ZeebeConstants.ELEMENT_EXECUTION_LISTENER)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeExecutionListenerImpl::new);
+
+    eventTypeAttribute =
+        typeBuilder
+            .enumAttribute(
+                ZeebeConstants.ATTRIBUTE_EVENT_TYPE, ZeebeExecutionListenerEventType.class)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    typeAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_TYPE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+
+    retriesAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_RETRIES)
+            .defaultValue(ZeebeExecutionListener.DEFAULT_RETRIES)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    typeBuilder.build();
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeExecutionListenersImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeExecutionListenersImpl.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import java.util.Collection;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.child.ChildElementCollection;
+
+public class ZeebeExecutionListenersImpl extends BpmnModelElementInstanceImpl
+    implements ZeebeExecutionListeners {
+
+  protected static ChildElementCollection<ZeebeExecutionListener> executionListenersCollection;
+
+  public ZeebeExecutionListenersImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public Collection<ZeebeExecutionListener> getExecutionListeners() {
+    return executionListenersCollection.get(this);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeExecutionListeners.class, ZeebeConstants.ELEMENT_EXECUTION_LISTENERS)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeExecutionListenersImpl::new);
+
+    executionListenersCollection =
+        typeBuilder.sequence().elementCollection(ZeebeExecutionListener.class).build();
+
+    typeBuilder.build();
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListener.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListener.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebeExecutionListener extends BpmnModelElementInstance {
+
+  String DEFAULT_RETRIES = "3";
+
+  ZeebeExecutionListenerEventType getEventType();
+
+  void setEventType(ZeebeExecutionListenerEventType eventType);
+
+  String getType();
+
+  void setType(String type);
+
+  String getRetries();
+
+  void setRetries(String retries);
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerEventType.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+/**
+ * Represents the type of event listener, that indicates when EL should be executed: at the start
+ * (beginning) or at the end (completion) of an element's processing.
+ */
+public enum ZeebeExecutionListenerEventType {
+  start,
+  end
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListeners.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListeners.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+import java.util.Collection;
+
+public interface ZeebeExecutionListeners extends BpmnModelElementInstance {
+  Collection<ZeebeExecutionListener> getExecutionListeners();
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ExecutionListenersValidator implements ModelElementValidator<ZeebeExecutionListeners> {
+
+  @Override
+  public Class<ZeebeExecutionListeners> getElementType() {
+    return ZeebeExecutionListeners.class;
+  }
+
+  @Override
+  public void validate(
+      final ZeebeExecutionListeners element,
+      final ValidationResultCollector validationResultCollector) {
+    final Collection<ZeebeExecutionListener> executionListeners = element.getExecutionListeners();
+    if (executionListeners == null || executionListeners.isEmpty()) {
+      return;
+    }
+
+    final Function<ZeebeExecutionListener, String> eventTypeAndTypeClassifier =
+        listener -> listener.getEventType() + "|" + listener.getType();
+
+    // Group listeners by the combination of `eventType` and `type`
+    final Map<String, List<ZeebeExecutionListener>> listenersGroupedByType =
+        executionListeners.stream().collect(Collectors.groupingBy(eventTypeAndTypeClassifier));
+
+    // Process only the groups with duplicates
+    listenersGroupedByType.values().stream()
+        .filter(duplicates -> duplicates.size() > 1)
+        .forEach(duplicates -> reportDuplicateListeners(duplicates, validationResultCollector));
+  }
+
+  private void reportDuplicateListeners(
+      final List<ZeebeExecutionListener> duplicates,
+      final ValidationResultCollector validationResultCollector) {
+    // Assumes all duplicates have the same `eventType` and `type`, so we take the first one
+    final ZeebeExecutionListener representative = duplicates.get(0);
+    final String errorMessage =
+        String.format(
+            "Found '%d' duplicates based on eventType[%s] and type[%s], these combinations should be unique.",
+            duplicates.size(), representative.getEventType(), representative.getType());
+
+    validationResultCollector.addError(0, errorMessage);
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.model.bpmn.instance.MultiInstanceLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
@@ -83,6 +84,14 @@ public final class ZeebeDesignTimeValidators {
             .hasNonEmptyAttribute(ZeebeTaskDefinition::getType, ZeebeConstants.ATTRIBUTE_TYPE)
             .hasNonEmptyAttribute(
                 ZeebeTaskDefinition::getRetries, ZeebeConstants.ATTRIBUTE_RETRIES));
+    validators.add(
+        ZeebeElementValidator.verifyThat(ZeebeExecutionListener.class)
+            .hasNonEmptyEnumAttribute(
+                ZeebeExecutionListener::getEventType, ZeebeConstants.ATTRIBUTE_EVENT_TYPE)
+            .hasNonEmptyAttribute(ZeebeExecutionListener::getType, ZeebeConstants.ATTRIBUTE_TYPE)
+            .hasNonEmptyAttribute(
+                ZeebeExecutionListener::getRetries, ZeebeConstants.ATTRIBUTE_RETRIES));
+    validators.add(new ExecutionListenersValidator());
     validators.add(
         ZeebeElementValidator.verifyThat(ZeebeSubscription.class)
             .hasNonEmptyAttribute(

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeElementValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeElementValidator.java
@@ -73,6 +73,12 @@ public final class ZeebeElementValidator<T extends ModelElementInstance>
     return this;
   }
 
+  public ZeebeElementValidator<T> hasNonEmptyEnumAttribute(
+      final Function<T, ? extends Enum<?>> enumAttributeSupplier, final String attributeName) {
+    return hasNonEmptyAttribute(
+        enumAttributeSupplier.andThen(e -> e == null ? null : e.name()), attributeName);
+  }
+
   public ZeebeElementValidator<T> hasOnlyOneAttributeInGroup(
       final Map<String, Function<T, String>> nameToAttributeSupplier) {
     nameToAttributeSupplier.forEach(

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ServiceTaskBuilderTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType.end;
+import static io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType.start;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
+import java.util.Collection;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.jupiter.api.Test;
+
+public class ServiceTaskBuilderTest {
+
+  @Test
+  void shouldSetServiceTaskPropertiesAsExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobTypeExpression("expressionType")
+                        .zeebeJobRetriesExpression("expressionRetries"))
+            .done();
+
+    // then
+    final ModelElementInstance serviceTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) serviceTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeTaskDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeTaskDefinition::getType, ZeebeTaskDefinition::getRetries)
+        .containsExactly(tuple("=expressionType", "=expressionRetries"));
+  }
+
+  @Test
+  void shouldDefineExecutionListenersForServiceTask() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType("service_task_type")
+                        .zeebeJobRetries("6")
+                        .zeebeStartExecutionListener("el_start_type_1")
+                        .zeebeStartExecutionListener("el_start_type_2", "2")
+                        .zeebeEndExecutionListener("el_end_type_1", "5")
+                        .zeebeEndExecutionListener("el_end_type_2"))
+            .done();
+
+    // then
+    final ModelElementInstance serviceTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) serviceTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeTaskDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeTaskDefinition::getType, ZeebeTaskDefinition::getRetries)
+        .containsExactly(tuple("service_task_type", "6"));
+    assertThat(getExecutionListeners(serviceTask))
+        .hasSize(4)
+        .extracting(
+            ZeebeExecutionListener::getEventType,
+            ZeebeExecutionListener::getType,
+            ZeebeExecutionListener::getRetries)
+        .containsExactly(
+            tuple(start, "el_start_type_1", ZeebeExecutionListener.DEFAULT_RETRIES),
+            tuple(start, "el_start_type_2", "2"),
+            tuple(end, "el_end_type_1", "5"),
+            tuple(end, "el_end_type_2", ZeebeExecutionListener.DEFAULT_RETRIES));
+  }
+
+  private Collection<ZeebeExecutionListener> getExecutionListeners(
+      final ModelElementInstance elementInstance) {
+    return elementInstance
+        .getUniqueChildElementByType(ExtensionElements.class)
+        .getUniqueChildElementByType(ZeebeExecutionListeners.class)
+        .getChildElementsByType(ZeebeExecutionListener.class);
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenerTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+public class ZeebeExecutionListenerTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Arrays.asList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "eventType", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "type", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "retries", false, false, "3"));
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.groups.Tuple.tuple;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.Test;
+
+public class ZeebeExecutionListenersTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Arrays.asList(
+        new ChildElementAssumption(BpmnModelConstants.ZEEBE_NS, ZeebeExecutionListener.class));
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Test
+  public void shouldReadExecutionListenerElements() {
+    // given
+    modelInstance =
+        Bpmn.readModelFromStream(
+            ZeebeExecutionListenersTest.class.getResourceAsStream(
+                "ZeebeExecutionListenersTest.bpmn"));
+
+    final ModelElementInstance serviceTask = modelInstance.getModelElementById("service_task");
+
+    // when
+    final Collection<ZeebeExecutionListener> executionListeners =
+        getExecutionListeners(serviceTask);
+
+    // then
+    assertThat(executionListeners)
+        .extracting("eventType", "type", "retries")
+        .containsExactly(
+            tuple(ZeebeExecutionListenerEventType.start, "task_start_el_1", "4"),
+            tuple(ZeebeExecutionListenerEventType.start, "task_start_el_2", "8"),
+            tuple(ZeebeExecutionListenerEventType.end, "task_end_el_1", "5"),
+            tuple(
+                ZeebeExecutionListenerEventType.end,
+                "task_end_el_2",
+                ZeebeExecutionListener.DEFAULT_RETRIES));
+  }
+
+  private Collection<ZeebeExecutionListener> getExecutionListeners(
+      final ModelElementInstance elementInstance) {
+    return elementInstance
+        .getUniqueChildElementByType(ExtensionElements.class)
+        .getUniqueChildElementByType(ZeebeExecutionListeners.class)
+        .getChildElementsByType(ZeebeExecutionListener.class);
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import org.camunda.bpm.model.xml.impl.util.ReflectUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class ZeebeExecutionListenersValidationTest {
+  @Test
+  @DisplayName("element with ExecutionListeners defined without job `type`")
+  void testJobTypeNotDefined() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType("service_task_type")
+                        .zeebeJobRetries("6")
+                        .zeebeStartExecutionListener(null /*job type not defined*/))
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(ZeebeExecutionListener.class, "Attribute 'type' must be present and not empty"));
+  }
+
+  @Test
+  @DisplayName("element with ExecutionListeners defined without `eventType`")
+  void testEventTypeNotDefined() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.testEventTypeNotDefined.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(ZeebeExecutionListener.class, "Attribute 'eventType' must be present"));
+  }
+
+  @Test
+  @DisplayName(
+      "element with ExecutionListeners defined with the same `type` but different `eventType`")
+  void testExecutionListenersTheSameJobTypeButDifferentEventType() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType("service_task_type")
+                        .zeebeStartExecutionListener("type_A")
+                        .zeebeEndExecutionListener("type_A"))
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName("element with ExecutionListeners defined with the same `eventType` and `type`")
+  void testExecutionListenersWithTheSameEventTypeAndJobType() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                task ->
+                    task.zeebeJobType("service_task_type")
+                        .zeebeJobRetries("6")
+                        .zeebeStartExecutionListener("type_A")
+                        .zeebeStartExecutionListener("type_A")
+                        .zeebeEndExecutionListener("type_A")
+                        .zeebeEndExecutionListener("type_b") // unique
+                        .zeebeEndExecutionListener("type_B")
+                        .zeebeEndExecutionListener("type_B")
+                        .zeebeEndExecutionListener("type_B")
+                        .zeebeEndExecutionListener(null)
+                        .zeebeEndExecutionListener(null))
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeExecutionListeners.class,
+            "Found '3' duplicates based on eventType[end] and type[type_B], these combinations should be unique."),
+        expect(
+            ZeebeExecutionListeners.class,
+            "Found '2' duplicates based on eventType[end] and type[null], these combinations should be unique."),
+        expect(
+            ZeebeExecutionListeners.class,
+            "Found '2' duplicates based on eventType[start] and type[type_A], these combinations should be unique."),
+        expect(ZeebeExecutionListener.class, "Attribute 'type' must be present and not empty"));
+  }
+}

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeExecutionListenersTest.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1hhbqbg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="Process_1a53s9c" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_1du2tni</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1du2tni" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:sequenceFlow id="Flow_029v1e2" sourceRef="service_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_029v1e2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="task_start_el_1" retries="4" />
+          <zeebe:executionListener eventType="start" type="task_start_el_2" retries="8" />
+          <zeebe:executionListener eventType="end" type="task_end_el_1" retries="5" />
+          <zeebe:executionListener eventType="end" type="task_end_el_2" />
+        </zeebe:executionListeners>
+        <zeebe:taskDefinition type="task_type" retries="8" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1du2tni</bpmn:incoming>
+      <bpmn:outgoing>Flow_029v1e2</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1a53s9c">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start_event">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05j5qkv_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_068g3bp_di" bpmnElement="end_event">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1du2tni_di" bpmnElement="Flow_1du2tni">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_029v1e2_di" bpmnElement="Flow_029v1e2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.testEventTypeNotDefined.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.testEventTypeNotDefined.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1hhbqbg" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="Process_1a53s9c" isExecutable="true">
+    <bpmn:startEvent id="start_event">
+      <bpmn:outgoing>Flow_1du2tni</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1du2tni" sourceRef="start_event" targetRef="service_task" />
+    <bpmn:sequenceFlow id="Flow_029v1e2" sourceRef="service_task" targetRef="end_event" />
+    <bpmn:endEvent id="end_event">
+      <bpmn:incoming>Flow_029v1e2</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="service_task">
+      <bpmn:extensionElements>
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="task_start_el_1" retries="4" />
+          <zeebe:executionListener type="task_start_el_2" retries="8" />
+          <zeebe:executionListener eventType="end" type="task_end_el_1" retries="5" />
+          <zeebe:executionListener eventType="" type="task_end_el_2" retries="5" />
+        </zeebe:executionListeners>
+        <zeebe:taskDefinition type="task_type" retries="8" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1du2tni</bpmn:incoming>
+      <bpmn:outgoing>Flow_029v1e2</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1a53s9c">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start_event">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05j5qkv_di" bpmnElement="service_task">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_068g3bp_di" bpmnElement="end_event">
+        <dc:Bounds x="472" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1du2tni_di" bpmnElement="Flow_1du2tni">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_029v1e2_di" bpmnElement="Flow_029v1e2">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="472" y="117" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableFlowNode.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.protocol.record.value.ExecutionListenerEventType;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -19,6 +20,8 @@ public class ExecutableFlowNode extends AbstractFlowElement {
 
   private Optional<Expression> inputMappings = Optional.empty();
   private Optional<Expression> outputMappings = Optional.empty();
+
+  private final List<ExecutionListener> executionListeners = new ArrayList<>();
 
   public ExecutableFlowNode(final String id) {
     super(id);
@@ -54,5 +57,29 @@ public class ExecutableFlowNode extends AbstractFlowElement {
 
   public void setOutputMappings(final Expression outputMappings) {
     this.outputMappings = Optional.of(outputMappings);
+  }
+
+  public void addListener(
+      final ExecutionListenerEventType eventType, final Expression type, final Expression retries) {
+    final ExecutionListener listener = new ExecutionListener();
+    listener.setEventType(eventType);
+
+    final JobWorkerProperties jobWorkerProperties = new JobWorkerProperties();
+    jobWorkerProperties.setType(type);
+    jobWorkerProperties.setRetries(retries);
+    listener.setJobWorkerProperties(jobWorkerProperties);
+    executionListeners.add(listener);
+  }
+
+  public List<ExecutionListener> getStartExecutionListeners() {
+    return executionListeners.stream()
+        .filter(el -> el.getEventType() == ExecutionListenerEventType.START)
+        .toList();
+  }
+
+  public List<ExecutionListener> getEndExecutionListeners() {
+    return executionListeners.stream()
+        .filter(el -> el.getEventType() == ExecutionListenerEventType.END)
+        .toList();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutionListener.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutionListener.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.element;
+
+import io.camunda.zeebe.protocol.record.value.ExecutionListenerEventType;
+
+public class ExecutionListener {
+  private ExecutionListenerEventType eventType;
+  private JobWorkerProperties jobWorkerProperties = new JobWorkerProperties();
+
+  public ExecutionListenerEventType getEventType() {
+    return eventType;
+  }
+
+  public void setEventType(final ExecutionListenerEventType eventType) {
+    this.eventType = eventType;
+  }
+
+  public JobWorkerProperties getJobWorkerProperties() {
+    return jobWorkerProperties;
+  }
+
+  public void setJobWorkerProperties(final JobWorkerProperties jobWorkerProperties) {
+    this.jobWorkerProperties = jobWorkerProperties;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/ExecutionListenerTransformer.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.deployment.model.transformer.zeebe;
+
+import io.camunda.zeebe.el.ExpressionLanguage;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+import io.camunda.zeebe.protocol.record.value.ExecutionListenerEventType;
+import java.util.Collection;
+
+public final class ExecutionListenerTransformer {
+
+  public void transform(
+      final ExecutableFlowNode executableFlowNode,
+      final Collection<ZeebeExecutionListener> executionListeners,
+      final ExpressionLanguage expressionLanguage) {
+
+    executionListeners.forEach(
+        listener -> addListenerToFlowNode(listener, executableFlowNode, expressionLanguage));
+  }
+
+  private void addListenerToFlowNode(
+      final ZeebeExecutionListener listener,
+      final ExecutableFlowNode flowNode,
+      final ExpressionLanguage expressionLanguage) {
+
+    flowNode.addListener(
+        fromZeebeExecutionListenerEventType(listener.getEventType()),
+        expressionLanguage.parseExpression(listener.getType()),
+        expressionLanguage.parseExpression(listener.getRetries()));
+  }
+
+  private ExecutionListenerEventType fromZeebeExecutionListenerEventType(
+      final ZeebeExecutionListenerEventType eventType) {
+    return switch (eventType) {
+      case ZeebeExecutionListenerEventType.start -> ExecutionListenerEventType.START;
+      case ZeebeExecutionListenerEventType.end -> ExecutionListenerEventType.END;
+    };
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExecutionListenerEventType.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ExecutionListenerEventType.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+public enum ExecutionListenerEventType {
+  START,
+  END
+}


### PR DESCRIPTION
## Description
Introduced the capability to define Execution Listeners for `Service tasks` within the BPMN model API of the Zeebe workflow engine. This update prepares the groundwork for further development where the actual processing of these ELs will be implemented. 

### Key enhancements:
- Extended the BPMN model API to allow specification of ELs for service tasks, detailing `eventType`, `type`, and `retries`.
- Refined the Java builder API, facilitating an intuitive approach to adding ELs to service tasks.
- Prepared the executable model for EL.
- Updated element transformers to recognize and handle EL definitions within the BPMN model.
- Implemented validation to ensure EL types are unique within the same `eventType`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16206 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
