### PR TITLE
Validate date-time attributes in Zeebe REST

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ProblemException.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ProblemException.java
@@ -21,7 +21,7 @@ public class ProblemException extends ClientHttpException {
   private final ProblemDetail details;
 
   public ProblemException(final int code, final String reason, final ProblemDetail details) {
-    super(code, reason);
+    super(code, String.format("%s'. Details: '%s", reason, details));
     this.details = details;
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -324,10 +324,12 @@ components:
       properties:
         dueDate:
           type: string
+          format: date-time
           description: The due date of the task. Reset by providing an empty String.
           nullable: true
         followUpDate:
           type: string
+          format: date-time
           description: The follow-up date of the task. Reset by providing an empty String.
           nullable: true
         candidateUsers:

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -81,6 +81,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-webflux</artifactId>
     </dependency>
@@ -122,12 +127,6 @@
     </dependency>
 
     <!-- test dependencies -->
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-context</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -231,7 +231,7 @@
               <generatorName>spring</generatorName>
               <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
               <modelPackage>io.camunda.zeebe.gateway.protocol.rest</modelPackage>
-              <schemaMappings>ProblemDetail=org.springframework.http.ProblemDetail</schemaMappings>
+              <typeMappings>OffsetDateTime=String</typeMappings>
               <generateApis>false</generateApis>
               <generateSupportingFiles>false</generateSupportingFiles>
               <generateModels>true</generateModels>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/GlobalControllerExceptionHandler.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/GlobalControllerExceptionHandler.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import java.net.URI;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.ServerWebInputException;
+
+@ControllerAdvice(annotations = RestController.class)
+public class GlobalControllerExceptionHandler {
+
+  @ExceptionHandler(ServerWebInputException.class)
+  public ResponseEntity<ProblemDetail> handleServerWebInputExceptions(
+      final ServerWebInputException ex, final ServerWebExchange context) {
+    final ProblemDetail problemDetail = ProblemDetail.forStatus(ex.getStatusCode());
+    problemDetail.setTitle(ex.getReason());
+    if (ex.getCause() != null) {
+      problemDetail.setDetail(ex.getCause().getMessage());
+    } else {
+      problemDetail.setDetail(ex.getMessage());
+    }
+    problemDetail.setInstance(URI.create(context.getRequest().getPath().toString()));
+    return ResponseEntity.of(problemDetail).build();
+  }
+
+  @ExceptionHandler(Exception.class)
+  public ResponseEntity<ProblemDetail> handleAllExceptions(
+      final Exception ex, final ServerWebExchange context) {
+    final ProblemDetail problemDetail =
+        ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
+    problemDetail.setInstance(URI.create(context.getRequest().getPath().toString()));
+    return ResponseEntity.of(problemDetail).build();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
@@ -422,7 +422,7 @@ public class UserTaskControllerTest {
             "No update data provided. Provide at least an \"action\" or a non-null value "
                 + "for a supported attribute in the \"changeset\".");
     expectedBody.setTitle("INVALID_ARGUMENT");
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1"));
 
     // when / then
     webClient
@@ -451,12 +451,12 @@ public class UserTaskControllerTest {
             HttpStatus.BAD_REQUEST,
             "The provided due date 'foo' cannot be parsed as a date according to RFC 3339, section 5.6.");
     expectedBody.setTitle("INVALID_ARGUMENT");
-    expectedBody.setInstance(URI.create("/api/v1/user-tasks/1"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1"));
 
     // when / then
     webClient
         .patch()
-        .uri("api/v1/user-tasks/1")
+        .uri(USER_TASKS_BASE_URL + "/1")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .body(Mono.just(request), UserTaskUpdateRequest.class)
@@ -481,12 +481,12 @@ public class UserTaskControllerTest {
             HttpStatus.BAD_REQUEST,
             "The provided follow-up date 'foo' cannot be parsed as a date according to RFC 3339, section 5.6.");
     expectedBody.setTitle("INVALID_ARGUMENT");
-    expectedBody.setInstance(URI.create("/api/v1/user-tasks/1"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1"));
 
     // when / then
     webClient
         .patch()
-        .uri("api/v1/user-tasks/1")
+        .uri(USER_TASKS_BASE_URL + "/1")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .body(Mono.just(request), UserTaskUpdateRequest.class)
@@ -513,12 +513,12 @@ public class UserTaskControllerTest {
             "The provided due date 'bar' cannot be parsed as a date according to RFC 3339, section 5.6. "
                 + "The provided follow-up date 'foo' cannot be parsed as a date according to RFC 3339, section 5.6.");
     expectedBody.setTitle("INVALID_ARGUMENT");
-    expectedBody.setInstance(URI.create("/api/v1/user-tasks/1"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1"));
 
     // when / then
     webClient
         .patch()
-        .uri("api/v1/user-tasks/1")
+        .uri(USER_TASKS_BASE_URL + "/1")
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .body(Mono.just(request), UserTaskUpdateRequest.class)
@@ -546,7 +546,7 @@ public class UserTaskControllerTest {
             "No update data provided. Provide at least an \"action\" or a non-null value "
                 + "for a supported attribute in the \"changeset\".");
     expectedBody.setTitle("INVALID_ARGUMENT");
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1"));
 
     // when / then
     webClient
@@ -575,7 +575,7 @@ public class UserTaskControllerTest {
             "No update data provided. Provide at least an \"action\" or a non-null value "
                 + "for a supported attribute in the \"changeset\".");
     expectedBody.setTitle("INVALID_ARGUMENT");
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1"));
 
     // when / then
     webClient
@@ -615,7 +615,7 @@ public class UserTaskControllerTest {
             HttpStatus.NOT_FOUND,
             "Command 'COMPLETE' rejected with code 'NOT_FOUND': Task not found");
     expectedBody.setTitle("NOT_FOUND");
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1/completion"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1/completion"));
 
     // when / then
     webClient
@@ -660,7 +660,7 @@ public class UserTaskControllerTest {
             HttpStatus.CONFLICT,
             "Command 'COMPLETE' rejected with code 'INVALID_STATE': Task is not in state CREATED");
     expectedBody.setTitle("INVALID_STATE");
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1/completion"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1/completion"));
 
     // when / then
     webClient
@@ -705,7 +705,7 @@ public class UserTaskControllerTest {
             HttpStatus.BAD_REQUEST,
             "Command 'COMPLETE' rejected with code '" + rejectionType + "': Just an error");
     expectedBody.setTitle(rejectionType.name());
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1/completion"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1/completion"));
 
     // when / then
     webClient
@@ -750,7 +750,7 @@ public class UserTaskControllerTest {
             HttpStatus.INTERNAL_SERVER_ERROR,
             "Command 'COMPLETE' rejected with code '" + rejectionType + "': Just an error");
     expectedBody.setTitle(rejectionType.name());
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1/completion"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1/completion"));
 
     // when / then
     webClient
@@ -956,7 +956,7 @@ public class UserTaskControllerTest {
     final var expectedBody =
         ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "No assignee provided");
     expectedBody.setTitle("INVALID_ARGUMENT");
-    expectedBody.setInstance(URI.create("/v1/user-tasks/1/assignment"));
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1/assignment"));
 
     // when / then
     webClient


### PR DESCRIPTION
## Description

* Adds the `format: date-time` configuration to date properties in the OpenAPI description. This way, date properties can be properly handled by generated clients to fulfill the server's expectations.
* Validates the date-time attributes `dueDate` and `followUpDate` in the changeset
of the user task update request in the Zeebe REST API. Those attributes have to
be parseable as a date defined by [RFC 3339, section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6). Possible violations are accumulated and returned
as a joined `ProblemDetail`.
* Adds a `ControllerAdvice` to the Zeebe REST gateway to ensure that we
always return a `ProblemDetail` in case of exceptions.
* Uses the details of the provided `ProblemDetail` in the `ProblemException` to provide
more information to the caller.
* Verifies that the date-time attributes `dueDate` and `followUpDate` in the changeset
of the user task update request in the Zeebe REST API are parseable as a date defined by [RFC 3339, section 5.6](https://www.rfc-editor.org/rfc/rfc3339#section-5.6).
Ensure appropriate violations are issued if they cannot be parsed accordingly.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16734 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [x] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
