### PR TITLE
ci: skip summary action on property tests

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -7,13 +7,17 @@ inputs:
   buildOutputFilePath:
     description: 'Path to the build log file.'
     required: true
+  skipSummary:
+    description: "Whether to run the test-summary action, it might run into problems an large test outputs"
+    default: "false"
+    required: false
 
 runs:
   using: composite
   steps:
   - name: Test Summary
     uses: test-summary/action@v2
-    if: always()
+    if: ${{ inputs.skipSummary == 'false' }}
     with:
       paths: |
         **/target/failsafe-reports/TEST-*.xml

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -258,6 +258,8 @@ jobs:
         uses: ./.github/actions/analyze-test-runs
         with:
           buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+          # workaround to avoid https://github.com/camunda/zeebe/issues/16604
+          skipSummary: true
       - name: Upload test artifacts
         uses: ./.github/actions/collect-test-artifacts
         if: ${{ failure() || cancelled() }}


### PR DESCRIPTION
## Description

It currently runs into a limitation due to the amount of data. See https://github.com/test-summary/action/issues/45 .

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16604
