### PR TITLE
[Backport stable/8.1] fix: respect offset and length on DbBytes#wrap

### DIFF
--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbBytes.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/DbBytes.java
@@ -24,7 +24,9 @@ public final class DbBytes implements DbKey, DbValue {
 
   @Override
   public void wrap(final DirectBuffer directBuffer, final int offset, final int length) {
-    bytes.wrap(directBuffer, offset, length);
+    final byte[] bytesToWrap = new byte[length];
+    directBuffer.getBytes(offset, bytesToWrap, 0, bytesToWrap.length);
+    bytes.wrap(bytesToWrap);
   }
 
   @Override

--- a/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbBytesTest.java
+++ b/zb-db/src/test/java/io/camunda/zeebe/db/impl/DbBytesTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.agrona.concurrent.UnsafeBuffer;
+import org.junit.Test;
+
+public final class DbBytesTest {
+
+  private final DbBytes zbBytes = new DbBytes();
+
+  @Test
+  public void shouldWrapBytes() {
+    // given
+    final byte[] bytes = {1, 2, 3, 4, 5, 6, 7};
+
+    // when
+    zbBytes.wrapBytes(bytes);
+
+    // then
+    assertThat(zbBytes.getLength()).isEqualTo(bytes.length);
+    assertThat(zbBytes.getBytes()).isEqualTo(bytes);
+  }
+
+  @Test
+  public void shouldWrapBytesWithOffsetAndLength() {
+    // given
+    final var bytes = new byte[] {1, 2, 3, 4, 5, 6, 7};
+    final var buffer = new UnsafeBuffer(bytes);
+
+    // when -- wrapping over part of the buffer
+    zbBytes.wrap(buffer, 2, 3);
+
+    // then
+    assertThat(zbBytes.getLength()).isEqualTo(3);
+    assertThat(zbBytes.getBytes()).isEqualTo(new byte[] {3, 4, 5});
+  }
+}


### PR DESCRIPTION
# Description
Backport of #16684 to `stable/8.1`.

relates to #16666
original author: @megglos 