### PR TITLE
test(zeebe): Verify incident handling for compensation handler

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CompensationIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CompensationIncidentTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.incident;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import java.util.function.Consumer;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class CompensationIncidentTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "compensation-process";
+  private static final String COMPENSATION_HANDLER_ID = "Undo-A";
+  private static final String COMPENSATION_HANDLER_JOB_TYPE = "Undo-A";
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private BpmnModelInstance processWithCompensation(
+      final Consumer<ServiceTaskBuilder> elementModifier) {
+    return Bpmn.createExecutableProcess(PROCESS_ID)
+        .startEvent()
+        .manualTask("A")
+        .boundaryEvent()
+        .compensation(
+            compensation -> {
+              final var serviceTask =
+                  compensation
+                      .serviceTask(COMPENSATION_HANDLER_ID)
+                      .zeebeJobType(COMPENSATION_HANDLER_JOB_TYPE);
+              elementModifier.accept(serviceTask);
+            })
+        .moveToActivity("A")
+        .endEvent()
+        .compensateEventDefinition()
+        .done();
+  }
+
+  @Test
+  public void shouldCreateIncidentForCompensationHandler() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithCompensation(compensationHandler -> {}))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).fail();
+
+    // then
+    final var compensationHandlerActivated =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(COMPENSATION_HANDLER_ID)
+            .getFirst();
+
+    final var jobCreated =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentCreated.getValue())
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
+        .hasErrorMessage("No more retries left.")
+        .hasElementId(COMPENSATION_HANDLER_ID)
+        .hasElementInstanceKey(compensationHandlerActivated.getKey())
+        .hasVariableScopeKey(compensationHandlerActivated.getKey())
+        .hasJobKey(jobCreated.getKey())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasProcessDefinitionKey(compensationHandlerActivated.getValue().getProcessDefinitionKey())
+        .hasBpmnProcessId(PROCESS_ID)
+        .hasTenantId(compensationHandlerActivated.getValue().getTenantId());
+  }
+
+  @Test
+  public void shouldCreateIncidentIfCompensationHandlerFails() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithCompensation(compensationHandler -> {}))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).fail();
+
+    // then
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+    ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).complete();
+
+    assertThat(RecordingExporter.records().limitToProcessInstance(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(ValueType.JOB, JobIntent.FAILED),
+            tuple(ValueType.INCIDENT, IncidentIntent.CREATED),
+            tuple(ValueType.INCIDENT, IncidentIntent.RESOLVED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.COMPLETED));
+  }
+
+  @Test
+  public void shouldCreateIncidentIfInputMappingsFail() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithCompensation(
+                compensationHandler ->
+                    compensationHandler.zeebeInputExpression("assert(x, x != null)", "not_null")))
+        .deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    ENGINE.variables().ofScope(processInstanceKey).withDocument(Map.of("x", "1")).update();
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+    ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).complete();
+
+    assertThat(RecordingExporter.records().limitToProcessInstance(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(ValueType.INCIDENT, IncidentIntent.CREATED),
+            tuple(ValueType.INCIDENT, IncidentIntent.RESOLVED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.COMPLETED));
+  }
+
+  @Test
+  public void shouldCreateIncidentIfOutputMappingsFail() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            processWithCompensation(
+                compensationHandler ->
+                    compensationHandler.zeebeOutputExpression("assert(x, x != null)", "not_null")))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).complete();
+
+    // then
+    ENGINE.variables().ofScope(processInstanceKey).withDocument(Map.of("x", "1")).update();
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+
+    assertThat(RecordingExporter.records().limitToProcessInstance(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(ValueType.INCIDENT, IncidentIntent.CREATED),
+            tuple(ValueType.INCIDENT, IncidentIntent.RESOLVED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.COMPLETED));
+  }
+
+  @Test
+  public void shouldResolveIncidentIfCompensationHandlerTerminates() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithCompensation(compensationHandler -> {}))
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).fail();
+
+    // when
+    ENGINE.processInstance().withInstanceKey(processInstanceKey).cancel();
+
+    // then
+    assertThat(RecordingExporter.records().limitToProcessInstance(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.TRIGGERED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(ValueType.INCIDENT, IncidentIntent.CREATED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.CANCEL),
+            tuple(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionIntent.DELETED),
+            tuple(ValueType.INCIDENT, IncidentIntent.RESOLVED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_TERMINATED));
+  }
+}


### PR DESCRIPTION
## Description

Add new test cases to verify that the incidents for compensation handlers are created and can be resolved.

The incident behavior worked already. :rocket: 

## Related issues

closes #15333 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
