### PR TITLE
Support `Unassign task` user task action

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
 import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
+import io.camunda.zeebe.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
@@ -483,7 +484,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * below may not yet have taken effect, and the interface and its description are subject to
    * change.</strong>
    *
-   * @param userTaskKey the key of the user tasks
+   * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
@@ -509,7 +510,7 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * below may not yet have taken effect, and the interface and its description are subject to
    * change.</strong>
    *
-   * @param userTaskKey the key of the user tasks
+   * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
@@ -535,9 +536,34 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * below may not yet have taken effect, and the interface and its description are subject to
    * change.</strong>
    *
-   * @param userTaskKey the key of the user tasks
+   * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
   UpdateUserTaskCommandStep1 newUserTaskUpdateCommand(long userTaskKey);
+
+  /**
+   * Command to unassign a user task.
+   *
+   * <pre>
+   * long userTaskKey = ..;
+   *
+   * zeebeClient
+   *  .newUserTaskUnassignCommand(userTaskKey)
+   *  .send();
+   * </pre>
+   *
+   * <p>This command is only sent via REST over HTTP, not via gRPC <br>
+   * <br>
+   *
+   * <p><strong>Experimental: This method is under development, and as such using it may have no
+   * effect on the client builder when called. Until this warning is removed, anything described
+   * below may not yet have taken effect, and the interface and its description are subject to
+   * change.</strong>
+   *
+   * @param userTaskKey the key of the user task
+   * @return a builder for the command
+   */
+  @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
+  UnassignUserTaskCommandStep1 newUserTaskUnassignCommand(long userTaskKey);
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignUserTaskCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UnassignUserTaskCommandStep1.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.UnassignUserTaskResponse;
+
+public interface UnassignUserTaskCommandStep1 extends FinalCommandStep<UnassignUserTaskResponse> {
+  // the place for new optional parameters
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignUserTaskResponse.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/response/UnassignUserTaskResponse.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface UnassignUserTaskResponse {}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -43,6 +43,7 @@ import io.camunda.zeebe.client.api.command.SetVariablesCommandStep1;
 import io.camunda.zeebe.client.api.command.StreamJobsCommandStep1;
 import io.camunda.zeebe.client.api.command.ThrowErrorCommandStep1;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
+import io.camunda.zeebe.client.api.command.UnassignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
@@ -67,6 +68,7 @@ import io.camunda.zeebe.client.impl.command.ResolveIncidentCommandImpl;
 import io.camunda.zeebe.client.impl.command.SetVariablesCommandImpl;
 import io.camunda.zeebe.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.TopologyRequestImpl;
+import io.camunda.zeebe.client.impl.command.UnassignUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.UpdateUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpClientFactory;
@@ -463,6 +465,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   @Override
   public UpdateUserTaskCommandStep1 newUserTaskUpdateCommand(final long userTaskKey) {
     return new UpdateUserTaskCommandImpl(httpClient, jsonMapper, userTaskKey);
+  }
+
+  @Override
+  public UnassignUserTaskCommandStep1 newUserTaskUnassignCommand(final long userTaskKey) {
+    return new UnassignUserTaskCommandImpl(httpClient, userTaskKey);
   }
 
   private JobClient newJobClient() {

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UnassignUserTaskCommandImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.command.UnassignUserTaskCommandStep1;
+import io.camunda.zeebe.client.api.response.UnassignUserTaskResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public final class UnassignUserTaskCommandImpl implements UnassignUserTaskCommandStep1 {
+
+  private final long userTaskKey;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public UnassignUserTaskCommandImpl(final HttpClient httpClient, final long userTaskKey) {
+    this.userTaskKey = userTaskKey;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public FinalCommandStep<UnassignUserTaskResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<UnassignUserTaskResponse> send() {
+    final HttpZeebeFuture<UnassignUserTaskResponse> result = new HttpZeebeFuture<>();
+    httpClient.delete(
+        "/user-tasks/" + userTaskKey + "/assignee", httpRequestConfig.build(), result);
+    return result;
+  }
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -114,6 +114,11 @@ public final class HttpClient implements AutoCloseable {
     sendRequest(Method.PATCH, path, body, requestConfig, Void.class, r -> null, result);
   }
 
+  public <HttpT, RespT> void delete(
+      final String path, final RequestConfig requestConfig, final HttpZeebeFuture<RespT> result) {
+    sendRequest(Method.DELETE, path, null, requestConfig, Void.class, r -> null, result);
+  }
+
   private <HttpT, RespT> void sendRequest(
       final Method httpMethod,
       final String path,


### PR DESCRIPTION
## Description

* Creates the API for issuing user task unassign commands in the Java client. User task unassign does not take any additional parameters.
* The HttpClient in the Zeebe Java client supports issuing DELETE requests that expect an empty response in the success case.
* Adds a user task unassign command method to the Java client. This command issues a DELETE request to the user task unassign endpoint at "/v1/user-tasks/{userTaskKey}/assignee".

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16664 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
