### PR TITLE
test(qa): parameterize `RollingUpdateTest` over versions

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -270,7 +270,7 @@ final class RollingUpdateTest {
   }
 
   private void updateBroker(final ZeebeBrokerNode<?> broker, final String version) {
-    if (version.equals("CURRENT")) {
+    if ("CURRENT".equals(version)) {
       broker.setDockerImageName(
           ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
     } else {

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -164,8 +164,7 @@ final class RollingUpdateTest {
           .pollInterval(Duration.ofMillis(500))
           .untilAsserted(() -> assertBrokerHasAtLeastOneSnapshot(0));
 
-      broker.setDockerImageName(
-          DockerImageName.parse("camunda/zeebe").withTag(to).asCanonicalNameString());
+      updateBroker(broker, to);
       broker.start();
       Awaitility.await("updated broker is added to topology")
           .atMost(Duration.ofSeconds(120))

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
-import io.camunda.zeebe.util.VersionUtil;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeVolume;
@@ -35,8 +34,9 @@ import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
@@ -50,10 +50,6 @@ import org.testcontainers.utility.DockerImageName;
  */
 final class RollingUpdateTest {
 
-  private static final DockerImageName PREVIOUS_VERSION =
-      DockerImageName.parse("camunda/zeebe").withTag(VersionUtil.getPreviousVersion());
-  private static final DockerImageName CURRENT_VERSION =
-      ZeebeTestContainerDefaults.defaultTestImage();
   private static final BpmnModelInstance PROCESS =
       Bpmn.createExecutableProcess("process")
           .startEvent()
@@ -86,16 +82,19 @@ final class RollingUpdateTest {
     CloseHelper.quietClose(network);
   }
 
-  @Test
-  void shouldBeAbleToRestartContainerWithNewVersion() {
+  @ParameterizedTest(name = "from {0} to {1}")
+  @ArgumentsSource(VersionCompatibilityMatrix.class)
+  void shouldBeAbleToRestartContainerWithNewVersion(final String from, final String to) {
     // given
+    updateAllBrokers(from);
+
     final var index = 0;
     final ZeebeBrokerNode<?> broker = cluster.getBrokers().get(index);
     cluster.start();
 
     // when
     broker.stop();
-    updateBroker(broker);
+    updateBroker(broker, to);
 
     // then
     try (final var client = cluster.newClientBuilder().build()) {
@@ -109,13 +108,15 @@ final class RollingUpdateTest {
       Awaitility.await()
           .atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofMillis(100))
-          .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, index));
+          .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, index, to));
     }
   }
 
-  @Test
-  void shouldReplicateSnapshotAcrossVersions() {
+  @ParameterizedTest(name = "from {0} to {1}")
+  @ArgumentsSource(VersionCompatibilityMatrix.class)
+  void shouldReplicateSnapshotAcrossVersions(final String from, final String to) {
     // given
+    updateAllBrokers(from);
     cluster.start();
 
     // when
@@ -163,12 +164,13 @@ final class RollingUpdateTest {
           .pollInterval(Duration.ofMillis(500))
           .untilAsserted(() -> assertBrokerHasAtLeastOneSnapshot(0));
 
-      updateBroker(broker);
+      broker.setDockerImageName(
+          DockerImageName.parse("camunda/zeebe").withTag(to).asCanonicalNameString());
       broker.start();
       Awaitility.await("updated broker is added to topology")
           .atMost(Duration.ofSeconds(120))
           .pollInterval(Duration.ofMillis(100))
-          .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, brokerId));
+          .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, brokerId, to));
     }
 
     Awaitility.await("until restarted broker has snapshot")
@@ -177,9 +179,11 @@ final class RollingUpdateTest {
         .untilAsserted(() -> assertBrokerHasAtLeastOneSnapshot(brokerId));
   }
 
-  @Test
-  void shouldPerformRollingUpdate() {
+  @ParameterizedTest(name = "from {0} to {1}")
+  @ArgumentsSource(VersionCompatibilityMatrix.class)
+  void shouldPerformRollingUpdate(final String from, final String to) {
     // given
+    updateAllBrokers(from);
     cluster.start();
 
     // when
@@ -209,12 +213,12 @@ final class RollingUpdateTest {
             .pollInterval(Duration.ofMillis(100))
             .untilAsserted(() -> assertTopologyDoesNotContainerBroker(client, brokerId));
 
-        updateBroker(broker);
+        updateBroker(broker, to);
         broker.start();
         Awaitility.await("updated broker is added to topology")
             .atMost(Duration.ofSeconds(120))
             .pollInterval(Duration.ofMillis(100))
-            .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, brokerId));
+            .untilAsserted(() -> assertTopologyContainsUpdatedBroker(client, brokerId, to));
 
         availableGateway = cluster.getGateways().get(String.valueOf(i));
       }
@@ -261,8 +265,18 @@ final class RollingUpdateTest {
     PartitionsActuator.of(node).takeSnapshot();
   }
 
-  private void updateBroker(final ZeebeBrokerNode<?> broker) {
-    broker.setDockerImageName(CURRENT_VERSION.asCanonicalNameString());
+  private void updateAllBrokers(final String version) {
+    cluster.getBrokers().forEach((id, broker) -> updateBroker(broker, version));
+  }
+
+  private void updateBroker(final ZeebeBrokerNode<?> broker, final String version) {
+    if (version.equals("CURRENT")) {
+      broker.setDockerImageName(
+          ZeebeTestContainerDefaults.defaultTestImage().asCanonicalNameString());
+    } else {
+      broker.setDockerImageName(
+          DockerImageName.parse("camunda/zeebe").withTag(version).asCanonicalNameString());
+    }
   }
 
   private ProcessInstanceEvent createProcessInstance(final ZeebeClient client) {
@@ -284,7 +298,7 @@ final class RollingUpdateTest {
   }
 
   private void assertTopologyContainsUpdatedBroker(
-      final ZeebeClient zeebeClient, final int brokerId) {
+      final ZeebeClient zeebeClient, final int brokerId, final String expectedVersion) {
     final var topology = zeebeClient.newTopologyRequest().send().join();
     TopologyAssert.assertThat(topology)
         .as("the topology contains all the brokers")
@@ -298,7 +312,7 @@ final class RollingUpdateTest {
               assertThat(brokerInfo.getNodeId()).as("the broker's node ID").isEqualTo(brokerId);
               assertThat(brokerInfo.getVersion())
                   .as("the broker's version")
-                  .isEqualTo(VersionUtil.getVersion());
+                  .isEqualTo(expectedVersion);
             });
   }
 
@@ -350,6 +364,5 @@ final class RollingUpdateTest {
         // TODO remove after 8.4 release
         .withCreateContainerCmdModifier(
             createContainerCmd -> createContainerCmd.withUser("1001:0"));
-    broker.setDockerImageName(PREVIOUS_VERSION.asCanonicalNameString());
   }
 }

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
+import io.camunda.zeebe.util.VersionUtil;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeVolume;
@@ -311,7 +312,10 @@ final class RollingUpdateTest {
               assertThat(brokerInfo.getNodeId()).as("the broker's node ID").isEqualTo(brokerId);
               assertThat(brokerInfo.getVersion())
                   .as("the broker's version")
-                  .isEqualTo(expectedVersion);
+                  .isEqualTo(
+                      "CURRENT".equals(expectedVersion)
+                          ? VersionUtil.getVersion()
+                          : expectedVersion);
             });
   }
 

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test;
+
+import io.camunda.zeebe.util.VersionUtil;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+
+/**
+ * Provides combinations of versions that should be compatible with each other. This matrix is used
+ * in {@link RollingUpdateTest}.
+ *
+ * <p>Currently we only test between the previous minor version and the current development version.
+ */
+public class VersionCompatibilityMatrix implements ArgumentsProvider {
+  private static final String PREVIOUS_VERSION = VersionUtil.getPreviousVersion();
+
+  @Override
+  public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
+    return Stream.of(Arguments.of(PREVIOUS_VERSION, "CURRENT"));
+  }
+}

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/SemanticVersion.java
@@ -126,4 +126,13 @@ public record SemanticVersion(
 
     return Integer.compare(preReleaseParts.length, otherPreReleaseParts.length);
   }
+
+  @Override
+  public String toString() {
+    final var version = major + "." + minor + "." + patch;
+    if (preRelease != null) {
+      return version + "-" + preRelease;
+    }
+    return version;
+  }
 }


### PR DESCRIPTION
This is the first refactoring which will make it easier to extend the matrix of versions where we want to verify that rolling updates work.

relates to #16608 