### PR TITLE
feat: Generate processes with compensation events

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/BlockSequenceBuilder.java
@@ -43,7 +43,8 @@ public class BlockSequenceBuilder extends AbstractBlockBuilder {
           new UserTaskBlockBuilder.Factory(),
           new ManualTaskBlockBuilder.Factory(),
           new IntermediateThrowEventBlockBuilder.Factory(),
-          new EscalationEventBlockBuilder.Factory());
+          new EscalationEventBlockBuilder.Factory(),
+          new CompensationEventBlockBuilder.Factory());
 
   private final List<BlockBuilder> blockBuilders = new ArrayList<>();
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CompensationEventBlockBuilder.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/bpmn/random/blocks/CompensationEventBlockBuilder.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.test.util.bpmn.random.blocks;
+
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.test.util.bpmn.random.BlockBuilder;
+import io.camunda.zeebe.test.util.bpmn.random.BlockBuilderFactory;
+import io.camunda.zeebe.test.util.bpmn.random.ConstructionContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathContext;
+import io.camunda.zeebe.test.util.bpmn.random.ExecutionPathSegment;
+import io.camunda.zeebe.test.util.bpmn.random.steps.StepActivateAndCompleteJob;
+
+public class CompensationEventBlockBuilder extends AbstractBlockBuilder {
+
+  private final String compensationActivityId;
+  private final String compensationActivityJobType;
+
+  private final String compensationHandlerId;
+  private final String compensationHandlerJobType;
+
+  private final String compensationThrowEventId;
+
+  public CompensationEventBlockBuilder(final ConstructionContext context) {
+    super(context.getIdGenerator().nextId());
+
+    compensationActivityId = getElementId();
+    compensationActivityJobType = "job_" + compensationActivityId;
+    compensationHandlerId = "compensation_handler_" + getElementId();
+    compensationHandlerJobType = "job_" + compensationHandlerId;
+    compensationThrowEventId = "compensation_throw_" + getElementId();
+  }
+
+  @Override
+  public AbstractFlowNodeBuilder<?, ?> buildFlowNodes(
+      final AbstractFlowNodeBuilder<?, ?> nodeBuilder) {
+
+    final var compensationActivity = nodeBuilder.serviceTask(compensationActivityId);
+    compensationActivity
+        .zeebeJobType(compensationActivityJobType)
+        .boundaryEvent()
+        .compensation(
+            compensation ->
+                compensation
+                    .serviceTask(compensationHandlerId)
+                    .zeebeJobType(compensationHandlerJobType));
+
+    return compensationActivity
+        .intermediateThrowEvent(compensationThrowEventId)
+        .compensateEventDefinition()
+        .compensateEventDefinitionDone();
+  }
+
+  @Override
+  public ExecutionPathSegment generateRandomExecutionPath(final ExecutionPathContext context) {
+    final var result = new ExecutionPathSegment();
+    result.appendDirectSuccessor(
+        new StepActivateAndCompleteJob(compensationActivityJobType, compensationActivityId));
+    result.appendDirectSuccessor(
+        new StepActivateAndCompleteJob(compensationHandlerJobType, compensationHandlerId));
+    return result;
+  }
+
+  static class Factory implements BlockBuilderFactory {
+
+    @Override
+    public BlockBuilder createBlockBuilder(final ConstructionContext context) {
+      return new CompensationEventBlockBuilder(context);
+    }
+
+    @Override
+    public boolean isAddingDepth() {
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
## Description

Extend the random process generator to create processes with compensation boundary events and compensation throw events. To keep it simple, the compensation throw event is directly after the activity with the compensation boundary event.

## Related issues

closes #15495

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
