### PR TITLE
Ensure lastProcessesPosition is set when StreamProcessor is paused

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -454,11 +454,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   public ActorFuture<Long> getLastProcessedPositionAsync() {
     return actor.call(
         () -> {
-          if (isInReplayOnlyMode()) {
+          if (isInReplayOnlyMode() || processingStateMachine == null) {
             return replayStateMachine.getLastSourceEventPosition();
-          } else if (processingStateMachine == null) {
-            // StreamProcessor is still replay mode
-            return StreamProcessor.UNSET_POSITION;
           } else {
             return processingStateMachine.getLastSuccessfulProcessedRecordPosition();
           }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorReplayTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.impl;
 
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ACTIVATE_ELEMENT;
 import static io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent.ELEMENT_ACTIVATING;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
@@ -25,10 +26,10 @@ import io.camunda.zeebe.protocol.record.intent.ErrorIntent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.stream.util.Records;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
-import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -153,19 +154,14 @@ final class StreamProcessorReplayTest {
 
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
-            () ->
-                Assertions.assertThat(streamProcessor.getLastProcessedPositionAsync().join())
-                    .isEqualTo(1L));
+            () -> assertThat(streamProcessor.getLastProcessedPositionAsync().join()).isEqualTo(1L));
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
-            () ->
-                Assertions.assertThat(streamProcessor.getLastWrittenPositionAsync().join())
-                    .isEqualTo(2L));
+            () -> assertThat(streamProcessor.getLastWrittenPositionAsync().join()).isEqualTo(2L));
 
     // state has to be updated
-    Assertions.assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(1);
-    Assertions.assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey()))
-        .isEqualTo(19L);
+    assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(1);
+    assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey())).isEqualTo(19L);
   }
 
   @Test
@@ -199,19 +195,14 @@ final class StreamProcessorReplayTest {
 
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
-            () ->
-                Assertions.assertThat(streamProcessor.getLastProcessedPositionAsync().join())
-                    .isEqualTo(1L));
+            () -> assertThat(streamProcessor.getLastProcessedPositionAsync().join()).isEqualTo(1L));
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
-            () ->
-                Assertions.assertThat(streamProcessor.getLastWrittenPositionAsync().join())
-                    .isEqualTo(2L));
+            () -> assertThat(streamProcessor.getLastWrittenPositionAsync().join()).isEqualTo(2L));
 
     // state has to be updated
-    Assertions.assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(1);
-    Assertions.assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey()))
-        .isEqualTo(19L);
+    assertThat(streamPlatform.getLastSuccessfulProcessedRecordPosition()).isEqualTo(1);
+    assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey())).isEqualTo(19L);
   }
 
   @Test
@@ -250,24 +241,19 @@ final class StreamProcessorReplayTest {
     inOrder.verify(recordProcessor, TIMEOUT).replay(recordCaptor.capture());
     inOrder.verifyNoMoreInteractions();
 
-    Assertions.assertThat(recordCaptor.getValue().getKey()).isEqualTo(eventKeyAfterSnapshot);
+    assertThat(recordCaptor.getValue().getKey()).isEqualTo(eventKeyAfterSnapshot);
 
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
-            () ->
-                Assertions.assertThat(streamProcessor.getLastProcessedPositionAsync().join())
-                    .isEqualTo(3L));
+            () -> assertThat(streamProcessor.getLastProcessedPositionAsync().join()).isEqualTo(3L));
     Awaitility.await("position has to be set on processing start")
         .untilAsserted(
-            () ->
-                Assertions.assertThat(streamProcessor.getLastWrittenPositionAsync().join())
-                    .isEqualTo(4L));
-    Assertions.assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey()))
-        .isEqualTo(21L);
+            () -> assertThat(streamProcessor.getLastWrittenPositionAsync().join()).isEqualTo(4L));
+    assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey())).isEqualTo(21L);
   }
 
   @RegressionTest("https://github.com/camunda/zeebe/issues/13101")
-  public void shouldNotReplayErrorEventAppliedInSnapshot() throws Exception {
+  void shouldNotReplayErrorEventAppliedInSnapshot() throws Exception {
     // given
     final var processorWhichFails = setupProcessorWhichFailsOnProcessing();
     setupOnErrorReactionForProcessor(processorWhichFails);
@@ -296,6 +282,44 @@ final class StreamProcessorReplayTest {
     verifyProcessingErrorLifecycle(processorWhichFails);
     // we shouldn't replay any events - due to snapshot
     verify(processorWhichFails, never()).replay(any());
+  }
+
+  @Test
+  void shouldReturnLastProcessedPositionInSnapshotWhenPausedDuringReplay() throws Exception {
+    // given
+    final var positionInSnapshot =
+        streamPlatform.writeBatch(
+            RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)));
+    streamPlatform.writeBatch(
+        RecordToWrite.event()
+            .processInstance(ELEMENT_ACTIVATING, Records.processInstance(1))
+            .key(1)
+            .causedBy((int) positionInSnapshot));
+    // starting the stream processor awaits until replay is completed
+    streamPlatform.startStreamProcessor();
+    streamPlatform.snapshot();
+
+    // write more events to make sure that the processor is paused in replay phase after recovery
+    streamPlatform.writeBatch(
+        RecordToWrite.command().processInstance(ACTIVATE_ELEMENT, Records.processInstance(1)),
+        RecordToWrite.event()
+            .processInstance(ELEMENT_ACTIVATING, Records.processInstance(1))
+            .key(2)
+            .causedBy(0));
+
+    streamPlatform.closeStreamProcessor();
+    streamPlatform.resetMockInvocations();
+
+    // when
+    final var streamProcessor = streamPlatform.startStreamProcessorPaused();
+
+    // then
+    assertThat(streamProcessor.getCurrentPhase().join()).isEqualTo(Phase.PAUSED);
+    Awaitility.await("position has to be set when replay is paused")
+        .untilAsserted(
+            () ->
+                assertThat(streamProcessor.getLastProcessedPositionAsync().join())
+                    .isEqualTo(positionInSnapshot));
   }
 
   private static void verifyProcessingErrorLifecycle(final RecordProcessor processorWhichFails) {
@@ -355,7 +379,6 @@ final class StreamProcessorReplayTest {
     streamPlatform.startStreamProcessor();
 
     // then
-    Assertions.assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey()))
-        .isEqualTo(19L);
+    assertThat(Protocol.decodeKeyInPartition(streamPlatform.getCurrentKey())).isEqualTo(19L);
   }
 }


### PR DESCRIPTION
## Description

1. `lastProcessedPosition` was UNSET when replay is paused. This prevents a new snapshot to be taken when the StreamProcessor is paused. Taking a new snapshot is required if the broker is currently OOD. This PR fixes this by ensuring the lastProcessedPosition is read from replay state machine.
2. The test was flaky because when StreamProcessor is paused at start, the `lastProcessedPosition` is not set when there is no snapshot. Thus it cannot take a snapshot and recover from OOD. We decided that we would not handle this case where the broker goes out of disk where the partitions has not taken any snapshot. This is unlikely to happen in production because resources are allocated properly. So to fix the flaky test, we now ensure that a snapshot exists before going OOD. 

## Related issues

closes #16550 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
