### PR TITLE
[Backport stable/8.2] ci(testbench): backport testbench workflow from stable/8.4

### DIFF
--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -84,13 +84,14 @@ jobs:
         \"branch\": \"${{ inputs.branch || 'main' }}\",
         \"build\":  \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
         \"clusterPlan\":\"${{ inputs.clusterPlan }}\",
-        \"region\":\"new chaos\",
+        \"region\":\"Chaos, Belgium, Europe (europe-west1)\",
         \"properties\":[\"allInstancesAreCompleted\"],
         \"testProcessId\": \"e2e-test\",
         \"testParams\":
         {
         \"maxTestDuration\": \"${{ inputs.maxTestDuration || 'P5D' }}\",
-        \"starter\": [ {\"rate\": 50, \"processId\": \"one-task-one-timer\" } ],
+        \"starter\": [ {\"rate\": 20, \"processId\": \"one-task-one-timer\" },
+                       {\"rate\": 10, \"processId\": \"ping-pong-message\" } ],
         \"verifier\" : { \"maxInstanceDuration\" : \"${{ inputs.maxInstanceDuration }}\" },
         \"fault\": ${{ inputs.fault || 'null' }}
         }

--- a/.github/workflows/testbench.yaml
+++ b/.github/workflows/testbench.yaml
@@ -25,19 +25,19 @@ jobs:
       contents: 'read'
       id-token: 'write'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: google-github-actions/auth@v1
+      - uses: google-github-actions/auth@v2
         id: auth
         with:
           token_format: 'access_token'
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - name: Setup BuildKit
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Login to GCR
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: gcr.io
           username: oauth2accesstoken
@@ -66,9 +66,13 @@ jobs:
           version: ${{ steps.image-tag.outputs.image-tag }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Build and Push Starter Image
+        run: ./mvnw -pl benchmarks/project jib:build -P starter -D image="gcr.io/zeebe-io/starter:${{ steps.image-tag.outputs.image-tag }}"
+      - name: Build and Push Worker Image
+        run: ./mvnw -pl benchmarks/project jib:build -P worker -D image="gcr.io/zeebe-io/worker:${{ steps.image-tag.outputs.image-tag }}"
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v2.5.0
+        uses: hashicorp/vault-action@v2.7.5
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -77,7 +81,6 @@ jobs:
           secrets: |
             secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CLIENT_SECRET;
             secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
-        # Start e2e test instance, do not wait for the result
       - name: Start Test
         shell: bash
         run: |
@@ -88,5 +91,5 @@ jobs:
           IMAGE: ${{ steps.build-docker.outputs.image }}
           ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
           ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
-          ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
-          ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'
+          ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.camunda.io/oauth/token'
+          ZEEBE_CLIENT_ID: 'Jg9caDRuAWHchvM7JiaVlndL-qVFfp~0'


### PR DESCRIPTION
## Description

As the project structure changed on main with #16522 and the benchmarks module moved to `zeebe/benchmark`, workflows from main are not compatible with stable branches anymore, see the failed QA run for patch releases https://github.com/camunda/zeebe/actions/workflows/dispatch-qa.yaml

We thus need to run QA workflows from the stable branches directly. However some are in a non-functional state now, see e.g. this run for a 8.2 release https://github.com/camunda/zeebe/actions/runs/8052402579

Testrun with these changes https://github.com/camunda/zeebe/actions/runs/8053899729/job/21997286607
