### PR TITLE
Migrate element instances with incidents in the processor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.processinstance;
 
 import static io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditionChecker.*;
+import static io.camunda.zeebe.engine.state.immutable.IncidentState.MISSING_INCIDENT;
 
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
@@ -31,6 +32,7 @@ import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -222,6 +224,19 @@ public class ProcessInstanceMigrationMigrateProcessor
               .setElementId(targetElementId));
     }
 
+    final long processIncidentKey =
+        incidentState.getProcessInstanceIncidentKey(elementInstance.getKey());
+    if (processIncidentKey != MISSING_INCIDENT) {
+      appendIncidentMigratedEvent(
+          processIncidentKey, targetProcessDefinition, targetElementId, processInstanceKey);
+    }
+
+    final var jobIncidentKey = incidentState.getJobIncidentKey(elementInstance.getJobKey());
+    if (jobIncidentKey != MISSING_INCIDENT) {
+      appendIncidentMigratedEvent(
+          jobIncidentKey, targetProcessDefinition, targetElementId, processInstanceKey);
+    }
+
     if (elementInstance.getUserTaskKey() > 0) {
       final var userTask = userTaskState.getUserTask(elementInstance.getUserTaskKey());
       if (userTask == null) {
@@ -274,6 +289,30 @@ public class ProcessInstanceMigrationMigrateProcessor
           }
           return true;
         });
+  }
+
+  private void appendIncidentMigratedEvent(
+      final long incidentKey,
+      final DeployedProcess targetProcessDefinition,
+      final String targetElementId,
+      final long processInstanceKey) {
+    final var incidentRecord = incidentState.getIncidentRecord(incidentKey);
+    if (incidentRecord == null) {
+      throw new SafetyCheckFailedException(
+          String.format(
+              """
+              Expected to migrate a user task for process instance with key '%d', \
+              but could not find incident with key '%d'. \
+              Please report this as a bug""",
+              processInstanceKey, incidentKey));
+    }
+    stateWriter.appendFollowUpEvent(
+        incidentKey,
+        IncidentIntent.MIGRATED,
+        incidentRecord
+            .setProcessDefinitionKey(targetProcessDefinition.getKey())
+            .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
+            .setElementId(BufferUtil.wrapString(targetElementId)));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -182,7 +182,6 @@ public class ProcessInstanceMigrationMigrateProcessor
 
     final String targetElementId = sourceElementIdToTargetElementId.get(elementId);
     requireNonNullTargetElementId(targetElementId, processInstanceKey, elementId);
-    requireNoIncident(incidentState, elementInstance);
     requireSameElementType(
         targetProcessDefinition, targetElementId, elementInstanceRecord, processInstanceKey);
     requireSameUserTaskImplementation(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -263,6 +263,7 @@ public final class EventAppliers implements EventApplier {
         IncidentIntent.RESOLVED,
         new IncidentResolvedApplier(
             state.getIncidentState(), state.getJobState(), state.getElementInstanceState()));
+    register(IncidentIntent.MIGRATED, new IncidentMigratedApplier(state.getIncidentState()));
   }
 
   private void registerProcessMessageSubscriptionEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentMigratedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentMigratedApplier.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
+import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+
+final class IncidentMigratedApplier implements TypedEventApplier<IncidentIntent, IncidentRecord> {
+  private final MutableIncidentState incidentState;
+
+  public IncidentMigratedApplier(final MutableIncidentState incidentState) {
+    this.incidentState = incidentState;
+  }
+
+  @Override
+  public void applyState(final long incidentKey, final IncidentRecord value) {
+    incidentState.migrateIncident(incidentKey, value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
@@ -112,7 +112,9 @@ public final class DbIncidentState implements MutableIncidentState {
 
   @Override
   public void migrateIncident(final long incidentKey, final IncidentRecord incident) {
-    // TODO - will be implemented with https://github.com/camunda/zeebe/issues/16621
+    this.incidentKey.wrapLong(incidentKey);
+    incidentWrite.setRecord(incident);
+    incidentColumnFamily.update(this.incidentKey, incidentWrite);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbIncidentState.java
@@ -111,6 +111,11 @@ public final class DbIncidentState implements MutableIncidentState {
   }
 
   @Override
+  public void migrateIncident(final long incidentKey, final IncidentRecord incident) {
+    // TODO - will be implemented with https://github.com/camunda/zeebe/issues/16621
+  }
+
+  @Override
   public IncidentRecord getIncidentRecord(final long incidentKey) {
     this.incidentKey.wrapLong(incidentKey);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableIncidentState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableIncidentState.java
@@ -15,4 +15,6 @@ public interface MutableIncidentState extends IncidentState {
   void createIncident(long incidentKey, IncidentRecord incident);
 
   void deleteIncident(long key);
+
+  void migrateIncident(long incidentKey, IncidentRecord incident);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/MigrateProcessInstanceRejectionTest.java
@@ -14,20 +14,13 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
-import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
-import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.DeploymentRecordValue;
-import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
-import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
-import java.util.Map;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -155,168 +148,6 @@ public class MigrateProcessInstanceRejectionTest {
                 Elements cannot be migrated without a mapping.""",
                 processInstanceKey))
         .hasKey(processInstanceKey);
-  }
-
-  @Test
-  public void shouldRejectCommandWhenActiveElementHasAJobIncident() {
-    // given
-    final var deployment =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess("process")
-                    .startEvent()
-                    .serviceTask("A", t -> t.zeebeJobType("jobType"))
-                    .endEvent()
-                    .done())
-            .withXmlResource(
-                Bpmn.createExecutableProcess("process2")
-                    .startEvent()
-                    .serviceTask("A", t -> t.zeebeJobType("jobType"))
-                    .endEvent()
-                    .done())
-            .deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
-
-    ENGINE.jobs().withType("jobType").withMaxJobsToActivate(1).activate();
-    RecordingExporter.jobRecords(JobIntent.CREATED).withType("jobType").await();
-
-    final Record<JobRecordValue> failedEvent =
-        ENGINE.job().withType("jobType").ofInstance(processInstanceKey).withRetries(0).fail();
-
-    final Record<IncidentRecordValue> incident =
-        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-            .withJobKey(failedEvent.getKey())
-            .getFirst();
-
-    final long targetProcessDefinitionKey =
-        extractTargetProcessDefinitionKey(deployment, "process2");
-
-    // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A")
-        .expectRejection()
-        .migrate();
-
-    // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
-    assertThat(rejectionRecord)
-        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
-        .hasRejectionType(RejectionType.INVALID_STATE)
-        .hasRejectionReason(
-            String.format(
-                """
-                Expected to migrate process instance '%d' \
-                but active element with id 'A' has an incident. \
-                Elements cannot be migrated with an incident yet. \
-                Please retry migration after resolving the incident.""",
-                processInstanceKey))
-        .hasKey(processInstanceKey);
-
-    // after resolving the incident, the migration should succeed
-    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A")
-        .migrate();
-
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.PROCESS)
-                .findAny())
-        .describedAs("Expected to have migrated the process instance")
-        .isPresent();
-  }
-
-  @Test
-  public void shouldRejectCommandWhenActiveElementHasAProcessIncident() {
-    // given
-    final var deployment =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess("process")
-                    .startEvent()
-                    .serviceTask(
-                        "A",
-                        b ->
-                            b.zeebeJobType("jobType")
-                                .zeebeInputExpression("assert(x, x != null)", "y"))
-                    .endEvent()
-                    .done())
-            .withXmlResource(
-                Bpmn.createExecutableProcess("process2")
-                    .startEvent()
-                    .serviceTask("A", t -> t.zeebeJobType("jobType"))
-                    .endEvent()
-                    .done())
-            .deploy();
-    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId("process").create();
-
-    final Record<IncidentRecordValue> incident =
-        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-            .withProcessInstanceKey(processInstanceKey)
-            .getFirst();
-
-    final long targetProcessDefinitionKey =
-        extractTargetProcessDefinitionKey(deployment, "process2");
-
-    // when
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A")
-        .expectRejection()
-        .migrate();
-
-    // then
-    final var rejectionRecord =
-        RecordingExporter.processInstanceMigrationRecords().onlyCommandRejections().getFirst();
-
-    assertThat(rejectionRecord)
-        .hasIntent(ProcessInstanceMigrationIntent.MIGRATE)
-        .hasRejectionType(RejectionType.INVALID_STATE)
-        .hasRejectionReason(
-            String.format(
-                """
-                Expected to migrate process instance '%d' \
-                but active element with id 'A' has an incident. \
-                Elements cannot be migrated with an incident yet. \
-                Please retry migration after resolving the incident.""",
-                processInstanceKey))
-        .hasKey(processInstanceKey);
-
-    // after resolving the incident, the migration should succeed
-    ENGINE.variables().ofScope(processInstanceKey).withDocument(Map.of("x", 1)).update();
-    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
-
-    ENGINE
-        .processInstance()
-        .withInstanceKey(processInstanceKey)
-        .migration()
-        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-        .addMappingInstruction("A", "A")
-        .migrate();
-
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.PROCESS)
-                .findAny())
-        .describedAs("Expected to have migrated the process instance")
-        .isPresent();
   }
 
   @Test

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/IncidentIntent.java
@@ -19,7 +19,8 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
   CREATED((short) 0),
 
   RESOLVE((short) 1, false),
-  RESOLVED((short) 2);
+  RESOLVED((short) 2),
+  MIGRATED((short) 3, false);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -45,6 +46,8 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
         return RESOLVE;
       case 2:
         return RESOLVED;
+      case 3:
+        return MIGRATED;
       default:
         return Intent.UNKNOWN;
     }
@@ -60,6 +63,7 @@ public enum IncidentIntent implements ProcessInstanceRelatedIntent {
     switch (this) {
       case CREATED:
       case RESOLVED:
+      case MIGRATED:
         return true;
       default:
         return false;


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

#### Introduce a new `IncidentIntent` `MIGRATED`.

#### In the `ProcessInstanceMigration` command processor, add:
- for each child instance of the process instance:
  - if this child has a process or job incident, append `Incident:MIGRATED` event by updating following fields:
    - `bpmnProcessId`: the BPMN ID of the target process definition
    - `processDefinitionKey`: the key of the target process definition
    - `elementId`: changes to the mapped element ID of the associated service task (note that the mapping may define the sourceElementId and the targetElementId as equivalent, in which case it stays the same)

#### Add test cases:
- Add a test case for process incident
- Add a test case for job incident
- In test cases show that we can migrate a process instance, and can still resolve the incident.

#### Cleanup:
- Remove `requireNoIncident` validation

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16620 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
