### PR TITLE
Transport task headers in Zeebe user task record

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -34,13 +34,19 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class BpmnUserTaskBehavior {
 
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(BpmnUserTaskBehavior.class.getPackageName());
   private static final Set<LifecycleState> CANCELABLE_LIFECYCLE_STATES =
       EnumSet.complementOf(EnumSet.of(LifecycleState.NOT_FOUND, LifecycleState.CANCELING));
   private final UserTaskRecord userTaskRecord =
       new UserTaskRecord().setVariables(DocumentValue.EMPTY_DOCUMENT);
+
+  private final HeaderEncoder headerEncoder = new HeaderEncoder(LOGGER);
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final ExpressionProcessor expressionBehavior;
@@ -101,6 +107,9 @@ public final class BpmnUserTaskBehavior {
       final UserTaskProperties userTaskProperties) {
     final var userTaskKey = keyGenerator.nextKey();
 
+    final var encodedHeaders =
+        headerEncoder.encode(element.getUserTaskProperties().getTaskHeaders());
+
     userTaskRecord
         .setUserTaskKey(userTaskKey)
         .setAssignee(userTaskProperties.getAssignee())
@@ -110,6 +119,7 @@ public final class BpmnUserTaskBehavior {
         .setFollowUpDate(userTaskProperties.getFollowUpDate())
         .setFormKey(userTaskProperties.getFormKey())
         .setExternalFormReference(userTaskProperties.getExternalFormReference())
+        .setCustomHeaders(encodedHeaders)
         .setBpmnProcessId(context.getBpmnProcessId())
         .setProcessDefinitionVersion(context.getProcessVersion())
         .setProcessDefinitionKey(context.getProcessDefinitionKey())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/HeaderEncoder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/HeaderEncoder.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+import org.agrona.ExpandableArrayBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.slf4j.Logger;
+
+public final class HeaderEncoder {
+
+  private static final int INITIAL_SIZE_KEY_VALUE_PAIR = 128;
+
+  private final Logger logger;
+
+  private final MsgPackWriter msgPackWriter = new MsgPackWriter();
+
+  public HeaderEncoder(final Logger logger) {
+    this.logger = logger;
+  }
+
+  public DirectBuffer encode(final Map<String, String> taskHeaders) {
+    if (taskHeaders == null || taskHeaders.isEmpty()) {
+      return JobRecord.NO_HEADERS;
+    }
+
+    final MutableDirectBuffer buffer = new UnsafeBuffer(0, 0);
+
+    final var validHeaders =
+        taskHeaders.entrySet().stream()
+            .filter(entry -> isValidHeader(entry.getKey(), entry.getValue()))
+            .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+    if (validHeaders.size() != taskHeaders.size()) {
+      logger.debug("Ignored {} invalid headers.", taskHeaders.size() - validHeaders.size());
+    }
+
+    final ExpandableArrayBuffer expandableBuffer =
+        new ExpandableArrayBuffer(INITIAL_SIZE_KEY_VALUE_PAIR * validHeaders.size());
+
+    msgPackWriter.wrap(expandableBuffer, 0);
+    msgPackWriter.writeMapHeader(validHeaders.size());
+
+    validHeaders.forEach(
+        (k, v) -> {
+          final DirectBuffer key = wrapString(k);
+          msgPackWriter.writeString(key);
+
+          final DirectBuffer value = wrapString(v);
+          msgPackWriter.writeString(value);
+        });
+
+    buffer.wrap(expandableBuffer.byteArray(), 0, msgPackWriter.getOffset());
+
+    return buffer;
+  }
+
+  private boolean isValidHeader(final String key, final String value) {
+    return key != null && !key.isEmpty() && value != null && !value.isEmpty();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/JobWorkerProperties.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
-import java.util.Map;
 
 /**
  * The properties of an element that is based on a job and should be processed by a job worker. For
@@ -18,8 +17,6 @@ public class JobWorkerProperties extends UserTaskProperties {
 
   private Expression type;
   private Expression retries;
-
-  private Map<String, String> taskHeaders = Map.of();
 
   public Expression getType() {
     return type;
@@ -35,13 +32,5 @@ public class JobWorkerProperties extends UserTaskProperties {
 
   public void setRetries(final Expression retries) {
     this.retries = retries;
-  }
-
-  public Map<String, String> getTaskHeaders() {
-    return taskHeaders;
-  }
-
-  public void setTaskHeaders(final Map<String, String> taskHeaders) {
-    this.taskHeaders = taskHeaders;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/UserTaskProperties.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/UserTaskProperties.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
+import java.util.Map;
 
 /** The properties of a user task element. */
 public class UserTaskProperties {
@@ -19,6 +20,7 @@ public class UserTaskProperties {
   private Expression externalFormReference;
   private Expression followUpDate;
   private Expression formId;
+  private Map<String, String> taskHeaders = Map.of();
 
   public Expression getAssignee() {
     return assignee;
@@ -76,6 +78,14 @@ public class UserTaskProperties {
     this.formId = formId;
   }
 
+  public Map<String, String> getTaskHeaders() {
+    return taskHeaders;
+  }
+
+  public void setTaskHeaders(final Map<String, String> taskHeaders) {
+    this.taskHeaders = taskHeaders;
+  }
+
   public void wrap(final UserTaskProperties userTaskProperties) {
     setAssignee(userTaskProperties.getAssignee());
     setCandidateGroups(userTaskProperties.getCandidateGroups());
@@ -84,5 +94,6 @@ public class UserTaskProperties {
     setExternalFormReference(userTaskProperties.getExternalFormReference());
     setFollowUpDate(userTaskProperties.getFollowUpDate());
     setFormId(userTaskProperties.getFormId());
+    setTaskHeaders(userTaskProperties.getTaskHeaders());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -57,6 +57,7 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     transformAssignmentDefinition(element, userTaskProperties);
     transformTaskSchedule(element, userTaskProperties);
     transformTaskFormId(element, userTaskProperties);
+    transformModelTaskHeaders(element, userTaskProperties);
 
     if (isZeebeUserTask) {
       transformExternalReference(element, userTaskProperties);
@@ -65,8 +66,8 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
       final var jobWorkerProperties = new JobWorkerProperties();
       jobWorkerProperties.wrap(userTaskProperties);
 
+      addZeebeUserTaskFormKeyHeader(element, jobWorkerProperties.getTaskHeaders());
       transformTaskDefinition(jobWorkerProperties);
-      transformTaskHeaders(element, jobWorkerProperties);
       userTask.setJobWorkerProperties(jobWorkerProperties);
     }
   }
@@ -88,16 +89,12 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     transformCandidateUsers(userTaskProperties, assignmentDefinition);
   }
 
-  private void transformTaskHeaders(
-      final UserTask element, final JobWorkerProperties jobWorkerProperties) {
+  private void transformModelTaskHeaders(
+      final UserTask element, final UserTaskProperties userTaskProperties) {
     final Map<String, String> taskHeaders = new HashMap<>();
 
     collectModelTaskHeaders(element, taskHeaders);
-    addZeebeUserTaskFormKeyHeader(element, taskHeaders);
-
-    if (!taskHeaders.isEmpty()) {
-      jobWorkerProperties.setTaskHeaders(taskHeaders);
-    }
+    userTaskProperties.setTaskHeaders(taskHeaders);
   }
 
   private void addZeebeUserTaskFormKeyHeader(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskTest.java
@@ -161,6 +161,27 @@ public final class NativeUserTaskTest {
   }
 
   @Test
+  public void shouldCreateUserTaskWithCustomHeaders() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(process(t -> t.zeebeTaskHeader("a", "b").zeebeTaskHeader("c", "d")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final Record<UserTaskRecordValue> userTask =
+        RecordingExporter.userTaskRecords(UserTaskIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final Map<String, String> customHeaders = userTask.getValue().getCustomHeaders();
+    assertThat(customHeaders).hasSize(2).containsEntry("a", "b").containsEntry("c", "d");
+  }
+
+  @Test
   public void shouldPickUpCustomFormForUserTask() {
     // given
     final String externalReference = "http://example.com/my-external-form";

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -73,6 +73,9 @@
             "variables": {
               "enabled": false
             },
+            "customHeaders": {
+              "enabled": false
+            },
             "tenantId": {
               "type": "keyword"
             }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-user-task-template.json
@@ -73,6 +73,9 @@
             "variables": {
               "enabled": false
             },
+            "customHeaders": {
+              "enabled": false
+            },
             "tenantId": {
               "type": "keyword"
             }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2088,6 +2088,8 @@ final class JsonSerializableToJsonTest {
                     .setFormKey(456)
                     .setExternalFormReference("myReference")
                     .setVariables(VARIABLES_MSGPACK)
+                    .setCustomHeaders(
+                        wrapArray(MsgPackConverter.convertToMsgPack(Map.of("foo", "bar"))))
                     .setChangedAttributes(List.of("foo", "bar"))
                     .setAction("complete")
                     .setBpmnProcessId("test-process")
@@ -2113,6 +2115,9 @@ final class JsonSerializableToJsonTest {
         "changedAttributes": ["foo", "bar"],
         "externalFormReference": "myReference",
         "variables": {
+          "foo": "bar"
+        },
+        "customHeaders": {
           "foo": "bar"
         },
         "action": "complete",
@@ -2146,6 +2151,7 @@ final class JsonSerializableToJsonTest {
         "changedAttributes": [],
         "externalFormReference": "",
         "variables": {},
+        "customHeaders": {},
         "action": "",
         "formKey": -1,
         "userTaskKey": -1,
@@ -2182,6 +2188,7 @@ final class JsonSerializableToJsonTest {
         "variables": {
           "foo": null
         },
+        "customHeaders": {},
         "action": "",
         "formKey": -1,
         "userTaskKey": -1,

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/UserTaskRecordValue.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import java.util.List;
+import java.util.Map;
 import org.immutables.value.Value;
 
 /**
@@ -50,6 +51,8 @@ public interface UserTaskRecordValue
   String getAction();
 
   String getExternalFormReference();
+
+  Map<String, String> getCustomHeaders();
 
   long getCreationTimestamp();
 


### PR DESCRIPTION
## Description

* User task records transport the `zeebe:taskHeaders` elements as `customHeaders` like job records do.
* The task headers are not interpreted by the engine. 

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16523 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
