### PR TITLE
ci(benchmark): lock benchmark chart to 0.1.22

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -205,6 +205,7 @@ jobs:
       - name: Helm install
         run: >
           helm upgrade --install ${{ inputs.name }} zeebe-benchmark/zeebe-benchmark
+          --version 0.1.22
           --namespace ${{ inputs.name }}
           --create-namespace
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}


### PR DESCRIPTION
## Description

The 8.1 release is not compatible with newer >=0.2.0 [benchmark](https://github.com/zeebe-io/benchmark-helm) releases.

Test invocation to update the 8.1 benchmark https://github.com/camunda/zeebe/actions/runs/8067726120 .