### PR TITLE
Add endpoint for removing a set of brokers forcefully

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -282,6 +282,10 @@ public final class ReconfigurationHelper {
             .filter(m -> !m.equals(raftContext.getCluster().getLocalMember().memberId()))
             .collect(Collectors.toSet());
 
+    if (otherMembers.isEmpty()) {
+      future.complete(null);
+    }
+
     final var quorum =
         new ForceConfigureQuorum(
             success -> {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -656,6 +656,23 @@ final class ReconfigurationTest {
     }
 
     @Test
+    void shouldForceConfigureIfOnlyOneRemainingMember() {
+      // when
+      m2.shutdown().join();
+      m3.shutdown().join();
+      m4.shutdown().join();
+      m1.forceConfigure(Map.of(id1, Type.ACTIVE)).join();
+
+      // then
+      awaitLeader(m1);
+
+      assertThat(m1.cluster().getMembers())
+          .describedAs("Force configuration should have only one members")
+          .containsExactlyInAnyOrderElementsOf(
+              Set.of(new DefaultRaftMember(id1, Type.ACTIVE, Instant.now())));
+    }
+
+    @Test
     void shouldFailForceConfigurationIfOneMemberUnreachable() {
       // when
       m2.shutdown().join();

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -211,13 +211,24 @@ public final class BrokerTopologyManagerImpl extends Actor
       return;
     }
     this.clusterTopology = clusterTopology;
-    LOG.debug("Received new cluster topology with clusterSize {}", clusterTopology.clusterSize());
 
     updateTopology(
         topologyToUpdate -> {
-          topologyToUpdate.setClusterSize(clusterTopology.clusterSize());
-          topologyToUpdate.setPartitionsCount(clusterTopology.partitionCount());
-          topologyToUpdate.setReplicationFactor(clusterTopology.replicationFactor());
+          final var newClusterSize = clusterTopology.clusterSize();
+          final var newPartitionsCount = clusterTopology.partitionCount();
+          final var newReplicationFactor = clusterTopology.replicationFactor();
+          if (newClusterSize != topologyToUpdate.getClusterSize()
+              || newPartitionsCount != topologyToUpdate.getPartitionsCount()
+              || newReplicationFactor != topologyToUpdate.getReplicationFactor()) {
+            LOG.debug(
+                "Updating topology with clusterSize {}, partitionsCount {} and replicationFactor {}",
+                newClusterSize,
+                newPartitionsCount,
+                newReplicationFactor);
+            topologyToUpdate.setClusterSize(newClusterSize);
+            topologyToUpdate.setPartitionsCount(newPartitionsCount);
+            topologyToUpdate.setReplicationFactor(newReplicationFactor);
+          }
         });
   }
 }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -216,7 +216,7 @@ public final class BrokerTopologyManagerImpl extends Actor
         topologyToUpdate -> {
           final var newClusterSize = clusterTopology.clusterSize();
           final var newPartitionsCount = clusterTopology.partitionCount();
-          final var newReplicationFactor = clusterTopology.replicationFactor();
+          final var newReplicationFactor = clusterTopology.minReplicationFactor();
           if (newClusterSize != topologyToUpdate.getClusterSize()
               || newPartitionsCount != topologyToUpdate.getPartitionsCount()
               || newReplicationFactor != topologyToUpdate.getReplicationFactor()) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerTopologyManagerImpl.java
@@ -166,8 +166,8 @@ public final class BrokerTopologyManagerImpl extends Actor
     if (topology.getClusterSize() == BrokerClusterStateImpl.UNINITIALIZED_CLUSTER_SIZE) {
       topology.setClusterSize(distributedBrokerInfo.getClusterSize());
       topology.setPartitionsCount(distributedBrokerInfo.getPartitionsCount());
+      topology.setReplicationFactor(distributedBrokerInfo.getReplicationFactor());
     }
-    topology.setReplicationFactor(distributedBrokerInfo.getReplicationFactor());
 
     final int nodeId = distributedBrokerInfo.getNodeId();
 
@@ -212,10 +212,12 @@ public final class BrokerTopologyManagerImpl extends Actor
     }
     this.clusterTopology = clusterTopology;
     LOG.debug("Received new cluster topology with clusterSize {}", clusterTopology.clusterSize());
+
     updateTopology(
-        topology -> {
-          topology.setClusterSize(clusterTopology.clusterSize());
-          topology.setPartitionsCount(clusterTopology.partitionCount());
+        topologyToUpdate -> {
+          topologyToUpdate.setClusterSize(clusterTopology.clusterSize());
+          topologyToUpdate.setPartitionsCount(clusterTopology.partitionCount());
+          topologyToUpdate.setReplicationFactor(clusterTopology.replicationFactor());
         });
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.clustering.dynamic;
+
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertThatAllJobsCanBeCompleted;
+import static io.camunda.zeebe.it.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.time.Duration;
+import java.util.List;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@ZeebeIntegration
+@AutoCloseResources
+@Timeout(2 * 60)
+class ForceScaleDownBrokersTest {
+
+  private static final int PARTITIONS_COUNT = 2;
+  private static final int CLUSTER_SIZE = 2;
+  private static final String JOB_TYPE = "job";
+  @AutoCloseResource ZeebeClient zeebeClient;
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          // Use standalone gateway because we will be shutting down some of the brokers
+          // during the test
+          .withGatewaysCount(1)
+          .withEmbeddedGateway(false)
+          .withBrokersCount(CLUSTER_SIZE)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(2)
+          .withGatewayConfig(
+              g ->
+                  g.gatewayConfig()
+                      .getCluster()
+                      .getMembership()
+                      // Decrease the timeouts for fast convergence of gateway topology. When the
+                      // broker is shutdown, the topology update takes at least 10 seconds with the
+                      // default values.
+                      .setSyncInterval(Duration.ofSeconds(1))
+                      .setFailureTimeout(Duration.ofSeconds(2)))
+          .build();
+
+  @BeforeEach
+  void createClient() {
+    zeebeClient = cluster.availableGateway().newClientBuilder().build();
+  }
+
+  @Test
+  void shouldForceRemoveBroker() {
+    // given
+    final var brokerToShutdown = cluster.brokers().get(MemberId.from("1"));
+    final var actuator = ClusterActuator.of(cluster.anyGateway());
+
+    final var createdInstances =
+        createInstanceWithAJobOnAllPartitions(zeebeClient, JOB_TYPE, PARTITIONS_COUNT);
+
+    // when
+    brokerToShutdown.close();
+    final var response = actuator.scaleBrokers(List.of(0), false, true);
+    Awaitility.await()
+        .timeout(Duration.ofMinutes(2))
+        .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
+
+    // then
+    // verify broker 1 is removed from the cluster topology
+    ClusterActuatorAssert.assertThat(cluster)
+        .brokerHasPartition(0, 1)
+        .brokerHasPartition(0, 2)
+        .doesNotHaveBroker(1);
+
+    // Changes are reflected in the topology returned by grpc query
+    cluster.awaitCompleteTopology(1, PARTITIONS_COUNT, 1, Duration.ofSeconds(20));
+
+    assertThatAllJobsCanBeCompleted(createdInstances, zeebeClient, JOB_TYPE);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ClusterEndpointIT.java
@@ -119,6 +119,22 @@ final class ClusterEndpointIT {
   }
 
   @Test
+  void shouldRequestForceScaleDownBrokers() {
+    // create cluster with two brokers
+    try (final var cluster = createCluster(2)) {
+      // given
+      cluster.awaitCompleteTopology();
+      final var actuator = ClusterActuator.of(cluster.availableGateway());
+
+      // when - force remove broker 1
+      final var response = actuator.scaleBrokers(List.of(0), false, true);
+
+      // then
+      assertThat(response.getExpectedTopology()).hasSize(1);
+    }
+  }
+
+  @Test
   void shouldRequestAddBroker() {
     try (final var cluster = createCluster(1)) {
       // given

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -123,6 +123,17 @@ public interface ClusterActuator {
   PlannedOperationsResponse scaleBrokers(@RequestBody List<Integer> ids, @Param boolean dryRun);
 
   /**
+   * Scales the given brokers up or down and reassigns partitions to the new brokers.
+   *
+   * @param dryRun if true, changes are not applied but only simulated.
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /brokers?dryRun={dryRun}&force={force}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse scaleBrokers(
+      @RequestBody List<Integer> ids, @Param boolean dryRun, @Param boolean force);
+
+  /**
    * Request that the broker is added to the cluster.
    *
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -126,6 +126,7 @@ public interface ClusterActuator {
    * Scales the given brokers up or down and reassigns partitions to the new brokers.
    *
    * @param dryRun if true, changes are not applied but only simulated.
+   * @param force if true, the brokers that are not specified will be forcely removed.
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
   @RequestLine("POST /brokers?dryRun={dryRun}&force={force}")

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/GatewayClusterTopologyService.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/GatewayClusterTopologyService.java
@@ -52,7 +52,15 @@ public class GatewayClusterTopologyService extends Actor implements TopologyUpda
           }
 
           try {
-            this.clusterTopology = this.clusterTopology.merge(clusterTopology);
+            final var mergedTopology = this.clusterTopology.merge(clusterTopology);
+            if (mergedTopology.equals(this.clusterTopology)) {
+              return;
+            }
+            LOG.debug(
+                "Received new topology {}. Updating local topology to {}",
+                clusterTopology,
+                mergedTopology);
+            this.clusterTopology = mergedTopology;
             clusterTopologyGossiper.updateClusterTopology(this.clusterTopology);
           } catch (final Exception updateFailed) {
             LOG.warn(

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -243,6 +243,20 @@ public record ClusterTopology(
         members.values().stream().flatMap(m -> m.partitions().keySet().stream()).distinct().count();
   }
 
+  public Integer replicationFactor() {
+    // return minimum replication factor. During a topology change, replication factor might
+    // increase temporarily.
+    return members.values().stream()
+        .filter(entry -> entry.state() != State.LEFT && entry.state() != State.UNINITIALIZED)
+        .flatMap(m -> m.partitions().entrySet().stream())
+        .collect(Collectors.groupingBy(Entry::getKey, Collectors.counting()))
+        .values()
+        .stream()
+        .reduce(Math::min)
+        .map(Long::intValue)
+        .orElse(0);
+  }
+
   public TopologyChangeOperation nextPendingOperation() {
     if (!hasPendingChanges()) {
       throw new NoSuchElementException();

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/state/ClusterTopology.java
@@ -243,7 +243,7 @@ public record ClusterTopology(
         members.values().stream().flatMap(m -> m.partitions().keySet().stream()).distinct().count();
   }
 
-  public Integer replicationFactor() {
+  public Integer minReplicationFactor() {
     // return minimum replication factor. During a topology change, replication factor might
     // increase temporarily.
     return members.values().stream()

--- a/zeebe/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/zeebe/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -50,6 +50,24 @@ class ClusterTopologyTest {
   }
 
   @Test
+  void canDetermineClusterSizePartitionAndReplicationFactor() {
+    // when
+    final var topology =
+        ClusterTopology.init()
+            .addMember(
+                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))))
+            .addMember(
+                member(2), MemberState.initializeAsActive(Map.of(1, PartitionState.active(2))))
+            .addMember(
+                member(3), MemberState.initializeAsActive(Map.of(1, PartitionState.active(3))));
+
+    // then
+    assertThat(topology.clusterSize()).isEqualTo(3);
+    assertThat(topology.partitionCount()).isEqualTo(1);
+    assertThat(topology.replicationFactor()).isEqualTo(3);
+  }
+
+  @Test
   void shouldMergeConcurrentUpdatesToMembers() {
     // given
     final var topology =

--- a/zeebe/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
+++ b/zeebe/topology/src/test/java/io/camunda/zeebe/topology/state/ClusterTopologyTest.java
@@ -64,7 +64,7 @@ class ClusterTopologyTest {
     // then
     assertThat(topology.clusterSize()).isEqualTo(3);
     assertThat(topology.partitionCount()).isEqualTo(1);
-    assertThat(topology.replicationFactor()).isEqualTo(3);
+    assertThat(topology.minReplicationFactor()).isEqualTo(3);
   }
 
   @Test


### PR DESCRIPTION
## Description

This operation also changes the replicationFactor. Since it is hard-coded in the `BrokerInfo`, gateway now update it's in-memory state from the `ClusterTopology`. This makes the data in BrokerInfo useless. We should eventually remove this from BrokerInfo (related #14018).  In theory, it is possible to have different `replicationFactor` for each partition, especially when we use the fine-grained partition endpoint. To keep it simple, we always take the minimum replicationFactor available. 

## Related issues

closes #16316 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
