### PR TITLE
[Backport stable/8.3] ci(testbench): backport testbench workflow from stable/8.4

### DIFF
--- a/.github/workflows/testbench.yaml
+++ b/.github/workflows/testbench.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch }}
-      - uses: google-github-actions/auth@v1
+      - uses: google-github-actions/auth@v2
         id: auth
         with:
           token_format: 'access_token'
@@ -66,9 +66,13 @@ jobs:
           version: ${{ steps.image-tag.outputs.image-tag }}
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Build and Push Starter Image
+        run: ./mvnw -pl benchmarks/project jib:build -P starter -D image="gcr.io/zeebe-io/starter:${{ steps.image-tag.outputs.image-tag }}"
+      - name: Build and Push Worker Image
+        run: ./mvnw -pl benchmarks/project jib:build -P worker -D image="gcr.io/zeebe-io/worker:${{ steps.image-tag.outputs.image-tag }}"
       - name: Import Secrets
         id: secrets
-        uses: hashicorp/vault-action@v2.7.4
+        uses: hashicorp/vault-action@v2.7.5
         with:
           url: ${{ secrets.VAULT_ADDR }}
           method: approle
@@ -77,7 +81,6 @@ jobs:
           secrets: |
             secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CLIENT_SECRET;
             secret/data/products/zeebe/ci/zeebe TESTBENCH_PROD_CONTACT_POINT;
-        # Start e2e test instance, do not wait for the result
       - name: Start Test
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Same as https://github.com/camunda/zeebe/pull/16568 but for 8.3 

QA testrun with the workflow from this PR https://github.com/camunda/zeebe/actions/runs/8062302197