### PR TITLE
test(qa): wait until topology is updated

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
@@ -69,10 +69,14 @@ final class TopologyCoordinatorTest {
 
     // when - then
     // No exception because the query will be forwarded to broker 1
-    ClusterActuatorAssert.assertThat(cluster)
-        .hasActiveBroker(1)
-        .hasActiveBroker(2)
-        .doesNotHaveBroker(0);
+    Awaitility.await("Query is forwarded to broker 1")
+        .timeout(Duration.ofSeconds(30)) // give enough time for topology to be gossiped
+        .untilAsserted(
+            () ->
+                ClusterActuatorAssert.assertThat(cluster)
+                    .hasActiveBroker(1)
+                    .hasActiveBroker(2)
+                    .doesNotHaveBroker(0));
     // can also start a new topology change
     assertChangeIsPlanned(actuator.scaleBrokers(List.of(1, 2, 3)));
   }


### PR DESCRIPTION
If the gateway did not receive gossip immediately, it will still send the request to broker 0 which fails the test. So wait until the query is success.

closes #16614 