### PR TITLE
[Backport stable/8.1] ci(testbench) backport testbench workflow from stable/8.4

### DIFF
--- a/.github/workflows/e2e-testbench.yaml
+++ b/.github/workflows/e2e-testbench.yaml
@@ -1,0 +1,100 @@
+name: Run E2E Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      maxTestDuration:
+        description: 'Test duration (Eg: PT2H, P3D)'
+        required: false
+        default: 'P5D'
+        type: string
+      generation:
+        description: 'Specifies the generation template which should be used by the testbench run'
+        required: false
+        default: 'Zeebe SNAPSHOT'
+        type: string
+      branch:
+        description: 'Specifies the branch, for which the E2E run should be executed'
+        default: 'main'
+        required: false
+        type: string
+      clusterPlan:
+        description: 'Cluster plan used by testbench to create the test cluster'
+        default: 'Production - M'
+        required: false
+        type: string
+      fault:
+        ## The fault added to variables as follows
+        ## \"fault\": ${{ inputs.fault || 'null' }}
+        ## So the input should contain escape quotes.
+        description: 'Fault to inject in the test cluster. Eg:- \"restart-leader-1\". Specify the quotes with escape.'
+        default: null
+        required: false
+        type: string
+      maxInstanceDuration:
+        description: 'If an instance takes longer than the given duration to complete, test will fail.'
+        default: '15m'
+        required: false
+        type: string
+
+  workflow_call:
+    inputs:
+      maxTestDuration:
+        description: 'Test duration (Eg: PT2H, P3D)'
+        required: false
+        default: 'P5D'
+        type: string
+      generation:
+        description: 'Specifies the generation template which should be used by the testbench run'
+        required: false
+        default: 'Zeebe SNAPSHOT'
+        type: string
+      branch:
+        description: 'Specifies the branch, for which the E2E run should be executed'
+        default: 'main'
+        required: false
+        type: string
+      clusterPlan:
+        description: 'Cluster plan used by testbench to create the test cluster'
+        default: 'Production - M'
+        required: false
+        type: string
+      fault:
+        description: 'Fault to inject in the test cluster. Eg:- \"restart-leader-1\". Specify the quotes with escape.'
+        default: null
+        required: false
+        type: string
+      maxInstanceDuration:
+        description: 'If an instance takes longer than the given duration to complete, test will fail.'
+        default: '15m'
+        required: false
+        type: string
+
+jobs:
+  e2e:
+    name: Run e2e testbench process
+    uses: ./.github/workflows/testbench.yaml
+    with:
+      processId: e2e_testbench_protocol
+      variables: >
+        {
+        \"zeebeImage\":\"$IMAGE\",
+        \"generationTemplate\":\"${{ inputs.generation || 'Zeebe SNAPSHOT' }}\",
+        \"channel\": \"Internal Dev\",
+        \"branch\": \"${{ inputs.branch || 'main' }}\",
+        \"build\":  \"${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}\",
+        \"clusterPlan\":\"${{ inputs.clusterPlan }}\",
+        \"region\":\"Chaos, Belgium, Europe (europe-west1)\",
+        \"properties\":[\"allInstancesAreCompleted\"],
+        \"testProcessId\": \"e2e-test\",
+        \"testParams\":
+        {
+        \"maxTestDuration\": \"${{ inputs.maxTestDuration || 'P5D' }}\",
+        \"starter\": [ {\"rate\": 20, \"processId\": \"one-task-one-timer\" },
+                       {\"rate\": 10, \"processId\": \"ping-pong-message\" } ],
+        \"verifier\" : { \"maxInstanceDuration\" : \"${{ inputs.maxInstanceDuration }}\" },
+        \"fault\": ${{ inputs.fault || 'null' }}
+        }
+        }
+      branch: ${{ inputs.branch }}
+    secrets: inherit

--- a/.github/workflows/qa-testbench.yaml
+++ b/.github/workflows/qa-testbench.yaml
@@ -7,166 +7,53 @@ on:
         description: 'Specifies the generation template which should be used by the testbench run'
         required: false
         default: 'Zeebe SNAPSHOT'
+        type: string
       branch:
         description: 'Specifies the branch, for which the QA Testbench run should be executed'
         default: 'main'
         required: false
-  schedule:
-  # * is a special character in YAML so you have to quote this string
-    - cron:  '0 23 * * *'
-env:
-  BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        type: string
+  workflow_call:
+    inputs:
+      generation:
+        description: 'Specifies the generation template which should be used by the testbench run'
+        required: false
+        default: 'Zeebe SNAPSHOT'
+        type: string
+      branch:
+        description: 'Specifies the branch, for which the QA Testbench run should be executed'
+        default: 'main'
+        required: false
+        type: string
 
 jobs:
-  qa-testbench:
-    name: QA Testbench run
+
+  prepare:
+    # variables in qa job cannot read env variable. So we are building buildUrl here as output so it can be re-used in both qa, wait and notify jobs
+    name: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    env:
-      IMAGE: "gcr.io/zeebe-io/zeebe"
-      GENERATION_TEMPLATE: "${{ github.event.inputs.generation }}"
-      BRANCH_NAME: "${{ github.event.inputs.branch }}"
-      ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.ultrawombat.com/oauth/token'
-      ZEEBE_CLIENT_ID: 'S7GNoVCE6J-8L~OdFiI59kWM19P.wvKo'
-
+    outputs:
+      buildUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
-      # Dynamic environment variables are not supported by GHA
-      # https://brandur.org/fragments/github-actions-env-vars-in-env-vars
-      #
-      # Since we run the workflow either on demand or via schedule we need to assign some defaults
-      # Furthermore we have branches like stable/1.0 where we have to replace certain patterns, in order to use the branch name as docker image tag
-      - id: evaluate-inputs
-        name: Evaluate Inputs
-        run: |
-          branch=${BRANCH_NAME/\//-}
-          branch=${branch//\./-}
-          branch=${branch:-main}
-          echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
-          echo "GENERATION_TEMPLATE=${GENERATION_TEMPLATE:-Zeebe SNAPSHOT}" >> $GITHUB_ENV
-      # We need to check out the evaluated branch and setup java (incl. maven), so we can retrieve the current project version
-      # The version is necessary, since CC Saas only accepts SemVer for docker image tags (need to start with a version tag)
-      - uses: actions/checkout@v3
-        with:
-          ref: "${{ github.event.inputs.branch }}"
-      - uses: actions/setup-java@v3.5.1
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      # Set further environment variables, which are needed for the QA Testbench run
-      - id: set-env
-        name: Set environment variables
-        run: |
-          version=$(./mvnw help:evaluate -q -DforceStdout -D"expression=project.version")
-          tag="$version-$BRANCH_NAME-${GITHUB_SHA::8}"
-          echo "TAG=$tag" >> $GITHUB_ENV
-          echo "QA_RUN_VARIABLES={\"zeebeImage\": \"$IMAGE:$tag\", \"generationTemplate\": \"$GENERATION_TEMPLATE\", \"channel\": \"Internal Dev\", \"branch\": \"$BRANCH_NAME\", \"build\": \"$BUILD_URL\", \"businessKey\": \"$BUILD_URL\", \"processId\": \"qa-protocol\"}" >> $GITHUB_ENV
-          echo "BUSINESS_KEY=$BUILD_URL" >> $GITHUB_ENV
+      - name: prepare variables
+        id: generate
+        run: exit 0
 
-      - name: Import Secrets
-        id: secrets
-        uses: hashicorp/vault-action@v2.4.3
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          method: approle
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secrets: |
-            secret/data/products/zeebe/ci/zeebe ZEEBE_GCR_SERVICEACCOUNT_JSON;
-            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CLIENT_SECRET;
-            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
-      - name: Login to GCR
-        uses: docker/login-action@v2
-        with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ steps.secrets.outputs.ZEEBE_GCR_SERVICEACCOUNT_JSON }}
-      - uses: ./.github/actions/setup-zeebe
-      - uses: ./.github/actions/build-zeebe
-        id: build-zeebe
-      - uses: ./.github/actions/build-docker
-        with:
-          repository: ${{ env.IMAGE }}
-          version: ${{ env.TAG }}
-          push: true
-          distball: ${{ steps.build-zeebe.outputs.distball }}
-        # Executes the Testbench QA run and awaits the result
-      - name: Run Testbench QA
-        run: .ci/scripts/distribution/qa-testbench.sh
-        env:
-          ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
-          ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
-
-  notify:
-    name: Send slack notification
-    runs-on: ubuntu-latest
-    needs: [qa-testbench]
-    if: ${{ always() }}
-    env:
-      GENERATION_TEMPLATE: "${{ github.event.inputs.generation }}"
-      BRANCH_NAME: "${{ github.event.inputs.branch }}"
-    steps:
-      # Sharing environment variables are not supported, so we have to do it here again
-      - id: evaluate-inputs
-        name: Evaluate Inputs
-        run: |
-          branch=${BRANCH_NAME:-main}
-          echo "BRANCH_NAME=$branch" >> $GITHUB_ENV
-          echo "GENERATION_TEMPLATE=${GENERATION_TEMPLATE:-Zeebe SNAPSHOT}" >> $GITHUB_ENV
-
-      - id: slack-failure-notify
-        name: Send failure slack notification
-        uses: slackapi/slack-github-action@v1.22.0
-        if: ${{ always() && needs.qa-testbench.result != 'success' }}
-        with:
-          payload: |
-            {
-              "text": ":alarm: QA run on `${{ env.BRANCH_NAME }}` with generation template `${{ env.GENERATION_TEMPLATE }}` failed! :alarm:\n ${{ env.BUILD_URL }}",
-             	"blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":alarm: QA run on `${{ env.BRANCH_NAME }}` with generation template `${{ env.GENERATION_TEMPLATE }}` failed! :alarm:"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Please check: ${{ env.BUILD_URL }}\n \\cc @zeebe-medic"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-      - id: slack-success-notify
-        name: Send success slack notification
-        uses: slackapi/slack-github-action@v1.22.0
-        if: ${{ always() && needs.qa-testbench.result == 'success' }}
-        with:
-          payload: |
-            {
-              "text": ":tada: QA run succeeded on `${{ env.BRANCH_NAME }}` with generation template `${{ env.GENERATION_TEMPLATE }}`! :tada:\n ${{ env.BUILD_URL }}",
-             	"blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": ":tada: QA run succeeded on `${{ env.BRANCH_NAME }}` with generation template `${{ env.GENERATION_TEMPLATE }}`! :tada:"
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "Nothing to check today. Good job! :clap:\n"
-                  }
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+  qa:
+    needs: prepare
+    name: Run testbench process
+    uses: ./.github/workflows/testbench.yaml
+    with:
+      processId: qa-github-trigger
+      variables: >
+        {
+        \"zeebeImage\": \"$IMAGE\",
+        \"generationTemplate\": \"${{ inputs.generation }}\",
+        \"channel\": \"Internal Dev\",
+        \"branch\": \"${{ inputs.branch }}\",
+        \"build\":  \"${{ needs.prepare.outputs.buildUrl }}\",
+        \"businessKey\": \"${{ needs.prepare.outputs.buildUrl }}\",
+        \"processId\": \"qa-protocol\"
+        }
+      branch: ${{ inputs.branch }}
+    secrets: inherit

--- a/.github/workflows/testbench.yaml
+++ b/.github/workflows/testbench.yaml
@@ -1,0 +1,95 @@
+name: Start a test in Testbench
+
+on:
+  workflow_call:
+    inputs:
+      variables:
+        description: 'Process instance variables'
+        required: true
+        type: string
+      processId:
+        description: 'Id of process to start in testbench (eg:- e2e-testbench-protocol)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch to test'
+        required: true
+        type: string
+
+jobs:
+  testbench:
+    name: Start a test in testbench
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.branch }}
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Setup BuildKit
+        uses: docker/setup-buildx-action@v3
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - id: image-tag
+        name: Calculate image tag
+        shell: bash
+        run: |
+          # Replace dots and slashes with dashes
+          branch=${BRANCH/[\/\.]/-}
+          version=$(mvn help:evaluate -q -DforceStdout -D"expression=project.version")
+          echo "image-tag=$version-$branch-${GITHUB_SHA::8}" >> $GITHUB_OUTPUT
+        env:
+          BRANCH: ${{ inputs.branch }}
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+      - uses: ./.github/actions/build-docker
+        id: build-docker
+        with:
+          repository: gcr.io/zeebe-io/zeebe
+          version: ${{ steps.image-tag.outputs.image-tag }}
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Build and Push Starter Image
+        run: ./mvnw -pl benchmarks/project jib:build -P starter -D image="gcr.io/zeebe-io/starter:${{ steps.image-tag.outputs.image-tag }}"
+      - name: Build and Push Worker Image
+        run: ./mvnw -pl benchmarks/project jib:build -P worker -D image="gcr.io/zeebe-io/worker:${{ steps.image-tag.outputs.image-tag }}"
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v2.7.5
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CLIENT_SECRET;
+            secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
+      - name: Start Test
+        shell: bash
+        run: |
+          chmod +x clients/go/cmd/zbctl/dist/zbctl
+          variables=$(echo "${{ inputs.variables }}" | envsubst)
+          clients/go/cmd/zbctl/dist/zbctl create instance ${{ inputs.processId }} --variables "$variables"
+        env:
+          IMAGE: ${{ steps.build-docker.outputs.image }}
+          ZEEBE_CLIENT_SECRET: ${{ steps.secrets.outputs.TESTBENCH_PROD_CLIENT_SECRET }}
+          ZEEBE_ADDRESS: ${{ steps.secrets.outputs.TESTBENCH_PROD_CONTACT_POINT }}
+          ZEEBE_AUTHORIZATION_SERVER_URL: 'https://login.cloud.camunda.io/oauth/token'
+          ZEEBE_CLIENT_ID: 'Jg9caDRuAWHchvM7JiaVlndL-qVFfp~0'


### PR DESCRIPTION
## Description

As the project structure changed on main with #16522 and the benchmarks module moved to `zeebe/benchmark`, workflows from main are not compatible with stable branches anymore, see the failed QA run for patch releases https://github.com/camunda/zeebe/actions/workflows/dispatch-qa.yaml

We thus need to run QA workflows from the stable branches directly. However some are in a non-functional state now, see e.g. this run for a 8.1 release https://github.com/camunda/zeebe/actions/runs/8052409945.

Testrun with these changes https://github.com/camunda/zeebe/actions/runs/8054170208
