### PR TITLE
Support Complete task user task action in Zeebe client

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -473,7 +473,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * <p>If the user task is linked to a process instance then this command will complete the related
    * activity and continue the flow.
    *
-   * <p>This command is only send via REST over HTTP, not via gRPC <br>
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
    * <br>
    *
    * <p><strong>Experimental: This method is under development, and as such using it may have no

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client;
 import io.camunda.zeebe.client.api.ExperimentalApi;
 import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
+import io.camunda.zeebe.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
@@ -456,4 +457,24 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return the builder for the command
    */
   DeleteResourceCommandStep1 newDeleteResourceCommand(long resourceKey);
+
+  /**
+   * Command to complete a user task.
+   *
+   * <pre>
+   * long userTaskKey = ..;
+   *
+   * zeebeClient
+   *  .newUserTaskCompleteCommand(userTaskKey)
+   *  .variables(map)
+   *  .send();
+   * </pre>
+   *
+   * <p>If the user task is linked to a process instance then this command will complete the related
+   * activity and continue the flow.
+   *
+   * @param userTaskKey the key of the user tasks
+   * @return a builder for the command
+   */
+  CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(long userTaskKey);
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -473,6 +473,8 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * <p>If the user task is linked to a process instance then this command will complete the related
    * activity and continue the flow.
    *
+   * <p>This command is only send via REST over HTTP, not via gRPC
+   *
    * @param userTaskKey the key of the user tasks
    * @return a builder for the command
    */

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -473,10 +473,17 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * <p>If the user task is linked to a process instance then this command will complete the related
    * activity and continue the flow.
    *
-   * <p>This command is only send via REST over HTTP, not via gRPC
+   * <p>This command is only send via REST over HTTP, not via gRPC <br>
+   * <br>
+   *
+   * <p><strong>Experimental: This method is under development, and as such using it may have no
+   * effect on the client builder when called. Until this warning is removed, anything described
+   * below may not yet have taken effect, and the interface and its description are subject to
+   * change.</strong>
    *
    * @param userTaskKey the key of the user tasks
    * @return a builder for the command
    */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
   CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(long userTaskKey);
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteUserTaskCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CompleteUserTaskCommandStep1.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.CompleteUserTaskResponse;
+import java.util.Map;
+
+/**
+ * The user task completion currently only accepts variables as a {@link Map} due to the current
+ * request handling before sending it the gateway. The list of options might be extended in the
+ * future.
+ */
+public interface CompleteUserTaskCommandStep1 extends FinalCommandStep<CompleteUserTaskResponse> {
+
+  /**
+   * Set the custom action to complete the user task with.
+   *
+   * @param action the action value
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  CompleteUserTaskCommandStep1 action(String action);
+
+  /**
+   * Set the variables to complete the user task with.
+   *
+   * @param variables the variables as map
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  CompleteUserTaskCommandStep1 variables(Map<String, Object> variables);
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteUserTaskResponse.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CompleteUserTaskResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface CompleteUserTaskResponse {}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
+import io.camunda.zeebe.client.api.command.CompleteUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
@@ -48,6 +49,7 @@ import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.command.BroadcastSignalCommandImpl;
 import io.camunda.zeebe.client.impl.command.CancelProcessInstanceCommandImpl;
+import io.camunda.zeebe.client.impl.command.CompleteUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.CreateProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeleteResourceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeployProcessCommandImpl;
@@ -442,6 +444,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
         asyncStub,
         credentialsProvider::shouldRetryRequest,
         config.getDefaultRequestTimeout());
+  }
+
+  @Override
+  public CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(final long userTaskKey) {
+    return new CompleteUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
   }
 
   private JobClient newJobClient() {

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CompleteUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CompleteUserTaskCommandImpl.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import java.time.Duration;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
 
 /**
@@ -52,6 +53,7 @@ public final class CompleteUserTaskCommandImpl implements CompleteUserTaskComman
 
   @Override
   public FinalCommandStep<CompleteUserTaskResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CompleteUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CompleteUserTaskCommandImpl.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.CompleteUserTaskCommandStep1;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.CompleteUserTaskResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
+import java.time.Duration;
+import java.util.Map;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+/**
+ * This command implementation currently does not extend {@link CommandWithVariables} since we would
+ * have to handle a String-ified JSON variables object. The request object itself expects a {@link
+ * Map} though. In the future, we might extend this to also allow all options from {@link
+ * CommandWithVariables} here.
+ */
+public final class CompleteUserTaskCommandImpl implements CompleteUserTaskCommandStep1 {
+
+  private final long userTaskKey;
+  private final UserTaskCompletionRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public CompleteUserTaskCommandImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final long userTaskKey) {
+    this.jsonMapper = jsonMapper;
+    this.userTaskKey = userTaskKey;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new UserTaskCompletionRequest();
+  }
+
+  @Override
+  public FinalCommandStep<CompleteUserTaskResponse> requestTimeout(final Duration requestTimeout) {
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<CompleteUserTaskResponse> send() {
+    final HttpZeebeFuture<CompleteUserTaskResponse> result = new HttpZeebeFuture<>();
+    httpClient.post(
+        "/user-tasks/" + userTaskKey + "/completion",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+
+  @Override
+  public CompleteUserTaskCommandStep1 action(final String action) {
+    request.setAction(action);
+    return this;
+  }
+
+  @Override
+  public CompleteUserTaskCommandStep1 variables(final Map<String, Object> variables) {
+    ArgumentUtil.ensureNotNull("variables", variables);
+    request.setVariables(variables);
+    return this;
+  }
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/TopologyRequestImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/TopologyRequestImpl.java
@@ -103,7 +103,9 @@ public final class TopologyRequestImpl implements TopologyRequestStep1 {
   private void sendHttpRequest(final HttpZeebeFuture<Topology> result) {
     httpClient.get(
         "/topology",
-        httpRequestConfig.build(),
+        httpRequestConfig
+            .setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            .build(),
         io.camunda.zeebe.gateway.protocol.rest.TopologyResponse.class,
         TopologyImpl::new,
         result);

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -24,6 +24,7 @@ import org.apache.hc.client5.http.async.methods.SimpleRequestProducer;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.Method;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.util.TimeValue;
@@ -94,7 +95,7 @@ public final class HttpClient implements AutoCloseable {
       final Class<HttpT> responseType,
       final JsonResponseTransformer<HttpT, RespT> transformer,
       final HttpZeebeFuture<RespT> result) {
-    sendRequest(path, null, requestConfig, responseType, transformer, result);
+    sendRequest(Method.GET, path, null, requestConfig, responseType, transformer, result);
   }
 
   public <HttpT, RespT> void post(
@@ -102,10 +103,11 @@ public final class HttpClient implements AutoCloseable {
       final String body,
       final RequestConfig requestConfig,
       final HttpZeebeFuture<RespT> result) {
-    sendRequest(path, body, requestConfig, Void.class, r -> null, result);
+    sendRequest(Method.POST, path, body, requestConfig, Void.class, r -> null, result);
   }
 
   private <HttpT, RespT> void sendRequest(
+      final Method httpMethod,
       final String path,
       final String body,
       final RequestConfig requestConfig,
@@ -113,7 +115,9 @@ public final class HttpClient implements AutoCloseable {
       final JsonResponseTransformer<HttpT, RespT> transformer,
       final HttpZeebeFuture<RespT> result) {
     final URI target = buildRequestURI(path);
-    final SimpleRequestBuilder requestBuilder = SimpleRequestBuilder.post(target);
+
+    final SimpleRequestBuilder requestBuilder =
+        SimpleRequestBuilder.create(httpMethod).setUri(target);
     if (body != null) {
       requestBuilder.setBody(body, ContentType.APPLICATION_JSON);
     }


### PR DESCRIPTION
## Description

* Add user task completion support to the Zeebe Java client via `ZeebeClient#newUserTaskCompleteCommand`.
* The command takes a user task key and can optionally take an `action` and a `Map<String, Object` of `variables`.

**Note**: due to the completion REST request object expecting a proper Map for variables, we currently only support a proper Map for the client command as well. This might be extended by follow-up issues.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16447 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
