### PR TITLE
[Backport stable/8.4] docs: Remove the ExperimentalApi annotation from the Java client CommandWithTenantStep interface

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithTenantStep.java
@@ -15,8 +15,6 @@
  */
 package io.camunda.zeebe.client.api.command;
 
-import io.camunda.zeebe.client.api.ExperimentalApi;
-
 public interface CommandWithTenantStep<T> {
 
   /**
@@ -27,15 +25,7 @@ public interface CommandWithTenantStep<T> {
   String DEFAULT_TENANT_IDENTIFIER = "<default>";
 
   /**
-   * <strong>Experimental: This method is under development, and as such using it may have no effect
-   * on the command builder when called. While unimplemented, it simply returns the command builder
-   * instance unchanged. This method already exists for software that is building support for
-   * multi-tenancy, and already wants to use this API during its development. As support for
-   * multi-tenancy is added to Zeebe, each of the commands that implement this method may start to
-   * take effect. Until this warning is removed, anything described below may not yet have taken
-   * effect, and the interface and its description are subject to change.</strong>
-   *
-   * <p>Specifies the tenant that will own any entities (e.g. process definition, process instances,
+   * Specifies the tenant that will own any entities (e.g. process definition, process instances,
    * etc.) resulting from this command, or that owns any entities (e.g. jobs) referred to from this
    * command.
    *
@@ -53,6 +43,5 @@ public interface CommandWithTenantStep<T> {
    * @return the builder for this command with the tenant specified
    * @since 8.3
    */
-  @ExperimentalApi("https://github.com/camunda/zeebe/issues/12653")
   T tenantId(String tenantId);
 }


### PR DESCRIPTION
# Description
Backport of #16753 to `stable/8.4`.

relates to #16548
original author: @mustafadagher