### PR TITLE
feat: I can use an embedded subprocess as compensation handler

### DIFF
--- a/zeebe/bpmn-model/revapi.json
+++ b/zeebe/bpmn-model/revapi.json
@@ -47,6 +47,24 @@
             "matcher": "java-package",
             "match": "io.camunda.zeebe.model.bpmn.validation.zeebe"
           }
+        },
+        {
+          "justification": "The parameter type of the builder changed to a more concrete type. This is okay because compensation was not officially supported yet.",
+          "code": "java.method.parameterTypeParameterChanged",
+          "package": "io.camunda.zeebe.model.bpmn.builder",
+          "classQualifiedName": "io.camunda.zeebe.model.bpmn.builder.BoundaryEventBuilder",
+          "methodName": "compensation",
+          "oldType": "java.util.function.Consumer<io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder>",
+          "newType": "java.util.function.Consumer<io.camunda.zeebe.model.bpmn.builder.BoundaryEventBuilder>"
+        },
+        {
+          "justification": "The parameter type of the builder changed to a more concrete type. This is okay because compensation was not officially supported yet.",
+          "code": "java.method.parameterTypeParameterChanged",
+          "package": "io.camunda.zeebe.model.bpmn.builder",
+          "classQualifiedName": "io.camunda.zeebe.model.bpmn.builder.AbstractBoundaryEventBuilder",
+          "methodName": "compensation",
+          "oldType": "java.util.function.Consumer<io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder>",
+          "newType": "java.util.function.Consumer<B extends io.camunda.zeebe.model.bpmn.builder.AbstractBoundaryEventBuilder<B>>"
         }
       ]
     }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBoundaryEventBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBoundaryEventBuilder.java
@@ -131,7 +131,7 @@ public abstract class AbstractBoundaryEventBuilder<B extends AbstractBoundaryEve
     return myself;
   }
 
-  public AbstractFlowNodeBuilder compensation(final Consumer<AbstractFlowNodeBuilder> consumer) {
+  public AbstractFlowNodeBuilder compensation(final Consumer<B> consumer) {
     compensateEventDefinition();
     compensationStart();
     consumer.accept(myself);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -163,7 +163,7 @@ public class BpmnCompensationSubscriptionBehaviour {
     long compensationHandlerInstanceKey = NONE_COMPENSATION_HANDLER_INSTANCE_KEY;
 
     // invoke the compensation handler if present
-    if (!subscription.getRecord().getCompensationHandlerId().isEmpty()) {
+    if (hasCompensationHandler(subscription)) {
       compensationHandlerInstanceKey =
           activateCompensationHandler(context, subscription.getRecord().getCompensableActivityId());
     }
@@ -175,6 +175,10 @@ public class BpmnCompensationSubscriptionBehaviour {
     // propagate the compensation to subprocesses
     triggerCompensationFromTopToBottom(
         context, subscriptions, subscription.getRecord().getCompensableActivityInstanceKey());
+  }
+
+  private static boolean hasCompensationHandler(final CompensationSubscription subscription) {
+    return !subscription.getRecord().getCompensationHandlerId().isEmpty();
   }
 
   private long activateCompensationHandler(
@@ -357,6 +361,7 @@ public class BpmnCompensationSubscriptionBehaviour {
         .filter(
             subscription ->
                 scopeKey == subscription.getRecord().getCompensableActivityInstanceKey())
+        .filter(not(BpmnCompensationSubscriptionBehaviour::hasCompensationHandler))
         .findFirst()
         .ifPresent(
             flowScopeSubscription -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -34,8 +34,6 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 public class BpmnCompensationSubscriptionBehaviour {
 
@@ -119,7 +117,7 @@ public class BpmnCompensationSubscriptionBehaviour {
                 context.getTenantId(), context.getProcessInstanceKey())
             .stream()
             .filter(not(BpmnCompensationSubscriptionBehaviour::isCompensationTriggered))
-            .collect(Collectors.toSet());
+            .toList();
 
     if (hasCompensationSubscriptionInScope(subscriptions, context.getFlowScopeKey())) {
       // trigger the compensation in the current scope and propagate to the subprocesses
@@ -132,7 +130,7 @@ public class BpmnCompensationSubscriptionBehaviour {
   }
 
   private static boolean hasCompensationSubscriptionInScope(
-      final Set<CompensationSubscription> subscriptions, final long scopeKey) {
+      final Collection<CompensationSubscription> subscriptions, final long scopeKey) {
     return subscriptions.stream()
         .anyMatch(
             subscription -> subscription.getRecord().getCompensableActivityScopeKey() == scopeKey);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -80,7 +80,11 @@ public final class SubProcessProcessor
               compensationSubscriptionBehaviour.createCompensationSubscription(element, completing);
               return stateTransitionBehavior.transitionToCompleted(element, completing);
             })
-        .thenDo(completed -> stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed));
+        .thenDo(
+            completed -> {
+              compensationSubscriptionBehaviour.completeCompensationHandler(completed);
+              stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
+            });
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/DbCompensationSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/DbCompensationSubscriptionState.java
@@ -19,10 +19,8 @@ import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionStat
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public class DbCompensationSubscriptionState implements MutableCompensationSubscriptionState {
 
@@ -64,12 +62,12 @@ public class DbCompensationSubscriptionState implements MutableCompensationSubsc
   }
 
   @Override
-  public Set<CompensationSubscription> findSubscriptionsByProcessInstanceKey(
+  public List<CompensationSubscription> findSubscriptionsByProcessInstanceKey(
       final String tenantId, final long piKey) {
     tenantIdKey.wrapString(tenantId);
     processInstanceKey.wrapLong(piKey);
 
-    final Set<CompensationSubscription> subscriptions = new HashSet<>();
+    final List<CompensationSubscription> subscriptions = new ArrayList<>();
     compensationSubscriptionColumnFamily.whileEqualPrefix(
         new DbCompositeKey<>(tenantIdKey, processInstanceKey),
         ((key, value) -> {
@@ -97,12 +95,12 @@ public class DbCompensationSubscriptionState implements MutableCompensationSubsc
   }
 
   @Override
-  public Set<CompensationSubscription> findSubscriptionsByThrowEventInstanceKey(
+  public List<CompensationSubscription> findSubscriptionsByThrowEventInstanceKey(
       final String tenantId, final long piKey, final long throwEventInstanceKey) {
     tenantIdKey.wrapString(tenantId);
     processInstanceKey.wrapLong(piKey);
 
-    final Set<CompensationSubscription> compensations = new HashSet<>();
+    final List<CompensationSubscription> compensations = new ArrayList<>();
     compensationSubscriptionColumnFamily.whileEqualPrefix(
         new DbCompositeKey<>(tenantIdKey, processInstanceKey),
         ((key, value) -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/CompensationSubscriptionState.java
@@ -8,19 +8,19 @@
 package io.camunda.zeebe.engine.state.immutable;
 
 import io.camunda.zeebe.engine.state.compensation.CompensationSubscription;
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 public interface CompensationSubscriptionState {
 
   CompensationSubscription get(String tenantId, long processInstanceKey, long key);
 
-  Set<CompensationSubscription> findSubscriptionsByProcessInstanceKey(
+  List<CompensationSubscription> findSubscriptionsByProcessInstanceKey(
       String tenantId, long processInstanceKey);
 
   Optional<CompensationSubscription> findSubscriptionByCompensationHandlerId(
       String tenantId, long processInstanceKey, String compensationHandlerId);
 
-  Set<CompensationSubscription> findSubscriptionsByThrowEventInstanceKey(
+  List<CompensationSubscription> findSubscriptionsByThrowEventInstanceKey(
       String tenantId, long processInstanceKey, long throwEventInstanceKey);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -13,7 +13,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionStat
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateExtension;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
-import java.util.Set;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -162,10 +162,10 @@ public class CompensationSubscriptionStateTest {
 
     state.delete(TENANT_ID, PROCESS_INSTANCE_KEY, 2L);
 
-    final Set<CompensationSubscription> compensations =
+    final List<CompensationSubscription> compensations =
         state.findSubscriptionsByProcessInstanceKey(TENANT_ID, PROCESS_INSTANCE_KEY);
     assertThat(compensations.size()).isEqualTo(1);
-    assertThat(compensations.stream().findFirst().get().getRecord().getCompensableActivityId())
+    assertThat(compensations.getFirst().getRecord().getCompensableActivityId())
         .isEqualTo(COMPENSABLE_ACTIVITY_ID);
   }
 
@@ -195,11 +195,11 @@ public class CompensationSubscriptionStateTest {
     state.put(1L, compensation);
     state.put(2L, notValidCompensation);
 
-    final Set<CompensationSubscription> compensations =
+    final List<CompensationSubscription> compensations =
         state.findSubscriptionsByThrowEventInstanceKey(
             TENANT_ID, PROCESS_INSTANCE_KEY, THROW_EVENT_INSTANCE_KEY);
     assertThat(compensations.size()).isEqualTo(1);
-    assertThat(compensations.stream().findFirst().get().getRecord().getThrowEventInstanceKey())
+    assertThat(compensations.getFirst().getRecord().getThrowEventInstanceKey())
         .isEqualTo(THROW_EVENT_INSTANCE_KEY);
   }
 


### PR DESCRIPTION
## Description

Extend the compensation behavior to enable the following cases:
- I can use an embedded subprocess as a compensation handler
- I can attach a compensation boundary event to an embedded subprocess
- Invoke compensation handlers for the subprocess and activities inside the subprocess

## Related issues

closes #16601 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
