### PR TITLE
ci: prefix Zeebe GHA workflows to avoid name collisions in monorepo

### DIFF
--- a/.github/actions/build-zeebe-docker/action.yml
+++ b/.github/actions/build-zeebe-docker/action.yml
@@ -2,7 +2,7 @@
 # If no version is given, the version is set to the Maven project version.
 
 ---
-name: Build Docker Image
+name: Build Zeebe Docker Image
 description: Builds the Zeebe Docker image
 
 inputs:

--- a/.github/actions/build-zeebe/action.yml
+++ b/.github/actions/build-zeebe/action.yml
@@ -1,5 +1,5 @@
 # This action packages the complete Zeebe distribution artifacts. This includes the Go client,
-# zbctl, and the Zeebe distribution TAR ball. This excludes the Docker image. See the build-docker
+# zbctl, and the Zeebe distribution TAR ball. This excludes the Docker image. See the build-zeebe-docker
 # for that.
 
 ---

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,5 +1,5 @@
-on: [pull_request]
 name: Commitlint
+on: [pull_request]
 
 jobs:
   lint-commits:

--- a/.github/workflows/dispatch-release-8-5.yaml
+++ b/.github/workflows/dispatch-release-8-5.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-release:
     name: "Release ${{ github.event.client_payload.releaseVersion }}"
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/zeebe-release.yml
     secrets: inherit
     with:
       releaseVersion: ${{ github.event.client_payload.releaseVersion }}

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -1,4 +1,4 @@
-name: Benchmark
+name: Zeebe Benchmark
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Zeebe CI
 
 on:
   push:
@@ -72,7 +72,7 @@ jobs:
         id: build-zeebe
         with:
           maven-extra-args: -T1C
-      - uses: ./.github/actions/build-docker
+      - uses: ./.github/actions/build-zeebe-docker
         with:
           repository: localhost:5000/camunda/zeebe
           version: current-test
@@ -196,8 +196,8 @@ jobs:
         with:
           go: false
           maven-extra-args: -T1C
-      - uses: ./.github/actions/build-docker
-        id: build-docker
+      - uses: ./.github/actions/build-zeebe-docker
+        id: build-zeebe-docker
         # Currently only Linux runners support building docker images without further ado
         if: ${{ runner.os == 'Linux' }}
         with:
@@ -207,7 +207,7 @@ jobs:
           push: false
       - name: Run smoke test on ${{ matrix.arch }}
         env:
-          # For non Linux runners there is no container available for testing, see build-docker job
+          # For non Linux runners there is no container available for testing, see build-zeebe-docker job
           EXCLUDED_TEST_GROUPS: ${{ runner.os != 'Linux' && 'container' }}
         run: >
           ./mvnw -B --no-snapshot-updates
@@ -320,8 +320,8 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
-      - uses: ./.github/actions/build-docker
-        id: build-docker
+      - uses: ./.github/actions/build-zeebe-docker
+        id: build-zeebe-docker
         with:
           repository: camunda/zeebe
           version: current-test
@@ -457,8 +457,8 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
-      - uses: ./.github/actions/build-docker
-        id: build-docker
+      - uses: ./.github/actions/build-zeebe-docker
+        id: build-zeebe-docker
         with:
           # we use a local registry for pushing
           repository: ${{ env.LOCAL_DOCKER_IMAGE }}
@@ -470,9 +470,9 @@ jobs:
         uses: ./.github/actions/verify-zeebe-docker
         with:
           imageName: ${{ env.LOCAL_DOCKER_IMAGE }}
-          date: ${{ steps.build-docker.outputs.date }}
+          date: ${{ steps.build-zeebe-docker.outputs.date }}
           revision: ${{ github.sha }}
-          version: ${{ steps.build-docker.outputs.version }}
+          version: ${{ steps.build-zeebe-docker.outputs.version }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
   test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
@@ -557,8 +557,8 @@ jobs:
           docker-token: REGISTRY_HUB_DOCKER_COM_PSW
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
-      - uses: ./.github/actions/build-docker
-        id: build-docker
+      - uses: ./.github/actions/build-zeebe-docker
+        id: build-zeebe-docker
         with:
           repository: camunda/zeebe
           version: SNAPSHOT
@@ -610,7 +610,7 @@ jobs:
     concurrency:
       group: deploy-snyk-projects
       cancel-in-progress: false
-    uses: ./.github/workflows/snyk.yml
+    uses: ./.github/workflows/zeebe-snyk.yml
     with:
       monitor: true
       build: true

--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -3,7 +3,7 @@
 #
 # As this is meant to be run via scheduling, the workflow itself only runs on the default branch
 # (e.g. main), so any changes you make will affect any other branches we test via this workflow.
-name: Daily tests
+name: Zeebe Daily tests
 
 on:
   workflow_dispatch: { }
@@ -35,7 +35,7 @@ jobs:
       - run: git fetch --tags
       - run: |
           versions=($(git tag | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sed -E -e 's/\.[0-9]+$//' | sort -Vr | uniq))
-          
+
           latest="${versions[0]}"
           second_last="${versions[1]}"
           third_last="${versions[2]}"
@@ -79,7 +79,7 @@ jobs:
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.fourth-last-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.fourth-last-version) }}
     name: Daily QA
-    uses: ./.github/workflows/qa-testbench.yaml
+    uses: ./.github/workflows/zeebe-qa-testbench.yaml
     with:
       branch: ${{ matrix.branch }}
       generation: ${{ matrix.generation_template }}

--- a/.github/workflows/zeebe-dispatch-qa.yaml
+++ b/.github/workflows/zeebe-dispatch-qa.yaml
@@ -1,10 +1,10 @@
 # This workflow runs our acceptance tests, triggered by our engineering process automation cluster. It runs the test suite against the
 # given branch.
 #
-name: Repo dispatch QA tests
+name: Zeebe Repo dispatch QA tests
 
 on:
-  repository_dispatch: 
+  repository_dispatch:
     types: [qa_run_testbench]
 
 env:
@@ -17,7 +17,7 @@ jobs:
       # do not cancel other jobs if one fails
       fail-fast: false
     name: Daily QA
-    uses: ./.github/workflows/qa-testbench.yaml
+    uses: ./.github/workflows/zeebe-qa-testbench.yaml
     with:
       branch: ${{ github.event.client_payload.branch }}
       generation: Zeebe SNAPSHOT

--- a/.github/workflows/zeebe-e2e-testbench.yaml
+++ b/.github/workflows/zeebe-e2e-testbench.yaml
@@ -1,4 +1,4 @@
-name: Run E2E Tests
+name: Run Zeebe E2E Tests
 
 on:
   workflow_dispatch:
@@ -73,7 +73,7 @@ on:
 jobs:
   e2e:
     name: Run e2e testbench process
-    uses: ./.github/workflows/testbench.yaml
+    uses: ./.github/workflows/zeebe-testbench.yaml
     with:
       processId: e2e_testbench_protocol
       variables: >

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -1,4 +1,4 @@
-name: Weekly medic benchmark
+name: Zeebe Weekly medic benchmark
 on:
   workflow_dispatch: { }
   schedule:
@@ -52,7 +52,7 @@ jobs:
     needs:
       - benchmark-data
       - delete-old-benchmarks
-    uses: ./.github/workflows/benchmark.yml
+    uses: ./.github/workflows/zeebe-benchmark.yml
     secrets: inherit
     with:
       name: ${{ needs.benchmark-data.outputs.benchmark }}
@@ -62,7 +62,7 @@ jobs:
       publish: "slack"
   setup-mixed-benchmark:
     name: Mixed Benchmark
-    uses: ./.github/workflows/benchmark.yml
+    uses: ./.github/workflows/zeebe-benchmark.yml
     secrets: inherit
     needs:
       - benchmark-data
@@ -87,7 +87,7 @@ jobs:
         --set camunda-platform.zeebe.retention.minimumAge=1d
   setup-latency-benchmark:
     name: Latency Benchmark
-    uses: ./.github/workflows/benchmark.yml
+    uses: ./.github/workflows/zeebe-benchmark.yml
     secrets: inherit
     needs:
       - benchmark-data

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -1,4 +1,4 @@
-name: Pull Request Benchmark
+name: Zeebe Pull Request Benchmark
 on:
   pull_request:
     types:
@@ -13,7 +13,7 @@ jobs:
     if: >
       (github.event.action == 'labeled' && github.event.label.name == 'benchmark')
       || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
-    uses: ./.github/workflows/benchmark.yml
+    uses: ./.github/workflows/zeebe-benchmark.yml
     secrets: inherit
     with:
       name: ${{github.event.pull_request.head.ref}}-benchmark

--- a/.github/workflows/zeebe-qa-testbench.yaml
+++ b/.github/workflows/zeebe-qa-testbench.yaml
@@ -1,4 +1,4 @@
-name: QA Testbench run
+name: Zeebe QA Testbench run
 
 on:
   workflow_dispatch:
@@ -42,7 +42,7 @@ jobs:
   qa:
     needs: prepare
     name: Run testbench process
-    uses: ./.github/workflows/testbench.yaml
+    uses: ./.github/workflows/zeebe-testbench.yaml
     with:
       processId: qa-github-trigger
       variables: >

--- a/.github/workflows/zeebe-release-main-dry-run.yml
+++ b/.github/workflows/zeebe-release-main-dry-run.yml
@@ -1,4 +1,4 @@
-name: Release Dry Run from main
+name: Zeebe Release Dry Run from main
 on:
   workflow_dispatch: { }
   schedule:
@@ -8,7 +8,7 @@ on:
 jobs:
   dry-run-release:
     name: "${{ matrix.version }} from main"
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/zeebe-release.yml
     secrets: inherit
     strategy:
       fail-fast: false

--- a/.github/workflows/zeebe-release-manual.yml
+++ b/.github/workflows/zeebe-release-manual.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Zeebe Release
 on:
   workflow_dispatch:
     inputs:
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   run-release:
     name: "Release ${{ inputs.releaseVersion }} from ${{ inputs.releaseBranch }}"
-    uses: ./.github/workflows/release.yml
+    uses: ./.github/workflows/zeebe-release.yml
     secrets: inherit
     with:
       releaseBranch: ${{ inputs.releaseBranch }}

--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -1,4 +1,4 @@
-name: Release Dry Run from stable branches
+name: Zeebe Release Dry Run from stable branches
 on:
   workflow_dispatch: { }
   schedule:

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -1,4 +1,4 @@
-name: Release Workflow
+name: Zeebe Release Workflow
 on:
   workflow_call:
     inputs:
@@ -290,8 +290,8 @@ jobs:
         with:
           name: release-artifacts-${{ inputs.releaseVersion }}
       - name: Build Docker Image
-        uses: ./.github/actions/build-docker
-        id: build-docker
+        uses: ./.github/actions/build-zeebe-docker
+        id: build-zeebe-docker
         with:
           repository: ${{ env.LOCAL_DOCKER_IMAGE }}
           version: ${{ inputs.releaseVersion }}
@@ -304,7 +304,7 @@ jobs:
         uses: ./.github/actions/verify-zeebe-docker
         with:
           imageName: ${{ env.LOCAL_DOCKER_IMAGE }}
-          date: ${{ steps.build-docker.outputs.date }}
+          date: ${{ steps.build-zeebe-docker.outputs.date }}
           revision: ${{ needs.release.outputs.releaseTagRevision }}
           version: ${{ inputs.releaseVersion }}
           platforms: ${{ env.PLATFORMS }}
@@ -316,7 +316,7 @@ jobs:
           docker buildx imagetools create \
             --tag ${{ env.DOCKER_IMAGE }}:${{ env.RELEASE_VERSION }} \
             ${{ inputs.isLatest && format('--tag {0}:latest', env.DOCKER_IMAGE) || '' }} \
-            ${{ steps.build-docker.outputs.image }}
+            ${{ steps.build-zeebe-docker.outputs.image }}
   snyk:
     name: Snyk Monitor
     needs: [ docker, release ]
@@ -325,7 +325,7 @@ jobs:
     concurrency:
       group: release-snyk-${{ inputs.releaseVersion }}
       cancel-in-progress: false
-    uses: ./.github/workflows/snyk.yml
+    uses: ./.github/workflows/zeebe-snyk.yml
     with:
       # Can't reference env.RELEASE_BRANCH directly due to https://github.com/actions/runner/issues/2372
       ref: ${{ needs.release.outputs.releaseBranch }}

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -1,6 +1,6 @@
 # This workflow either scans all distribute-able projects with snyk, or updates the relevant
 # projects on the Snyk servers
-name: Snyk
+name: Zeebe Snyk
 
 on:
   workflow_dispatch:
@@ -105,8 +105,8 @@ jobs:
         id: build-zeebe
         if: inputs.build
       - name: Build Docker Image
-        uses: ./.github/actions/build-docker
-        id: build-docker
+        uses: ./.github/actions/build-zeebe-docker
+        id: build-zeebe-docker
         if: inputs.build
         with:
           distball: ${{ steps.build-zeebe.outputs.distball }}
@@ -123,7 +123,7 @@ jobs:
           export LIFECYCLE=$([[ "${VERSION}" == *-SNAPSHOT ]] && echo 'development' || echo 'production')
 
           # use inputs.dockerImage if present; otherwise if building, use the output of the build step; otherwise infer from version and default repository camunda/zeebe
-          export DOCKER_IMAGE=$([[ ! -z '${{ inputs.dockerImage }}' ]] && echo '${{ inputs.dockerImage }}' || ([[ '${{ inputs.build }}' == 'true' ]] && echo '${{ steps.build-docker.outputs.image }}' || echo "camunda/zeebe:${VERSION}"))
+          export DOCKER_IMAGE=$([[ ! -z '${{ inputs.dockerImage }}' ]] && echo '${{ inputs.dockerImage }}' || ([[ '${{ inputs.build }}' == 'true' ]] && echo '${{ steps.build-zeebe-docker.outputs.image }}' || echo "camunda/zeebe:${VERSION}"))
 
           if [[ '${{ inputs.useMinorVersion }}' == 'true' ]]; then
             export TARGET="$(echo $VERSION | sed -E -e 's/\.[^.]*$//')"

--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -1,4 +1,4 @@
-name: Start a test in Testbench
+name: Start a Zeebe test in Testbench
 
 on:
   workflow_call:
@@ -59,8 +59,8 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
-      - uses: ./.github/actions/build-docker
-        id: build-docker
+      - uses: ./.github/actions/build-zeebe-docker
+        id: build-zeebe-docker
         with:
           repository: gcr.io/zeebe-io/zeebe
           version: ${{ steps.image-tag.outputs.image-tag }}
@@ -88,7 +88,7 @@ jobs:
           variables=$(echo "${{ inputs.variables }}" | envsubst)
           clients/go/cmd/zbctl/dist/zbctl create instance ${{ inputs.processId }} --variables "$variables"
         env:
-          IMAGE: ${{ steps.build-docker.outputs.image }}
+          IMAGE: ${{ steps.build-zeebe-docker.outputs.image }}
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
           ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
           ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.camunda.io/oauth/token'

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -3,7 +3,7 @@
 
 # As this is meant to be run via scheduling, the workflow itself only runs on the default branch
 # (e.g. main), so any changes you make will affect any other branches we test via this workflow.
-name: Weekly E2E tests
+name: Zeebe Weekly E2E tests
 
 on:
   workflow_dispatch: { }
@@ -71,7 +71,7 @@ jobs:
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
     name: Weekly E2E
-    uses: ./.github/workflows/e2e-testbench.yaml
+    uses: ./.github/workflows/zeebe-e2e-testbench.yaml
     with:
       branch: ${{ matrix.branch }}
       generation: ${{ matrix.generation_template }}
@@ -82,7 +82,7 @@ jobs:
 
   e2e-multiregion-failover:
     name: Multi-region failover with data loss
-    uses: ./.github/workflows/e2e-testbench.yaml
+    uses: ./.github/workflows/zeebe-e2e-testbench.yaml
     with:
       branch: main
       generation: Zeebe SNAPSHOT
@@ -94,7 +94,7 @@ jobs:
 
   e2e-scaling-brokers:
     name: Scaling brokers
-    uses: ./.github/workflows/e2e-testbench.yaml
+    uses: ./.github/workflows/zeebe-e2e-testbench.yaml
     with:
       branch: main
       generation: Zeebe SNAPSHOT

--- a/zeebe/docs/ci.md
+++ b/zeebe/docs/ci.md
@@ -106,7 +106,7 @@ services:
 With the registry set up, the next step is to push the Docker image we're building to it.
 
 ```yaml
-- uses: ./.github/actions/build-docker
+- uses: ./.github/actions/build-zeebe-docker
   with:
     repository: localhost:5000/camunda/zeebe
     version: current-test
@@ -186,7 +186,7 @@ git push --set-upstream origin 12983-flaky-test-issue-repro
 ```
 
 This will also allow you to
-run [the CI workflow](https://github.com/camunda/zeebe/actions/workflows/ci.yml) for that specific
+run [the CI workflow](https://github.com/camunda/zeebe/actions/workflows/zeebe-ci.yml) for that specific
 branch as many times as you want. If you don't know how to do this, you can read up on
 it [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow).
 
@@ -203,7 +203,7 @@ shorter, and minimize resource usage during investigation.
 
 First, identify the job where the failing test is running. If that job is `Integration tests`, then
 you should skip all other jobs in
-the [ci.yml workflow](https://github.com/camunda/zeebe/blob/main/.github/workflows/ci.yml). You can
+the [zeebe-ci.yml workflow](https://github.com/camunda/zeebe/blob/main/.github/workflows/zeebe-ci.yml). You can
 do this easily by adding a `if: false` to every job definition except the one you want to run,
 e.g. `integration-tests`.
 
@@ -215,7 +215,7 @@ up on narrowing.
 
 Assuming you can still narrow the scope of the workflow, the next step is to have the job execute
 only a single test. In
-the [ci.yml workflow](https://github.com/camunda/zeebe/blob/main/.github/workflows/ci.yml), under
+the [zeebe-ci.yml workflow](https://github.com/camunda/zeebe/blob/main/.github/workflows/zeebe-ci.yml), under
 the job you wish to execute (e.g. `integration-tests`), look for the step which is actually
 executing the test, i.e. the one running `mvn verify`, or `mvn test`, etc. If the test is a unit
 test (and as such run by surefire), then you can add `-Dtest=MyTestClass` (


### PR DESCRIPTION
## Description

This PR is part of the monorepo refactoring from https://github.com/camunda/team-infrastructure/issues/616

In this first step many independent GHA workflows from Zeebe/Operate/... will have to coexist before they get refactored into central GHA workflows. During this phase we need to distinguish e.g. between zeebe-ci.yml and operate-ci.yml. It also helps if workflows can be attributed to a certain part of the codebase.

**Which GHA workflow files got renamed**: all that are directly related to Zeebe source code and/or have conflicting names with Operate GHA and/or are used by files that got renamed.

Due to this rename the Github Advanced Security code scanning is currently not working but should resume to work on `main` after merge. The required Github status checks for branches remain the same and should still work on `main`.

## Related issues

Related to camunda/team-infrastructure#616