### PR TITLE
deps: adjust renovate commit prefix to lint changes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,7 +3,7 @@
   "extends": [
     "config:base"
   ],
-  "commitMessagePrefix": "deps({{datasource}}):",
+  "commitMessagePrefix": "deps:",
   "baseBranches": [
     "main",
     "/^stable\\/8\\..*/"


### PR DESCRIPTION
## Description

Renovate was setting the scope, see e.g. this failure https://github.com/camunda/zeebe/actions/runs/8242069088/job/22540428288