### PR TITLE
docs: Remove the ExperimentalApi annotation from the Java client CommandWithTenantStep interface

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client.api.command;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
 
 public interface CommandWithTenantStep<T> {
 
@@ -27,14 +26,6 @@ public interface CommandWithTenantStep<T> {
   String DEFAULT_TENANT_IDENTIFIER = "<default>";
 
   /**
-   * <strong>Experimental: This method is under development, and as such using it may have no effect
-   * on the command builder when called. While unimplemented, it simply returns the command builder
-   * instance unchanged. This method already exists for software that is building support for
-   * multi-tenancy, and already wants to use this API during its development. As support for
-   * multi-tenancy is added to Zeebe, each of the commands that implement this method may start to
-   * take effect. Until this warning is removed, anything described below may not yet have taken
-   * effect, and the interface and its description are subject to change.</strong>
-   *
    * <p>Specifies the tenant that will own any entities (e.g. process definition, process instances,
    * etc.) resulting from this command, or that owns any entities (e.g. jobs) referred to from this
    * command.
@@ -53,6 +44,5 @@ public interface CommandWithTenantStep<T> {
    * @return the builder for this command with the tenant specified
    * @since 8.3
    */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
   T tenantId(String tenantId);
 }


### PR DESCRIPTION
## Description

As multi-tenancy has been implemented for all RPCs in the Zeebe Java client, the ExperimentalApi annotation can be removed from the Java client CommandWithTenantStep interface.

- The ExperimentalApi annotation is removed from the Java client CommandWithTenantStep interface.
- The Experimental note in the tenantId(String) Javadoc should be removed

## Related issues

closes #16548 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
