### PR TITLE
fix: exclude operate folder from license plugin

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -186,6 +186,7 @@
             </includes>
             <excludes>
               <exclude>zeebe/benchmarks/project/**/*</exclude>
+              <exclude>operate/**/*</exclude>
             </excludes>
             <mapping>
               <java>SLASHSTAR_STYLE</java>


### PR DESCRIPTION
## Description

This PR is a preparation for the merge of Operate source code into this repo. As [discovered](https://camunda.slack.com/archives/C06HTSPD5AP/p1709720579737679?thread_ts=1709713323.576829&cid=C06HTSPD5AP) in the [simulated merge test](https://github.com/camunda/zeebe/pull/16716) the Zeebe license plugin will complain when the Operate source code is added.

Roman found a fix in https://github.com/camunda/zeebe/pull/16716/commits/df6c4405554f168cba48f8b1f517f2714b79fd3d which we want to already include in this repository (outside of the simulated merge test PR) as preparation for the merge.

## Related issues

Related to https://github.com/camunda/team-infrastructure/issues/616