### PR TITLE
test: increase log level to help debug when test fails

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/DiskSpaceRecoveryIT.java
@@ -54,7 +54,8 @@ final class DiskSpaceRecoveryIT {
           .withEnv("ZEEBE_BROKER_DATA_LOGSEGMENTSIZE", "1MB")
           .withEnv("ZEEBE_BROKER_NETWORK_MAXMESSAGESIZE", "1MB")
           .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_PROCESSING", "8MB")
-          .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION", "1MB");
+          .withEnv("ZEEBE_BROKER_DATA_DISK_FREESPACE_REPLICATION", "1MB")
+          .withEnv("ZEEBE_LOG_LEVEL", "DEBUG");
 
   @SuppressWarnings("JUnitMalformedDeclaration")
   @RegisterExtension


### PR DESCRIPTION
## Description

To help debug the flaky test, we have to understand why snapshot was not taken. Increasing the log level to debug so that when the test fails again, we have more information to debug.

## Related issues

related to #16550 

