### PR TITLE
feat: Trigger compensation for activity

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
@@ -48,21 +48,30 @@ public class CompensationEventDefinitionValidator
       }
 
     } else {
-      if (!isValidCompensationActivity(referencedActivity)) {
-        validationResultCollector.addError(
-            0,
-            String.format(
-                "The referenced compensation activity '%s' must have either a compensation boundary event or be a subprocess",
-                activityRef));
-      }
+      validateReferencedActivity(
+          compensateEventDefinition, validationResultCollector, referencedActivity);
+    }
+  }
 
-      if (referencedActivity.getScope() != compensateEventDefinition.getScope()) {
-        validationResultCollector.addError(
-            0,
-            String.format(
-                "The referenced compensation activity '%s' must be in the same scope as the compensation throw event",
-                activityRef));
-      }
+  private static void validateReferencedActivity(
+      final CompensateEventDefinition compensateEventDefinition,
+      final ValidationResultCollector validationResultCollector,
+      final Activity referencedActivity) {
+
+    if (!isValidCompensationActivity(referencedActivity)) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "The referenced compensation activity '%s' must have either a compensation boundary event or be a subprocess",
+              referencedActivity.getId()));
+    }
+
+    if (referencedActivity.getScope() != compensateEventDefinition.getScope()) {
+      validationResultCollector.addError(
+          0,
+          String.format(
+              "The referenced compensation activity '%s' must be in the same scope as the compensation throw event",
+              referencedActivity.getId()));
     }
   }
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.Activity;
+import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
+import io.camunda.zeebe.model.bpmn.instance.SubProcess;
+import io.camunda.zeebe.model.bpmn.util.ModelUtil;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class CompensationEventDefinitionValidator
+    implements ModelElementValidator<CompensateEventDefinition> {
+
+  @Override
+  public Class<CompensateEventDefinition> getElementType() {
+    return CompensateEventDefinition.class;
+  }
+
+  @Override
+  public void validate(
+      final CompensateEventDefinition compensateEventDefinition,
+      final ValidationResultCollector validationResultCollector) {
+
+    final String activityRef =
+        compensateEventDefinition.getAttributeValue(BpmnModelConstants.BPMN_ATTRIBUTE_ACTIVITY_REF);
+    final Activity referencedActivity = compensateEventDefinition.getActivity();
+
+    if (referencedActivity == null) {
+      if (activityRef != null && !activityRef.isEmpty()) {
+        validationResultCollector.addError(
+            0,
+            String.format("The referenced compensation activity '%s' doesn't exist", activityRef));
+      }
+
+    } else {
+      if (!isValidCompensationActivity(referencedActivity)) {
+        validationResultCollector.addError(
+            0,
+            String.format(
+                "The referenced compensation activity '%s' must have either a compensation boundary event or be a subprocess",
+                activityRef));
+      }
+
+      if (referencedActivity.getScope() != compensateEventDefinition.getScope()) {
+        validationResultCollector.addError(
+            0,
+            String.format(
+                "The referenced compensation activity '%s' must be in the same scope as the compensation throw event",
+                activityRef));
+      }
+    }
+  }
+
+  private static boolean isValidCompensationActivity(final Activity activity) {
+    return hasCompensationBoundaryEvent(activity) || isSubprocess(activity);
+  }
+
+  private static boolean hasCompensationBoundaryEvent(final Activity activity) {
+    return ModelUtil.getEventDefinitionsForBoundaryEvents(activity).stream()
+        .anyMatch(CompensateEventDefinition.class::isInstance);
+  }
+
+  private static boolean isSubprocess(final Activity activity) {
+    if (activity instanceof SubProcess) {
+      return !((SubProcess) activity).triggeredByEvent();
+    } else {
+      return false;
+    }
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -121,6 +121,7 @@ public final class ZeebeDesignTimeValidators {
                 ZeebePublishMessage::getCorrelationKey, ZeebeConstants.ATTRIBUTE_CORRELATION_KEY));
     validators.add(new IntermediateThrowEventValidator());
     validators.add(new CompensationTaskValidator());
+    validators.add(new CompensationEventDefinitionValidator());
 
     VALIDATORS = Collections.unmodifiableList(validators);
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BpmnElementBuilder.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BpmnElementBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import java.util.function.UnaryOperator;
+
+final class BpmnElementBuilder {
+
+  private final String elementType;
+  private final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder;
+
+  private BpmnElementBuilder(
+      final String elementType, final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder) {
+    this.elementType = elementType;
+    this.builder = builder;
+  }
+
+  public AbstractFlowNodeBuilder<?, ?> build(final AbstractFlowNodeBuilder<?, ?> processBuilder) {
+    return builder.apply(processBuilder);
+  }
+
+  public static BpmnElementBuilder of(
+      final String elementType, final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder) {
+    return new BpmnElementBuilder(elementType, builder);
+  }
+
+  public String getElementType() {
+    return elementType;
+  }
+
+  @Override
+  public String toString() {
+    return elementType;
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/CompensationEventValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/CompensationEventValidationTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
 import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import java.util.function.Consumer;
-import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -189,31 +188,5 @@ class CompensationEventValidationTest {
                 builder.endEvent(
                     "compensation-event",
                     event -> event.compensateEventDefinition(COMPENSATION_EVENT_DEFINITION_ID))));
-  }
-
-  private static final class BpmnElementBuilder {
-
-    private final String elementType;
-    private final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder;
-
-    private BpmnElementBuilder(
-        final String elementType, final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder) {
-      this.elementType = elementType;
-      this.builder = builder;
-    }
-
-    public AbstractFlowNodeBuilder<?, ?> build(final AbstractFlowNodeBuilder<?, ?> processBuilder) {
-      return builder.apply(processBuilder);
-    }
-
-    private static BpmnElementBuilder of(
-        final String elementType, final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder) {
-      return new BpmnElementBuilder(elementType, builder);
-    }
-
-    @Override
-    public String toString() {
-      return elementType;
-    }
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/CompensationEventValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/CompensationEventValidationTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
+import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class CompensationEventValidationTest {
+
+  private static final String COMPENSATION_EVENT_DEFINITION_ID = "compensation-event-definition";
+
+  @ParameterizedTest
+  @MethodSource("compensationThrowEvents")
+  @DisplayName("A compensation throw event don't need to reference an activity")
+  void noActivityRef(final BpmnElementBuilder elementBuilder) {
+    // given
+    final BpmnModelInstance process =
+        processWithCompensationThrowEvent(
+            Bpmn.createExecutableProcess().startEvent(),
+            elementBuilder,
+            compensationEventDefinition -> {});
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @ParameterizedTest
+  @MethodSource("compensationThrowEvents")
+  @DisplayName("A compensation throw event should reference an existing activity")
+  void activityRefNonExisting(final BpmnElementBuilder elementBuilder) {
+    // given
+    final BpmnModelInstance process =
+        processWithCompensationThrowEvent(
+            Bpmn.createExecutableProcess().startEvent(),
+            elementBuilder,
+            compensationEventDefinition ->
+                compensationEventDefinition.setAttributeValue("activityRef", "non-existing"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            CompensateEventDefinition.class,
+            "The referenced compensation activity 'non-existing' doesn't exist"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("compensationThrowEvents")
+  @DisplayName(
+      "A compensation throw event can reference an activity with a compensation boundary event")
+  void activityRefToCompensationHandler(final BpmnElementBuilder elementBuilder) {
+    // given
+    final BpmnModelInstance process =
+        processWithCompensationThrowEvent(
+            Bpmn.createExecutableProcess()
+                .startEvent()
+                .userTask(
+                    "task",
+                    userTask ->
+                        userTask
+                            .boundaryEvent()
+                            .compensation(compensation -> compensation.userTask("undo-task"))),
+            elementBuilder,
+            compensationEventDefinition ->
+                compensationEventDefinition.setAttributeValue("activityRef", "task"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @ParameterizedTest
+  @MethodSource("compensationThrowEvents")
+  @DisplayName("A compensation throw event can reference a subprocess")
+  void activityRefToSubprocess(final BpmnElementBuilder elementBuilder) {
+    // given
+    final BpmnModelInstance process =
+        processWithCompensationThrowEvent(
+            Bpmn.createExecutableProcess()
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    subprocess -> subprocess.embeddedSubProcess().startEvent().endEvent()),
+            elementBuilder,
+            compensationEventDefinition ->
+                compensationEventDefinition.setAttributeValue("activityRef", "subprocess"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @ParameterizedTest
+  @MethodSource("compensationThrowEvents")
+  @DisplayName("A compensation throw event should reference a compensation handler")
+  void activityRefToNonCompensationHandler(final BpmnElementBuilder elementBuilder) {
+    // given
+    final BpmnModelInstance process =
+        processWithCompensationThrowEvent(
+            Bpmn.createExecutableProcess().startEvent().userTask("task"),
+            elementBuilder,
+            compensationEventDefinition ->
+                compensationEventDefinition.setAttributeValue("activityRef", "task"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            CompensateEventDefinition.class,
+            "The referenced compensation activity 'task' must have either a compensation boundary event or be a subprocess"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("compensationThrowEvents")
+  @DisplayName("A compensation throw event should reference an activity in the same scope")
+  void activityRefToActivityOutOfScope(final BpmnElementBuilder elementBuilder) {
+    // given
+    final BpmnModelInstance process =
+        processWithCompensationThrowEvent(
+            Bpmn.createExecutableProcess()
+                .startEvent()
+                .subProcess(
+                    "subprocess",
+                    subprocess ->
+                        subprocess
+                            .embeddedSubProcess()
+                            .startEvent()
+                            .userTask("task")
+                            .boundaryEvent()
+                            .compensation(compensation -> compensation.userTask("undo-task"))),
+            elementBuilder,
+            compensationEventDefinition ->
+                compensationEventDefinition.setAttributeValue("activityRef", "task"));
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            CompensateEventDefinition.class,
+            "The referenced compensation activity 'task' must be in the same scope as the compensation throw event"));
+  }
+
+  private BpmnModelInstance processWithCompensationThrowEvent(
+      final AbstractFlowNodeBuilder<?, ?> processBuilder,
+      final BpmnElementBuilder elementBuilder,
+      final Consumer<CompensateEventDefinition> consumer) {
+
+    final BpmnModelInstance process = elementBuilder.build(processBuilder).done();
+
+    final CompensateEventDefinition compensateEventDefinition =
+        process.getModelElementById(COMPENSATION_EVENT_DEFINITION_ID);
+    consumer.accept(compensateEventDefinition);
+
+    return process;
+  }
+
+  private static Stream<BpmnElementBuilder> compensationThrowEvents() {
+    return Stream.of(
+        BpmnElementBuilder.of(
+            "intermediate throw event",
+            builder ->
+                builder.intermediateThrowEvent(
+                    "compensation-event",
+                    event -> event.compensateEventDefinition(COMPENSATION_EVENT_DEFINITION_ID))),
+        BpmnElementBuilder.of(
+            "end event",
+            builder ->
+                builder.endEvent(
+                    "compensation-event",
+                    event -> event.compensateEventDefinition(COMPENSATION_EVENT_DEFINITION_ID))));
+  }
+
+  private static final class BpmnElementBuilder {
+
+    private final String elementType;
+    private final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder;
+
+    private BpmnElementBuilder(
+        final String elementType, final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder) {
+      this.elementType = elementType;
+      this.builder = builder;
+    }
+
+    public AbstractFlowNodeBuilder<?, ?> build(final AbstractFlowNodeBuilder<?, ?> processBuilder) {
+      return builder.apply(processBuilder);
+    }
+
+    private static BpmnElementBuilder of(
+        final String elementType, final UnaryOperator<AbstractFlowNodeBuilder<?, ?>> builder) {
+      return new BpmnElementBuilder(elementType, builder);
+    }
+
+    @Override
+    public String toString() {
+      return elementType;
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -165,8 +165,7 @@ public class BpmnCompensationSubscriptionBehaviour {
     // invoke the compensation handler if present
     if (!subscription.getRecord().getCompensationHandlerId().isEmpty()) {
       compensationHandlerInstanceKey =
-          activateCompensationHandler(
-              context, subscription.getRecord().getCompensableActivityId());
+          activateCompensationHandler(context, subscription.getRecord().getCompensableActivityId());
     }
 
     // mark the subscription as triggered
@@ -175,9 +174,7 @@ public class BpmnCompensationSubscriptionBehaviour {
 
     // propagate the compensation to subprocesses
     triggerCompensationFromTopToBottom(
-        context,
-        subscriptions,
-        subscription.getRecord().getCompensableActivityInstanceKey());
+        context, subscriptions, subscription.getRecord().getCompensableActivityInstanceKey());
   }
 
   private long activateCompensationHandler(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -296,16 +296,15 @@ public class BpmnCompensationSubscriptionBehaviour {
                         == context.getFlowScopeKey())
             .toList();
 
-    if (!subscriptionsForActivity.isEmpty()) {
-      // trigger the compensation for the given activity
-      subscriptionsForActivity.forEach(
-          subscription ->
-              triggerCompensationForSubscription(context, notTriggeredSubscriptions, subscription));
-      return true;
-
-    } else {
-      return false;
+    if (subscriptionsForActivity.isEmpty()) {
+      return false; // no subscriptions are triggered
     }
+
+    // trigger the compensation for the given activity
+    subscriptionsForActivity.forEach(
+        subscription ->
+            triggerCompensationForSubscription(context, notTriggeredSubscriptions, subscription));
+    return true;
   }
 
   public void completeCompensationHandler(final BpmnElementContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -337,8 +337,12 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
       final var activated =
           stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
 
+      final var compensation = element.getCompensation();
       final var isCompensationTriggered =
-          compensationSubscriptionBehaviour.triggerCompensation(activating);
+          compensation.hasReferenceActivity()
+              ? compensationSubscriptionBehaviour.triggerCompensationForActivity(
+                  compensation.getReferenceCompensationActivity(), activated)
+              : compensationSubscriptionBehaviour.triggerCompensation(activating);
 
       if (isCompensationTriggered) {
         return SUCCESS;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -314,8 +314,12 @@ public class IntermediateThrowEventProcessor
       final BpmnElementContext activated =
           stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
 
+      final var compensation = element.getCompensation();
       final var isCompensationTriggered =
-          compensationSubscriptionBehaviour.triggerCompensation(activating);
+          compensation.hasReferenceActivity()
+              ? compensationSubscriptionBehaviour.triggerCompensationForActivity(
+                  compensation.getReferenceCompensationActivity(), activated)
+              : compensationSubscriptionBehaviour.triggerCompensation(activating);
 
       if (isCompensationTriggered) {
         return SUCCESS;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCompensation.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCompensation.java
@@ -11,6 +11,10 @@ public class ExecutableCompensation extends AbstractFlowElement {
 
   private ExecutableActivity compensationHandler;
 
+  /* Activity that could be referenced by a compensation throw event via attribute "activityRef".
+   */
+  private ExecutableActivity referenceCompensationActivity;
+
   public ExecutableCompensation(final String id) {
     super(id);
   }
@@ -21,5 +25,18 @@ public class ExecutableCompensation extends AbstractFlowElement {
 
   public void setCompensationHandler(final ExecutableActivity compensationHandler) {
     this.compensationHandler = compensationHandler;
+  }
+
+  public ExecutableActivity getReferenceCompensationActivity() {
+    return referenceCompensationActivity;
+  }
+
+  public void setReferenceCompensationActivity(
+      final ExecutableActivity referenceCompensationActivity) {
+    this.referenceCompensationActivity = referenceCompensationActivity;
+  }
+
+  public boolean hasReferenceActivity() {
+    return referenceCompensationActivity != null;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableEndEvent.java
@@ -19,6 +19,8 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
 
   private boolean isTerminateEndEvent;
 
+  private ExecutableCompensation compensation;
+
   public ExecutableEndEvent(final String id) {
     super(id);
   }
@@ -45,6 +47,14 @@ public class ExecutableEndEvent extends ExecutableFlowNode implements Executable
 
   public void setSignal(final ExecutableSignal signal) {
     this.signal = signal;
+  }
+
+  public ExecutableCompensation getCompensation() {
+    return compensation;
+  }
+
+  public void setCompensation(final ExecutableCompensation compensation) {
+    this.compensation = compensation;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableIntermediateThrowEvent.java
@@ -20,6 +20,8 @@ public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
 
   private ExecutableSignal signal;
 
+  private ExecutableCompensation compensation;
+
   public ExecutableIntermediateThrowEvent(final String id) {
     super(id);
   }
@@ -56,6 +58,14 @@ public class ExecutableIntermediateThrowEvent extends ExecutableFlowNode
 
   public void setSignal(final ExecutableSignal signal) {
     this.signal = signal;
+  }
+
+  public ExecutableCompensation getCompensation() {
+    return compensation;
+  }
+
+  public void setCompensation(final ExecutableCompensation compensation) {
+    this.compensation = compensation;
   }
 
   public boolean isNoneThrowEvent() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/IntermediateThrowEventTransformer.java
@@ -41,43 +41,38 @@ public final class IntermediateThrowEventTransformer
 
     throwEvent.setEventType(BpmnEventType.NONE);
 
-    if (isMessageEvent(element)) {
-      throwEvent.setEventType(BpmnEventType.MESSAGE);
-      if (hasTaskDefinition(element)) {
-        jobWorkerElementTransformer.transform(element, context);
-      }
-    } else if (isLinkEvent(element)) {
-      transformLinkEventDefinition(element, context, throwEvent);
-    } else if (isEscalationEvent(element)) {
-      transformEscalationEventDefinition(element, context);
-    } else if (isSignalEvent(element)) {
-      transformSignalEventDefinition(element, context);
-    } else if (isCompensationEvent(element)) {
-      transformCompensationEventDefinition(element, throwEvent, context);
+    if (!element.getEventDefinitions().isEmpty()) {
+      transformEventDefinition(element, context, throwEvent);
     }
   }
 
-  private boolean isMessageEvent(final IntermediateThrowEvent element) {
-    return element.getEventDefinitions().stream()
-        .anyMatch(MessageEventDefinition.class::isInstance);
-  }
+  private void transformEventDefinition(
+      final IntermediateThrowEvent element,
+      final TransformContext context,
+      final ExecutableIntermediateThrowEvent executableElement) {
 
-  private boolean isLinkEvent(final IntermediateThrowEvent element) {
-    return element.getEventDefinitions().stream().anyMatch(LinkEventDefinition.class::isInstance);
-  }
+    final var eventDefinition = element.getEventDefinitions().iterator().next();
 
-  private boolean isEscalationEvent(final IntermediateThrowEvent element) {
-    return element.getEventDefinitions().stream()
-        .anyMatch(EscalationEventDefinition.class::isInstance);
-  }
+    if (eventDefinition instanceof MessageEventDefinition) {
+      executableElement.setEventType(BpmnEventType.MESSAGE);
+      if (hasTaskDefinition(element)) {
+        jobWorkerElementTransformer.transform(element, context);
+      }
 
-  private boolean isSignalEvent(final IntermediateThrowEvent element) {
-    return element.getEventDefinitions().stream().anyMatch(SignalEventDefinition.class::isInstance);
-  }
+    } else if (eventDefinition instanceof final LinkEventDefinition linkEventDefinition) {
+      transformLinkEventDefinition(context, executableElement, linkEventDefinition);
 
-  private boolean isCompensationEvent(final IntermediateThrowEvent element) {
-    return element.getEventDefinitions().stream()
-        .anyMatch(CompensateEventDefinition.class::isInstance);
+    } else if (eventDefinition
+        instanceof final EscalationEventDefinition escalationEventDefinition) {
+      transformEscalationEventDefinition(context, executableElement, escalationEventDefinition);
+
+    } else if (eventDefinition instanceof final SignalEventDefinition signalEventDefinition) {
+      transformSignalEventDefinition(context, executableElement, signalEventDefinition);
+
+    } else if (eventDefinition
+        instanceof final CompensateEventDefinition compensateEventDefinition) {
+      transformCompensationEventDefinition(context, executableElement, compensateEventDefinition);
+    }
   }
 
   private boolean hasTaskDefinition(final IntermediateThrowEvent element) {
@@ -85,12 +80,9 @@ public final class IntermediateThrowEventTransformer
   }
 
   private void transformLinkEventDefinition(
-      final IntermediateThrowEvent element,
       final TransformContext context,
-      final ExecutableIntermediateThrowEvent executableThrowEventElement) {
-
-    final var eventDefinition =
-        (LinkEventDefinition) element.getEventDefinitions().iterator().next();
+      final ExecutableIntermediateThrowEvent executableThrowEventElement,
+      final LinkEventDefinition eventDefinition) {
 
     final var name = eventDefinition.getName();
     final var executableLink = context.getLink(name);
@@ -99,27 +91,21 @@ public final class IntermediateThrowEventTransformer
   }
 
   private void transformEscalationEventDefinition(
-      final IntermediateThrowEvent element, final TransformContext context) {
-    final var currentProcess = context.getCurrentProcess();
-    final var executableElement =
-        currentProcess.getElementById(element.getId(), ExecutableIntermediateThrowEvent.class);
-
-    final var eventDefinition =
-        (EscalationEventDefinition) element.getEventDefinitions().iterator().next();
+      final TransformContext context,
+      final ExecutableIntermediateThrowEvent executableElement,
+      final EscalationEventDefinition eventDefinition) {
     final var escalation = eventDefinition.getEscalation();
+
     final var executableEscalation = context.getEscalation(escalation.getId());
     executableElement.setEscalation(executableEscalation);
     executableElement.setEventType(BpmnEventType.ESCALATION);
   }
 
   private void transformSignalEventDefinition(
-      final IntermediateThrowEvent element, final TransformContext context) {
-    final var currentProcess = context.getCurrentProcess();
-    final var executableElement =
-        currentProcess.getElementById(element.getId(), ExecutableIntermediateThrowEvent.class);
+      final TransformContext context,
+      final ExecutableIntermediateThrowEvent executableElement,
+      final SignalEventDefinition eventDefinition) {
 
-    final var eventDefinition =
-        (SignalEventDefinition) element.getEventDefinitions().iterator().next();
     final var signal = eventDefinition.getSignal();
     final var executableSignal = context.getSignal(signal.getId());
     executableElement.setSignal(executableSignal);
@@ -127,13 +113,9 @@ public final class IntermediateThrowEventTransformer
   }
 
   private void transformCompensationEventDefinition(
-      final IntermediateThrowEvent element,
+      final TransformContext context,
       final ExecutableIntermediateThrowEvent executableElement,
-      final TransformContext context) {
-    executableElement.setEventType(BpmnEventType.COMPENSATION);
-
-    final var eventDefinition =
-        (CompensateEventDefinition) element.getEventDefinitions().iterator().next();
+      final CompensateEventDefinition eventDefinition) {
 
     final ExecutableCompensation compensation = new ExecutableCompensation(eventDefinition.getId());
 
@@ -144,5 +126,6 @@ public final class IntermediateThrowEventTransformer
       compensation.setReferenceCompensationActivity(activity);
     }
     executableElement.setCompensation(compensation);
+    executableElement.setEventType(BpmnEventType.COMPENSATION);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -1804,6 +1804,240 @@ public class CompensationEventExecutionTest {
         .doesNotContain(tuple("Undo-A", ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 
+  @Test
+  public void shouldTriggerCompensationForSubprocess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .subProcess("subprocess")
+            .embeddedSubProcess()
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .subProcessDone()
+            .parallelGateway("join")
+            .moveToNode("fork")
+            .serviceTask(
+                "B",
+                task ->
+                    task.zeebeJobType("B")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-B").zeebeJobType("Undo-B")))
+            .connectTo("join")
+            .intermediateThrowEvent("compensation-throw-event")
+            .compensateEventDefinition()
+            .activityRef("subprocess")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("B", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(tuple("Undo-B", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void shouldTriggerCompensationForMultiInstanceSubprocess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .subProcess("subprocess")
+            .multiInstance(m -> m.zeebeInputCollectionExpression("[1,2,3]"))
+            .embeddedSubProcess()
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .subProcessDone()
+            .parallelGateway("join")
+            .moveToNode("fork")
+            .serviceTask(
+                "B",
+                task ->
+                    task.zeebeJobType("B")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-B").zeebeJobType("Undo-B")))
+            .connectTo("join")
+            .intermediateThrowEvent("compensation-throw-event")
+            .compensateEventDefinition()
+            .activityRef("subprocess")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    completeJobs(processInstanceKey, "A", 3);
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    completeJobs(processInstanceKey, "Undo-A", 3);
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("B", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(tuple("Undo-B", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void shouldNotTriggerCompensationForSubprocessAgain() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess("subprocess")
+            .embeddedSubProcess()
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .subProcessDone()
+            .parallelGateway("fork")
+            .intermediateThrowEvent(
+                "compensation-throw-event-1",
+                event -> event.compensateEventDefinition().activityRef("subprocess"))
+            .moveToNode("fork")
+            .intermediateThrowEvent(
+                "compensation-throw-event-2",
+                event -> event.compensateEventDefinition().activityRef("subprocess"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event-2", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event-1", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event-1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event-2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .containsOnlyOnce(tuple("Undo-A", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void shouldNotTriggerCompensationForSubprocessIfActive() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .subProcess("subprocess")
+            .embeddedSubProcess()
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .subProcessDone()
+            .moveToNode("fork")
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .intermediateThrowEvent(
+                "compensation-throw-event",
+                event -> event.compensateEventDefinition().activityRef("subprocess"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(tuple("Undo-A", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {
     final var resourceAsStream = getClass().getResourceAsStream(classpath);
     return Bpmn.readModelFromStream(resourceAsStream);

--- a/zeebe/engine/src/test/resources/compensation/compensation-throw-event-attribute-false.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-throw-event-attribute-false.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.15.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
   <bpmn:process id="compensation-process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1evmw69</bpmn:outgoing>
@@ -21,7 +21,7 @@
     <bpmn:intermediateThrowEvent id="Event_1afnxa2">
       <bpmn:incoming>Flow_13spwoi</bpmn:incoming>
       <bpmn:outgoing>Flow_0n0oakg</bpmn:outgoing>
-      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" waitForCompletion="false" activityRef="Activity_05iamly" />
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" waitForCompletion="false" />
     </bpmn:intermediateThrowEvent>
     <bpmn:association id="Association_1jwpcsv" associationDirection="One" sourceRef="Event_14k1uqy" targetRef="Activity_1epoz0g" />
   </bpmn:process>
@@ -33,12 +33,12 @@
       <bpmndi:BPMNShape id="Activity_1761rwu_di" bpmnElement="Activity_05iamly">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0iasuoa_di" bpmnElement="Event_0iasuoa">
+        <dc:Bounds x="632" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1en6ywx_di" bpmnElement="Activity_1epoz0g">
         <dc:Bounds x="440" y="200" width="100" height="80" />
         <bpmndi:BPMNLabel />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0iasuoa_di" bpmnElement="Event_0iasuoa">
-        <dc:Bounds x="632" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1qpwd18_di" bpmnElement="Event_1afnxa2">
         <dc:Bounds x="472" y="99" width="36" height="36" />
@@ -54,14 +54,14 @@
         <di:waypoint x="370" y="117" />
         <di:waypoint x="472" y="117" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n0oakg_di" bpmnElement="Flow_0n0oakg">
+        <di:waypoint x="508" y="117" />
+        <di:waypoint x="632" y="117" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
         <di:waypoint x="350" y="175" />
         <di:waypoint x="350" y="240" />
         <di:waypoint x="420" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0n0oakg_di" bpmnElement="Flow_0n0oakg">
-        <di:waypoint x="508" y="117" />
-        <di:waypoint x="632" y="117" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/zeebe/engine/src/test/resources/compensation/compensation-throw-event.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-throw-event.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
   <bpmn:process id="compensation-process" isExecutable="true">
     <bpmn:startEvent id="StartEvent">
       <bpmn:outgoing>Flow_1evmw69</bpmn:outgoing>
@@ -17,7 +17,7 @@
     <bpmn:intermediateThrowEvent id="CompensationThrowEvent">
       <bpmn:incoming>Flow_13spwoi</bpmn:incoming>
       <bpmn:outgoing>Flow_0n0oakg</bpmn:outgoing>
-      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" activityRef="ActivityToCompensate" />
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" />
     </bpmn:intermediateThrowEvent>
     <bpmn:serviceTask id="ActivityToCompensate" name="A">
       <bpmn:extensionElements>
@@ -50,11 +50,6 @@
       <bpmndi:BPMNShape id="Activity_1rbmmlo_di" bpmnElement="CompensationHandler">
         <dc:Bounds x="440" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
-        <di:waypoint x="350" y="157" />
-        <di:waypoint x="350" y="240" />
-        <di:waypoint x="440" y="240" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="CompensationBoundaryEvent">
         <dc:Bounds x="352" y="139" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -69,6 +64,11 @@
       <bpmndi:BPMNEdge id="Flow_0n0oakg_di" bpmnElement="Flow_0n0oakg">
         <di:waypoint x="508" y="117" />
         <di:waypoint x="632" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
+        <di:waypoint x="350" y="157" />
+        <di:waypoint x="350" y="240" />
+        <di:waypoint x="440" y="240" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/zeebe/engine/src/test/resources/compensation/multiple-compensation-throw-event.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/multiple-compensation-throw-event.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1x2c0k1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.20.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
   <bpmn:process id="compensation-process" isExecutable="true">
     <bpmn:startEvent id="StartEvent">
       <bpmn:outgoing>Flow_1vslwh8</bpmn:outgoing>
@@ -15,7 +15,7 @@
     <bpmn:intermediateThrowEvent id="CompensationThrowEvent">
       <bpmn:incoming>Flow_08yr8s3</bpmn:incoming>
       <bpmn:outgoing>Flow_0n0oakg</bpmn:outgoing>
-      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" activityRef="ActivityToCompensate" />
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1ce2r2v" />
     </bpmn:intermediateThrowEvent>
     <bpmn:sequenceFlow id="Flow_1vslwh8" sourceRef="StartEvent" targetRef="Gateway_118x39o" />
     <bpmn:parallelGateway id="Gateway_118x39o">
@@ -92,21 +92,11 @@
       <bpmndi:BPMNShape id="Activity_1upgh7w_di" bpmnElement="CompensationHandler2">
         <dc:Bounds x="450" y="550" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
-        <di:waypoint x="430" y="157" />
-        <di:waypoint x="430" y="240" />
-        <di:waypoint x="500" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Association_1ebe076_di" bpmnElement="Association_1ebe076">
-        <di:waypoint x="410" y="508" />
-        <di:waypoint x="410" y="590" />
-        <di:waypoint x="450" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="CompensationBoundaryEvent">
-        <dc:Bounds x="432" y="139" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="BPMNShape_0rexz0f" bpmnElement="CompensationBoundaryEvent2">
         <dc:Bounds x="392" y="472" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1n78lze_di" bpmnElement="CompensationBoundaryEvent">
+        <dc:Bounds x="432" y="139" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="Flow_0n0oakg_di" bpmnElement="Flow_0n0oakg">
         <di:waypoint x="908" y="117" />
@@ -137,6 +127,16 @@
         <di:waypoint x="410" y="450" />
         <di:waypoint x="790" y="450" />
         <di:waypoint x="790" y="142" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1jwpcsv_di" bpmnElement="Association_1jwpcsv">
+        <di:waypoint x="430" y="157" />
+        <di:waypoint x="430" y="240" />
+        <di:waypoint x="500" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_1ebe076_di" bpmnElement="Association_1ebe076">
+        <di:waypoint x="410" y="508" />
+        <di:waypoint x="410" y="590" />
+        <di:waypoint x="450" y="590" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
## Description

- Parse `activityRef` property of compensation throw event
- Validate that the referenced activity:
  - Has a compensation boundary event or is a subprocess
  - Is in the same scope as the compensation throw event 
- Trigger the compensation for the given activity
- If the activity is a subprocess then propagate the compensation to the subprocess and its child instances

## Related issues

closes #15459 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
