### PR TITLE
fix(broker): transition is stuck only if too much time elapses

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionTransitionProcess.java
@@ -213,7 +213,7 @@ final class PartitionTransitionProcess {
   }
 
   public HealthIssue getHealthIssue() {
-    if (currentStep != null && stepStartedAtMs + STEP_TIMEOUT_MS > ActorClock.currentTimeMillis()) {
+    if (currentStep != null && ActorClock.currentTimeMillis() > stepStartedAtMs + STEP_TIMEOUT_MS) {
       return HealthIssue.of(
           "Transition from %s on term %s appears blocked, step %s has been running for %s"
               .formatted(


### PR DESCRIPTION
The comparison was exactly the wrong way around, reporting unhealthy when the transition step was running for only a short time.

Closes #16633 