### PR TITLE
ci: path filters for Zeebe-only GHA workflows to ignore (future) Operate-only changes

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -8,7 +8,13 @@ on:
       - release-*
       - trying
       - staging
-  pull_request: { }
+    paths-ignore:
+      - '.github/workflows/operate-*'
+      - 'operate/**'
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/operate-*'
+      - 'operate/**'
   merge_group: { }
   workflow_dispatch: { }
   workflow_call: { }


### PR DESCRIPTION
## Description

We want to keep CI costs in control and have a leaner UX (no unneeded GH status checks) by only running necessary GHA workflows.
If only Operate-related files have been changed in a commit or PR then the Zeebe CI does not need to run (and vice versa).

Options considered:

1. **inclusive filter** using GHA's [on.<push|pull_request>.paths](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) and listing all directories that should lead to running the Zeebe CI:
    - long list of directories since we want to trigger when e.g. any change in the CI, the bom, the zeebe folder, etc happens
    - brittle for future changes like new directories added -> could lead to skipping CI although it should have been run
2. **exclusive filter** using GHA's [on.<push|pull_request>.paths-ignore](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) and listing all directories that should **NOT** lead to running the Zeebe CI:
    - short list of directories that are only used for Operate-related files like the operate folder and Operate CI workflows
    - less brittle since by default we assume we run the Zeebe CI _unless_ we are very certain we don't need it (same would happen for Operate)

I went for option 2 here since the outcome is the same with less effort needed. Note that we still plan to unify Operate+Zeebe CI at some point so this mechanism will have to evolve over time -> its current implementation will not stay this way for long.

**Example in action:** https://github.com/camunda/zeebe/pull/16636

## Related issues

https://github.com/camunda/team-infrastructure/issues/616