### PR TITLE
test(journal): ensure journal is closed always

### DIFF
--- a/zeebe/journal/src/test/resources/log4j2-test.xml
+++ b/zeebe/journal/src/test/resources/log4j2-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%X{actor-name}] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="io.camunda.zeebe" level="trace"/>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
## Description

I couldn't reproduce it. The logs attached in the issue was also not useful because nothing was logged. So in this PR, the log level for the tests in this module is set to trace. This would help in future failing tests.

After increasing the log level, it was observed that the journal created in this test was never closed. My assumption is that this is cause of flakiness. Since it is not closed, the asynchronous segment creation has a race condition with directory deletion. This is now fixed in this PR, by ensuring every journal object created by `openJournal` is closed after each test.

## Related issues

closes #16183 

