### PR TITLE
Use concrete class to ensure ForceConfigureRequest can be serialized

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -31,6 +31,7 @@ import io.atomix.utils.logging.LoggerContext;
 import java.net.ConnectException;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
@@ -304,7 +305,8 @@ public final class ReconfigurationHelper {
             .withTerm(configuration.term())
             .withIndex(configuration.index())
             .withTime(configuration.time())
-            .withNewMembers(Set.copyOf(configuration.newMembers()))
+            // Beware that using ImmutableCollections can break Kryo serialization
+            .withNewMembers(new HashSet<>(configuration.newMembers()))
             .from(raftContext.getCluster().getLocalMember().memberId())
             .build();
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/ReconfigurationHelper.java
@@ -285,6 +285,7 @@ public final class ReconfigurationHelper {
 
     if (otherMembers.isEmpty()) {
       future.complete(null);
+      return;
     }
 
     final var quorum =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ForceScaleDownBrokersTest.java
@@ -11,85 +11,91 @@ import static io.camunda.zeebe.it.clustering.dynamic.Utils.assertThatAllJobsCanB
 import static io.camunda.zeebe.it.clustering.dynamic.Utils.createInstanceWithAJobOnAllPartitions;
 
 import io.atomix.cluster.MemberId;
-import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.actuator.ClusterActuator;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
-import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources;
-import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import java.time.Duration;
-import java.util.List;
+import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-@ZeebeIntegration
 @AutoCloseResources
 @Timeout(2 * 60)
 class ForceScaleDownBrokersTest {
-
-  private static final int PARTITIONS_COUNT = 2;
-  private static final int CLUSTER_SIZE = 2;
+  private static final int PARTITIONS_COUNT = 1;
   private static final String JOB_TYPE = "job";
-  @AutoCloseResource ZeebeClient zeebeClient;
 
-  @TestZeebe
-  private final TestCluster cluster =
-      TestCluster.builder()
-          .useRecordingExporter(true)
-          // Use standalone gateway because we will be shutting down some of the brokers
-          // during the test
-          .withGatewaysCount(1)
-          .withEmbeddedGateway(false)
-          .withBrokersCount(CLUSTER_SIZE)
-          .withPartitionsCount(PARTITIONS_COUNT)
-          .withReplicationFactor(2)
-          .withGatewayConfig(
-              g ->
-                  g.gatewayConfig()
-                      .getCluster()
-                      .getMembership()
-                      // Decrease the timeouts for fast convergence of gateway topology. When the
-                      // broker is shutdown, the topology update takes at least 10 seconds with the
-                      // default values.
-                      .setSyncInterval(Duration.ofSeconds(1))
-                      .setFailureTimeout(Duration.ofSeconds(2)))
-          .build();
+  @ParameterizedTest
+  @CsvSource({"2, 1", "4, 2", "6, 3"})
+  void shouldForceRemoveBrokers(final int oldClusterSize, final int newClusterSize) {
+    // given
+    try (final var cluster = createCluster(oldClusterSize, oldClusterSize);
+        final var zeebeClient = cluster.availableGateway().newClientBuilder().build()) {
+      final var brokersToShutdown =
+          IntStream.range(newClusterSize, oldClusterSize)
+              .mapToObj(String::valueOf)
+              .map(MemberId::from)
+              .map(cluster.brokers()::get)
+              .toList();
 
-  @BeforeEach
-  void createClient() {
-    zeebeClient = cluster.availableGateway().newClientBuilder().build();
+      final var brokersToKeep = IntStream.range(0, newClusterSize).boxed().toList();
+
+      final var createdInstances =
+          createInstanceWithAJobOnAllPartitions(zeebeClient, JOB_TYPE, PARTITIONS_COUNT);
+
+      // when
+      brokersToShutdown.forEach(TestApplication::close);
+      final var response =
+          ClusterActuator.of(cluster.availableGateway()).scaleBrokers(brokersToKeep, false, true);
+      Awaitility.await()
+          .timeout(Duration.ofMinutes(2))
+          .untilAsserted(
+              () -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
+
+      // then
+      brokersToKeep.forEach(
+          brokerId -> ClusterActuatorAssert.assertThat(cluster).brokerHasPartition(brokerId, 1));
+      brokersToShutdown.forEach(
+          brokerId ->
+              ClusterActuatorAssert.assertThat(cluster)
+                  .doesNotHaveBroker(brokerId.brokerConfig().getCluster().getNodeId()));
+
+      // Changes are reflected in the topology returned by grpc query
+      cluster.awaitCompleteTopology(
+          newClusterSize, PARTITIONS_COUNT, newClusterSize, Duration.ofSeconds(20));
+
+      assertThatAllJobsCanBeCompleted(createdInstances, zeebeClient, JOB_TYPE);
+    }
   }
 
-  @Test
-  void shouldForceRemoveBroker() {
-    // given
-    final var brokerToShutdown = cluster.brokers().get(MemberId.from("1"));
-    final var actuator = ClusterActuator.of(cluster.anyGateway());
-
-    final var createdInstances =
-        createInstanceWithAJobOnAllPartitions(zeebeClient, JOB_TYPE, PARTITIONS_COUNT);
-
-    // when
-    brokerToShutdown.close();
-    final var response = actuator.scaleBrokers(List.of(0), false, true);
-    Awaitility.await()
-        .timeout(Duration.ofMinutes(2))
-        .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
-
-    // then
-    // verify broker 1 is removed from the cluster topology
-    ClusterActuatorAssert.assertThat(cluster)
-        .brokerHasPartition(0, 1)
-        .brokerHasPartition(0, 2)
-        .doesNotHaveBroker(1);
-
-    // Changes are reflected in the topology returned by grpc query
-    cluster.awaitCompleteTopology(1, PARTITIONS_COUNT, 1, Duration.ofSeconds(20));
-
-    assertThatAllJobsCanBeCompleted(createdInstances, zeebeClient, JOB_TYPE);
+  TestCluster createCluster(final int clusterSize, final int replicationFactor) {
+    final var cluster =
+        TestCluster.builder()
+            .useRecordingExporter(true)
+            // Use standalone gateway because we will be shutting down some of the brokers
+            // during the test
+            .withGatewaysCount(1)
+            .withEmbeddedGateway(false)
+            .withBrokersCount(clusterSize)
+            .withPartitionsCount(PARTITIONS_COUNT)
+            .withReplicationFactor(replicationFactor)
+            .withGatewayConfig(
+                g ->
+                    g.gatewayConfig()
+                        .getCluster()
+                        .getMembership()
+                        // Decrease the timeouts for fast convergence of gateway topology. When the
+                        // broker is shutdown, the topology update takes at least 10 seconds with
+                        // the default values.
+                        .setSyncInterval(Duration.ofSeconds(1))
+                        .setFailureTimeout(Duration.ofSeconds(2)))
+            .build()
+            .start();
+    cluster.awaitCompleteTopology();
+    return cluster;
   }
 }


### PR DESCRIPTION
## Description

ImmutableCollection$Set12 and SetN is not registered in the Kryo serializer. Hence force configure request fails. This was not caught in raft tests because it uses a dummy communication service. To fix this, we use `HashSet` in the request. Alternately we can add ImmutableCollections#Set12 and SetN to Namespaces.BASIC. Depending on the size of the set either Set12 or SetN is used. The resulting class also changes depending on whether we are using Set.of() or Set.copyOf(). Since there are so many possinle classes with Immutable collections, it is better to use a concrete class directly to ensure consistent serialization.

An integration test with different cluster sizes is added to cover this case.

## Related issues

related to #16316 

