### PR TITLE
Adjust Zeebe issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/zeebe_bug_report.md
+++ b/.github/ISSUE_TEMPLATE/zeebe_bug_report.md
@@ -1,9 +1,9 @@
 ---
 
-name: Bug report
+name: Zeebe Bug report
 about: Create a report to help us improve
 title: ''
-labels: 'kind/bug'
+labels: ['kind/bug', 'component/zeebe']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/zeebe_documentation_issue.md
+++ b/.github/ISSUE_TEMPLATE/zeebe_documentation_issue.md
@@ -1,9 +1,9 @@
 ---
 
-name: Documentation issue
+name: Zeebe Documentation issue
 about: Changes to the documentation
 title: ''
-labels: 'kind/documentation'
+labels: ['kind/documentation', 'component/zeebe']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/zeebe_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/zeebe_feature_request.md
@@ -1,9 +1,9 @@
 ---
 
-name: Feature request
+name: Zeebe Feature request
 about: Suggest an idea for this project
 title: ''
-labels: 'kind/feature'
+labels: ['kind/feature', 'component/zeebe']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/zeebe_general_issue.md
+++ b/.github/ISSUE_TEMPLATE/zeebe_general_issue.md
@@ -1,9 +1,9 @@
 ---
 
-name: General issue
-about: General changes to the project
+name: Zeebe general issue
+about: General changes to the Zeebe project
 title: ''
-labels: 'kind/toil'
+labels: ['kind/toil', 'component/zeebe']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/zeebe_unstable_test.md
+++ b/.github/ISSUE_TEMPLATE/zeebe_unstable_test.md
@@ -1,9 +1,9 @@
 ---
 
-name: Unstable test
-about: Report tests that are flaky/non-deterministic
+name: Zeebe unstable test
+about: Report tests that are flaky/non-deterministic in the Zeebe CI
 title: ''
-labels: 'kind/flake'
+labels: ['kind/flake', 'component/zeebe']
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/zeebe_zpa_epic.md
+++ b/.github/ISSUE_TEMPLATE/zeebe_zpa_epic.md
@@ -3,7 +3,7 @@
 name: Zeebe Process Automation team Epic
 about: Prepare a new Epic for the ZPA team
 title: '[EPIC] '
-labels: 'kind/epic'
+labels: ['kind/epic', 'component/zeebe']
 assignees: ''
 
 ---


### PR DESCRIPTION
## Description

In preparation for the streamlining we have to prefix the existing
issue templates with the Team/Component names.

The same has been done already for Operate https://github.com/camunda/operate/pull/6516

The PR does the following for all templates:

 * adjust the name of the template
 * adjust the description
 * add a component new label to better identify the issue
 * rename the template file
<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

related https://github.com/camunda/team-infrastructure/issues/616
