### PR TITLE
Support `Assign task` user task action

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -500,7 +500,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *  .send();
    * </pre>
    *
-   * <p>This command is only send via REST over HTTP, not via gRPC <br>
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
    * <br>
    *
    * <p><strong>Experimental: This method is under development, and as such using it may have no

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client;
 
 import io.camunda.zeebe.client.api.ExperimentalApi;
+import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteUserTaskCommandStep1;
@@ -486,4 +487,30 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
   CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(long userTaskKey);
+
+  /**
+   * Command to assign a user task.
+   *
+   * <pre>
+   * long userTaskKey = ..;
+   *
+   * zeebeClient
+   *  .newUserTaskAssignCommand(userTaskKey)
+   *  .assignee(newAssignee)
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only send via REST over HTTP, not via gRPC <br>
+   * <br>
+   *
+   * <p><strong>Experimental: This method is under development, and as such using it may have no
+   * effect on the client builder when called. Until this warning is removed, anything described
+   * below may not yet have taken effect, and the interface and its description are subject to
+   * change.</strong>
+   *
+   * @param userTaskKey the key of the user tasks
+   * @return a builder for the command
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
+  AssignUserTaskCommandStep1 newUserTaskAssignCommand(long userTaskKey);
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignUserTaskCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/AssignUserTaskCommandStep1.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.AssignUserTaskResponse;
+
+public interface AssignUserTaskCommandStep1 extends FinalCommandStep<AssignUserTaskResponse> {
+
+  /**
+   * Set the custom action to assign the user task with.
+   *
+   * @param action the action value
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  AssignUserTaskCommandStep1 action(String action);
+
+  /**
+   * Set the assignee to set for the user task.
+   *
+   * @param assignee the assignee to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  AssignUserTaskCommandStep1 assignee(String assignee);
+
+  /**
+   * Flag to allow overriding an existing assignee for the user task without unassigning it first.
+   *
+   * @param allowOverride allow overriding an existing assignee
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  AssignUserTaskCommandStep1 allowOverride(boolean allowOverride);
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignUserTaskResponse.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/AssignUserTaskResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface AssignUserTaskResponse {}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
+import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.ClientException;
@@ -47,6 +48,7 @@ import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
+import io.camunda.zeebe.client.impl.command.AssignUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.BroadcastSignalCommandImpl;
 import io.camunda.zeebe.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.CompleteUserTaskCommandImpl;
@@ -449,6 +451,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(final long userTaskKey) {
     return new CompleteUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
+  }
+
+  @Override
+  public AssignUserTaskCommandStep1 newUserTaskAssignCommand(final long userTaskKey) {
+    return new AssignUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
   }
 
   private JobClient newJobClient() {

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AssignUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/AssignUserTaskCommandImpl.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.AssignUserTaskResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class AssignUserTaskCommandImpl implements AssignUserTaskCommandStep1 {
+
+  private final long userTaskKey;
+  private final UserTaskAssignmentRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public AssignUserTaskCommandImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final long userTaskKey) {
+    this.jsonMapper = jsonMapper;
+    this.userTaskKey = userTaskKey;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new UserTaskAssignmentRequest();
+  }
+
+  @Override
+  public FinalCommandStep<AssignUserTaskResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<AssignUserTaskResponse> send() {
+    final HttpZeebeFuture<AssignUserTaskResponse> result = new HttpZeebeFuture<>();
+    httpClient.post(
+        "/user-tasks/" + userTaskKey + "/assignment",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+
+  @Override
+  public AssignUserTaskCommandStep1 action(final String action) {
+    request.setAction(action);
+    return this;
+  }
+
+  @Override
+  public AssignUserTaskCommandStep1 assignee(final String assignee) {
+    ArgumentUtil.ensureNotNull("assignee", assignee);
+    request.setAssignee(assignee);
+    return this;
+  }
+
+  @Override
+  public AssignUserTaskCommandStep1 allowOverride(final boolean allowOverride) {
+    request.setAllowOverride(allowOverride);
+    return this;
+  }
+}


### PR DESCRIPTION
## Description

* Add user task assignment support to the Zeebe Java client via `ZeebeClient#newUserTaskAssignCommand`.
* The command takes a user task key and assignee and can optionally take an `action`.
* Plus, users can allow overriding an assignee in the engine.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16663 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
