### PR TITLE
Invoke a compensation handler for a multi-instance activity

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -63,6 +63,9 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
       innerActivity.getInterruptingElementIds().clear();
 
+      // remove compensation boundary events from inner activity
+      innerActivity.getBoundaryEvents().removeIf(boundary -> boundary.getCompensation() != null);
+
       // attach incoming and outgoing sequence flows to the multi-instance body
       innerActivity.getIncoming().forEach(flow -> flow.setTarget(multiInstanceBody));
       innerActivity.getOutgoing().forEach(flow -> flow.setSource(multiInstanceBody));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/MultiInstanceActivityTransformer.java
@@ -63,8 +63,8 @@ public final class MultiInstanceActivityTransformer implements ModelElementTrans
 
       innerActivity.getInterruptingElementIds().clear();
 
-      // remove compensation boundary events from inner activity
-      innerActivity.getBoundaryEvents().removeIf(boundary -> boundary.getCompensation() != null);
+      // remove boundary events from inner activity
+      innerActivity.getBoundaryEvents().clear();
 
       // attach incoming and outgoing sequence flows to the multi-instance body
       innerActivity.getIncoming().forEach(flow -> flow.setTarget(multiInstanceBody));

--- a/zeebe/engine/src/test/resources/compensation/compensation-multi-instance-activity-parallel.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-multi-instance-activity-parallel.bpmn
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1705lk6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1lqxsls</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1lqxsls" sourceRef="StartEvent_1" targetRef="Gateway_057rfit" />
+    <bpmn:serviceTask id="CompensableActivity" name="A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="compensableActivity" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0uk38x8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0epiml1</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=for i in 1..3 return i" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+    </bpmn:serviceTask>
+    <bpmn:boundaryEvent id="Event_0jurki8" attachedToRef="CompensableActivity">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1sdgn4g" />
+    </bpmn:boundaryEvent>
+    <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="compensationHandler" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0epiml1" sourceRef="CompensableActivity" targetRef="Gateway_15v058v" />
+    <bpmn:endEvent id="Event_17vtu0h">
+      <bpmn:incoming>Flow_06h17kx</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0uk38x8" sourceRef="Gateway_057rfit" targetRef="CompensableActivity" />
+    <bpmn:parallelGateway id="Gateway_057rfit">
+      <bpmn:incoming>Flow_1lqxsls</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uk38x8</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1etz100</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_06h17kx" sourceRef="Gateway_15v058v" targetRef="Event_17vtu0h" />
+    <bpmn:parallelGateway id="Gateway_15v058v">
+      <bpmn:incoming>Flow_0epiml1</bpmn:incoming>
+      <bpmn:incoming>Flow_0lr56dp</bpmn:incoming>
+      <bpmn:outgoing>Flow_06h17kx</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1etz100" sourceRef="Gateway_057rfit" targetRef="Activity" />
+    <bpmn:serviceTask id="Activity" name="B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="activity" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1etz100</bpmn:incoming>
+      <bpmn:outgoing>Flow_0yhktm8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0yhktm8" sourceRef="Activity" targetRef="Event_0keghgb" />
+    <bpmn:intermediateThrowEvent id="Event_0keghgb">
+      <bpmn:incoming>Flow_0yhktm8</bpmn:incoming>
+      <bpmn:outgoing>Flow_0lr56dp</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_0cjxou7" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:sequenceFlow id="Flow_0lr56dp" sourceRef="Event_0keghgb" targetRef="Gateway_15v058v" />
+    <bpmn:association id="Association_05vn9eq" associationDirection="One" sourceRef="Event_0jurki8" targetRef="CompensationHandler" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="Activity_0sifzcx_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="340" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ykci7s_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="510" y="200" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_103hmmw_di" bpmnElement="Gateway_057rfit">
+        <dc:Bounds x="235" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_17vtu0h_di" bpmnElement="Event_17vtu0h">
+        <dc:Bounds x="852" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tukw21_di" bpmnElement="Gateway_15v058v">
+        <dc:Bounds x="705" y="92" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0nh3n9l_di" bpmnElement="Activity">
+        <dc:Bounds x="340" y="340" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1hp4hu6_di" bpmnElement="Event_0keghgb">
+        <dc:Bounds x="542" y="362" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_111hsdn_di" bpmnElement="Event_0jurki8">
+        <dc:Bounds x="422" y="139" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1lqxsls_di" bpmnElement="Flow_1lqxsls">
+        <di:waypoint x="188" y="117" />
+        <di:waypoint x="235" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0epiml1_di" bpmnElement="Flow_0epiml1">
+        <di:waypoint x="440" y="117" />
+        <di:waypoint x="705" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_05vn9eq_di" bpmnElement="Association_05vn9eq">
+        <di:waypoint x="440" y="175" />
+        <di:waypoint x="440" y="240" />
+        <di:waypoint x="510" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uk38x8_di" bpmnElement="Flow_0uk38x8">
+        <di:waypoint x="285" y="117" />
+        <di:waypoint x="340" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06h17kx_di" bpmnElement="Flow_06h17kx">
+        <di:waypoint x="755" y="117" />
+        <di:waypoint x="852" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1etz100_di" bpmnElement="Flow_1etz100">
+        <di:waypoint x="260" y="142" />
+        <di:waypoint x="260" y="380" />
+        <di:waypoint x="340" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yhktm8_di" bpmnElement="Flow_0yhktm8">
+        <di:waypoint x="440" y="380" />
+        <di:waypoint x="542" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lr56dp_di" bpmnElement="Flow_0lr56dp">
+        <di:waypoint x="578" y="380" />
+        <di:waypoint x="730" y="380" />
+        <di:waypoint x="730" y="142" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

When a process instance enters a compensation intermediate throw or end event, it triggers the compensation and invokes the compensation handlers of completed activities.

If an activity is a multi-instance activity or multi-instance subprocess, the compensation handler should be invoked once.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15152 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
