### PR TITLE
feat: enhance PI lifecycle to support Els

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -15,17 +15,23 @@
  */
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 
 public class ExecutionListenersValidator implements ModelElementValidator<ZeebeExecutionListeners> {
+
+  private static final Set<String> ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS =
+      Collections.singleton(BpmnModelConstants.BPMN_ELEMENT_SERVICE_TASK);
 
   @Override
   public Class<ZeebeExecutionListeners> getElementType() {
@@ -38,6 +44,29 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       final ValidationResultCollector validationResultCollector) {
     final Collection<ZeebeExecutionListener> executionListeners = element.getExecutionListeners();
     if (executionListeners == null || executionListeners.isEmpty()) {
+      return;
+    }
+
+    /*
+     * Temporary validation check to ensure execution listeners are only associated with supported
+     * BPMN elements.
+     *
+     * <p>Note: This validation is currently limited to specific BPMN elements that support
+     * execution listeners. As we extend the support for execution listeners across more BPMN
+     * elements, this check will be updated accordingly to reflect those changes. This is a
+     * transitional safeguard to ensure consistency and correctness in the model until full support
+     * is implemented.
+     *
+     * TODO: Review and update this validation as execution listener support is expanded to additional BPMN elements.
+     */
+    final String parentElementTypeName =
+        element.getParentElement().getParentElement().getElementType().getTypeName();
+    if (!ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS.contains(parentElementTypeName)) {
+      final String errorMessage =
+          String.format(
+              "Execution listeners are not supported for the '%s' element. Currently, only %s elements can have execution listeners.",
+              parentElementTypeName, ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS);
+      validationResultCollector.addError(0, errorMessage);
       return;
     }
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -62,6 +62,23 @@ public class ZeebeExecutionListenersValidationTest {
   }
 
   @Test
+  @DisplayName("validate execution listeners are supported only for specified BPMN elements")
+  void validateExecutionListenersSupportedOnlyForSpecifiedElements() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.readModelFromStream(
+            ReflectUtil.getResourceAsStream(
+                "io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.testElementThatNotSupportExecutionListeners.bpmn"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            ZeebeExecutionListeners.class,
+            "Execution listeners are not supported for the 'scriptTask' element. Currently, only [serviceTask] elements can have execution listeners."));
+  }
+
+  @Test
   @DisplayName(
       "element with ExecutionListeners defined with the same `type` but different `eventType`")
   void testExecutionListenersTheSameJobTypeButDifferentEventType() {

--- a/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.testElementThatNotSupportExecutionListeners.bpmn
+++ b/zeebe/bpmn-model/src/test/resources/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.testElementThatNotSupportExecutionListeners.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="definitions_7b2230cb-14cf-4977-8c8d-222b7e2def2e" targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <process id="process" isExecutable="true">
+    <startEvent id="start">
+      <outgoing>Flow_031kcs6</outgoing>
+    </startEvent>
+    <sequenceFlow id="Flow_031kcs6" sourceRef="start" targetRef="current_date_script_task" />
+    <scriptTask id="current_date_script_task">
+      <extensionElements>
+        <zeebe:script expression="=today()" resultVariable="currentDate" />
+        <zeebe:executionListeners>
+          <zeebe:executionListener eventType="start" type="task_start_el_1" retries="4" />
+          <zeebe:executionListener eventType="end" type="task_end_el_1" retries="5" />
+        </zeebe:executionListeners>
+      </extensionElements>
+      <incoming>Flow_031kcs6</incoming>
+      <outgoing>Flow_1gxaiqa</outgoing>
+    </scriptTask>
+    <intermediateThrowEvent id="end">
+      <incoming>Flow_1gxaiqa</incoming>
+    </intermediateThrowEvent>
+    <sequenceFlow id="Flow_1gxaiqa" sourceRef="current_date_script_task" targetRef="end" />
+  </process>
+  <message id="message_5c4c771e-735e-4349-8a9b-1577290cdf9a" name="dmk_message_name" />
+  <escalation id="Escalation_2940gmd" name="escalation_1" escalationCode="err1" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_02ffdc18-4c6d-499c-9a38-0bc5785566a6">
+    <bpmndi:BPMNPlane id="BPMNPlane_16481d31-0d02-4597-9118-0da47ee4ddc2" bpmnElement="process">
+      <bpmndi:BPMNShape id="Event_1u3mp0u_di" bpmnElement="start">
+        <dc:Bounds x="152" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gdqgrw_di" bpmnElement="current_date_script_task">
+        <dc:Bounds x="240" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_075uda6_di" bpmnElement="end">
+        <dc:Bounds x="392" y="112" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_031kcs6_di" bpmnElement="Flow_031kcs6">
+        <di:waypoint x="188" y="130" />
+        <di:waypoint x="240" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gxaiqa_di" bpmnElement="Flow_1gxaiqa">
+        <di:waypoint x="340" y="130" />
+        <di:waypoint x="392" y="130" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</definitions>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnElementProcessor.java
@@ -65,6 +65,21 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
   }
 
   /**
+   * Finalizes the activation of the BPMN element. This method is invoked after the element has been
+   * initialized and activated, ensuring that any additional steps required to fully establish the
+   * element's active state are completed.
+   *
+   * <p>This method is typically invoked after the processing of START Execution Listeners.
+   *
+   * @param element the instance of the BPMN element that is executed
+   * @param context process instance-related data of the element that is executed
+   * @return Either<Failure, ?> indicating the outcome of the finalize activation attempt
+   */
+  default Either<Failure, ?> finalizeActivation(final T element, final BpmnElementContext context) {
+    return SUCCESS;
+  }
+
+  /**
    * The element is going to be left. Perform every action to leave the element and continue with
    * the next element.
    *
@@ -89,6 +104,20 @@ public interface BpmnElementProcessor<T extends ExecutableFlowElement> {
    * @return Either<Failure, ?> indicating the outcome of the completion attempt
    */
   default Either<Failure, ?> onComplete(final T element, final BpmnElementContext context) {
+    return SUCCESS;
+  }
+
+  /**
+   * Finalizes the completion of the BPMN element. This method is called when the element has
+   * finished executing its main behavior and is ready to transition to a completed state.
+   *
+   * <p>This method is typically invoked after the processing of END Execution Listeners.
+   *
+   * @param element the instance of the BPMN element that is executed
+   * @param context process instance-related data of the element that is executed
+   * @return Either<Failure, ?> indicating the outcome of the finalize completion attempt
+   */
+  default Either<Failure, ?> finalizeCompletion(final T element, final BpmnElementContext context) {
     return SUCCESS;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -7,20 +7,23 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn;
 
-import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
-import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.COMPLETE_ELEMENT;
-import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.TERMINATE_ELEMENT;
-
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnIncidentBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobBehavior;
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateTransitionBehavior;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutionListener;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
+import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
@@ -30,7 +33,12 @@ import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.slf4j.Logger;
 
 public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessInstanceRecord> {
@@ -45,6 +53,11 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
   private final BpmnStateTransitionBehavior stateTransitionBehavior;
   private final TypedRejectionWriter rejectionWriter;
   private final BpmnIncidentBehavior incidentBehavior;
+  private final BpmnStateBehavior stateBehavior;
+  private final BpmnJobBehavior jobBehavior;
+  private final EventTriggerBehavior eventTriggerBehavior;
+  private final VariableBehavior variableBehavior;
+  private final EventScopeInstanceState eventScopeInstanceState;
 
   public BpmnStreamProcessor(
       final BpmnBehaviors bpmnBehaviors,
@@ -64,6 +77,11 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
             this::getContainerProcessor,
             writers);
     processors = new BpmnElementProcessors(bpmnBehaviors, stateTransitionBehavior);
+    stateBehavior = bpmnBehaviors.stateBehavior();
+    jobBehavior = bpmnBehaviors.jobBehavior();
+    eventTriggerBehavior = bpmnBehaviors.eventTriggerBehavior();
+    variableBehavior = bpmnBehaviors.variableBehavior();
+    eventScopeInstanceState = processingState.getEventScopeInstanceState();
   }
 
   private BpmnElementContainerProcessor<ExecutableFlowElement> getContainerProcessor(
@@ -141,17 +159,34 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
         stateTransitionBehavior
             .onElementActivating(element, activatingContext)
             .flatMap(ok -> processor.onActivate(element, activatingContext))
+            .flatMap(ok -> afterActivating(element, processor, activatingContext))
             .ifLeft(failure -> incidentBehavior.createIncident(failure, activatingContext));
         break;
       case COMPLETE_ELEMENT:
         final var completingContext = stateTransitionBehavior.transitionToCompleting(context);
         processor
             .onComplete(element, completingContext)
+            .flatMap(ok -> afterCompleting(element, processor, completingContext))
             .ifLeft(failure -> incidentBehavior.createIncident(failure, completingContext));
         break;
       case TERMINATE_ELEMENT:
         final var terminatingContext = stateTransitionBehavior.transitionToTerminating(context);
         processor.onTerminate(element, terminatingContext);
+        break;
+      case COMPLETE_EXECUTION_LISTENER:
+        final ProcessInstanceIntent elementState =
+            stateBehavior.getElementInstance(context).getState();
+        switch (elementState) {
+          case ELEMENT_ACTIVATING ->
+              onStartExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
+                  .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+          case ELEMENT_COMPLETING ->
+              onEndExecutionListenerComplete((ExecutableFlowNode) element, processor, context)
+                  .ifLeft(failure -> incidentBehavior.createIncident(failure, context));
+          default ->
+              throw new BpmnProcessingException(
+                  context, String.format("Unexpected element state: '%s'", elementState));
+        }
         break;
       default:
         throw new BpmnProcessingException(
@@ -160,6 +195,139 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
                 "Expected the processor '%s' to handle the event but the intent '%s' is not supported",
                 processor.getClass(), intent));
     }
+  }
+
+  private Either<Failure, ?> afterActivating(
+      final ExecutableFlowElement element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    return processElementWithListeners(
+        element,
+        context,
+        ExecutableFlowNode::getStartExecutionListeners,
+        processor::finalizeActivation);
+  }
+
+  private Either<Failure, ?> afterCompleting(
+      final ExecutableFlowElement element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    return processElementWithListeners(
+        element,
+        context,
+        ExecutableFlowNode::getEndExecutionListeners,
+        processor::finalizeCompletion);
+  }
+
+  private Either<Failure, ?> processElementWithListeners(
+      final ExecutableFlowElement element,
+      final BpmnElementContext context,
+      final Function<ExecutableFlowNode, List<ExecutionListener>> listenersGetter,
+      final BiFunction<ExecutableFlowElement, BpmnElementContext, Either<Failure, ?>> finalizer) {
+
+    if (!(element instanceof final ExecutableFlowNode node)) {
+      // other elements, like sequence flows, do not have execution listeners
+      // assume that the element is activated already
+      return BpmnElementProcessor.SUCCESS;
+    }
+
+    final List<ExecutionListener> listeners = listenersGetter.apply(node);
+    if (listeners.isEmpty()) {
+      return finalizer.apply(element, context);
+    }
+
+    return createExecutionListenerJob(element, context, listeners.getFirst());
+  }
+
+  private Either<Failure, ?> createExecutionListenerJob(
+      final ExecutableFlowElement element,
+      final BpmnElementContext context,
+      final ExecutionListener listener) {
+    return jobBehavior
+        .evaluateJobExpressions(listener.getJobWorkerProperties(), context)
+        .thenDo(
+            elJobProperties ->
+                jobBehavior.createNewExecutionListenerJob(context, element, elJobProperties));
+  }
+
+  public Either<Failure, ?> onStartExecutionListenerComplete(
+      final ExecutableFlowNode element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    mergeVariablesOfExecutionListener(context, true);
+    return onExecutionListenerComplete(
+        element,
+        context,
+        ExecutableFlowNode::getStartExecutionListeners,
+        processor::finalizeActivation);
+  }
+
+  public Either<Failure, ?> onEndExecutionListenerComplete(
+      final ExecutableFlowNode element,
+      final BpmnElementProcessor<ExecutableFlowElement> processor,
+      final BpmnElementContext context) {
+    mergeVariablesOfExecutionListener(context, false);
+    return onExecutionListenerComplete(
+        element,
+        context,
+        ExecutableFlowNode::getEndExecutionListeners,
+        processor::finalizeCompletion);
+  }
+
+  private Either<Failure, ?> onExecutionListenerComplete(
+      final ExecutableFlowNode element,
+      final BpmnElementContext context,
+      final Function<ExecutableFlowNode, List<ExecutionListener>> listenersGetter,
+      final BiFunction<ExecutableFlowElement, BpmnElementContext, Either<Failure, ?>> finalizer) {
+
+    final String currentListenerType =
+        stateBehavior.getElementInstance(context).getExecutionListenerType();
+
+    final List<ExecutionListener> listeners = listenersGetter.apply(element);
+
+    final Optional<ExecutionListener> nextListener =
+        findNextExecutionListener(listeners, currentListenerType);
+    return nextListener.isPresent()
+        ? createExecutionListenerJob(element, context, nextListener.get())
+        : finalizer.apply(element, context);
+  }
+
+  private void mergeVariablesOfExecutionListener(
+      final BpmnElementContext context, final boolean local) {
+    Optional.ofNullable(eventScopeInstanceState.peekEventTrigger(context.getElementInstanceKey()))
+        .ifPresent(
+            eventTrigger -> {
+              if (eventTrigger.getVariables().capacity() > 0) {
+                final long scopeKey =
+                    local || context.getFlowScopeKey() <= 0
+                        ? context.getElementInstanceKey()
+                        : context.getFlowScopeKey();
+
+                variableBehavior.mergeLocalDocument(
+                    scopeKey,
+                    context.getProcessDefinitionKey(),
+                    context.getProcessInstanceKey(),
+                    context.getBpmnProcessId(),
+                    context.getTenantId(),
+                    eventTrigger.getVariables());
+              }
+
+              eventTriggerBehavior.processEventTriggered(
+                  eventTrigger.getEventKey(),
+                  context.getProcessDefinitionKey(),
+                  eventTrigger.getProcessInstanceKey(),
+                  context.getTenantId(),
+                  context.getElementInstanceKey(),
+                  eventTrigger.getElementId());
+            });
+  }
+
+  private Optional<ExecutionListener> findNextExecutionListener(
+      final List<ExecutionListener> listeners, final String currentType) {
+    return listeners.stream()
+        .dropWhile(el -> !el.getJobWorkerProperties().getType().getExpression().equals(currentType))
+        .skip(1) // skip current listener
+        .findFirst();
   }
 
   private ExecutableFlowElement getElement(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -64,6 +64,11 @@ public final class ProcessInstanceStateTransitionGuard {
               ProcessInstanceIntent.ELEMENT_ACTIVATING,
               ProcessInstanceIntent.ELEMENT_ACTIVATED,
               ProcessInstanceIntent.ELEMENT_COMPLETING);
+      case COMPLETE_EXECUTION_LISTENER ->
+          hasElementInstanceWithState(
+              context,
+              ProcessInstanceIntent.ELEMENT_ACTIVATING,
+              ProcessInstanceIntent.ELEMENT_COMPLETING);
       default ->
           Either.left(
               String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -96,7 +96,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);
 
     variableMappingBehavior =
-        new BpmnVariableMappingBehavior(expressionBehavior, processingState, variableBehavior);
+        new BpmnVariableMappingBehavior(
+            expressionBehavior, processingState, variableBehavior, eventTriggerBehavior);
 
     eventSubscriptionBehavior =
         new BpmnEventSubscriptionBehavior(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnVariableMappingBehavior.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
@@ -32,15 +33,19 @@ public final class BpmnVariableMappingBehavior {
   private final VariableBehavior variableBehavior;
   private final EventScopeInstanceState eventScopeInstanceState;
 
+  private final EventTriggerBehavior eventTriggerBehavior;
+
   public BpmnVariableMappingBehavior(
       final ExpressionProcessor expressionProcessor,
       final ProcessingState processingState,
-      final VariableBehavior variableBehavior) {
+      final VariableBehavior variableBehavior,
+      final EventTriggerBehavior eventTriggerBehavior) {
     this.expressionProcessor = expressionProcessor;
     elementInstanceState = processingState.getElementInstanceState();
     variablesState = processingState.getVariableState();
     this.variableBehavior = variableBehavior;
     eventScopeInstanceState = processingState.getEventScopeInstanceState();
+    this.eventTriggerBehavior = eventTriggerBehavior;
   }
 
   /**
@@ -100,6 +105,14 @@ public final class BpmnVariableMappingBehavior {
     if (eventTrigger != null) {
       variables = eventTrigger.getVariables();
       hasVariables = variables.capacity() > 0;
+
+      eventTriggerBehavior.processEventTriggered(
+          eventTrigger.getEventKey(),
+          processDefinitionKey,
+          processInstanceKey,
+          context.getTenantId(),
+          elementInstanceKey,
+          element.getId());
     }
 
     if (outputMappingExpression.isPresent()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -193,7 +193,9 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
         final ExecutableEndEvent element, final BpmnElementContext activating) {
       return variableMappingBehavior
           .applyInputMappings(activating, element)
-          .flatMap(ok -> jobBehavior.evaluateJobExpressions(element, activating))
+          .flatMap(
+              ok ->
+                  jobBehavior.evaluateJobExpressions(element.getJobWorkerProperties(), activating))
           .thenDo(
               jobProperties -> {
                 jobBehavior.createNewJob(activating, element, jobProperties);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -161,7 +161,10 @@ public class IntermediateThrowEventProcessor
           ? SUCCESS
           : variableMappingBehavior
               .applyInputMappings(activating, element)
-              .flatMap(ok -> jobBehavior.evaluateJobExpressions(element, activating))
+              .flatMap(
+                  ok ->
+                      jobBehavior.evaluateJobExpressions(
+                          element.getJobWorkerProperties(), activating))
               .thenDo(
                   jobProperties -> {
                     jobBehavior.createNewJob(activating, element, jobProperties);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskSupportingProcessor.java
@@ -34,10 +34,24 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
   }
 
   @Override
+  public Either<Failure, ?> finalizeActivation(final T element, final BpmnElementContext context) {
+    return isJobBehavior(element, context)
+        ? delegate.finalizeActivation(element, context)
+        : onFinalizeActivationInternal(element, context);
+  }
+
+  @Override
   public Either<Failure, ?> onComplete(final T element, final BpmnElementContext context) {
     return isJobBehavior(element, context)
         ? delegate.onComplete(element, context)
         : onCompleteInternal(element, context);
+  }
+
+  @Override
+  public Either<Failure, ?> finalizeCompletion(final T element, final BpmnElementContext context) {
+    return isJobBehavior(element, context)
+        ? delegate.finalizeCompletion(element, context)
+        : onFinalizeCompletionInternal(element, context);
   }
 
   @Override
@@ -54,8 +68,18 @@ public abstract class JobWorkerTaskSupportingProcessor<T extends ExecutableJobWo
   protected abstract Either<Failure, ?> onActivateInternal(
       final T element, final BpmnElementContext context);
 
+  protected Either<Failure, ?> onFinalizeActivationInternal(
+      final T element, final BpmnElementContext context) {
+    return SUCCESS;
+  }
+
   protected abstract Either<Failure, ?> onCompleteInternal(
       final T element, final BpmnElementContext context);
+
+  protected Either<Failure, ?> onFinalizeCompletionInternal(
+      final T element, final BpmnElementContext context) {
+    return SUCCESS;
+  }
 
   protected abstract void onTerminateInternal(final T element, final BpmnElementContext context);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 
 final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
@@ -34,6 +35,10 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
       final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
       if (elementInstance != null) {
+        if (value.getJobKind() == JobKind.EXECUTION_LISTENER) {
+          elementInstance.setExecutionListenerType(value.getType());
+        }
+
         elementInstance.setJobKey(key);
         elementInstanceState.updateInstance(elementInstance);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public final class ElementInstance extends UnpackedObject implements DbValue {
@@ -40,9 +41,11 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final IntegerProperty activeSequenceFlowsProp =
       new IntegerProperty("activeSequenceFlows", 0);
   private final LongProperty userTaskKeyProp = new LongProperty("userTaskKey", -1L);
+  private final StringProperty executionListenerTypeProp =
+      new StringProperty("executionListenerType", "");
 
   public ElementInstance() {
-    super(12);
+    super(13);
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(childActivatedCountProp)
@@ -54,7 +57,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(calledChildInstanceKeyProp)
         .declareProperty(recordProp)
         .declareProperty(activeSequenceFlowsProp)
-        .declareProperty(userTaskKeyProp);
+        .declareProperty(userTaskKeyProp)
+        .declareProperty(executionListenerTypeProp);
   }
 
   public ElementInstance(
@@ -229,5 +233,13 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
 
   public void setUserTaskKey(final long userTaskKey) {
     userTaskKeyProp.setValue(userTaskKey);
+  }
+
+  public String getExecutionListenerType() {
+    return BufferUtil.bufferAsString(executionListenerTypeProp.getValue());
+  }
+
+  public void setExecutionListenerType(final String executionListenerType) {
+    executionListenerTypeProp.setValue(executionListenerType);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerJobTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerJobTest.java
@@ -1,0 +1,653 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static io.camunda.zeebe.protocol.record.intent.JobIntent.FAILED;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
+import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
+import io.camunda.zeebe.test.util.record.ProcessInstanceRecordStream;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ExecutionListenerJobTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  private static final String PROCESS_ID = "process";
+  private static final String SERVICE_TASK_TYPE = "test_service_task";
+  private static final String START_EL_TYPE = "start_execution_listener";
+  private static final String END_EL_TYPE = "end_execution_listener";
+
+  private static final BpmnModelInstance SIMPLE_PROCESS =
+      Bpmn.createExecutableProcess(PROCESS_ID)
+          .startEvent()
+          .serviceTask(
+              "task",
+              t -> t.zeebeJobType(SERVICE_TASK_TYPE).zeebeStartExecutionListener(START_EL_TYPE))
+          .endEvent()
+          .done();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldCompleteServiceTaskWithExecutionListeners() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+            .zeebeStartExecutionListener(START_EL_TYPE + "_1")
+            .zeebeStartExecutionListener(START_EL_TYPE + "_2")
+            .zeebeEndExecutionListener(END_EL_TYPE)
+            .endEvent()
+            .done();
+    // when
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    verifyJobCreationThenComplete(
+        processInstanceKey, 0, START_EL_TYPE + "_1", JobKind.EXECUTION_LISTENER);
+    verifyJobCreationThenComplete(
+        processInstanceKey, 1, START_EL_TYPE + "_2", JobKind.EXECUTION_LISTENER);
+    verifyJobCreationThenComplete(processInstanceKey, 2, SERVICE_TASK_TYPE, JobKind.BPMN_ELEMENT);
+    verifyJobCreationThenComplete(processInstanceKey, 3, END_EL_TYPE, JobKind.EXECUTION_LISTENER);
+
+    final ProcessInstanceRecordStream processInstanceRecordStream =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .limitToProcessInstanceCompleted();
+    assertThat(processInstanceRecordStream)
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_ELEMENT),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldRetryExecutionListener() {
+    // given
+    ENGINE.deployment().withXmlResource(SIMPLE_PROCESS).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).withRetries(1).fail();
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+
+    // then: service task job should be created
+    assertJobState(
+        processInstanceKey, 1, SERVICE_TASK_TYPE, JobIntent.CREATED, JobKind.BPMN_ELEMENT);
+  }
+
+  @Test
+  public void shouldCreateIncidentForExecutionListenerWhenNoRetriesLeft() {
+    // given
+    ENGINE.deployment().withXmlResource(SIMPLE_PROCESS).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: fail EL[start] job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).withRetries(0).fail();
+
+    // then
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
+        .hasErrorMessage("No more retries left.");
+
+    // resolve incident & complete EL[start] job
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+
+    // then: service task job should be created
+    assertJobState(
+        processInstanceKey, 1, SERVICE_TASK_TYPE, JobIntent.CREATED, JobKind.BPMN_ELEMENT);
+  }
+
+  @Test
+  public void shouldProceedWithRemainingExecutionListenersAfterResolvingIncidentForEndEL() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeEndExecutionListener(END_EL_TYPE + "_1")
+                        .zeebeEndExecutionListener(END_EL_TYPE + "_2")
+                        .zeebeEndExecutionListener(END_EL_TYPE + "_3"))
+            .endEvent("end")
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // complete EL[start], service task, and 1st EL[end] jobs
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_1").complete();
+
+    // when: fail 2nd EL[end] job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_2").withRetries(0).fail();
+
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
+        .hasErrorMessage("No more retries left.");
+
+    // and: resolve incident & complete 2nd EL[end] job
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_2").complete();
+
+    // then: 3rd EL[end] job should be created
+    assertJobState(
+        processInstanceKey, 4, END_EL_TYPE + "_3", JobIntent.CREATED, JobKind.EXECUTION_LISTENER);
+  }
+
+  @Test
+  public void
+      shouldCreateIncidentDuringEvaluatingServiceTaskInputMappingsAndResumeWithStartELsAfterResolving() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeInputExpression("assert(some_var, some_var != null)", "o_var_1")
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeEndExecutionListener(END_EL_TYPE))
+            .endEvent("end")
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then: incident created
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
+        .hasErrorMessage(
+            """
+                Assertion failure on evaluate the expression '{o_var_1:assert(some_var, some_var != null)}': \
+                The condition is not fulfilled The evaluation reported the following warnings:
+                [NO_VARIABLE_FOUND] No variable found with name 'some_var'
+                [NO_VARIABLE_FOUND] No variable found with name 'some_var'
+                [ASSERT_FAILURE] The condition is not fulfilled""");
+
+    // fix issue with missing `some_var` variable
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("some_var", "foo_bar"))
+        .update();
+    // resolve incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then: job for the 1st EL[start] should be created
+    verifyJobCreationThenComplete(processInstanceKey, 0, START_EL_TYPE, JobKind.EXECUTION_LISTENER);
+    verifyJobCreationThenComplete(processInstanceKey, 1, SERVICE_TASK_TYPE, JobKind.BPMN_ELEMENT);
+    verifyJobCreationThenComplete(processInstanceKey, 2, END_EL_TYPE, JobKind.EXECUTION_LISTENER);
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void
+      shouldCreateIncidentDuringEvaluatingServiceTaskOutputMappingsAndResumeWithEndELsAfterResolving() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeOutputExpression("assert(some_var, some_var != null)", "o_var_1")
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeEndExecutionListener(END_EL_TYPE))
+            .endEvent("end")
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // complete EL[start] and service task jobs
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+
+    // then
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.IO_MAPPING_ERROR)
+        .hasErrorMessage(
+            """
+                Assertion failure on evaluate the expression '{o_var_1:assert(some_var, some_var != null)}': \
+                The condition is not fulfilled The evaluation reported the following warnings:
+                [NO_VARIABLE_FOUND] No variable found with name 'some_var'
+                [NO_VARIABLE_FOUND] No variable found with name 'some_var'
+                [ASSERT_FAILURE] The condition is not fulfilled""");
+
+    // fix issue with missing `some_var` variable
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("some_var", "foo_bar"))
+        .update();
+
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // job for EL[end] should be created
+    verifyJobCreationThenComplete(processInstanceKey, 2, END_EL_TYPE, JobKind.EXECUTION_LISTENER);
+  }
+
+  @Test
+  public void
+      shouldCreateIncidentWhenCorrelationKeyNotProvidedBeforeProcessingTaskWithMessageBoundaryEvent() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeEndExecutionListener(END_EL_TYPE))
+            .boundaryEvent("boundary_event")
+            .message(b -> b.name("service_task_event").zeebeCorrelationKeyExpression("order_id"))
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: complete EL[start] job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+    final Record<IncidentRecordValue> firstIncident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .skip(0)
+            .getFirst();
+
+    // then: incident created
+    Assertions.assertThat(firstIncident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Failed to extract the correlation key for 'order_id': The value must be either a string or a number, but was 'NULL'. "
+                + "The evaluation reported the following warnings:\n"
+                + "[NO_VARIABLE_FOUND] No variable found with name 'order_id'");
+
+    // fix issue with missing `correlationKey` variable
+    ENGINE.variables().ofScope(processInstanceKey).withDocument(Map.of("order_id", 123)).update();
+
+    // resolve incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(firstIncident.getKey()).resolve();
+
+    // complete EL[start] job again
+    completeJobByType(processInstanceKey, START_EL_TYPE, 1);
+
+    // Job for service task should be created
+    verifyJobCreationThenComplete(processInstanceKey, 2, SERVICE_TASK_TYPE, JobKind.BPMN_ELEMENT);
+
+    // job for EL[end] should be created
+    assertJobState(
+        processInstanceKey, 3, END_EL_TYPE, JobIntent.CREATED, JobKind.EXECUTION_LISTENER);
+  }
+
+  @Test
+  public void shouldCreateIncidentWhenServiceTaskWithExecutionListenersFailed() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeEndExecutionListener(END_EL_TYPE))
+            .endEvent("end")
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: complete EL[start] job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+    // fail service task job
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).withRetries(0).fail();
+
+    final Record<IncidentRecordValue> firstIncident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    // and: resolve first incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(firstIncident.getKey()).resolve();
+    // complete service task job (NO need to re-complete EL[start] job(s))
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+
+    // then: EL[end] created
+    assertJobState(
+        processInstanceKey, 2, END_EL_TYPE, JobIntent.CREATED, JobKind.EXECUTION_LISTENER);
+  }
+
+  @Test
+  public void shouldRecurFailedExecutionListenerJobAfterBackoff() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t -> t.zeebeJobType(SERVICE_TASK_TYPE).zeebeStartExecutionListener(START_EL_TYPE))
+            .endEvent("end")
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: fail service task job
+    final Duration backOff = Duration.ofMinutes(30);
+    final Record<JobRecordValue> failedStartElJobRecord =
+        ENGINE
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(START_EL_TYPE)
+            .withBackOff(backOff)
+            .withRetries(2)
+            .fail();
+
+    Assertions.assertThat(failedStartElJobRecord).hasRecordType(RecordType.EVENT).hasIntent(FAILED);
+
+    ENGINE.increaseTime(backOff);
+
+    // verify that our job recurred after backoff
+    final Record<JobRecordValue> recurredJob =
+        jobRecords(JobIntent.RECURRED_AFTER_BACKOFF).withType(START_EL_TYPE).getFirst();
+    assertThat(recurredJob.getKey()).isEqualTo(failedStartElJobRecord.getKey());
+
+    // when: complete recreated job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+
+    // job for service task should be created
+    assertJobState(
+        processInstanceKey, 1, SERVICE_TASK_TYPE, JobIntent.CREATED, JobKind.BPMN_ELEMENT);
+  }
+
+  @Test
+  public void
+      shouldReCreateFirstElJobAfterResolvingIncidentCreatedDuringResolvingServiceJobExpressions() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent("start")
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobTypeExpression("=service_task_job_name_var + \"_type\"")
+                        .zeebeStartExecutionListener(START_EL_TYPE))
+            .endEvent("end")
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: complete EL[start] job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+
+    // an incident is created due to the unresolved job type expression in the service task
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+               Expected result of the expression 'service_task_job_name_var + "_type"' to be \
+               'STRING', but was 'NULL'. The evaluation reported the following warnings:
+               [NO_VARIABLE_FOUND] No variable found with name 'service_task_job_name_var'
+               [INVALID_TYPE] Can't add '"_type"' to 'null'""");
+
+    // and: resolve incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then: the first EL[start] job is re-created
+    assertJobState(
+        processInstanceKey, 1, START_EL_TYPE, JobIntent.CREATED, JobKind.EXECUTION_LISTENER);
+  }
+
+  @Test
+  public void shouldAccessJobVariablesInEndListener() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .endEvent()
+                .done())
+        .deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .withVariable("x", 1)
+        .complete();
+
+    // then
+    final Optional<JobRecordValue> jobActivated =
+        ENGINE.jobs().withType(END_EL_TYPE).activate().getValue().getJobs().stream()
+            .filter(job -> job.getProcessInstanceKey() == processInstanceKey)
+            .findFirst();
+
+    assertThat(jobActivated).isPresent();
+    assertThat(jobActivated.get().getVariables()).contains(entry("x", 1));
+  }
+
+  @Test
+  public void shouldCompleteExecutionListenerJobWithVariablesMerging() {
+    // given: a simple process with a service task and execution listeners
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .zeebeOutput("=\"aValue\"", "startEventVar")
+            .serviceTask(
+                "serviceTask",
+                t ->
+                    t.zeebeJobType(SERVICE_TASK_TYPE)
+                        .zeebeStartExecutionListener(START_EL_TYPE)
+                        .zeebeEndExecutionListener(END_EL_TYPE + "_1")
+                        .zeebeEndExecutionListener(END_EL_TYPE + "_2"))
+            .zeebeInput("=\"bValue\"", "serviceTaskVar")
+            .zeebeOutput("=startEventVar + \"+\" + serviceTaskVar", "mergedVars")
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // Validate initial variable creation
+    assertVariable(processInstanceKey, VariableIntent.CREATED, "startEventVar", "\"aValue\"");
+    assertVariable(processInstanceKey, VariableIntent.CREATED, "serviceTaskVar", "\"bValue\"");
+
+    // when: Completing the start execution listener job with new variables
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(START_EL_TYPE)
+        .withVariables(
+            Map.of("newVarFromStartListener", "cValue", "serviceTaskVar", "bValueUpdated"))
+        .complete();
+
+    // then: Validate variables updated or created by the start execution listener
+    assertVariable(
+        processInstanceKey, VariableIntent.UPDATED, "serviceTaskVar", "\"bValueUpdated\"");
+    assertVariable(
+        processInstanceKey, VariableIntent.CREATED, "newVarFromStartListener", "\"cValue\"");
+
+    // when: Completing the service task job
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+
+    // and: Completing the first EL[end] job with updated start event variable
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(END_EL_TYPE + "_1")
+        .withVariable("startEventVar", "aValueUpdated")
+        .complete();
+
+    // then: Validate start event variable updated by the end execution listener
+    assertVariable(
+        processInstanceKey, VariableIntent.UPDATED, "startEventVar", "\"aValueUpdated\"");
+
+    // when: Completing the second end execution listener job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_2").complete();
+
+    // then: Validate merged variables after all listeners and tasks are completed
+    assertVariable(
+        processInstanceKey, VariableIntent.CREATED, "mergedVars", "\"aValue+bValueUpdated\"");
+  }
+
+  private static void completeJobByType(
+      final long processInstanceKey, final String jobType, final int jobIndex) {
+    final long jobKey =
+        RecordingExporter.jobRecords(JobIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withType(jobType)
+            .skip(jobIndex)
+            .getFirst()
+            .getKey();
+    ENGINE.job().ofInstance(processInstanceKey).withKey(jobKey).complete();
+  }
+
+  private void assertVariable(
+      final long processInstanceKey,
+      final VariableIntent intent,
+      final String varName,
+      final String expectedVarValue) {
+    final Record<VariableRecordValue> variableRecordValueRecord =
+        RecordingExporter.variableRecords(intent)
+            .withProcessInstanceKey(processInstanceKey)
+            .withName(varName)
+            .getFirst();
+
+    Assertions.assertThat(variableRecordValueRecord.getValue())
+        .hasName(varName)
+        .hasValue(expectedVarValue);
+  }
+
+  private void assertJobState(
+      final long processInstanceKey,
+      final long jobIndex,
+      final String expectedJobType,
+      final JobIntent expectedJobIntent,
+      final JobKind expectedJobKind) {
+    final Record<ProcessInstanceRecordValue> activatingJob =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .getFirst();
+
+    final Record<JobRecordValue> jobRecord =
+        RecordingExporter.jobRecords(expectedJobIntent)
+            .withProcessInstanceKey(processInstanceKey)
+            .skip(jobIndex)
+            .getFirst();
+
+    Assertions.assertThat(jobRecord.getValue())
+        .hasElementInstanceKey(activatingJob.getKey())
+        .hasElementId(activatingJob.getValue().getElementId())
+        .hasProcessDefinitionKey(activatingJob.getValue().getProcessDefinitionKey())
+        .hasBpmnProcessId(activatingJob.getValue().getBpmnProcessId())
+        .hasProcessDefinitionVersion(activatingJob.getValue().getVersion())
+        .hasJobKind(expectedJobKind)
+        .hasType(expectedJobType);
+  }
+
+  private void verifyJobCreationThenComplete(
+      final long processInstanceKey,
+      final long jobIndex,
+      final String jobType,
+      final JobKind jobKind) {
+    // given: assert job created
+    assertJobState(processInstanceKey, jobIndex, jobType, JobIntent.CREATED, jobKind);
+
+    // when: complete job
+    ENGINE.job().ofInstance(processInstanceKey).withType(jobType).complete();
+
+    // then: assert job completed
+    assertJobState(processInstanceKey, jobIndex, jobType, JobIntent.COMPLETED, jobKind);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceIntent.java
@@ -34,11 +34,14 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
   COMPLETE_ELEMENT((short) 9),
   TERMINATE_ELEMENT((short) 10),
 
-  ELEMENT_MIGRATED((short) 11);
+  ELEMENT_MIGRATED((short) 11),
+
+  COMPLETE_EXECUTION_LISTENER((short) 12);
 
   private static final Set<ProcessInstanceIntent> PROCESS_INSTANCE_COMMANDS = EnumSet.of(CANCEL);
   private static final Set<ProcessInstanceIntent> BPMN_ELEMENT_COMMANDS =
-      EnumSet.of(ACTIVATE_ELEMENT, COMPLETE_ELEMENT, TERMINATE_ELEMENT);
+      EnumSet.of(
+          ACTIVATE_ELEMENT, COMPLETE_ELEMENT, TERMINATE_ELEMENT, COMPLETE_EXECUTION_LISTENER);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -82,6 +85,8 @@ public enum ProcessInstanceIntent implements ProcessInstanceRelatedIntent {
         return TERMINATE_ELEMENT;
       case 11:
         return ELEMENT_MIGRATED;
+      case 12:
+        return COMPLETE_EXECUTION_LISTENER;
       default:
         return Intent.UNKNOWN;
     }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ExecutionListenerJobTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ExecutionListenerJobTest.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.it.util.RecordingJobHandler;
+import io.camunda.zeebe.it.util.ZeebeAssertHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class ExecutionListenerJobTest {
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldCompleteFirstExecutionListenerJobWithoutVariables() {
+    // given
+    final String startElJobType = helper.getStartExecutionListenerType();
+    final String serviceTaskJobType = helper.getJobType();
+
+    // create model with one EL[start]
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(serviceTaskJobType)
+                        .zeebeStartExecutionListener(startElJobType)
+                        .zeebeEndExecutionListener(helper.getEndExecutionListenerType()))
+            .done();
+    final long processDefinitionKey = CLIENT_RULE.deployProcess(modelInstance);
+    CLIENT_RULE.createProcessInstance(processDefinitionKey, "{}");
+
+    final RecordingJobHandler elJobHandler = new RecordingJobHandler();
+    CLIENT_RULE.getClient().newWorker().jobType(startElJobType).handler(elJobHandler).open();
+
+    waitUntil(() -> !elJobHandler.getHandledJobs().isEmpty());
+
+    final ActivatedJob elJobEvent = elJobHandler.getHandledJobs().getFirst();
+    final long elJobKey = elJobEvent.getKey();
+
+    // when
+    CLIENT_RULE.getClient().newCompleteCommand(elJobKey).send().join();
+
+    // then: EL[start] job completed
+    ZeebeAssertHelper.assertJobCompleted(
+        startElJobType, (job) -> assertThat(job.getVariables()).isEmpty());
+
+    // service task job created
+    ZeebeAssertHelper.assertJobCreated(
+        serviceTaskJobType, (job) -> assertThat(job.getVariables()).isEmpty());
+  }
+
+  @Test
+  public void shouldCompleteFirstExecutionListenerJobWithVariablesAndNextElShouldAccessThem() {
+    // given
+    final String firstStartElJobType = helper.getStartExecutionListenerType().concat("-1");
+    final String secondStartElJobType = helper.getStartExecutionListenerType().concat("-2");
+    final String serviceTaskJobType = helper.getJobType();
+
+    // create model with 2 EL[start]
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .serviceTask(
+                "task",
+                t ->
+                    t.zeebeJobType(serviceTaskJobType)
+                        .zeebeStartExecutionListener(firstStartElJobType)
+                        .zeebeStartExecutionListener(secondStartElJobType))
+            .done();
+    final long processDefinitionKey = CLIENT_RULE.deployProcess(modelInstance);
+    CLIENT_RULE.createProcessInstance(processDefinitionKey, "{}");
+
+    final RecordingJobHandler elJobHandler = new RecordingJobHandler();
+    CLIENT_RULE.getClient().newWorker().jobType(firstStartElJobType).handler(elJobHandler).open();
+    CLIENT_RULE.getClient().newWorker().jobType(secondStartElJobType).handler(elJobHandler).open();
+
+    waitUntil(() -> !elJobHandler.getHandledJobs().isEmpty());
+
+    final long firstElJobKey = elJobHandler.getHandledJobs().getFirst().getKey();
+
+    // when
+    CLIENT_RULE
+        .getClient()
+        .newCompleteCommand(firstElJobKey)
+        .variable("el1_var_a", "value_a")
+        .send()
+        .join();
+
+    waitUntil(() -> elJobHandler.getHandledJobs().size() == 2);
+
+    // then: EL[start] job completed
+    ZeebeAssertHelper.assertJobCompleted(
+        firstStartElJobType,
+        (job) -> assertThat(job.getVariables()).containsOnly(entry("el1_var_a", "value_a")));
+
+    // service task job created
+    ZeebeAssertHelper.assertJobCreated(secondStartElJobType);
+    final ActivatedJob secondElActivatedJob = elJobHandler.getHandledJobs().getLast();
+    assertThat(secondElActivatedJob.getType()).isEqualTo(secondStartElJobType);
+    assertThat(secondElActivatedJob.getVariablesAsMap())
+        .containsOnly(entry("el1_var_a", "value_a"));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/BrokerClassRuleHelper.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/BrokerClassRuleHelper.java
@@ -40,6 +40,18 @@ public final class BrokerClassRuleHelper extends TestWatcher {
     return "job-" + currentTestMethod;
   }
 
+  public String getStartExecutionListenerType() {
+    return "start-" + getExecutionListenerType();
+  }
+
+  public String getEndExecutionListenerType() {
+    return "end-" + getExecutionListenerType();
+  }
+
+  private String getExecutionListenerType() {
+    return "el-".concat(currentTestMethod);
+  }
+
   public String getBpmnProcessId() {
     return "process-" + currentTestMethod;
   }


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the lifecycle management of process instances within the Zeebe workflow engine, with a specific focus on the integration and management of Execution Listeners.
Here, we lay the foundational groundwork for extending EL support to additional elements in future iterations.

### Key Enhancements:
- New `COMPLETE_EXECUTION_LISTENER` command developed and introduced to the process instance lifecycle.
- Modifications were made to the `JobCompleteProcessor` to incorporate special handling for execution listener jobs,  to write `COMPLETE_EXECUTION_LISTENER ` command after EL completion.
- The `BpmnElementProcessor` interface has been enhanced with the introduction of `finalizeActivation` & `finalizeCompletion` methods. These methods are crucial for the post-processing of start/end execution listeners and have been implemented for the `JobWorkerTaskProcessor` to enable EL support for service tasks.
- A new lifecycle phase specifically tailored for execution listeners has been implemented within the `BpmnStreamProcessor`. This dedicated phase encapsulates the logic necessary for managing transitions before and after EL processing.
- A handler for the newly introduced `COMPLETE_EXECUTION_LISTENER` command has been created. This handler is responsible for managing the lifecycle of process instances following EL processing.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16209 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
