### PR TITLE
fix: respect offset and length on DbBytes#wrap

### DIFF
--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbBytes.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbBytes.java
@@ -24,7 +24,9 @@ public final class DbBytes implements DbKey, DbValue {
 
   @Override
   public void wrap(final DirectBuffer directBuffer, final int offset, final int length) {
-    bytes.wrap(directBuffer, offset, length);
+    final byte[] bytesToWrap = new byte[length];
+    directBuffer.getBytes(offset, bytesToWrap, 0, bytesToWrap.length);
+    bytes.wrap(bytesToWrap);
   }
 
   @Override

--- a/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbBytesTest.java
+++ b/zeebe/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbBytesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+
+public final class DbBytesTest {
+
+  private final DbBytes zbBytes = new DbBytes();
+
+  @Test
+  public void shouldWrapBytes() {
+    // given
+    final byte[] bytes = {1, 2, 3, 4, 5, 6, 7};
+
+    // when
+    zbBytes.wrapBytes(bytes);
+
+    // then
+    assertThat(zbBytes.getLength()).isEqualTo(bytes.length);
+    assertThat(zbBytes.getBytes()).isEqualTo(bytes);
+  }
+
+  @Test
+  public void shouldWrapBytesWithOffsetAndLength() {
+    // given
+    final var bytes = new byte[] {1, 2, 3, 4, 5, 6, 7};
+    final var buffer = new UnsafeBuffer(bytes);
+
+    // when -- wrapping over part of the buffer
+    zbBytes.wrap(buffer, 2, 3);
+
+    // then
+    assertThat(zbBytes.getLength()).isEqualTo(3);
+    assertThat(zbBytes.getBytes()).isEqualTo(new byte[] {3, 4, 5});
+  }
+}


### PR DESCRIPTION
## Description

Aligned wrap implementation to DbString#wrap, it will create a copy on wrap which I considered the better compromise vs. doing it every time on get.

## Related issues


closes #16666 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
