### PR TITLE
feat(gateway-rest): error responses are content type problem+json

### DIFF
--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 
@@ -36,7 +37,7 @@ public class RestErrorMapper {
         .map(e -> mapErrorToProblem(e, rejectionMapper))
         .or(() -> mapBrokerErrorToProblem(brokerResponse))
         .or(() -> mapRejectionToProblem(brokerResponse, rejectionMapper))
-        .map(p -> ResponseEntity.of(p).build());
+        .map(RestErrorMapper::mapProblemToResponse);
   }
 
   private static ProblemDetail mapErrorToProblem(
@@ -125,5 +126,11 @@ public class RestErrorMapper {
     final var problemDetail = ProblemDetail.forStatusAndDetail(status, detail);
     problemDetail.setTitle(title);
     return problemDetail;
+  }
+
+  public static <T> ResponseEntity<T> mapProblemToResponse(final ProblemDetail problemDetail) {
+    return ResponseEntity.of(problemDetail)
+        .headers(httpHeaders -> httpHeaders.setContentType(MediaType.APPLICATION_PROBLEM_JSON))
+        .build();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TopologyController.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.util.VersionUtil;
 import java.util.ArrayList;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @ZeebeRestController
@@ -30,7 +31,7 @@ public final class TopologyController {
     this.client = client;
   }
 
-  @GetMapping(path = "/topology", produces = "application/json")
+  @GetMapping(path = "/topology", produces = MediaType.APPLICATION_JSON_VALUE)
   public TopologyResponse get() {
 
     final var response = new TopologyResponse();

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -37,8 +38,8 @@ public class UserTaskController {
 
   @PostMapping(
       path = "/user-tasks/{userTaskKey}/completion",
-      produces = "application/json",
-      consumes = "application/json")
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> completeUserTask(
       final ServerWebExchange context,
       @PathVariable final long userTaskKey,
@@ -50,8 +51,8 @@ public class UserTaskController {
 
   @PostMapping(
       path = "/user-tasks/{userTaskKey}/assignment",
-      produces = "application/json",
-      consumes = "application/json")
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> assignUserTask(
       final ServerWebExchange context,
       @PathVariable final long userTaskKey,
@@ -71,8 +72,8 @@ public class UserTaskController {
 
   @PatchMapping(
       path = "/user-tasks/{userTaskKey}",
-      produces = "application/json",
-      consumes = "application/json")
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> updateUserTask(
       final ServerWebExchange context,
       @PathVariable final long userTaskKey,
@@ -95,7 +96,7 @@ public class UserTaskController {
 
   private static CompletableFuture<ResponseEntity<Object>> handleRequestMappingError(
       final ProblemDetail problemDetail) {
-    return CompletableFuture.completedFuture(ResponseEntity.of(problemDetail).build());
+    return CompletableFuture.completedFuture(RestErrorMapper.mapProblemToResponse(problemDetail));
   }
 
   private static ProblemDetail mapRejectionToProblem(final BrokerRejection rejection) {

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
@@ -424,6 +424,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 
@@ -455,6 +457,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 
@@ -482,6 +486,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 
@@ -520,6 +526,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .isNotFound()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 
@@ -563,6 +571,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .isEqualTo(HttpStatus.CONFLICT)
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 
@@ -606,6 +616,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 
@@ -649,6 +661,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .is5xxServerError()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 
@@ -853,6 +867,8 @@ public class UserTaskControllerTest {
         .exchange()
         .expectStatus()
         .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
         .expectBody(ProblemDetail.class)
         .isEqualTo(expectedBody);
 


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Ensure that when a REST API controller maps an Error to a Response, the content type of the response is set to application/problem+json. This makes it easier for REST clients to recognize when a received response is an error. As a result, the can optimize their response processing logic.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16660

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
