### PR TITLE
Allow changing replication factor while scaling brokers

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -113,6 +113,19 @@ public interface ClusterActuator {
   PlannedOperationsResponse scaleBrokers(@RequestBody List<Integer> ids);
 
   /**
+   * Scales the given brokers up or down and reassigns partitions to the new brokers based on new
+   * replication factor.
+   *
+   * @param ids
+   * @param newReplicationFactor new replication factor after scaling, if <=0 use the current value
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /brokers?replicationFactor={newReplicationFactor}")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse scaleBrokers(
+      @RequestBody List<Integer> ids, @Param final int newReplicationFactor);
+
+  /**
    * Scales the given brokers up or down and reassigns partitions to the new brokers.
    *
    * @param dryRun if true, changes are not applied but only simulated.

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/ScaleRequestTransformer.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/ScaleRequestTransformer.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.topology.api;
 
-import static io.camunda.zeebe.topology.api.PartitionReassignRequestTransformer.USE_CURRENT_REPLICATION_FACTOR;
-
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.topology.changes.TopologyChangeCoordinator.TopologyChangeRequest;
 import io.camunda.zeebe.topology.state.ClusterTopology;
@@ -16,20 +14,22 @@ import io.camunda.zeebe.topology.state.TopologyChangeOperation;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 public class ScaleRequestTransformer implements TopologyChangeRequest {
 
   private final Set<MemberId> members;
-  private final int newReplicationFactor;
+  private final Optional<Integer> newReplicationFactor;
   private final ArrayList<TopologyChangeOperation> generatedOperations = new ArrayList<>();
 
   public ScaleRequestTransformer(final Set<MemberId> members) {
-    this(members, USE_CURRENT_REPLICATION_FACTOR);
+    this(members, Optional.empty());
   }
 
-  public ScaleRequestTransformer(final Set<MemberId> members, final int newReplicationFactor) {
+  public ScaleRequestTransformer(
+      final Set<MemberId> members, final Optional<Integer> newReplicationFactor) {
     this.members = members;
     this.newReplicationFactor = newReplicationFactor;
   }

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.topology.api;
 
 import io.atomix.cluster.MemberId;
+import java.util.Optional;
 import java.util.Set;
 
 /** Defines the supported requests for the topology management. */
@@ -34,7 +35,12 @@ public sealed interface TopologyManagementRequest {
   record ReassignPartitionsRequest(Set<MemberId> members, boolean dryRun)
       implements TopologyManagementRequest {}
 
-  record ScaleRequest(Set<MemberId> members, boolean dryRun) implements TopologyManagementRequest {}
+  record ScaleRequest(Set<MemberId> members, Optional<Integer> newReplicationFactor, boolean dryRun)
+      implements TopologyManagementRequest {
+    public ScaleRequest(final Set<MemberId> members, final boolean dryRun) {
+      this(members, Optional.empty(), dryRun);
+    }
+  }
 
   record CancelChangeRequest(long changeId) implements TopologyManagementRequest {
 

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -30,16 +30,12 @@ import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles the requests for the topology management. This is expected be running on the coordinator
  * node.
  */
 public final class TopologyManagementRequestsHandler implements TopologyManagementApi {
-  private static final Logger LOG =
-      LoggerFactory.getLogger(TopologyManagementRequestsHandler.class);
   private final TopologyChangeCoordinator coordinator;
   private final ConcurrencyControl executor;
   private final MemberId localMemberId;

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.topology.api;
 
-import static io.camunda.zeebe.topology.api.PartitionReassignRequestTransformer.USE_CURRENT_REPLICATION_FACTOR;
-
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -102,9 +100,7 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
   public ActorFuture<TopologyChangeResponse> scaleMembers(final ScaleRequest scaleRequest) {
     return handleRequest(
         scaleRequest.dryRun(),
-        new ScaleRequestTransformer(
-            scaleRequest.members(),
-            scaleRequest.newReplicationFactor().orElse(USE_CURRENT_REPLICATION_FACTOR)));
+        new ScaleRequestTransformer(scaleRequest.members(), scaleRequest.newReplicationFactor()));
   }
 
   @Override
@@ -112,7 +108,7 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
       final ScaleRequest forceScaleDownRequest) {
     final Optional<Integer> optionalNewReplicationFactor =
         forceScaleDownRequest.newReplicationFactor();
-    if (optionalNewReplicationFactor.isPresent() && optionalNewReplicationFactor.get() > 0) {
+    if (optionalNewReplicationFactor.isPresent()) {
       final var failedFuture = executor.<TopologyChangeResponse>createFuture();
       final String errorMessage =
           String.format(

--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/api/TopologyManagementRequestsHandler.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.topology.api;
 
+import static io.camunda.zeebe.topology.api.PartitionReassignRequestTransformer.USE_CURRENT_REPLICATION_FACTOR;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -98,7 +100,10 @@ public final class TopologyManagementRequestsHandler implements TopologyManageme
   @Override
   public ActorFuture<TopologyChangeResponse> scaleMembers(final ScaleRequest scaleRequest) {
     return handleRequest(
-        scaleRequest.dryRun(), new ScaleRequestTransformer(scaleRequest.members()));
+        scaleRequest.dryRun(),
+        new ScaleRequestTransformer(
+            scaleRequest.members(),
+            scaleRequest.newReplicationFactor().orElse(USE_CURRENT_REPLICATION_FACTOR)));
   }
 
   @Override

--- a/zeebe/topology/src/main/resources/proto/proto.lock
+++ b/zeebe/topology/src/main/resources/proto/proto.lock
@@ -116,6 +116,11 @@
                 "id": 2,
                 "name": "dryRun",
                 "type": "bool"
+              },
+              {
+                "id": 3,
+                "name": "newReplicationFactor",
+                "type": "int32"
               }
             ]
           },

--- a/zeebe/topology/src/main/resources/proto/proto.lock
+++ b/zeebe/topology/src/main/resources/proto/proto.lock
@@ -120,7 +120,7 @@
               {
                 "id": 3,
                 "name": "newReplicationFactor",
-                "type": "int32"
+                "type": "uint32"
               }
             ]
           },

--- a/zeebe/topology/src/main/resources/proto/requests.proto
+++ b/zeebe/topology/src/main/resources/proto/requests.proto
@@ -31,6 +31,7 @@ message LeavePartitionRequest {
 message ScaleRequest {
   repeated string memberIds = 1;
   bool dryRun = 2;
+  optional int32 newReplicationFactor = 3; // can be -1 to keep the current replication factor
 }
 
 message ReassignAllPartitionsRequest {

--- a/zeebe/topology/src/main/resources/proto/requests.proto
+++ b/zeebe/topology/src/main/resources/proto/requests.proto
@@ -31,7 +31,7 @@ message LeavePartitionRequest {
 message ScaleRequest {
   repeated string memberIds = 1;
   bool dryRun = 2;
-  optional int32 newReplicationFactor = 3; // can be -1 to keep the current replication factor
+  optional uint32 newReplicationFactor = 3;
 }
 
 message ReassignAllPartitionsRequest {

--- a/zeebe/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/topology/src/test/java/io/camunda/zeebe/topology/api/PartitionReassignRequestTransformerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.topology.util.TopologyUtil;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -163,10 +164,9 @@ class PartitionReassignRequestTransformerTest {
     final var request =
         oldReplicationFactor == newReplicationFactor
             ? new PartitionReassignRequestTransformer(
-                getClusterMembers(newClusterSize),
-                PartitionReassignRequestTransformer.USE_CURRENT_REPLICATION_FACTOR)
+                getClusterMembers(newClusterSize), Optional.empty())
             : new PartitionReassignRequestTransformer(
-                getClusterMembers(newClusterSize), newReplicationFactor);
+                getClusterMembers(newClusterSize), Optional.of(newReplicationFactor));
     final var operations = request.operations(oldClusterTopology).get();
 
     // apply operations to generate new topology

--- a/zeebe/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
+++ b/zeebe/topology/src/test/java/io/camunda/zeebe/topology/api/TopologyManagementApiTest.java
@@ -30,9 +30,11 @@ import io.camunda.zeebe.topology.state.TopologyChangeOperation.MemberRemoveOpera
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.topology.state.TopologyChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.AfterEach;
@@ -214,6 +216,57 @@ final class TopologyManagementApiTest {
             new MemberJoinOperation(id1),
             new PartitionJoinOperation(id1, 2, 1),
             new PartitionLeaveOperation(id0, 2));
+  }
+
+  @Test
+  void shouldScaleBrokersWithNewReplicationFactor() {
+    // given
+    final var request =
+        new TopologyManagementRequest.ScaleRequest(Set.of(id0, id1), Optional.of(2), false);
+    final ClusterTopology currentTopology =
+        initialTopology
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1)));
+
+    recordingCoordinator.setCurrentTopology(currentTopology);
+
+    // when
+    final var changeStatus = clientApi.scaleMembers(request).join().get();
+
+    // then
+    assertThat(changeStatus.plannedChanges())
+        .containsExactly(
+            new MemberJoinOperation(id1),
+            new PartitionJoinOperation(id1, 2, 2),
+            new PartitionJoinOperation(id1, 1, 1),
+            new PartitionReconfigurePriorityOperation(id0, 1, 2));
+  }
+
+  @Test
+  void shouldReduceReplicationFactorWithoutScalingDown() {
+    // given
+    final var request =
+        new TopologyManagementRequest.ScaleRequest(Set.of(id0, id1), Optional.of(1), false);
+    final ClusterTopology currentTopology =
+        initialTopology
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(2)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1)))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(1)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(2)));
+
+    recordingCoordinator.setCurrentTopology(currentTopology);
+
+    // when
+    final var changeStatus = clientApi.scaleMembers(request).join().get();
+
+    // then
+    assertThat(changeStatus.plannedChanges())
+        .containsExactlyInAnyOrder(
+            new PartitionLeaveOperation(id0, 2),
+            new PartitionLeaveOperation(id1, 1),
+            new PartitionReconfigurePriorityOperation(id0, 1, 1),
+            new PartitionReconfigurePriorityOperation(id1, 2, 1));
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR adds an endpoint to change the `replicationFactor` using the cluster scaling endpoint. This allows to re-add the brokers with the same replicationFactor as before the force removal. 

```
POST actuator/cluster/brokers?replicationFactor=4   
[
 <brokerId1>, <brokerId2>, ...
]
```

As an example, in a cluster of 4 brokers, we remove broker 0 and 2 using `POST actuator/cluster/broker?force=true ["1", "3"]`. Now you can add 0 and 2 back by `POST actuator/cluster/broker?replicationFactor=4 ["0","1","2","3"]`. Note that re-adding is not a "force" operation. 

This endpoint is not restricted to use when re-adding removed brokers. But it can be generally used to change the replicationFactor. For example, if you started the cluster with replicationFactor 1 but later decided to change it to 3, this endpoint can be used.

## Related issues

closes #16673 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
