### PR TITLE
Skip Exporting Specific Records

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -685,16 +685,13 @@
     # exporting:
       # This section contains definitions common to all exporters.
       #
-      # Skip records Exporter ------------
-        #
-        # Enable the exporters to skip record position
-        #
-        # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTING_SKIPRECORDS"
-        # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
-        # preventing processing or exporting to continue.
-        # Record positions defined to skip in this definition will be skipped in all exporters.
-        # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
-        # skipRecords:
+      # Enable the exporters to skip record position.
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTING_SKIPRECORDS"
+      # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
+      # preventing processing or exporting to continue.
+      # Record positions defined to skip in this definition will be skipped in all exporters.
+      # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
+      # skipRecords:
 
     # exporters:
       # Configure exporters below

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -725,6 +725,17 @@
         #   port = 8000
         #   limit = 1024
 
+      # Skip records Exporter ------------
+      #
+      # Enable the exporter to skip record position
+      #
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_[exporter name]_SKIPRECORDS"
+      # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
+      # preventing processing or exporting to continue.
+      # Record positions defined to skip in one of the exporters will be skipped in all exporters.
+      # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
+      # skipRecords:
+
       # Elasticsearch Exporter ----------
       # An example configuration for the elasticsearch exporter:
       #

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -682,6 +682,20 @@
         # This setting can also be overridden using the environment ZEEBE_BROKER_BACKPRESSURE_GRADIENT2_LONGWINDOW
         # longWindow: 600
 
+    # exporting:
+      # This section contains definitions common to all exporters.
+      #
+      # Skip records Exporter ------------
+        #
+        # Enable the exporters to skip record position
+        #
+        # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTING_SKIPRECORDS"
+        # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
+        # preventing processing or exporting to continue.
+        # Record positions defined to skip in this definition will be skipped in all exporters.
+        # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
+        # skipRecords:
+
     # exporters:
       # Configure exporters below
       #
@@ -724,17 +738,6 @@
         # args:
         #   port = 8000
         #   limit = 1024
-
-      # Skip records Exporter ------------
-      #
-      # Enable the exporter to skip record position
-      #
-      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_[exporter name]_SKIPRECORDS"
-      # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
-      # preventing processing or exporting to continue.
-      # Record positions defined to skip in one of the exporters will be skipped in all exporters.
-      # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
-      # skipRecords:
 
       # Elasticsearch Exporter ----------
       # An example configuration for the elasticsearch exporter:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -578,16 +578,13 @@
     # exporting:
       # This section contains definitions common to all exporters.
       #
-      # Skip records Exporter ------------
-        #
-        # Enable the exporters to skip record position
-        #
-        # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTING_SKIPRECORDS"
-        # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
-        # preventing processing or exporting to continue.
-        # Record positions defined to skip in this definition will be skipped in all exporters.
-        # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
-        # skipRecords:
+      # Enable the exporters to skip record position.
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTING_SKIPRECORDS"
+      # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
+      # preventing processing or exporting to continue.
+      # Record positions defined to skip in this definition will be skipped in all exporters.
+      # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
+      # skipRecords:
 
     # exporters:
       # Configure exporters below

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -618,6 +618,17 @@
         #   port = 8000
         #   limit = 1024
 
+      # Skip records Exporter ------------
+      #
+      # Enable the exporter to skip record position
+      #
+      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_[exporter name]_SKIPRECORDS"
+      # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
+      # preventing processing or exporting to continue.
+      # Record positions defined to skip in one of the exporters will be skipped in all exporters.
+      # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
+      # skipRecords:
+
       # Elasticsearch Exporter ----------
       # An example configuration for the elasticsearch exporter:
       #

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -575,6 +575,20 @@
         # This setting can also be overridden using the environment ZEEBE_BROKER_BACKPRESSURE_GRADIENT2_LONGWINDOW
         # longWindow: 600
 
+    # exporting:
+      # This section contains definitions common to all exporters.
+      #
+      # Skip records Exporter ------------
+        #
+        # Enable the exporters to skip record position
+        #
+        # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTING_SKIPRECORDS"
+        # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
+        # preventing processing or exporting to continue.
+        # Record positions defined to skip in this definition will be skipped in all exporters.
+        # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
+        # skipRecords:
+
     # exporters:
       # Configure exporters below
       #
@@ -617,17 +631,6 @@
         # args:
         #   port = 8000
         #   limit = 1024
-
-      # Skip records Exporter ------------
-      #
-      # Enable the exporter to skip record position
-      #
-      # These setting can also be overridden using the environment variables "ZEEBE_BROKER_EXPORTERS_[exporter name]_SKIPRECORDS"
-      # Allows to skip certain records by their position. This is useful for debugging or skipping a record that is
-      # preventing processing or exporting to continue.
-      # Record positions defined to skip in one of the exporters will be skipped in all exporters.
-      # The value is a comma-separated list of records ids to skip. Whitespace is ignored.
-      # skipRecords:
 
       # Elasticsearch Exporter ----------
       # An example configuration for the elasticsearch exporter:

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -282,7 +282,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       container.configureExporter();
     }
 
-    eventFilter = createEventFilter(containers).and(positionsToSkipFilter);
+    eventFilter = positionsToSkipFilter.and(createEventFilter(containers));
     LOG.debug("Set event filter for exporters: {}", eventFilter);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -83,8 +83,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private final Duration distributionInterval;
   private ExporterStateDistributionService exporterDistributionService;
   private final int partitionId;
-
-  private final Set<Long> positionsToSkip;
+  private final EventFilter positionsToSkipFilter;
 
   public ExporterDirector(final ExporterDirectorContext context, final boolean shouldPauseOnStart) {
     name = context.getName();
@@ -105,7 +104,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     exporterPositionsTopic = String.format(EXPORTER_STATE_TOPIC_FORMAT, partitionId);
     exporterMode = context.getExporterMode();
     distributionInterval = context.getDistributionInterval();
-    positionsToSkip = context.getPositionsToSkip();
+    positionsToSkipFilter = context.getPositionsToSkipFilter();
   }
 
   public ActorFuture<Void> startAsync(final ActorSchedulingService actorSchedulingService) {
@@ -283,7 +282,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       container.configureExporter();
     }
 
-    eventFilter = createEventFilter(containers);
+    eventFilter = createEventFilter(containers).and(positionsToSkipFilter);
     LOG.debug("Set event filter for exporters: {}", eventFilter);
   }
 
@@ -394,9 +393,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private void readNextEvent() {
     if (shouldExport()) {
       final LoggedEvent currentEvent = logStreamReader.next();
-      if (eventFilter == null
-          || eventFilter.applies(currentEvent)
-              && !positionsToSkip.contains(currentEvent.getPosition())) {
+      if (eventFilter == null || eventFilter.applies(currentEvent)) {
         inExportingPhase = true;
         exportEvent(currentEvent);
       } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -84,6 +84,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private ExporterStateDistributionService exporterDistributionService;
   private final int partitionId;
 
+  private final Set<Long> positionsToSkip;
+
   public ExporterDirector(final ExporterDirectorContext context, final boolean shouldPauseOnStart) {
     name = context.getName();
 
@@ -103,6 +105,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     exporterPositionsTopic = String.format(EXPORTER_STATE_TOPIC_FORMAT, partitionId);
     exporterMode = context.getExporterMode();
     distributionInterval = context.getDistributionInterval();
+    positionsToSkip = context.getPositionsToSkip();
   }
 
   public ActorFuture<Void> startAsync(final ActorSchedulingService actorSchedulingService) {
@@ -391,7 +394,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private void readNextEvent() {
     if (shouldExport()) {
       final LoggedEvent currentEvent = logStreamReader.next();
-      if (eventFilter == null || eventFilter.applies(currentEvent)) {
+      if (eventFilter == null
+          || eventFilter.applies(currentEvent)
+              && !positionsToSkip.contains(currentEvent.getPosition())) {
         inExportingPhase = true;
         exportEvent(currentEvent);
       } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -11,9 +11,9 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.system.partitions.PartitionMessagingService;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
+import io.camunda.zeebe.stream.api.EventFilter;
 import java.time.Duration;
 import java.util.Collection;
-import java.util.Set;
 
 public final class ExporterDirectorContext {
 
@@ -27,7 +27,7 @@ public final class ExporterDirectorContext {
   private PartitionMessagingService partitionMessagingService;
   private ExporterMode exporterMode = ExporterMode.ACTIVE; // per default we export records
   private Duration distributionInterval = DEFAULT_DISTRIBUTION_INTERVAL;
-  private Set<Long> positionsToSkip;
+  private EventFilter positionsToSkipFilter;
 
   public int getId() {
     return id;
@@ -61,8 +61,8 @@ public final class ExporterDirectorContext {
     return distributionInterval;
   }
 
-  public Set<Long> getPositionsToSkip() {
-    return positionsToSkip != null ? positionsToSkip : Set.of();
+  public EventFilter getPositionsToSkipFilter() {
+    return positionsToSkipFilter;
   }
 
   public ExporterDirectorContext id(final int id) {
@@ -106,8 +106,8 @@ public final class ExporterDirectorContext {
     return this;
   }
 
-  public ExporterDirectorContext positionsToSkip(final Set<Long> positionsToSkip) {
-    this.positionsToSkip = positionsToSkip;
+  public ExporterDirectorContext positionsToSkipFilter(final EventFilter skipPositionsFilter) {
+    positionsToSkipFilter = skipPositionsFilter;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import java.time.Duration;
 import java.util.Collection;
+import java.util.Set;
 
 public final class ExporterDirectorContext {
 
@@ -26,6 +27,7 @@ public final class ExporterDirectorContext {
   private PartitionMessagingService partitionMessagingService;
   private ExporterMode exporterMode = ExporterMode.ACTIVE; // per default we export records
   private Duration distributionInterval = DEFAULT_DISTRIBUTION_INTERVAL;
+  private Set<Long> positionsToSkip;
 
   public int getId() {
     return id;
@@ -57,6 +59,10 @@ public final class ExporterDirectorContext {
 
   public Duration getDistributionInterval() {
     return distributionInterval;
+  }
+
+  public Set<Long> getPositionsToSkip() {
+    return positionsToSkip != null ? positionsToSkip : Set.of();
   }
 
   public ExporterDirectorContext id(final int id) {
@@ -97,6 +103,11 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext distributionInterval(final Duration distributionInterval) {
     this.distributionInterval = distributionInterval;
+    return this;
+  }
+
+  public ExporterDirectorContext positionsToSkip(final Set<Long> positionsToSkip) {
+    this.positionsToSkip = positionsToSkip;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/BrokerCfg.java
@@ -23,6 +23,7 @@ public class BrokerCfg {
   private ThreadsCfg threads = new ThreadsCfg();
   private DataCfg data = new DataCfg();
   private Map<String, ExporterCfg> exporters = new HashMap<>();
+  private ExportingCfg exporting = new ExportingCfg();
   private EmbeddedGatewayCfg gateway = new EmbeddedGatewayCfg();
   private BackpressureCfg backpressure = new BackpressureCfg();
   private ProcessingCfg processingCfg = new ProcessingCfg();
@@ -99,6 +100,14 @@ public class BrokerCfg {
     this.exporters = exporters;
   }
 
+  public ExportingCfg getExporting() {
+    return exporting;
+  }
+
+  public void setExporting(final ExportingCfg exporting) {
+    this.exporting = exporting;
+  }
+
   public EmbeddedGatewayCfg getGateway() {
     return gateway;
   }
@@ -154,6 +163,8 @@ public class BrokerCfg {
         + data
         + ", exporters="
         + exporters
+        + ", exporting="
+        + exporting
         + ", gateway="
         + gateway
         + ", backpressure="

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExporterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExporterCfg.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * Exporter component configuration. To be expanded eventually to allow enabling/disabling
@@ -24,6 +25,8 @@ public final class ExporterCfg implements ConfigurationEntry {
 
   /** fully qualified class name pointing to the class implementing the exporter interface */
   private String className;
+
+  private Set<Long> skipRecords;
 
   /** map of arguments to use when instantiating the exporter */
   private Map<String, Object> args;
@@ -45,6 +48,14 @@ public final class ExporterCfg implements ConfigurationEntry {
 
   public void setJarPath(final String jarPath) {
     this.jarPath = jarPath;
+  }
+
+  public Set<Long> getSkipRecords() {
+    return skipRecords != null ? skipRecords : Set.of();
+  }
+
+  public void setSkipRecords(final Set<Long> skipRecords) {
+    this.skipRecords = skipRecords;
   }
 
   public String getClassName() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExporterCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExporterCfg.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * Exporter component configuration. To be expanded eventually to allow enabling/disabling
@@ -25,8 +24,6 @@ public final class ExporterCfg implements ConfigurationEntry {
 
   /** fully qualified class name pointing to the class implementing the exporter interface */
   private String className;
-
-  private Set<Long> skipRecords;
 
   /** map of arguments to use when instantiating the exporter */
   private Map<String, Object> args;
@@ -48,14 +45,6 @@ public final class ExporterCfg implements ConfigurationEntry {
 
   public void setJarPath(final String jarPath) {
     this.jarPath = jarPath;
-  }
-
-  public Set<Long> getSkipRecords() {
-    return skipRecords != null ? skipRecords : Set.of();
-  }
-
-  public void setSkipRecords(final Set<Long> skipRecords) {
-    this.skipRecords = skipRecords;
   }
 
   public String getClassName() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExportingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ExportingCfg.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Exporting component configuration. This configuration pertains to configurations that are common
+ * to all exporters.
+ */
+public final class ExportingCfg implements ConfigurationEntry {
+  private Set<Long> skipRecords;
+
+  public Set<Long> getSkipRecords() {
+    return skipRecords != null ? skipRecords : Set.of();
+  }
+
+  public void setSkipRecords(final Set<Long> skipRecords) {
+    this.skipRecords = skipRecords;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(skipRecords);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ExportingCfg that = (ExportingCfg) o;
+    return Objects.equals(skipRecords, that.skipRecords);
+  }
+
+  @Override
+  public String toString() {
+    return "ExporterCfg{" + "skipRecords='" + skipRecords + '}';
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -12,12 +12,14 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.ExporterMode;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.Collection;
+import java.util.Set;
 
 public final class ExporterDirectorPartitionTransitionStep implements PartitionTransitionStep {
 
@@ -92,7 +94,8 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .zeebeDb(context.getZeebeDb())
             .partitionMessagingService(context.getMessagingService())
             .descriptors(exporterDescriptors)
-            .exporterMode(exporterMode);
+            .exporterMode(exporterMode)
+            .positionsToSkip(getPositionsToSkip(context));
 
     final ExporterDirector director = new ExporterDirector(exporterCtx, !context.shouldExport());
 
@@ -112,5 +115,23 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
           }
         });
     return startFuture;
+  }
+
+  private Set<Long> getPositionsToSkip(final PartitionTransitionContext context) {
+    // Since the filtering of the positions to skip is done at the ExporterDirector level, we need
+    // to collect all the positions to skip from all the exporter configurations.
+    // This means that positions to skip in exporter A will also be skipped in exporter B.
+    final Set<Long> positionsToSkip = new java.util.HashSet<>(Set.of());
+    context.getExportedDescriptors().stream()
+        .map(ExporterDescriptor::getId)
+        .forEach(
+            id -> {
+              final ExporterCfg exporterCfg = context.getBrokerCfg().getExporters().get(id);
+              if (exporterCfg != null) {
+                positionsToSkip.addAll(exporterCfg.getSkipRecords());
+              }
+            });
+
+    return positionsToSkip;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import java.util.Collection;
 
 public final class ExporterDirectorPartitionTransitionStep implements PartitionTransitionStep {
@@ -81,7 +82,8 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
   private ActorFuture<Void> openExporter(
       final PartitionTransitionContext context, final Role targetRole) {
     final Collection<ExporterDescriptor> exporterDescriptors = context.getExportedDescriptors();
-
+    final var exporterFilter =
+        SkipPositionsFilter.of(context.getBrokerCfg().getExporting().getSkipRecords());
     final ExporterMode exporterMode =
         targetRole == Role.LEADER ? ExporterMode.ACTIVE : ExporterMode.PASSIVE;
     final ExporterDirectorContext exporterCtx =
@@ -93,7 +95,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .partitionMessagingService(context.getMessagingService())
             .descriptors(exporterDescriptors)
             .exporterMode(exporterMode)
-            .positionsToSkip(context.getBrokerCfg().getExporting().getSkipRecords());
+            .positionsToSkipFilter(exporterFilter);
 
     final ExporterDirector director = new ExporterDirector(exporterCtx, !context.shouldExport());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import java.util.Collection;
+import java.util.Set;
 
 public final class ExporterDirectorPartitionTransitionStep implements PartitionTransitionStep {
 
@@ -83,7 +84,10 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
       final PartitionTransitionContext context, final Role targetRole) {
     final Collection<ExporterDescriptor> exporterDescriptors = context.getExportedDescriptors();
     final var exporterFilter =
-        SkipPositionsFilter.of(context.getBrokerCfg().getExporting().getSkipRecords());
+        SkipPositionsFilter.of(
+            context.getBrokerCfg() != null
+                ? context.getBrokerCfg().getExporting().getSkipRecords()
+                : Set.of());
     final ExporterMode exporterMode =
         targetRole == Role.LEADER ? ExporterMode.ACTIVE : ExporterMode.PASSIVE;
     final ExporterDirectorContext exporterCtx =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -341,7 +342,7 @@ public final class ExporterDirectorTest {
         .get(1)
         .onConfigure(withFilter(List.of(RecordType.COMMAND), List.of(ValueType.DEPLOYMENT)));
 
-    rule.withSkipRecords(Set.of(1L));
+    rule.withPositionsToSkipFilter(SkipPositionsFilter.of(Set.of(1L)));
     startExporterDirector(exporterDescriptors);
 
     // when

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -23,9 +23,11 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.stream.api.EventFilter;
+import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -55,7 +57,7 @@ public final class ExporterRule implements TestRule {
   private PartitionMessagingService partitionMessagingService = new SimplePartitionMessageService();
   private ExporterDirector director;
   private Duration distributionInterval = Duration.ofSeconds(15);
-  private EventFilter positionsToSkipFilter;
+  private EventFilter positionsToSkipFilter = SkipPositionsFilter.of(Set.of());
 
   private ExporterRule(final ExporterMode exporterMode) {
     this.exporterMode = exporterMode;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -54,6 +55,7 @@ public final class ExporterRule implements TestRule {
   private PartitionMessagingService partitionMessagingService = new SimplePartitionMessageService();
   private ExporterDirector director;
   private Duration distributionInterval = Duration.ofSeconds(15);
+  private Set<Long> skipRecords;
 
   private ExporterRule(final ExporterMode exporterMode) {
     this.exporterMode = exporterMode;
@@ -83,6 +85,11 @@ public final class ExporterRule implements TestRule {
     return this;
   }
 
+  public ExporterRule withSkipRecords(final Set<Long> skipRecords) {
+    this.skipRecords = skipRecords;
+    return this;
+  }
+
   @Override
   public Statement apply(final Statement base, final Description description) {
     return chain.apply(base, description);
@@ -102,7 +109,8 @@ public final class ExporterRule implements TestRule {
             .exporterMode(exporterMode)
             .distributionInterval(distributionInterval)
             .partitionMessagingService(partitionMessagingService)
-            .descriptors(exporterDescriptors);
+            .descriptors(exporterDescriptors)
+            .positionsToSkip(skipRecords);
 
     director = new ExporterDirector(context, false);
     director.startAsync(actorSchedulerRule.get()).join();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -22,10 +22,10 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
+import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.time.Duration;
 import java.util.List;
-import java.util.Set;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -55,7 +55,7 @@ public final class ExporterRule implements TestRule {
   private PartitionMessagingService partitionMessagingService = new SimplePartitionMessageService();
   private ExporterDirector director;
   private Duration distributionInterval = Duration.ofSeconds(15);
-  private Set<Long> skipRecords;
+  private EventFilter positionsToSkipFilter;
 
   private ExporterRule(final ExporterMode exporterMode) {
     this.exporterMode = exporterMode;
@@ -85,8 +85,8 @@ public final class ExporterRule implements TestRule {
     return this;
   }
 
-  public ExporterRule withSkipRecords(final Set<Long> skipRecords) {
-    this.skipRecords = skipRecords;
+  public ExporterRule withPositionsToSkipFilter(final EventFilter positionsToSkipFilter) {
+    this.positionsToSkipFilter = positionsToSkipFilter;
     return this;
   }
 
@@ -110,7 +110,7 @@ public final class ExporterRule implements TestRule {
             .distributionInterval(distributionInterval)
             .partitionMessagingService(partitionMessagingService)
             .descriptors(exporterDescriptors)
-            .positionsToSkip(skipRecords);
+            .positionsToSkipFilter(positionsToSkipFilter);
 
     director = new ExporterDirector(context, false);
     director.startAsync(actorSchedulerRule.get()).join();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
@@ -19,13 +19,13 @@ class ExporterConfigurationTest {
   void shouldSetSkipPositionsFromEnvironment() {
     // given
     final var environment = new HashMap<String, String>();
-    environment.put("zeebe.broker.exporters.elasticsearch.skipRecords", "1, 2, 3 , 3, 2, 1, 0");
+    environment.put("zeebe.broker.exporting.skipRecords", "1, 2, 3 , 3, 2, 1, 0");
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
-    final ExporterCfg exporterCfg = cfg.getExporters().get("elasticsearch");
+    final ExportingCfg exportingCfg = cfg.getExporting();
 
     // then
-    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L, 0L));
+    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L, 0L));
   }
 
   @Test
@@ -35,32 +35,31 @@ class ExporterConfigurationTest {
 
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
-    final ExporterCfg exporterCfg = cfg.getExporters().get("elasticsearch");
-
+    final ExportingCfg exportingCfg = cfg.getExporting();
     // then
-    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(112233L, 445566L));
+    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(112233L, 445566L));
   }
 
   @Test
   void shouldSetSkipPositions() {
     // given
-    final ExporterCfg exporterCfg = new ExporterCfg();
-    exporterCfg.setSkipRecords(Set.of(1L, 2L));
+    final ExportingCfg exportingCfg = new ExportingCfg();
+    exportingCfg.setSkipRecords(Set.of(1L, 2L));
 
     // then
-    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L));
+    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L));
   }
 
   @Test
   void shouldSetSkipPositionsForOtherExporters() {
     // given
     final var environment = new HashMap<String, String>();
-    environment.put("zeebe.broker.exporters.openSearch.skipRecords", "1, 2, 3");
+    environment.put("zeebe.broker.exporting.skipRecords", "1, 2, 3");
     // when
     final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
-    final ExporterCfg exporterCfg = cfg.getExporters().get("openSearch");
+    final ExportingCfg exportingCfg = cfg.getExporting();
 
     // then
-    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L));
+    assertThat(exportingCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L));
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/ExporterConfigurationTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class ExporterConfigurationTest {
+
+  @Test
+  void shouldSetSkipPositionsFromEnvironment() {
+    // given
+    final var environment = new HashMap<String, String>();
+    environment.put("zeebe.broker.exporters.elasticsearch.skipRecords", "1, 2, 3 , 3, 2, 1, 0");
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
+    final ExporterCfg exporterCfg = cfg.getExporters().get("elasticsearch");
+
+    // then
+    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L, 0L));
+  }
+
+  @Test
+  void shouldSetSkipPositionsFromConfigurationFile() {
+    // given
+    final var environment = new HashMap<String, String>();
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
+    final ExporterCfg exporterCfg = cfg.getExporters().get("elasticsearch");
+
+    // then
+    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(112233L, 445566L));
+  }
+
+  @Test
+  void shouldSetSkipPositions() {
+    // given
+    final ExporterCfg exporterCfg = new ExporterCfg();
+    exporterCfg.setSkipRecords(Set.of(1L, 2L));
+
+    // then
+    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L));
+  }
+
+  @Test
+  void shouldSetSkipPositionsForOtherExporters() {
+    // given
+    final var environment = new HashMap<String, String>();
+    environment.put("zeebe.broker.exporters.openSearch.skipRecords", "1, 2, 3");
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("exporters", environment);
+    final ExporterCfg exporterCfg = cfg.getExporters().get("openSearch");
+
+    // then
+    assertThat(exporterCfg.getSkipRecords()).isEqualTo(Set.of(1L, 2L, 3L));
+  }
+}

--- a/zeebe/broker/src/test/resources/system/exporters.yaml
+++ b/zeebe/broker/src/test/resources/system/exporters.yaml
@@ -2,4 +2,5 @@ zeebe:
   broker:
     exporters:
       elasticsearch:
+        skipRecords: 112233, 445566
         className: io.camunda.zeebe.exporter.ElasticsearchExporter

--- a/zeebe/broker/src/test/resources/system/exporters.yaml
+++ b/zeebe/broker/src/test/resources/system/exporters.yaml
@@ -1,6 +1,7 @@
 zeebe:
   broker:
+    exporting:
+      skipRecords: 112233, 445566
     exporters:
       elasticsearch:
-        skipRecords: 112233, 445566
         className: io.camunda.zeebe.exporter.ElasticsearchExporter


### PR DESCRIPTION
## Description

This pr allows the confiration of record's positions to skip in the exporters. A record position in this list will be treated as a record to skip similar to the event filter (`ExporterDirector.skipRecord()`).

The record positions to skip are being filtered out at the level of the export director, which means that a record position that is configured, will be skipped in all other exporters. 

This configuration can be changed on the broker config in `zeebe.broker.exporting.skipRecords` or in the env var `ZEEBE_BROKER_EXPORTING_SKIPRECORDS`.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/16177

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
