### PR TITLE
fix: do not detect inconsistent topology when local member state is left

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerShutdownHelper.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerShutdownHelper.java
@@ -22,6 +22,12 @@ public class BrokerShutdownHelper {
   @Autowired private ApplicationContext appContext;
 
   public void initiateShutdown(final int returnCode) {
+    // This can be called from an Actor. We should ensure that any blocking operation is not run on
+    // the actor. Hence, schedule it on a common thread pool.
+    Thread.ofVirtual().start(() -> shutdown(returnCode));
+  }
+
+  private void shutdown(final int returnCode) {
     SpringApplication.exit(appContext, () -> returnCode);
   }
 }


### PR DESCRIPTION
## Description

This PR fixes two issues that causes #16777 
1. Inconsistent topology was detected when the local member has left, and the received topology has removed the member. This should not be detected as inconsistent topology.
2. The shutdown initiated by the inconsistent topology is run on the calling actor. The shutdown triggers shutting down of `SpringApplication` which blocks on the actor future when closing the broker components.

## Related issues

closes #16777 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
