### PR TITLE
ci(weekly-e2e): invoke weekly e2e tests on stable branch

### DIFF
--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Weekly E2E
     steps:
-      - uses: ./.github/workflows/zeebe-e2e-testbench.yaml
+      - uses: actions/checkout@v4
       - name: Trigger Weekly E2E on ${{ matrix.branch }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zeebe-weekly-e2e.yml
+++ b/.github/workflows/zeebe-weekly-e2e.yml
@@ -70,15 +70,14 @@ jobs:
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.previous-latest-major-minor-version) }}
           - branch: ${{ format('stable/{0}', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
             generation_template: ${{ format('Camunda {0}.0', needs.get-versions.outputs.previous-previous-latest-major-minor-version) }}
+    runs-on: ubuntu-latest
     name: Weekly E2E
-    uses: ./.github/workflows/zeebe-e2e-testbench.yaml
-    with:
-      branch: ${{ matrix.branch }}
-      generation: ${{ matrix.generation_template }}
-      maxTestDuration: P5D
-      clusterPlan: Production - M
-      maxInstanceDuration: 40m
-    secrets: inherit
+    steps:
+      - uses: ./.github/workflows/zeebe-e2e-testbench.yaml
+      - name: Trigger Weekly E2E on ${{ matrix.branch }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run --ref ${{ matrix.branch }} zeebe-e2e-testbench.yaml -F generation='${{ matrix.generation_template }}' -F branch=${{ matrix.branch }} -F maxTestDuration='P5D' -F maxInstanceDuration='40m' -F clusterPlan='Production - M'
 
   e2e-multiregion-failover:
     name: Multi-region failover with data loss


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
We need to invoke the zeebe-e2e-testbench.yaml workflow from the correct stable branch since the structure of the Zeebe project changed after version `8.4`.

The solution is the same as #16623 

Test run was triggered here: https://github.com/camunda/zeebe/actions/runs/8154759421

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16706 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
