### PR TITLE
Client communication API configuration

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -32,6 +32,11 @@ public final class ClientProperties {
   public static final String GATEWAY_ADDRESS = "zeebe.client.gateway.address";
 
   /**
+   * @see ZeebeClientBuilder#defaultCommunicationApi(String)
+   */
+  public static final String DEFAULT_COMMUNICATION_API = "zeebe.client.communicationApi";
+
+  /**
    * @see ZeebeClientBuilder#defaultTenantId(String)
    */
   public static final String DEFAULT_TENANT_ID = "zeebe.client.tenantId";

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -51,6 +51,17 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder gatewayAddress(String gatewayAddress);
 
   /**
+   * @param communicationApi the communication API to use. It can be one of:
+   *     <ul>
+   *       <li>REST
+   *       <li>GRPC
+   *     </ul>
+   *     The default value is {@link
+   *     io.camunda.zeebe.client.api.command.CommandWithCommunicationApiStep#DEFAULT_COMMUNICATION_API}.
+   */
+  ZeebeClientBuilder defaultCommunicationApi(String communicationApi);
+
+  /**
    * @param tenantId the tenant identifier which is used for tenant-aware commands when no tenant
    *     identifier is set. The default value is {@link
    *     io.camunda.zeebe.client.api.command.CommandWithTenantStep#DEFAULT_TENANT_IDENTIFIER}.

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -22,10 +22,21 @@ import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 
 public interface ZeebeClientConfiguration {
+
   /**
    * @see ZeebeClientBuilder#gatewayAddress(String)
    */
   String getGatewayAddress();
+
+  /**
+   * @see ZeebeClientBuilder#defaultCommunicationApi(String)
+   */
+  String getDefaultCommunicationApi();
+
+  /**
+   * @see ZeebeClientBuilder#defaultCommunicationApi(String)
+   */
+  boolean useRestApi();
 
   /**
    * @see ZeebeClientBuilder#defaultTenantId(String)

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithCommunicationApiStep.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithCommunicationApiStep.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.ExperimentalApi;
+import java.util.Arrays;
+import java.util.List;
+
+public interface CommandWithCommunicationApiStep<T> {
+
+  String REST = "REST";
+  String GRPC = "GRPC";
+  List<String> AVAILABLE_COMMUNICATION_API = Arrays.asList(REST, GRPC);
+
+  /** The communication API for commands to use if no communication API is explicitly set. */
+  String DEFAULT_COMMUNICATION_API = REST;
+
+  /**
+   * <strong>Experimental: This method is under development, and as such using it may have no effect
+   * on the command builder when called. While unimplemented, it simply returns the command builder
+   * instance unchanged. This method already exists for software that is building support for a REST
+   * API in Zeebe, and already wants to use this API during its development. As support for REST is
+   * added to Zeebe, each of the commands that implement this method may start to take effect. Until
+   * this warning is removed, anything described below may not yet have taken effect, and the
+   * interface and its description are subject to change.</strong>
+   *
+   * <p>Sets REST as the communication API for this command. If this command doesn't support
+   * communication over REST, it simply returns the command builder instance unchanged. The default
+   * communication API can be configured using {@link
+   * io.camunda.zeebe.client.ZeebeClientBuilder#defaultCommunicationApi(String)}.
+   *
+   * @return the configured command
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
+  T useRest();
+
+  /**
+   * <strong>Experimental: This method is under development, and as such using it may have no effect
+   * on the command builder when called. While unimplemented, it simply returns the command builder
+   * instance unchanged. This method already exists for software that is building support for a REST
+   * API in Zeebe, and already wants to use this API during its development. As support for REST is
+   * added to Zeebe, each of the commands that implement this method may start to take effect. Until
+   * this warning is removed, anything described below may not yet have taken effect, and the
+   * interface and its description are subject to change.</strong>
+   *
+   * <p>Sets gRPC as the communication API for this command. If this command doesn't support
+   * communication over gRPC, it simply returns the command builder instance unchanged. The default
+   * communication API can be configured using {@link
+   * io.camunda.zeebe.client.ZeebeClientBuilder#defaultCommunicationApi(String)}.
+   *
+   * @return the configured command
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
+  T useGrpc();
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/TopologyRequestStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/TopologyRequestStep1.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.Topology;
 
-public interface TopologyRequestStep1 extends FinalCommandStep<Topology> {
+public interface TopologyRequestStep1
+    extends CommandWithCommunicationApiStep<TopologyRequestStep1>, FinalCommandStep<Topology> {
   // the place for new optional parameters
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -120,6 +120,12 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder defaultCommunicationApi(final String communicationApi) {
+    innerBuilder.defaultCommunicationApi(communicationApi);
+    return this;
+  }
+
+  @Override
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/14106")
   public ZeebeClientCloudBuilderStep4 defaultTenantId(final String tenantId) {
     Loggers.LOGGER.debug(

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/TopologyRequestImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/TopologyRequestImpl.java
@@ -34,6 +34,7 @@ public final class TopologyRequestImpl implements TopologyRequestStep1 {
   private final GatewayStub asyncStub;
   private final Predicate<Throwable> retryPredicate;
   private Duration requestTimeout;
+  private boolean useRest;
 
   public TopologyRequestImpl(
       final GatewayStub asyncStub,
@@ -42,6 +43,18 @@ public final class TopologyRequestImpl implements TopologyRequestStep1 {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;
+    useRest = false;
+  }
+
+  @Override
+  public TopologyRequestStep1 useRest() {
+    return this;
+  }
+
+  @Override
+  public TopologyRequestStep1 useGrpc() {
+    useRest = false;
+    return this;
   }
 
   @Override


### PR DESCRIPTION
## Description

In the Zeebe Java client, we need to enable users to configure what communication API they want to use for the client commands.

Users can pick between `REST` and `GRPC` as the available communication APIs. By default, if nothing is explicitly set, `REST` is used.

For this, a client configuration property is provided called `defaultCommunicationApi`. The property can be set through:
- A `ZeebeClientBuilder` setter
- Through a properties file using `zeebe.client.communicationApi`
- Through an env var `ZEEBE_DEFAULT_COMMUNICATION_API`

Furthermore, an additional command interface is provided `CommandWithCommunicationApiStep`. The goal fo this interface is to allow client users to override the default communication API, and set it explicitly for each command.

:information_source: I decided to use the term "communication API" as the term seems to be common for gRPC and REST. I considered the term "protocol", but REST is an API that operates on the HTTP protocol, so it would be wrong. On the other hand, in some places gRPC is referred to as an API architecture. So "communication API" seems like a common denominator.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16588 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
