### PR TITLE
Introduce `fold` method for `Either`

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -344,6 +344,30 @@ public sealed interface Either<L, R> {
   void ifRightOrLeft(Consumer<R> rightAction, Consumer<L> leftAction);
 
   /**
+   * Maps the right or left value into a new type using the provided functions, depending on whether
+   * this is a {@link Left} or {@link Right}.
+   *
+   * <p>A common use case is to map to a new common value in success and error cases. Example:
+   *
+   * <pre>{@code
+   * * Either<String, Integer> success = Either.right(42); // => Right(42)
+   * * Either<String, Integer> failure = Either.left("Error occurred"); // => Left("Error occurred")
+   * *
+   * * var rightFn = result -> "Success: " + result;
+   * * var leftFn = error -> "Failure: " + error;
+   * *
+   * * success.fold(rightFn, leftFn); // => "Success: 42"
+   * * failure.fold(rightFn, leftFn); // => "Failure: Error occurred"
+   * }</pre>
+   *
+   * @param rightFn the mapping function for the right value
+   * @param leftFn the mapping function for the left value
+   * @return either a mapped {@link Left} or {@link Right}, folded to the new type
+   * @param <T> the type of the resulting value
+   */
+  <T> T fold(Function<? super R, ? extends T> rightFn, Function<? super L, ? extends T> leftFn);
+
+  /**
    * A right for either a left or right. By convention, right is used for success and left for
    * error.
    *
@@ -412,6 +436,13 @@ public sealed interface Either<L, R> {
     @Override
     public void ifRightOrLeft(final Consumer<R> rightAction, final Consumer<L> leftAction) {
       rightAction.accept(value);
+    }
+
+    @Override
+    public <T> T fold(
+        final Function<? super R, ? extends T> rightFn,
+        final Function<? super L, ? extends T> leftFn) {
+      return rightFn.apply(value);
     }
   }
 
@@ -484,6 +515,13 @@ public sealed interface Either<L, R> {
     @Override
     public void ifRightOrLeft(final Consumer<R> rightAction, final Consumer<L> leftAction) {
       leftAction.accept(value);
+    }
+
+    @Override
+    public <T> T fold(
+        final Function<? super R, ? extends T> rightFn,
+        final Function<? super L, ? extends T> leftFn) {
+      return leftFn.apply(value);
     }
   }
 

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
@@ -305,4 +305,31 @@ class EitherTest {
       assertThat(result.getLeft()).isEqualTo(value);
     }
   }
+
+  @DisplayName("Folding method tests")
+  @Nested
+  class FoldingMethodTests {
+
+    @DisplayName("Folds `Left`s into target types using the left function.")
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.util.EitherTest#parameters")
+    void foldsLeftsIntoTargetTypeUsingLeftFunction(final Object value) {
+      final Function<Object, String> leftMapper = o -> "Expected-" + o.toString();
+      final Function<Object, String> rightMapper = o -> "Unexpected-" + o.toString();
+      final String mappedValue = leftMapper.apply(value);
+      assertThat(mappedValue).isNotEqualTo(value);
+      assertThat(Either.left(value).fold(rightMapper, leftMapper)).isEqualTo(mappedValue);
+    }
+
+    @DisplayName("Folds `Right`s into target types using the right function.")
+    @ParameterizedTest
+    @MethodSource("io.camunda.zeebe.util.EitherTest#parameters")
+    void foldsRightsIntoTargetTypeUsingRightFunction(final Object value) {
+      final Function<Object, String> leftMapper = o -> "Unexpected-" + o.toString();
+      final Function<Object, String> rightMapper = o -> "Expected-" + o.toString();
+      final String mappedValue = rightMapper.apply(value);
+      assertThat(mappedValue).isNotEqualTo(value);
+      assertThat(Either.right(value).fold(rightMapper, leftMapper)).isEqualTo(mappedValue);
+    }
+  }
 }


### PR DESCRIPTION
## Description

Introduces the `fold` method for Either types. This allows to map lefts and rights to a common result type, providing mapping functions for each type respectively.

Example:

```java
Either<String, Integer> success = Either.right(42); // => Right(42)
Either<String, Integer> failure = Either.left("Error occurred"); // => Left("Error occurred")

var rightFn = result -> "Success: " + result;
var leftFn = error -> "Failure: " + error;

success.fold(rightFn, leftFn); // => "Success: 42"
failure.fold(rightFn, leftFn); // => "Failure: Error occurred"
```

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16561 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
