### PR TITLE
test: reduce scope of ruleChain on LargeMessageSizeTest

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/LargeMessageSizeTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/network/LargeMessageSizeTest.java
@@ -28,7 +28,6 @@ import java.util.Random;
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.Before;
-import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
@@ -46,16 +45,11 @@ public final class LargeMessageSizeTest {
   private static final long METADATA_SIZE = 512;
 
   private static final String LARGE_TEXT = "x".repeat((int) (LARGE_SIZE - METADATA_SIZE));
-
-  private static final EmbeddedBrokerRule BROKER_RULE =
-      new EmbeddedBrokerRule(b -> b.getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE));
-  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
-
-  @ClassRule
-  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
-
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
-
+  private final EmbeddedBrokerRule brokerRule =
+      new EmbeddedBrokerRule(b -> b.getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE));
+  private final GrpcClientRule clientRule = new GrpcClientRule(brokerRule);
+  @Rule public RuleChain ruleChain = RuleChain.outerRule(brokerRule).around(clientRule);
   private String jobType;
 
   private static BpmnModelInstance process(final String jobType) {
@@ -80,7 +74,7 @@ public final class LargeMessageSizeTest {
 
     // when
     final var deployment =
-        CLIENT_RULE
+        clientRule
             .getClient()
             .newDeployResourceCommand()
             .addResourceStringUtf8(largeProcess, "process.bpmn")
@@ -91,7 +85,7 @@ public final class LargeMessageSizeTest {
 
     // then
     final var processInstanceEvent =
-        CLIENT_RULE
+        clientRule
             .getClient()
             .newCreateInstanceCommand()
             .processDefinitionKey(processDefinitionKey)
@@ -104,13 +98,13 @@ public final class LargeMessageSizeTest {
   @Test
   public void shouldCreateInstanceWithLargeVariables() {
     // given
-    final var processDefinitionKey = CLIENT_RULE.deployProcess(process(jobType));
+    final var processDefinitionKey = clientRule.deployProcess(process(jobType));
 
     // when
     final Map<String, Object> largeVariables = Map.of("largeVariable", LARGE_TEXT);
 
     final var processInstanceEvent =
-        CLIENT_RULE
+        clientRule
             .getClient()
             .newCreateInstanceCommand()
             .processDefinitionKey(processDefinitionKey)
@@ -125,10 +119,10 @@ public final class LargeMessageSizeTest {
   @Test
   public void shouldCompleteJobWithLargeVariables() {
     // given
-    final var processDefinitionKey = CLIENT_RULE.deployProcess(process(jobType));
+    final var processDefinitionKey = clientRule.deployProcess(process(jobType));
 
     final var processInstanceEvent =
-        CLIENT_RULE
+        clientRule
             .getClient()
             .newCreateInstanceCommand()
             .processDefinitionKey(processDefinitionKey)
@@ -138,7 +132,7 @@ public final class LargeMessageSizeTest {
     // when
     final Map<String, Object> largeVariables = Map.of("largeVariable", LARGE_TEXT);
 
-    CLIENT_RULE
+    clientRule
         .getClient()
         .newWorker()
         .jobType(jobType)
@@ -162,7 +156,7 @@ public final class LargeMessageSizeTest {
             .endEvent()
             .done();
 
-    CLIENT_RULE
+    clientRule
         .getClient()
         .newDeployResourceCommand()
         .addProcessModel(modelInstance, "foo.bpmn")
@@ -175,7 +169,7 @@ public final class LargeMessageSizeTest {
 
     final int numberOfJobsToActivate = 5;
     for (int i = 0; i < numberOfJobsToActivate; i++) {
-      CLIENT_RULE
+      clientRule
           .getClient()
           .newCreateInstanceCommand()
           .bpmnProcessId("foo")
@@ -193,7 +187,7 @@ public final class LargeMessageSizeTest {
 
     // when
     final JobWorkerBuilderStep3 builder =
-        CLIENT_RULE.getClient().newWorker().jobType("foo").handler(COMPLETING_JOB_HANDLER);
+        clientRule.getClient().newWorker().jobType("foo").handler(COMPLETING_JOB_HANDLER);
 
     // then
     try (final JobWorker ignored = builder.open()) {
@@ -222,8 +216,8 @@ public final class LargeMessageSizeTest {
     final DataSize maxMessageSize = DataSize.ofBytes(5100);
     final int jobVariableSize = 144;
 
-    BROKER_RULE.getBrokerCfg().getGateway().getNetwork().setMaxMessageSize(maxMessageSize);
-    BROKER_RULE.restartBroker();
+    brokerRule.getBrokerCfg().getGateway().getNetwork().setMaxMessageSize(maxMessageSize);
+    brokerRule.restartBroker();
 
     // given
     final var modelInstance =
@@ -234,7 +228,7 @@ public final class LargeMessageSizeTest {
             .endEvent()
             .done();
 
-    CLIENT_RULE
+    clientRule
         .getClient()
         .newDeployResourceCommand()
         .addProcessModel(modelInstance, "foo.bpmn")
@@ -246,7 +240,7 @@ public final class LargeMessageSizeTest {
 
     final int numberOfJobsToActivate = 5;
     for (int i = 0; i < numberOfJobsToActivate; i++) {
-      CLIENT_RULE
+      clientRule
           .getClient()
           .newCreateInstanceCommand()
           .bpmnProcessId("foo")
@@ -264,7 +258,7 @@ public final class LargeMessageSizeTest {
 
     // when
     final JobWorkerBuilderStep3 builder =
-        CLIENT_RULE.getClient().newWorker().jobType("foo").handler(COMPLETING_JOB_HANDLER);
+        clientRule.getClient().newWorker().jobType("foo").handler(COMPLETING_JOB_HANDLER);
 
     // then
     try (final JobWorker ignored = builder.open()) {
@@ -282,7 +276,7 @@ public final class LargeMessageSizeTest {
     }
 
     // reset max message size to the initial value
-    BROKER_RULE.getBrokerCfg().getGateway().getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE);
-    BROKER_RULE.restartBroker();
+    brokerRule.getBrokerCfg().getGateway().getNetwork().setMaxMessageSize(MAX_MESSAGE_SIZE);
+    brokerRule.restartBroker();
   }
 }


### PR DESCRIPTION
## Description

As individual tests mutate the broker state, we may have side-effects between tests, depending on the execution order.

Before the change I could reproduce the issues after <10 test executions, now it survives 100+ till we hit this issue https://github.com/camunda/zeebe/issues/16698 .

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16583 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
