### PR TITLE
build: fix configurations for moved benchmarks folder

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -71,7 +71,7 @@
   ],
   "dockerfile": {
     "ignorePaths": [
-      "benchmarks/**",
+      "zeebe/benchmarks/**",
       "clients/go/vendor/**"
     ]
   },

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -185,7 +185,7 @@
               <include>**/*.scala</include>
             </includes>
             <excludes>
-              <exclude>benchmarks/project/**/*</exclude>
+              <exclude>zeebe/benchmarks/project/**/*</exclude>
             </excludes>
             <mapping>
               <java>SLASHSTAR_STYLE</java>

--- a/zeebe/benchmarks/setup/README.md
+++ b/zeebe/benchmarks/setup/README.md
@@ -122,7 +122,7 @@ Possible future extension point: Use https://docs.camunda.io/docs/apis-clients/c
 ### Setup Cloud Benchmark
 
 * Create a new cloud benchmark in our benchmark folder, via `./newCloudBenchmark`. This will create a new namespace in our k8 cluster, such that we can deploy our starters and workers. They will connect to the camunda cloud cluster after we added the correct credentials.
-* Edit the `cloudcredentials.yaml` file, replace the old/default values with your client credentials. **NOTE: Please make sure that you're not pushing your credentials to the repository!** https://github.com/camunda/zeebe/blob/main/benchmarks/setup/cloud-default/cloudcredentials.yaml contains an example.
+* Edit the `cloudcredentials.yaml` file, replace the old/default values with your client credentials. **NOTE: Please make sure that you're not pushing your credentials to the repository!** https://github.com/camunda/zeebe/blob/main/zeebe/benchmarks/setup/cloud-default/cloudcredentials.yaml contains an example.
 * Deploy everything you need, e. g. run `make clean all` to deploy the secret, worker and starter. **Alternatively**, you can also manually provision the resources:
 * `make secret worker starter`
 


### PR DESCRIPTION
## Description

I found an outdated path in the README and in the  Renovate configuration that needs to be adjusted for the new `zeebe/benchmarks/...` folder location. I'm not sure about the change to the bom?

## Related issues

Related to camunda/team-infrastructure#616