### PR TITLE
Do no run Migration if Snapshot is the same as current version.

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -75,8 +75,7 @@ public class DbMigratorImpl implements DbMigrator {
 
   @Override
   public void runMigrations() {
-    final CheckResult checkResult = checkVersionCompatibility();
-    if (checkResult instanceof Compatible.SameVersion) {
+    if (checkVersionCompatibility() instanceof Compatible.SameVersion) {
       LOGGER.info("No migrations to run, snapshot is the same as current version");
       return;
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/migration/DbMigratorImpl.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.migration;
 
+import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult;
 import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Compatible;
 import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Incompatible;
 import io.camunda.zeebe.engine.state.migration.VersionCompatibilityCheck.CheckResult.Indeterminate;
@@ -74,7 +75,11 @@ public class DbMigratorImpl implements DbMigrator {
 
   @Override
   public void runMigrations() {
-    checkVersionCompatibility();
+    final CheckResult checkResult = checkVersionCompatibility();
+    if (checkResult instanceof Compatible.SameVersion) {
+      LOGGER.info("No migrations to run, snapshot is the same as current version");
+      return;
+    }
     logPreview(migrationTasks);
 
     final var executedMigrations = new ArrayList<MigrationTask>();
@@ -90,10 +95,12 @@ public class DbMigratorImpl implements DbMigrator {
     logSummary(executedMigrations);
   }
 
-  private void checkVersionCompatibility() {
+  private VersionCompatibilityCheck.CheckResult checkVersionCompatibility() {
     final var migratedByVersion = processingState.getMigrationState().getMigratedByVersion();
     final var currentVersion = VersionUtil.getVersion();
-    switch (VersionCompatibilityCheck.check(migratedByVersion, currentVersion)) {
+    final CheckResult checkResult =
+        VersionCompatibilityCheck.check(migratedByVersion, currentVersion);
+    switch (checkResult) {
       case final Indeterminate.PreviousVersionUnknown previousVersionUnknown ->
           LOGGER.trace(
               "Snapshot is from an unknown version, not checking compatibility with current version: {}",
@@ -112,6 +119,7 @@ public class DbMigratorImpl implements DbMigrator {
       case final Compatible compatible ->
           LOGGER.info("Snapshot is compatible with current version: {}", compatible);
     }
+    return checkResult;
   }
 
   private void markMigrationsAsCompleted() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/DbMigratorImplTest.java
@@ -197,4 +197,26 @@ public class DbMigratorImplTest {
     // then -- migration is not run
     verify(mockMigration, never()).runMigration(mockProcessingState);
   }
+
+  @Test
+  void shouldNotRunMigrationsIfTheSameVersion() {
+    // given
+    final var mockProcessingState = mock(MutableProcessingState.class);
+    final var mockMigrationState = mock(MutableMigrationState.class);
+    // the version is the same as the migrated version
+    when(mockProcessingState.getMigrationState()).thenReturn(mockMigrationState);
+    final String currentVersion = VersionUtil.getVersion();
+    when(mockMigrationState.getMigratedByVersion()).thenReturn(currentVersion);
+
+    final var mockMigration = mock(MigrationTask.class);
+
+    final var sut =
+        new DbMigratorImpl(mockProcessingState, Collections.singletonList(mockMigration));
+
+    // when
+    sut.runMigrations();
+
+    // then
+    verify(mockMigration, never()).runMigration(mockProcessingState);
+  }
 }


### PR DESCRIPTION
## Description

We don't run the Migration if the snapshot version is the same as the current version.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/15678

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
