### PR TITLE
 test(qa): extend version compatibility matrix for `RollingUpdateTest`

### DIFF
--- a/zeebe/qa/update-tests/pom.xml
+++ b/zeebe/qa/update-tests/pom.xml
@@ -105,6 +105,18 @@
       <artifactId>agrona</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/qa/update-tests/pom.xml
+++ b/zeebe/qa/update-tests/pom.xml
@@ -14,6 +14,9 @@
   <packaging>jar</packaging>
 
   <name>Zeebe QA Update Tests</name>
+  <properties>
+    <version.resilience4j>2.2.0</version.resilience4j>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -117,6 +120,20 @@
       <artifactId>jackson-annotations</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-retry</artifactId>
+      <version>${version.resilience4j}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.github.resilience4j</groupId>
+      <artifactId>resilience4j-core</artifactId>
+      <version>${version.resilience4j}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -36,8 +36,10 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.containers.ContainerState;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
@@ -49,6 +51,7 @@ import org.testcontainers.utility.DockerImageName;
  * <p>The important part is that we should be aware whether rolling update is possible between
  * versions.
  */
+@Execution(ExecutionMode.CONCURRENT)
 final class RollingUpdateTest {
 
   private static final BpmnModelInstance PROCESS =
@@ -84,7 +87,7 @@ final class RollingUpdateTest {
   }
 
   @ParameterizedTest(name = "from {0} to {1}")
-  @ArgumentsSource(VersionCompatibilityMatrix.class)
+  @MethodSource("io.camunda.zeebe.test.VersionCompatibilityMatrix#auto")
   void shouldBeAbleToRestartContainerWithNewVersion(final String from, final String to) {
     // given
     updateAllBrokers(from);
@@ -114,7 +117,7 @@ final class RollingUpdateTest {
   }
 
   @ParameterizedTest(name = "from {0} to {1}")
-  @ArgumentsSource(VersionCompatibilityMatrix.class)
+  @MethodSource("io.camunda.zeebe.test.VersionCompatibilityMatrix#auto")
   void shouldReplicateSnapshotAcrossVersions(final String from, final String to) {
     // given
     updateAllBrokers(from);
@@ -180,7 +183,7 @@ final class RollingUpdateTest {
   }
 
   @ParameterizedTest(name = "from {0} to {1}")
-  @ArgumentsSource(VersionCompatibilityMatrix.class)
+  @MethodSource("io.camunda.zeebe.test.VersionCompatibilityMatrix#auto")
   void shouldPerformRollingUpdate(final String from, final String to) {
     // given
     updateAllBrokers(from);

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -7,23 +7,96 @@
  */
 package io.camunda.zeebe.test;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.util.SemanticVersion;
 import io.camunda.zeebe.util.VersionUtil;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse.BodyHandlers;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.ArgumentsProvider;
 
 /**
  * Provides combinations of versions that should be compatible with each other. This matrix is used
  * in {@link RollingUpdateTest}.
- *
- * <p>Currently we only test between the previous minor version and the current development version.
  */
-public class VersionCompatibilityMatrix implements ArgumentsProvider {
-  private static final String PREVIOUS_VERSION = VersionUtil.getPreviousVersion();
+@SuppressWarnings("unused")
+final class VersionCompatibilityMatrix {
 
-  @Override
-  public Stream<? extends Arguments> provideArguments(final ExtensionContext context) {
-    return Stream.of(Arguments.of(PREVIOUS_VERSION, "CURRENT"));
+  /**
+   * Automatically chooses the matrix to use depending on the environment where tests are run.
+   *
+   * <ul>
+   *   <li>Locally: {@link #fromPreviousMinorToCurrent()} for fast feedback.
+   *   <li>CI: {@link #fromPreviousPatchesToCurrent()} for extended coverage without taking too much
+   *       time.
+   *   <li>Periodic tests: {@link #full()} for full coverage of all allowed upgrade paths.
+   * </ul>
+   */
+  private static Stream<Arguments> auto() throws IOException, InterruptedException {
+    if (System.getenv("ZEEBE_CI_CHECK_VERSION_COMPATIBILITY") != null) {
+      return full();
+    } else if (System.getenv("CI") != null) {
+      return fromPreviousPatchesToCurrent();
+    } else {
+      return fromPreviousMinorToCurrent();
+    }
+  }
+
+  private static Stream<Arguments> fromPreviousMinorToCurrent() {
+    return Stream.of(Arguments.of(VersionUtil.getPreviousVersion(), "CURRENT"));
+  }
+
+  private static Stream<Arguments> fromPreviousPatchesToCurrent()
+      throws IOException, InterruptedException {
+    final var current = VersionUtil.getSemanticVersion().orElseThrow();
+    return discoverVersions()
+        .filter(version -> version.compareTo(current) < 0)
+        .filter(version -> current.minor() - version.minor() <= 1)
+        .map(version -> Arguments.of(version.toString(), "CURRENT"));
+  }
+
+  private static Stream<Arguments> full() throws IOException, InterruptedException {
+    final var versions = discoverVersions().toList();
+    return versions.stream()
+        .filter(version -> version.minor() > 0)
+        .flatMap(
+            version1 ->
+                versions.stream()
+                    .filter(version2 -> version1.compareTo(version2) < 0)
+                    .filter(version2 -> version2.minor() - version1.minor() <= 1)
+                    .map(version2 -> Arguments.of(version1.toString(), version2.toString())));
+  }
+
+  /**
+   * Discovers Zeebe versions that aren't pre-releases. Sourced from the GitHub API. Includes all
+   * versions since 8.0.
+   *
+   * @see <a
+   *     href="https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#list-matching-references--parameters">GitHub
+   *     API</a>
+   */
+  private static Stream<SemanticVersion> discoverVersions()
+      throws IOException, InterruptedException {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    record Ref(String ref) {
+      SemanticVersion toSemanticVersion() {
+        return SemanticVersion.parse(ref.substring("refs/tags/".length())).orElse(null);
+      }
+    }
+
+    try (final var httpClient = HttpClient.newHttpClient()) {
+      final var endpoint =
+          URI.create("https://api.github.com/repos/camunda/zeebe/git/matching-refs/tags/8.");
+      final var request = HttpRequest.newBuilder().GET().uri(endpoint).build();
+      final var response = httpClient.send(request, BodyHandlers.ofByteArray());
+      final var refs = new ObjectMapper().readValue(response.body(), Ref[].class);
+      return Stream.of(refs)
+          .map(Ref::toSemanticVersion)
+          .filter(version -> version != null && version.preRelease() == null);
+    }
   }
 }


### PR DESCRIPTION
Adds three types of modes to run `RollingUpdateTest`:
- full coverage, only run when `ZEEBE_CI_CHECK_VERSION_COMPATIBILITY` is set.
- partial coverage, all previous patch versions to the current version. Used by default in CI
- minimal coverage, only the first patch of the previous minor with the current version. Used by default when running tests locally.

The full coverage mode isn't used yet because it currently checks 1591 version combinations which is too many for our regular CI.

Effectively this extends our CI to not just check "8.4.0 -> current version" but check "all patch versions of 8.4 -> current version".

Builds on top of #16610 
Relates to #16608 