### PR TITLE
Support `Update task` user task action

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
 import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
+import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
@@ -513,4 +514,30 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
   AssignUserTaskCommandStep1 newUserTaskAssignCommand(long userTaskKey);
+
+  /**
+   * Command to update a user task.
+   *
+   * <pre>
+   * long userTaskKey = ..;
+   *
+   * zeebeClient
+   *  .newUserTaskUpdateCommand(userTaskKey)
+   *  .candidateGroups(newCandidateGroups)
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   * <br>
+   *
+   * <p><strong>Experimental: This method is under development, and as such using it may have no
+   * effect on the client builder when called. Until this warning is removed, anything described
+   * below may not yet have taken effect, and the interface and its description are subject to
+   * change.</strong>
+   *
+   * @param userTaskKey the key of the user tasks
+   * @return a builder for the command
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
+  UpdateUserTaskCommandStep1 newUserTaskUpdateCommand(long userTaskKey);
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
+import java.util.List;
+
+public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserTaskResponse> {
+
+  /**
+   * Set the custom action to update the user task with.
+   *
+   * @param action the action value
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 action(String action);
+
+  /**
+   * Set the due date to set in the user task.
+   *
+   * @param dueDate the due date to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 dueDate(String dueDate);
+
+  /**
+   * Clear the due date in the user task.
+   *
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 clearDueDate();
+
+  /**
+   * Set the follow-up date to set in the user task.
+   *
+   * @param followUpDate the follow-up date to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 followUpDate(String followUpDate);
+
+  /**
+   * Clear the follow-up date in the user task.
+   *
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 clearFollowUpDate();
+
+  /**
+   * Set the candidate groups to set in the user task.
+   *
+   * @param candidateGroups the candidate groups to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 candidateGroups(List<String> candidateGroups);
+
+  /**
+   * Set the candidate groups to set in the user task.
+   *
+   * @param candidateGroups the candidate groups to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 candidateGroups(String... candidateGroups);
+
+  /**
+   * Clear the candidate groups in the user task.
+   *
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 clearCandidateGroups();
+
+  /**
+   * Set the candidate users to set in the user task.
+   *
+   * @param candidateUsers the candidate users to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 candidateUsers(List<String> candidateUsers);
+
+  /**
+   * Set the candidate users to set in the user task.
+   *
+   * @param candidateUsers the candidate users to set
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 candidateUsers(String... candidateUsers);
+
+  /**
+   * Clear the candidate users in the user task.
+   *
+   * @return the builder for this command. Call {@link #send()} to complete the command and send it
+   *     to the broker.
+   */
+  UpdateUserTaskCommandStep1 clearCandidateUsers();
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateUserTaskCommandStep1.java
@@ -30,7 +30,8 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 action(String action);
 
   /**
-   * Set the due date to set in the user task.
+   * Set the due date to set in the user task. Use {@link #clearDueDate()} to remove the due date
+   * from the task.
    *
    * @param dueDate the due date to set
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
@@ -47,7 +48,8 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 clearDueDate();
 
   /**
-   * Set the follow-up date to set in the user task.
+   * Set the follow-up date to set in the user task. Use {@link #clearFollowUpDate()} to remove the
+   * follow-up date from the task.
    *
    * @param followUpDate the follow-up date to set
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
@@ -64,7 +66,8 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 clearFollowUpDate();
 
   /**
-   * Set the candidate groups to set in the user task.
+   * Set the candidate groups to set in the user task. This replaces the candidate groups in the
+   * task. Use {@link #clearCandidateGroups()} to remove the candidate groups from the task.
    *
    * @param candidateGroups the candidate groups to set
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
@@ -73,7 +76,8 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 candidateGroups(List<String> candidateGroups);
 
   /**
-   * Set the candidate groups to set in the user task.
+   * Set the candidate groups to set in the user task. This replaces the candidate groups in the
+   * task. Use {@link #clearCandidateGroups()} to remove the candidate groups from the task.
    *
    * @param candidateGroups the candidate groups to set
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
@@ -82,7 +86,7 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 candidateGroups(String... candidateGroups);
 
   /**
-   * Clear the candidate groups in the user task.
+   * Remove the candidate groups from the user task.
    *
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.
@@ -90,7 +94,8 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 clearCandidateGroups();
 
   /**
-   * Set the candidate users to set in the user task.
+   * Set the candidate users to set in the user task. This replaces the candidate users in the task.
+   * Use {@link #clearCandidateUsers()} to remove the candidate users from the task.
    *
    * @param candidateUsers the candidate users to set
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
@@ -99,7 +104,8 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 candidateUsers(List<String> candidateUsers);
 
   /**
-   * Set the candidate users to set in the user task.
+   * Set the candidate users to set in the user task. This replaces the candidate users in the task.
+   * Use {@link #clearCandidateUsers()} to remove the candidate users from the task.
    *
    * @param candidateUsers the candidate users to set
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
@@ -108,7 +114,7 @@ public interface UpdateUserTaskCommandStep1 extends FinalCommandStep<UpdateUserT
   UpdateUserTaskCommandStep1 candidateUsers(String... candidateUsers);
 
   /**
-   * Clear the candidate users in the user task.
+   * Remove the candidate users from the user task.
    *
    * @return the builder for this command. Call {@link #send()} to complete the command and send it
    *     to the broker.

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateUserTaskResponse.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UpdateUserTaskResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface UpdateUserTaskResponse {}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
 import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
+import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
@@ -66,6 +67,7 @@ import io.camunda.zeebe.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.zeebe.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.zeebe.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.TopologyRequestImpl;
+import io.camunda.zeebe.client.impl.command.UpdateUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpClientFactory;
 import io.camunda.zeebe.client.impl.util.ExecutorResource;
@@ -456,6 +458,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public AssignUserTaskCommandStep1 newUserTaskAssignCommand(final long userTaskKey) {
     return new AssignUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 newUserTaskUpdateCommand(final long userTaskKey) {
+    return new UpdateUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
   }
 
   private JobClient newJobClient() {

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -74,66 +74,70 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
   @Override
   public UpdateUserTaskCommandStep1 dueDate(final String dueDate) {
     ArgumentUtil.ensureNotNull("dueDate", dueDate);
-    getChangesetEnsureInitialized().setDueDate(dueDate);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_DUE_DATE, dueDate);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearDueDate() {
-    getChangesetEnsureInitialized().setDueDate("");
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_DUE_DATE, "");
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 followUpDate(final String followUpDate) {
     ArgumentUtil.ensureNotNull("followUpDate", followUpDate);
-    getChangesetEnsureInitialized().setFollowUpDate(followUpDate);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_FOLLOW_UP_DATE, followUpDate);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearFollowUpDate() {
-    getChangesetEnsureInitialized().setFollowUpDate("");
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_FOLLOW_UP_DATE, "");
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateGroups(final List<String> candidateGroups) {
     ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
-    getChangesetEnsureInitialized().setCandidateGroups(candidateGroups);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, candidateGroups);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateGroups(final String... candidateGroups) {
     ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
-    getChangesetEnsureInitialized().setCandidateGroups(Arrays.asList(candidateGroups));
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, Arrays.asList(candidateGroups));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateGroups() {
-    getChangesetEnsureInitialized().setCandidateGroups(Collections.emptyList());
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, Collections.emptyList());
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateUsers(final List<String> candidateUsers) {
     ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
-    getChangesetEnsureInitialized().setCandidateUsers(candidateUsers);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, candidateUsers);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateUsers(final String... candidateUsers) {
     ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
-    getChangesetEnsureInitialized().setCandidateUsers(Arrays.asList(candidateUsers));
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, Arrays.asList(candidateUsers));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateUsers() {
-    getChangesetEnsureInitialized().setCandidateUsers(Collections.emptyList());
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, Collections.emptyList());
     return this;
   }
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.gateway.protocol.rest.Changeset;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandStep1 {
+
+  private final long userTaskKey;
+  private final UserTaskUpdateRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public UpdateUserTaskCommandImpl(
+      final HttpClient httpClient, final JsonMapper jsonMapper, final long userTaskKey) {
+    this.jsonMapper = jsonMapper;
+    this.userTaskKey = userTaskKey;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+    request = new UserTaskUpdateRequest();
+  }
+
+  @Override
+  public FinalCommandStep<UpdateUserTaskResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<UpdateUserTaskResponse> send() {
+    final HttpZeebeFuture<UpdateUserTaskResponse> result = new HttpZeebeFuture<>();
+    httpClient.patch(
+        "/user-tasks/" + userTaskKey,
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        result);
+    return result;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 action(final String action) {
+    request.setAction(action);
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 dueDate(final String dueDate) {
+    ArgumentUtil.ensureNotNull("dueDate", dueDate);
+    getChangesetEnsureInitialized().setDueDate(dueDate);
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 clearDueDate() {
+    getChangesetEnsureInitialized().setDueDate("");
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 followUpDate(final String followUpDate) {
+    ArgumentUtil.ensureNotNull("followUpDate", followUpDate);
+    getChangesetEnsureInitialized().setFollowUpDate(followUpDate);
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 clearFollowUpDate() {
+    getChangesetEnsureInitialized().setFollowUpDate("");
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 candidateGroups(final List<String> candidateGroups) {
+    ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
+    getChangesetEnsureInitialized().setCandidateGroups(candidateGroups);
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 candidateGroups(final String... candidateGroups) {
+    ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
+    getChangesetEnsureInitialized().setCandidateGroups(Arrays.asList(candidateGroups));
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 clearCandidateGroups() {
+    getChangesetEnsureInitialized().setCandidateGroups(Collections.emptyList());
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 candidateUsers(final List<String> candidateUsers) {
+    ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
+    getChangesetEnsureInitialized().setCandidateUsers(candidateUsers);
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 candidateUsers(final String... candidateUsers) {
+    ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
+    getChangesetEnsureInitialized().setCandidateUsers(Arrays.asList(candidateUsers));
+    return this;
+  }
+
+  @Override
+  public UpdateUserTaskCommandStep1 clearCandidateUsers() {
+    getChangesetEnsureInitialized().setCandidateUsers(Collections.emptyList());
+    return this;
+  }
+
+  private Changeset getChangesetEnsureInitialized() {
+    Changeset changeset = request.getChangeset();
+    if (changeset == null) {
+      changeset = new Changeset();
+      request.setChangeset(changeset);
+    }
+    return changeset;
+  }
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -106,6 +106,14 @@ public final class HttpClient implements AutoCloseable {
     sendRequest(Method.POST, path, body, requestConfig, Void.class, r -> null, result);
   }
 
+  public <HttpT, RespT> void patch(
+      final String path,
+      final String body,
+      final RequestConfig requestConfig,
+      final HttpZeebeFuture<RespT> result) {
+    sendRequest(Method.PATCH, path, body, requestConfig, Void.class, r -> null, result);
+  }
+
   private <HttpT, RespT> void sendRequest(
       final Method httpMethod,
       final String path,


### PR DESCRIPTION
## Description

* Creates the API for issuing user task update commands in the Java client.
* User task updates can take a custom "action" and adjust the due date, follow-up date, candidate groups, and candidate users.
* The update command allows clearing the supported attributes in the user task as well by invoking the respective "clearXYZ" methods.
* The HttpClient supports issuing PATCH requests that expect an empty response in the success case.
* The command issues a PATCH request to the user task update endpoint at "/v1/user-tasks/{userTaskKey}".

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16662 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
