### PR TITLE
test(dmn): fix flaky EvaluateDecisionTest

### DIFF
--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionStub.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionStub.java
@@ -21,19 +21,18 @@ public class EvaluateDecisionStub
     implements RequestStub<
         BrokerEvaluateDecisionRequest, BrokerResponse<DecisionEvaluationRecord>> {
 
-  public static final DecisionEvaluationRecord DECISION_RECORD = new DecisionEvaluationRecord();
-
-  {
-    DECISION_RECORD
-        .setDecisionId("decision")
-        .setDecisionKey(123L)
-        .setDecisionVersion(1)
-        .setDecisionName("Decision")
-        .setDecisionOutput(toMessagePack("\"decision-output\""))
-        .setDecisionRequirementsId("decisionRequirements")
-        .setDecisionRequirementsKey(124L);
+  public static DecisionEvaluationRecord createDecisionRecord() {
+    final DecisionEvaluationRecord evaluationRecord =
+        new DecisionEvaluationRecord()
+            .setDecisionId("decision")
+            .setDecisionKey(123L)
+            .setDecisionVersion(1)
+            .setDecisionName("Decision")
+            .setDecisionOutput(toMessagePack("\"decision-output\""))
+            .setDecisionRequirementsId("decisionRequirements")
+            .setDecisionRequirementsKey(124L);
     final EvaluatedDecisionRecord evaluatedDecisionRecord =
-        DECISION_RECORD.evaluatedDecisions().add();
+        evaluationRecord.evaluatedDecisions().add();
     evaluatedDecisionRecord
         .setDecisionId("intermediateDecision")
         .setDecisionKey(125L)
@@ -56,6 +55,7 @@ public class EvaluateDecisionStub
         .setOutputId("outputId")
         .setOutputName("OUTPUT NAME")
         .setOutputValue(toMessagePack("\"output-value\""));
+    return evaluationRecord;
   }
 
   @Override
@@ -66,9 +66,9 @@ public class EvaluateDecisionStub
   @Override
   public BrokerResponse<DecisionEvaluationRecord> handle(
       final BrokerEvaluateDecisionRequest request) throws Exception {
-    // In practise the decision instance key is generated newly by the broker
-    final long decisionInstanceKey = DECISION_RECORD.getDecisionKey() + 1;
-    return new BrokerResponse<>(DECISION_RECORD, request.getPartitionId(), decisionInstanceKey);
+    final DecisionEvaluationRecord evaluationRecord = createDecisionRecord();
+    return new BrokerResponse<>(
+        evaluationRecord, request.getPartitionId(), evaluationRecord.getDecisionKey());
   }
 
   private static DirectBuffer toMessagePack(final String json) {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/decision/EvaluateDecisionTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.gateway.api.decision;
 
-import static io.camunda.zeebe.gateway.api.decision.EvaluateDecisionStub.DECISION_RECORD;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.gateway.api.util.GatewayTest;
@@ -28,6 +27,7 @@ public class EvaluateDecisionTest extends GatewayTest {
   @Test
   public void shouldMapToBrokerRequest() {
     // given
+    final DecisionEvaluationRecord evaluationRecord = EvaluateDecisionStub.createDecisionRecord();
     final EvaluateDecisionStub stub = new EvaluateDecisionStub();
     stub.registerWith(brokerClient);
 
@@ -35,8 +35,8 @@ public class EvaluateDecisionTest extends GatewayTest {
 
     final EvaluateDecisionRequest request =
         EvaluateDecisionRequest.newBuilder()
-            .setDecisionId(DECISION_RECORD.getDecisionId())
-            .setDecisionKey(DECISION_RECORD.getDecisionKey())
+            .setDecisionId(evaluationRecord.getDecisionId())
+            .setDecisionKey(evaluationRecord.getDecisionKey())
             .setVariables(variables)
             .build();
 
@@ -49,8 +49,8 @@ public class EvaluateDecisionTest extends GatewayTest {
     assertThat(brokerRequest.getValueType()).isEqualTo(ValueType.DECISION_EVALUATION);
 
     final DecisionEvaluationRecord record = brokerRequest.getRequestWriter();
-    assertThat(record.getDecisionId()).isEqualTo(DECISION_RECORD.getDecisionId());
-    assertThat(record.getDecisionKey()).isEqualTo(DECISION_RECORD.getDecisionKey());
+    assertThat(record.getDecisionId()).isEqualTo(evaluationRecord.getDecisionId());
+    assertThat(record.getDecisionKey()).isEqualTo(evaluationRecord.getDecisionKey());
     MsgPackUtil.assertEqualityExcluding(record.getVariablesBuffer(), variables);
     assertThat(record.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
@@ -58,6 +58,7 @@ public class EvaluateDecisionTest extends GatewayTest {
   @Test
   public void shouldMapRequestAndResponse() {
     // given
+    final DecisionEvaluationRecord evaluationRecord = EvaluateDecisionStub.createDecisionRecord();
     final EvaluateDecisionStub stub = new EvaluateDecisionStub();
     stub.registerWith(brokerClient);
 
@@ -65,8 +66,8 @@ public class EvaluateDecisionTest extends GatewayTest {
 
     final EvaluateDecisionRequest request =
         EvaluateDecisionRequest.newBuilder()
-            .setDecisionId(DECISION_RECORD.getDecisionId())
-            .setDecisionKey(DECISION_RECORD.getDecisionKey())
+            .setDecisionId(evaluationRecord.getDecisionId())
+            .setDecisionKey(evaluationRecord.getDecisionKey())
             .setVariables(variables)
             .build();
 
@@ -77,22 +78,22 @@ public class EvaluateDecisionTest extends GatewayTest {
     assertThat(response).isNotNull();
 
     // assert DecisionEvaluationRecord mapping
-    assertThat(response.getDecisionInstanceKey()).isGreaterThan(DECISION_RECORD.getDecisionKey());
-    assertThat(response.getDecisionId()).isEqualTo(DECISION_RECORD.getDecisionId());
-    assertThat(response.getDecisionKey()).isEqualTo(DECISION_RECORD.getDecisionKey());
-    assertThat(response.getDecisionName()).isEqualTo(DECISION_RECORD.getDecisionName());
-    assertThat(response.getDecisionVersion()).isEqualTo(DECISION_RECORD.getDecisionVersion());
+    assertThat(response.getDecisionInstanceKey()).isEqualTo(evaluationRecord.getDecisionKey());
+    assertThat(response.getDecisionId()).isEqualTo(evaluationRecord.getDecisionId());
+    assertThat(response.getDecisionKey()).isEqualTo(evaluationRecord.getDecisionKey());
+    assertThat(response.getDecisionName()).isEqualTo(evaluationRecord.getDecisionName());
+    assertThat(response.getDecisionVersion()).isEqualTo(evaluationRecord.getDecisionVersion());
     assertThat(response.getDecisionRequirementsId())
-        .isEqualTo(DECISION_RECORD.getDecisionRequirementsId());
+        .isEqualTo(evaluationRecord.getDecisionRequirementsId());
     assertThat(response.getDecisionRequirementsKey())
-        .isEqualTo(DECISION_RECORD.getDecisionRequirementsKey());
-    assertThat(response.getDecisionOutput()).isEqualTo(DECISION_RECORD.getDecisionOutput());
+        .isEqualTo(evaluationRecord.getDecisionRequirementsKey());
+    assertThat(response.getDecisionOutput()).isEqualTo(evaluationRecord.getDecisionOutput());
     assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
     // assert EvaluatedDecisionRecord mapping
     assertThat(response.getEvaluatedDecisionsCount()).isOne();
     final var intermediateResultResponse = response.getEvaluatedDecisions(0);
-    final var expectedIntermediateDecisionResult = DECISION_RECORD.getEvaluatedDecisions().get(0);
+    final var expectedIntermediateDecisionResult = evaluationRecord.getEvaluatedDecisions().get(0);
     assertThat(intermediateResultResponse.getDecisionId())
         .isEqualTo(expectedIntermediateDecisionResult.getDecisionId());
     assertThat(intermediateResultResponse.getDecisionKey())


### PR DESCRIPTION
## Description

Test was referencing a static field that got eventually mutated, resulting int failing asserts on the evaluationCount value.

![image](https://github.com/camunda/zeebe/assets/209518/e723574b-3aaf-4367-9176-3b9943e493d2)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15662 
