### PR TITLE
Add unassign task rest endpoint

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -131,6 +131,33 @@ paths:
             The user task with the given key cannot be updated.
             More details are provided in the response body.
           $ref: "#/components/responses/ProblemResponse"
+  /user-tasks/{userTaskKey}/assignee:
+    delete:
+      summary: Remove the assignee of a task.
+      description: Removes the assignee of a task with the given key.
+      parameters:
+        - name: userTaskKey
+          in: path
+          required: true
+          description: The key of the user task.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: The user task was unassigned successfully.
+        '404':
+          description: The user task with the given key was not found.
+        '409':
+          description: >
+            The user task with the given key is in the wrong state currently.
+            More details are provided in the response body.
+          $ref: "#/components/responses/ProblemResponse"
+        '400':
+          description: >
+            The user task with the given key cannot be unassigned.
+            More details are provided in the response body.
+          $ref: "#/components/responses/ProblemResponse"
 
 components:
   responses:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -86,6 +86,17 @@ public class RequestMapper {
     return Either.right(brokerRequest);
   }
 
+  public static Either<ProblemDetail, BrokerUserTaskAssignmentRequest>
+      toUserTaskUnassignmentRequest(final long userTaskKey, final ServerWebExchange context) {
+    final BrokerUserTaskAssignmentRequest brokerRequest =
+        new BrokerUserTaskAssignmentRequest(userTaskKey, "", "unassign", UserTaskIntent.ASSIGN);
+
+    final String authorizationToken = getAuthorizationToken(context);
+    brokerRequest.setAuthorization(authorizationToken);
+
+    return Either.right(brokerRequest);
+  }
+
   private static Optional<ProblemDetail> validateAssignmentRequest(
       final UserTaskAssignmentRequest assignmentRequest) {
     if (assignmentRequest.getAssignee() == null || assignmentRequest.getAssignee().isBlank()) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -58,6 +59,16 @@ public class UserTaskController {
 
     return RequestMapper.toUserTaskAssignmentRequest(assignmentRequest, userTaskKey, context)
         .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
+  }
+
+  @DeleteMapping(path = "/user-tasks/{userTaskKey}/assignee")
+  public CompletableFuture<ResponseEntity<Object>> unassignUserTask(
+      final ServerWebExchange context, @PathVariable final long userTaskKey) {
+
+    return fold(
+        RequestMapper.toUserTaskUnassignmentRequest(userTaskKey, context),
+        this::sendBrokerRequest,
+        UserTaskController::handleRequestMappingError);
   }
 
   @PatchMapping(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
@@ -65,10 +65,8 @@ public class UserTaskController {
   public CompletableFuture<ResponseEntity<Object>> unassignUserTask(
       final ServerWebExchange context, @PathVariable final long userTaskKey) {
 
-    return fold(
-        RequestMapper.toUserTaskUnassignmentRequest(userTaskKey, context),
-        this::sendBrokerRequest,
-        UserTaskController::handleRequestMappingError);
+    return RequestMapper.toUserTaskUnassignmentRequest(userTaskKey, context)
+        .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
   }
 
   @PatchMapping(

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
@@ -858,4 +858,26 @@ public class UserTaskControllerTest {
 
     Mockito.verifyNoInteractions(brokerClient);
   }
+
+  @Test
+  public void shouldUnassignTask() {
+    // when / then
+    webClient
+        .delete()
+        .uri("api/v1/user-tasks/2251799813685732/assignee")
+        .exchange()
+        .expectStatus()
+        .isNoContent()
+        .expectBody()
+        .isEmpty();
+
+    final var argumentCaptor = ArgumentCaptor.forClass(BrokerUserTaskAssignmentRequest.class);
+    Mockito.verify(brokerClient).sendRequest(argumentCaptor.capture());
+    Assertions.assertThat(argumentCaptor.getValue().getRequestWriter())
+        .hasUserTaskKey(2251799813685732L)
+        .hasAction("unassign")
+        .hasAssignee("");
+
+    Assertions.assertThat(argumentCaptor.getValue().getIntent()).isEqualTo(UserTaskIntent.ASSIGN);
+  }
 }


### PR DESCRIPTION
## Description

Adding REST endpoint `DELETE v1/user-tasks/{userTaskKey}/assignee` as per [this issue](https://github.com/camunda/zeebe/issues/16414)


<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16414

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
