### PR TITLE
ci: use renamed workflow files for stable branches

### DIFF
--- a/.github/workflows/zeebe-release-stable-dry-run.yml
+++ b/.github/workflows/zeebe-release-stable-dry-run.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   dry-run-release-84:
     name: "Release from stable/8.4"
-    uses: camunda/zeebe/.github/workflows/release.yml@stable/8.4
+    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.4
     secrets: inherit
     strategy:
       fail-fast: false
@@ -20,7 +20,7 @@ jobs:
       dryRun: true
   dry-run-release-83:
     name: "Release from stable/8.3"
-    uses: camunda/zeebe/.github/workflows/release.yml@stable/8.3
+    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.3
     secrets: inherit
     strategy:
       fail-fast: false
@@ -32,7 +32,7 @@ jobs:
       dryRun: true
   dry-run-release-82:
     name: "Release from stable/8.2"
-    uses: camunda/zeebe/.github/workflows/release.yml@stable/8.2
+    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.2
     secrets: inherit
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
       dryRun: true
   dry-run-release-81:
     name: "Release from stable/8.1"
-    uses: camunda/zeebe/.github/workflows/release.yml@stable/8.1
+    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.1
     secrets: inherit
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Release dry run on stable branches are not running after the renaming of worklow  #16559. Workflows are also renamed in stable branches. #16639 


