### PR TITLE
ci(daily-qa): invoke qa workflow on stable branch

### DIFF
--- a/.github/workflows/zeebe-daily-qa.yml
+++ b/.github/workflows/zeebe-daily-qa.yml
@@ -50,7 +50,7 @@ jobs:
           echo "THIRD_LAST_VERSION=${third_last}" >> $GITHUB_ENV
           echo "FOURTH_LAST_VERSION=${fourth_last}" >> $GITHUB_ENV
   # Runs the qa-testbench workflow against the stable branches. It assumes that branches follow the
-  # pattern of `stable/VERSION`, and generations of `Zeebe VERSION`.
+  # pattern of `stable/VERSION`, and generations of `Camunda VERSION`.
   #
   # NOTE: it's not possible to use the env context in a matrix, which is why we use job outputs
   # here.
@@ -78,9 +78,11 @@ jobs:
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.third-last-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.fourth-last-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.fourth-last-version) }}
+    runs-on: ubuntu-latest
     name: Daily QA
-    uses: ./.github/workflows/zeebe-qa-testbench.yaml
-    with:
-      branch: ${{ matrix.branch }}
-      generation: ${{ matrix.generation_template }}
-    secrets: inherit
+    steps:
+      - uses: actions/checkout@v4
+      - name: Trigger QA on ${{ matrix.branch }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run --ref ${{ matrix.branch }} zeebe-qa-testbench.yaml -F generation='${{ matrix.generation_template }}' -F branch=${{ matrix.branch }}


### PR DESCRIPTION
## Description

Instead of using the qa workflow from main which might be incompatible with the stable branches, invoke qa workflow on stable branch. We can't use variables in `uses` thus I went for invoking the corresponding workflows via workflow dispatch.

Successful invocation https://github.com/camunda/zeebe/actions/runs/8084204592/job/22088984403

I tend to prefer this approach as it allows to keep duplication low compared to e.g. how we solved a similar problem for [the release dry runs with static jobs](https://github.com/camunda/zeebe/blob/main/.github/workflows/release-stable-dry-run.yml).

closes #16603