### PR TITLE
Reset error phase only after processing current record is completed

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/MultipleInvalidResourceDeletionTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/MultipleInvalidResourceDeletionTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.processing;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ClientStatusException;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.grpc.Status.Code;
+import org.junit.jupiter.api.BeforeEach;
+
+@ZeebeIntegration
+public class MultipleInvalidResourceDeletionTest {
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker()
+          // disable long polling to increase the load in streamprocessor
+          .withGatewayConfig(cfg -> cfg.getLongPolling().setEnabled(false))
+          .withRecordingExporter(true);
+
+  private final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
+  @AutoCloseResource private ZeebeClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = zeebe.newClientBuilder().build();
+  }
+
+  @RegressionTest("https://github.com/camunda/zeebe/issues/16429")
+  public void shouldRejectMultipleResourceDeletion() {
+    // given
+    // generate load on stream processor. This is to increase the chance of the issue to happen.
+    client
+        .newWorker()
+        .jobType("test")
+        .handler(
+            (jobClient, job) -> {
+              jobClient.newCompleteCommand(job.getKey()).send().join();
+            })
+        .open();
+
+    // when
+    final var firstRejection =
+        client.newDeleteResourceCommand(Protocol.encodePartitionId(1, 999999L)).send();
+    final var secondRejection =
+        client.newDeleteResourceCommand(Protocol.encodePartitionId(1, 999999L)).send();
+    final var thirdRejection =
+        client.newDeleteResourceCommand(Protocol.encodePartitionId(1, 999999L)).send();
+
+    // then
+    // All requests should be rejected. In the original issue, the second/third requests can timeout
+    assertThatThrownBy(firstRejection::join)
+        .isInstanceOf(ClientStatusException.class)
+        .extracting("status.code")
+        .isEqualTo(Code.NOT_FOUND);
+
+    assertThatThrownBy(secondRejection::join)
+        .isInstanceOf(ClientStatusException.class)
+        .extracting("status.code")
+        .isEqualTo(Code.NOT_FOUND);
+
+    assertThatThrownBy(thirdRejection::join)
+        .isInstanceOf(ClientStatusException.class)
+        .extracting("status.code")
+        .isEqualTo(Code.NOT_FOUND);
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -60,7 +60,7 @@ import org.slf4j.Logger;
  *
  * +------------------+            +--------------------+
  * |                  |            |                    |      exception
- * | readNextRecord() |----------->|  processCommand()  |------------------+
+ * | tryToReadNextRecord() |----------->|  processCommand()  |------------------+
  * |                  |            |                    |                  v
  * +------------------+            +--------------------+            +---------------+
  *           ^                             |                         |               |------+
@@ -201,12 +201,8 @@ public final class ProcessingStateMachine {
   private void skipRecord() {
     notifySkippedListener(currentRecord);
     markProcessingCompleted();
-    actor.submit(this::readNextRecord);
+    actor.submit(this::tryToReadNextRecord);
     metrics.eventSkipped();
-  }
-
-  void readNextRecord() {
-    tryToReadNextRecord();
   }
 
   void markProcessingCompleted() {
@@ -217,7 +213,7 @@ public final class ProcessingStateMachine {
     }
   }
 
-  private void tryToReadNextRecord() {
+  void tryToReadNextRecord() {
     final var hasNext = logStreamReader.hasNext();
 
     if (currentRecord != null) {
@@ -700,7 +696,7 @@ public final class ProcessingStateMachine {
 
           // continue with next record
           markProcessingCompleted();
-          actor.submit(this::readNextRecord);
+          actor.submit(this::tryToReadNextRecord);
         });
   }
 
@@ -753,7 +749,7 @@ public final class ProcessingStateMachine {
       lastWrittenPosition = lastProcessingPositions.getLastWrittenPosition();
     }
 
-    actor.submit(this::readNextRecord);
+    actor.submit(this::tryToReadNextRecord);
   }
 
   private record BatchProcessingStepResult(

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -200,18 +200,21 @@ public final class ProcessingStateMachine {
 
   private void skipRecord() {
     notifySkippedListener(currentRecord);
-    inProcessing = false;
+    markProcessingCompleted();
     actor.submit(this::readNextRecord);
     metrics.eventSkipped();
   }
 
   void readNextRecord() {
+    tryToReadNextRecord();
+  }
+
+  void markProcessingCompleted() {
+    inProcessing = false;
     if (onErrorRetries > 0) {
       onErrorRetries = 0;
       errorHandlingPhase = ErrorHandlingPhase.NO_ERROR;
     }
-
-    tryToReadNextRecord();
   }
 
   private void tryToReadNextRecord() {
@@ -696,7 +699,7 @@ public final class ProcessingStateMachine {
           processingTimer.close();
 
           // continue with next record
-          inProcessing = false;
+          markProcessingCompleted();
           actor.submit(this::readNextRecord);
         });
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -563,7 +563,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               lifecycleAwareListeners.forEach(StreamProcessorLifecycleAware::onResumed);
               streamProcessorContext.streamProcessorPhase(Phase.PROCESSING);
               if (processingStateMachine != null) {
-                actor.submit(processingStateMachine::readNextRecord);
+                actor.submit(processingStateMachine::tryToReadNextRecord);
               }
               LOG.debug("Resumed processing for partition {}", partitionId);
             }
@@ -573,7 +573,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
 
   @Override
   public void onRecordAvailable() {
-    actor.run(processingStateMachine::readNextRecord);
+    actor.run(processingStateMachine::tryToReadNextRecord);
   }
 
   private static final class AsyncProcessingScheduleServiceActor extends Actor {


### PR DESCRIPTION
## Description

The root cause for issue #16429 
Error phase was reset everytime `readNextRecord` was called. As a result, it was reset even before the error was handled. So at some point, the `onErrorRetries` is 0, while `errorHandlingPhase` is something other than `NO_ERROR`. As a result, the next command that encounters an exception, skips the error handling in the engine and would be directly handled by the error handling in `ProcessingStateMachine`. 

This is fixed by ensuring that the error phase is always reset after the processing of current record is completed.

It was not possible to reproduce this with a unit test. So an integration test is added.

The second issue that `ProcessingStateMachine` could not prevent endless error loop is not yet fixed. This is less critical, as it is not a regression. It will be fixed in a follow up PR.

## Related issues

closes #16429 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
