### PR TITLE
ci: add job that runs the full version compatibility checks

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -1,0 +1,89 @@
+name: Zeebe Version Compatibility
+on:
+  workflow_dispatch:
+  schedule:
+    # Run at 10:00 on every tuesday
+    - cron: '0 10 * * 2'
+concurrency:
+  group: zeebe-version-compatibility
+  cancel-in-progress: false
+
+permissions:
+  actions: read # Required to get the previous report
+
+jobs:
+  rolling-update-tests:
+    name: Rolling Update Tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shards: [ 1, 2, 3] # Values are not used, we just need an array of the right length
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find previous report
+        id: get-last-run-id
+        run: |
+          runs=$(gh api /repos/camunda/zeebe/actions/workflows/zeebe-version-compatibility.yml/runs)
+          last_run_id=$(echo $runs | jq 'first(.workflow_runs[] | select((.status=="completed") and (.conclusion=="success")).id)')
+          echo "last_run_id=$last_run_id" >> $GITHUB_OUTPUT
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Download previous report
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: zeebe-version-compatibility
+          path: ${{ github.workspace }}
+          run-id: ${{ steps.get-last-run-id.outputs.last_run_id }}
+          github-token: ${{ github.token }}
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+      - name: Test rolling update
+        run: >
+          ./mvnw -B --no-snapshot-updates -pl zeebe/qa/update-tests
+          -D it.test=io.camunda.zeebe.test.RollingUpdateTest
+          -D failsafe.rerunFailingTestsCount=3
+          -D skipChecks
+          verify
+        env:
+          ZEEBE_CI_CHECK_VERSION_COMPATIBILITY: true
+          ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_INDEX: ${{ strategy.job-index }}
+          ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_TOTAL: ${{ strategy.job-total }}
+          ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT: ${{ github.workspace }}/zeebe-version-compatibility
+      - uses: ./.github/actions/collect-test-artifacts
+        if: always()
+        with:
+          name: "Version compatibility ${{ strategy.job-index }}"
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: zeebe-version-compatibility-${{ strategy.job-index }}
+          path: ${{ github.workspace }}/zeebe-version-compatibility
+  update-shared-report:
+    name: Update Report
+    runs-on: ubuntu-latest
+    needs: rolling-update-tests
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: zeebe-version-compatibility-*
+      - name: Merge reports
+        run : |
+          cat zeebe-version-compatibility-*/** | sort | uniq > ${{ github.workspace }}/zeebe-version-compatibility
+          if [ ! -s ${{ github.workspace }}/zeebe-version-compatibility ]; then
+            exit 1
+          fi
+      - name: Upload shared report
+        uses: actions/upload-artifact@v4
+        with:
+          name: zeebe-version-compatibility
+          path: ${{ github.workspace }}/zeebe-version-compatibility

--- a/zeebe/docs/rolling_updates.md
+++ b/zeebe/docs/rolling_updates.md
@@ -1,0 +1,65 @@
+# Rolling Updates
+
+## Testing
+
+### Continuous Integration
+
+Rolling updates are testing mainly through `RollingUpdateTest` in the qa/update-tests module.
+These tests run in three different modes, depending on the environment:
+
+1. **Local**: Checks compatibility between the current version and the first patch of the previous minor.
+2. **CI**: Checks compatibility between the current version and all patches of the current and previous minor.
+3. **Full**: Checks all supported upgrade paths, i.e. upgrading from any patch to any other patch of the current or next minor.
+
+### Full test coverage
+
+Testing the full coverage is expensive because it tests more than 1.5k upgrade paths.
+We run this test periodically through the [zeebe-version-compatibility.yml workflow].
+
+In order to reduce the time and cost of the full test coverage, we run this test incrementally.
+Each run reports a list of tests and version combinations that were tested successfully.
+This list is saved as an artifact and used in the next run to skip the tests that were already successful.
+
+#### FAQ
+
+##### How do I check if a version combination was tested?
+
+The full test coverage report is stored as an artifact of the last successful run of the [zeebe-version-compatibility.yml workflow].
+You can download the `zeebe-version-compatibility` artifact and search for the version you are interested.
+The specific version combination should appear multiple times, once for each test method.
+
+##### How do I run the full test coverage locally?
+
+Set the following environment variables:
+- `ZEEBE_CI_CHECK_VERSION_COMPATIBILITY=true`
+- `ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT=~/zeebe-version-compatibility.csv`
+Then run the `RollingUpdateTest`s: with `mvn verify -D it.test=io.camunda.zeebe.test.RollingUpdateTest`
+If you keep the report file around, another run of this test will continue from where the previous run stopped and only test version combinations that weren't tested successfully yet.
+
+##### I changed the `RollingUpdateTest`, do I need to do anything?
+
+**Adding another test method** to `RollingUpdateTest` will automatically run all this test method for all supported version combinations.
+
+**Changing an existing test method**, requires a reset of the stored coverage report to restart the incremental testing from scratch.
+You can do this by navigating to the last successful test run of the [zeebe-version-compatibility.yml workflow] and deleting the `zeebe-version-compatibility` artifact.
+
+##### How does the incremental testing work?
+
+The `RollingUpdateTest` uses our own `CachedTestResultsExtension` JUnit extension.
+This extension allows to cache the test results of the parameterized test methods by storing them in a file.
+In the `zeebe-version-compatibility.yml` workflow merges the caches of all parallel test runs and stores the result as an artifact.
+The next run of the `RollingUpdateTest` restores the cache from the artifact of the last successful run.
+Then the `CachedTestResultsExtension` uses the cache to skip tests that already ran.
+
+##### How can I change the parallelism of the full test coverage?
+
+The parallelism is controlled by the `zeebe-version-compatibility.yml` workflow by using a matrix strategy.
+You can change the parallelism by adding more entries to the `shards` input of the matrix strategy.
+The actual values of the matrix input are not important, only the number of entries is relevant.
+For each matrix job, the `RollingUpdateTest` will run with on a separate "shard" of the full set of version combinations.
+
+You may want to increase parallelism after a reset of the coverage report to speed up the testing.
+Once the report is complete, you can reduce the parallelism to save resources.
+
+[zeebe-version-compatibility.yml workflow]: https://github.com/camunda/zeebe/actions/workflows/zeebe-version-compatibility.yml
+

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -17,14 +17,18 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.testcontainers.ZeebeTestContainerDefaults;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
+import io.camunda.zeebe.test.util.junit.CachedTestResultsExtension;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
 import io.camunda.zeebe.util.VersionUtil;
 import io.zeebe.containers.ZeebeBrokerNode;
 import io.zeebe.containers.ZeebeGatewayNode;
 import io.zeebe.containers.ZeebeVolume;
 import io.zeebe.containers.cluster.ZeebeCluster;
+import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -61,14 +65,21 @@ final class RollingUpdateTest {
           .serviceTask("task2", s -> s.zeebeJobType("secondTask"))
           .endEvent()
           .done();
-  private final Network network = Network.newNetwork();
+
+  @SuppressWarnings("unused")
+  @RegisterExtension()
+  private static final CachedTestResultsExtension CACHED_TEST_RESULTS_EXTENSION =
+      new CachedTestResultsExtension(
+          Optional.ofNullable(System.getenv("ZEEBE_CI_CHECK_VERSION_COMPATIBILITY_REPORT"))
+              .map(Path::of)
+              .orElse(null));
+
   private final ZeebeCluster cluster =
       ZeebeCluster.builder()
           .withEmbeddedGateway(true)
           .withBrokersCount(3)
           .withPartitionsCount(1)
           .withReplicationFactor(3)
-          .withNetwork(network)
           .build();
 
   @SuppressWarnings("unused")

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -40,8 +40,6 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.DockerClientFactory;
@@ -55,7 +53,6 @@ import org.testcontainers.utility.DockerImageName;
  * <p>The important part is that we should be aware whether rolling update is possible between
  * versions.
  */
-@Execution(ExecutionMode.CONCURRENT)
 final class RollingUpdateTest {
 
   private static final BpmnModelInstance PROCESS =

--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrixTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import java.util.LinkedList;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class VersionCompatibilityMatrixTest {
+  @ParameterizedTest(name = "Sharding {0} elements into {1} shards")
+  @MethodSource("sizeAndShards")
+  void shouldShardCompletely(final int size, final int totalShards) {
+    final var input = IntStream.range(0, size).boxed().toList();
+    final var sharded = new LinkedList<Integer>();
+    for (int i = 0; i < totalShards; i++) {
+      final var shard = VersionCompatibilityMatrix.shard(input, i, totalShards).toList();
+      assertThat(shard).isNotEmpty();
+      sharded.addAll(shard);
+    }
+    assertThat(sharded).isEqualTo(input);
+  }
+
+  static Stream<Arguments> sizeAndShards() {
+    return IntStream.rangeClosed(0, 10)
+        .boxed()
+        .flatMap(
+            size ->
+                IntStream.rangeClosed(1, 10)
+                    .boxed()
+                    .filter(shards -> shards < size)
+                    .map(shards -> arguments(size, shards)));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.junit;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.DynamicTestInvocationContext;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+/**
+ * JUnit extension to cache successfully executed test methods and skip them on subsequent runs.
+ * Results are written after all tests have run or (in a best-effort manner) when the JVM is shut
+ * down to avoid losing the cache in case of a crash or an unexpected termination.
+ *
+ * <p>
+ * The cache is organized by test method name and arguments and should not be used across different test classes to avoid conflicts.
+ *
+ * <p>Usage:
+ * <pre>{@code
+ * final class MyExpensiveTest {
+ *   @RegisterExtension
+ *   static final CachedTestResultsExtension cache = new CachedTestResultsExtension(Path.of("my-expensive-test"));
+ *
+ *   @ParameterizedTest
+ *   @ValueSource(strings = {"foo", "bar"})
+ *   void testSomethingSlowly(String arg) {
+ *
+ *   }
+ * }</pre>
+ */
+public final class CachedTestResultsExtension
+    implements TestWatcher, AfterAllCallback, BeforeAllCallback, InvocationInterceptor {
+  public static final String CACHE_KEY = "cache";
+  public static final String SHUTDOWN_HOOK_KEY = "shutdownHook";
+  private final Path cachePath;
+
+  /**
+   * Create a new extension that caches all successful test invocations in a local file.
+   *
+   * @param cachePath the path to the file to store the cache in. If null, a temporary file will be
+   *     used.
+   */
+  public CachedTestResultsExtension(final Path cachePath) {
+    this.cachePath =
+        Optional.ofNullable(cachePath)
+            .orElseGet(
+                () -> {
+                  try {
+                    return Files.createTempFile("cached-test-results-", null);
+                  } catch (final IOException e) {
+                    throw new UncheckedIOException(e);
+                  }
+                });
+  }
+
+  private ExtensionContext.Store getStore(final ExtensionContext context) {
+    return context.getStore(Namespace.create(CachedTestResultsExtension.class));
+  }
+
+  private InvocationCache getCache(final ExtensionContext context) {
+    return getStore(context).get(CACHE_KEY, InvocationCache.class);
+  }
+
+  @Override
+  public void testSuccessful(final ExtensionContext context) {
+    getCache(context).confirm(context.getUniqueId());
+  }
+
+  @Override
+  public void beforeAll(final ExtensionContext context) {
+    final var cache =
+        getStore(context)
+            .getOrComputeIfAbsent(
+                CACHE_KEY, (k) -> InvocationCache.recover(cachePath), InvocationCache.class);
+    final var hook =
+        getStore(context)
+            .getOrComputeIfAbsent(
+                SHUTDOWN_HOOK_KEY, key -> new Thread(cache::snapshot), Thread.class);
+    Runtime.getRuntime().addShutdownHook(hook);
+  }
+
+  @Override
+  public void afterAll(final ExtensionContext context) {
+    final var shutdownHook = getStore(context).remove(SHUTDOWN_HOOK_KEY, Thread.class);
+    Runtime.getRuntime().removeShutdownHook(shutdownHook);
+    getCache(context).snapshot();
+  }
+
+  @Override
+  public void interceptTestMethod(
+      final Invocation<Void> invocation,
+      final ReflectiveInvocationContext<Method> invocationContext,
+      final ExtensionContext extensionContext)
+      throws Throwable {
+    interceptMethod(extensionContext, invocation, invocationContext.getArguments());
+  }
+
+  @Override
+  public <T> T interceptTestFactoryMethod(
+      final Invocation<T> invocation,
+      final ReflectiveInvocationContext<Method> invocationContext,
+      final ExtensionContext extensionContext)
+      throws Throwable {
+    return interceptMethod(extensionContext, invocation, invocationContext.getArguments());
+  }
+
+  @Override
+  public void interceptTestTemplateMethod(
+      final Invocation<Void> invocation,
+      final ReflectiveInvocationContext<Method> invocationContext,
+      final ExtensionContext extensionContext)
+      throws Throwable {
+    interceptMethod(extensionContext, invocation, invocationContext.getArguments());
+  }
+
+  @Override
+  public void interceptDynamicTest(
+      final Invocation<Void> invocation,
+      final DynamicTestInvocationContext invocationContext,
+      final ExtensionContext extensionContext) {
+    // `invocationContext` doesn't contain the arguments, so we can't cache dynamic tests
+    throw new UnsupportedOperationException("Can't cache dynamic tests.");
+  }
+
+  <T> T interceptMethod(
+      final ExtensionContext extensionContext,
+      final Invocation<T> invocation,
+      final List<Object> arguments)
+      throws Throwable {
+    final var cache = getCache(extensionContext);
+    final var cached =
+        CachedInvocation.ofMethod(extensionContext.getRequiredTestMethod(), arguments);
+    if (cache.contains(cached)) {
+      invocation.skip();
+      return null;
+    }
+    cache.stage(extensionContext.getUniqueId(), cached);
+    return invocation.proceed();
+  }
+
+  /**
+   * Manages the in-memory and on-disk cache of test invocations. New invocations have to be {@link
+   * #stage(String, CachedInvocation) staged} with a unique id first and then {@link
+   * #confirm(String) confirmed}. Confirmed invocations are written to disk when {@link #snapshot()
+   * snapshotted} and are recovered from disk when the cache is {@link #recover(Path) recovered}.
+   *
+   * <p>Usage:
+   *
+   * <pre>{@code
+   * final var cache = InvocationCache.recover(Path.of("my-cache"));
+   * assertThat(cache.contains(new CachedInvocation("myTest1", "arg1->arg2"))).isTrue();
+   * assertThat(cache.contains(new CachedInvocation("myTest1", "arg1->arg3"))).isFalse();
+   * cache.stage("test-run-id-123", new CachedInvocation("myTest1", "arg1->arg3"));
+   * assertThat(cache.contains(new CachedInvocation("myTest1", "arg1->arg3"))).isFalse();
+   * cache.confirm("test-run-id-123");
+   * assertThat(cache.contains(new CachedInvocation("myTest1", "arg1->arg3"))).isTrue();
+   *
+   * final var cache2 = InvocationCache.recover(Path.of("my-cache"));
+   * assertThat(cache2.contains(new CachedInvocation("myTest1", "arg1->arg3"))).isFalse();
+   * cache2.stage("test-run-id-123", new CachedInvocation("myTest1", "arg1->arg3"));
+   * cache2.confirm("myTest2");
+   * cache2.snapshot();
+   *
+   * final var cache3 = InvocationCache.recover(Path.of("my-cache"));
+   * assertThat(cache3.contains(new CachedInvocation("myTest1", "arg1->arg3"))).isTrue();
+   * }</pre>
+   */
+  private static final class InvocationCache {
+    final Path path;
+    final SortedSet<CachedInvocation> cached;
+    final Map<String, CachedInvocation> staged;
+
+    private InvocationCache(final Path path, final SortedSet<CachedInvocation> arguments) {
+      this.path = Objects.requireNonNull(path);
+      cached = new ConcurrentSkipListSet<>(arguments);
+      staged = new ConcurrentHashMap<>();
+    }
+
+    boolean contains(final CachedInvocation invocation) {
+      return cached.contains(invocation);
+    }
+
+    void stage(final String id, final CachedInvocation invocation) {
+      final var previous = staged.putIfAbsent(id, invocation);
+      if (previous != null) {
+        throw new IllegalArgumentException(
+            "Invocation with id " + id + " is already staged: " + previous);
+      }
+    }
+
+    void confirm(final String id) {
+      final var invocation = staged.remove(id);
+      if (invocation == null) {
+        throw new IllegalArgumentException("No staged invocation with id " + id + " found.");
+      }
+      if (!cached.add(invocation)) {
+        throw new IllegalStateException("Invocation " + invocation + "is already cached.");
+      }
+    }
+
+    static InvocationCache recover(final Path path) {
+      if (!Files.exists(path)) {
+        return new InvocationCache(path, new TreeSet<>());
+      }
+
+      try (final var reader = Files.newBufferedReader(path)) {
+        final var pairs =
+            reader
+                .lines()
+                .map(CachedInvocation::fromLine)
+                .collect(Collectors.toCollection(TreeSet::new));
+        return new InvocationCache(path, pairs);
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+
+    void snapshot() {
+      try (final var writer = Files.newBufferedWriter(path)) {
+        for (final var version : cached) {
+          writer.write(version.toLine());
+          writer.newLine();
+        }
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+    }
+  }
+
+  private record CachedInvocation(String method, String arguments)
+      implements Comparable<CachedInvocation> {
+
+    static CachedInvocation ofMethod(final Method method, final List<Object> arguments) {
+      return new CachedInvocation(
+          method.getName(),
+          arguments.stream().map(Object::toString).collect(Collectors.joining("->")));
+    }
+
+    @Override
+    public int compareTo(final CachedTestResultsExtension.CachedInvocation o) {
+      return Comparator.comparing(CachedInvocation::method)
+          .thenComparing(CachedInvocation::arguments)
+          .compare(this, o);
+    }
+
+    String toLine() {
+      return "%s,%s".formatted(method(), arguments());
+    }
+
+    static CachedInvocation fromLine(final String line) {
+      final var parts = line.split(",");
+      return new CachedInvocation(parts[0], parts[1]);
+    }
+  }
+}


### PR DESCRIPTION
This ads a new workflow that runs `RollingUpdateTest` with the full version matrix, currently >1.7k combinations. This workflow runs periodically and incrementally to reduce costs while still checking for full coverage.

Test runs looks like this: https://github.com/camunda/zeebe/actions/workflows/zeebe-version-compatibility.yml. Once this is merged to `main`, we can also trigger it manually.

I've added documentation to make sure everyone can work with this setup and I'd recommend to read before the review: https://github.com/camunda/zeebe/blob/5081a33bf1a1564e635bcbbfb74da5ef38c22a3c/zeebe/docs/rolling_updates.md

Closes #16608