### PR TITLE
Unsubscribe from message boundary event on migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -91,7 +91,8 @@ public final class BpmnProcessors {
         typedRecordProcessors, processingState, writers, bpmnBehaviors, processEngineMetrics);
     addProcessInstanceModificationStreamProcessors(
         typedRecordProcessors, processingState, writers, bpmnBehaviors);
-    addProcessInstanceMigrationStreamProcessors(typedRecordProcessors, processingState, writers);
+    addProcessInstanceMigrationStreamProcessors(
+        typedRecordProcessors, processingState, writers, bpmnBehaviors);
     addProcessInstanceBatchStreamProcessors(typedRecordProcessors, processingState, writers);
 
     return bpmnStreamProcessor;
@@ -227,11 +228,12 @@ public final class BpmnProcessors {
   private static void addProcessInstanceMigrationStreamProcessors(
       final TypedRecordProcessors typedRecordProcessors,
       final ProcessingState processingState,
-      final Writers writers) {
+      final Writers writers,
+      final BpmnBehaviors bpmnBehaviors) {
     typedRecordProcessors.onCommand(
         ValueType.PROCESS_INSTANCE_MIGRATION,
         ProcessInstanceMigrationIntent.MIGRATE,
-        new ProcessInstanceMigrationMigrateProcessor(writers, processingState));
+        new ProcessInstanceMigrationMigrateProcessor(writers, processingState, bpmnBehaviors));
   }
 
   private static void addProcessInstanceBatchStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -392,7 +392,7 @@ public final class CatchEventBehavior {
     stateWriter.appendFollowUpEvent(timer.getKey(), TimerIntent.CANCELED, timerRecord);
   }
 
-  private void unsubscribeFromMessageEvents(
+  public void unsubscribeFromMessageEvents(
       final long elementInstanceKey, final Predicate<DirectBuffer> elementIdFilter) {
     processMessageSubscriptionState.visitElementSubscriptions(
         elementInstanceKey,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -34,10 +34,12 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceMigrationRecordValue.ProcessInstanceMigrationMappingInstructionValue;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayDeque;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -182,7 +184,8 @@ public class ProcessInstanceMigrationMigrateProcessor
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
     requireUnchangedFlowScope(
         elementInstanceState, elementInstanceRecord, targetProcessDefinition, targetElementId);
-    requireNoBoundaryEventInSource(sourceProcessDefinition, elementInstanceRecord);
+    requireNoBoundaryEventInSource(
+        sourceProcessDefinition, elementInstanceRecord, EnumSet.of(BpmnEventType.MESSAGE));
     requireNoBoundaryEventInTarget(targetProcessDefinition, targetElementId, elementInstanceRecord);
     requireNoConcurrentCommand(eventScopeInstanceState, elementInstance, processInstanceKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
@@ -482,20 +482,21 @@ public final class ProcessInstanceMigrationPreconditionChecker {
             .getElementById(elementInstanceRecord.getElementId(), ExecutableActivity.class)
             .getBoundaryEvents();
 
-    final List<String> disallowedBoundaryEventsInSource =
+    final var rejectedBoundaryEvents =
         boundaryEvents.stream()
-            .map(AbstractFlowElement::getEventType)
-            .filter(eventType -> !allowedEventTypes.contains(eventType))
-            .map(BpmnEventType::name)
+            .filter(event -> !allowedEventTypes.contains(event.getEventType()))
             .toList();
 
-    if (!disallowedBoundaryEventsInSource.isEmpty()) {
+    if (!rejectedBoundaryEvents.isEmpty()) {
       final String reason =
           String.format(
               ERROR_ACTIVE_ELEMENT_WITH_BOUNDARY_EVENT,
               elementInstanceRecord.getProcessInstanceKey(),
               elementInstanceRecord.getElementId(),
-              String.join(",", disallowedBoundaryEventsInSource));
+              rejectedBoundaryEvents.stream()
+                  .map(ExecutableBoundaryEvent::getEventType)
+                  .map(BpmnEventType::name)
+                  .collect(Collectors.joining(",")));
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.INVALID_STATE);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
@@ -488,15 +488,17 @@ public final class ProcessInstanceMigrationPreconditionChecker {
             .toList();
 
     if (!rejectedBoundaryEvents.isEmpty()) {
+      final String rejectedEventTypes =
+          rejectedBoundaryEvents.stream()
+              .map(ExecutableBoundaryEvent::getEventType)
+              .map(BpmnEventType::name)
+              .collect(Collectors.joining(","));
       final String reason =
           String.format(
               ERROR_ACTIVE_ELEMENT_WITH_BOUNDARY_EVENT,
               elementInstanceRecord.getProcessInstanceKey(),
               elementInstanceRecord.getElementId(),
-              rejectedBoundaryEvents.stream()
-                  .map(ExecutableBoundaryEvent::getEventType)
-                  .map(BpmnEventType::name)
-                  .collect(Collectors.joining(",")));
+              rejectedEventTypes);
       throw new ProcessInstanceMigrationPreconditionFailedException(
           reason, RejectionType.INVALID_STATE);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditionChecker.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.engine.state.immutable.IncidentState.MISSING_INCI
 import io.camunda.zeebe.auth.impl.TenantAuthorizationCheckerImpl;
 import io.camunda.zeebe.engine.processing.deployment.model.element.AbstractFlowElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBoundaryEvent;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableUserTask;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
@@ -475,12 +476,14 @@ public final class ProcessInstanceMigrationPreconditionChecker {
       final DeployedProcess sourceProcessDefinition,
       final ProcessInstanceRecord elementInstanceRecord,
       final EnumSet<BpmnEventType> allowedEventTypes) {
-    final List<String> disallowedBoundaryEventsInSource =
+    final List<ExecutableBoundaryEvent> boundaryEvents =
         sourceProcessDefinition
             .getProcess()
             .getElementById(elementInstanceRecord.getElementId(), ExecutableActivity.class)
-            .getBoundaryEvents()
-            .stream()
+            .getBoundaryEvents();
+
+    final List<String> disallowedBoundaryEventsInSource =
+        boundaryEvents.stream()
             .map(AbstractFlowElement::getEventType)
             .filter(eventType -> !allowedEventTypes.contains(eventType))
             .map(BpmnEventType::name)

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessMessageSubscriptionRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ProcessMessageSubscriptionRecordStream.java
@@ -40,6 +40,10 @@ public final class ProcessMessageSubscriptionRecordStream
     return valueFilter(v -> messageName.equals(v.getMessageName()));
   }
 
+  public ProcessMessageSubscriptionRecordStream withCorrelationKey(final String correlationKey) {
+    return valueFilter(v -> correlationKey.equals(v.getCorrelationKey()));
+  }
+
   public ProcessMessageSubscriptionRecordStream withTenantId(final String tenantId) {
     return valueFilter(v -> tenantId.equals(v.getTenantId()));
   }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Like the C7 behavior, element instances are unsubscribed from message boundary events without mapping instructions.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16383 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
