### PR TITLE
test(qa): ignore exception while waiting for updated topology

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/TopologyCoordinatorTest.java
@@ -71,6 +71,7 @@ final class TopologyCoordinatorTest {
     // No exception because the query will be forwarded to broker 1
     Awaitility.await("Query is forwarded to broker 1")
         .timeout(Duration.ofSeconds(30)) // give enough time for topology to be gossiped
+        .ignoreExceptions() // query will fail if the broker is not reachable
         .untilAsserted(
             () ->
                 ClusterActuatorAssert.assertThat(cluster)


### PR DESCRIPTION
## Description

When broker 0 is not reachable actuator query throws exception, this fails the Awaitility check before hitting the timeout of 30 seconds. As a result the test was still flaky.

## Related issues

closes #16614 

