### PR TITLE
feat: Complete compensation throw event that invoked the compensation handler

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -176,22 +176,6 @@ public class BpmnCompensationSubscriptionBehaviour {
             });
   }
 
-  private void appendCompensationSubscriptionTriggerEvent(
-      final BpmnElementContext context,
-      final CompensationSubscription subscription,
-      final long compensationHandlerInstanceKey) {
-
-    final var key = subscription.getKey();
-    final var compensationRecord = subscription.getRecord();
-    compensationRecord
-        .setThrowEventId(BufferUtil.bufferAsString(context.getElementId()))
-        .setThrowEventInstanceKey(context.getElementInstanceKey())
-        .setCompensationHandlerInstanceKey(compensationHandlerInstanceKey);
-
-    stateWriter.appendFollowUpEvent(
-        key, CompensationSubscriptionIntent.TRIGGERED, compensationRecord);
-  }
-
   private long activateCompensationHandler(
       final BpmnElementContext context, final String elementId) {
 
@@ -215,6 +199,22 @@ public class BpmnCompensationSubscriptionBehaviour {
         compensationHandlerRecord);
 
     return compensationHandlerInstanceKey;
+  }
+
+  private void appendCompensationSubscriptionTriggerEvent(
+      final BpmnElementContext context,
+      final CompensationSubscription subscription,
+      final long compensationHandlerInstanceKey) {
+
+    final var key = subscription.getKey();
+    final var compensationRecord = subscription.getRecord();
+    compensationRecord
+        .setThrowEventId(BufferUtil.bufferAsString(context.getElementId()))
+        .setThrowEventInstanceKey(context.getElementInstanceKey())
+        .setCompensationHandlerInstanceKey(compensationHandlerInstanceKey);
+
+    stateWriter.appendFollowUpEvent(
+        key, CompensationSubscriptionIntent.TRIGGERED, compensationRecord);
   }
 
   private ExecutableBoundaryEvent getCompensationBoundaryEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -74,7 +74,6 @@ public class BpmnCompensationSubscriptionBehaviour {
               .setProcessInstanceKey(context.getProcessInstanceKey())
               .setProcessDefinitionKey(context.getProcessDefinitionKey())
               .setCompensableActivityId(elementId)
-              .setCompensableActivityScopeId(flowScopeId)
               .setCompensableActivityInstanceKey(context.getElementInstanceKey())
               .setCompensableActivityScopeKey(context.getFlowScopeKey());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -66,7 +66,6 @@ public class BpmnCompensationSubscriptionBehaviour {
 
       final var key = keyGenerator.nextKey();
       final var elementId = BufferUtil.bufferAsString(element.getId());
-      final var flowScopeId = BufferUtil.bufferAsString(element.getFlowScope().getId());
 
       final var compensation =
           new CompensationSubscriptionRecord()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -39,6 +39,9 @@ import java.util.stream.Collectors;
 
 public class BpmnCompensationSubscriptionBehaviour {
 
+  /** Default instance key if no compensation handler was activated. */
+  private static final long NONE_COMPENSATION_HANDLER_INSTANCE_KEY = -1L;
+
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final CompensationSubscriptionState compensationSubscriptionState;
@@ -59,11 +62,10 @@ public class BpmnCompensationSubscriptionBehaviour {
   public void createCompensationSubscription(
       final ExecutableActivity element, final BpmnElementContext context) {
 
-    final var elementId = BufferUtil.bufferAsString(element.getId());
-
     if (hasCompensationBoundaryEvent(element) || isFlowScopeWithSubscriptions(context)) {
 
       final var key = keyGenerator.nextKey();
+      final var elementId = BufferUtil.bufferAsString(element.getId());
       final var flowScopeId = BufferUtil.bufferAsString(element.getFlowScope().getId());
 
       final var compensation =
@@ -153,14 +155,18 @@ public class BpmnCompensationSubscriptionBehaviour {
             subscription -> scopeKey == subscription.getRecord().getCompensableActivityScopeKey())
         .forEach(
             subscription -> {
-              // mark the subscription as triggered
-              appendCompensationSubscriptionTriggerEvent(context, subscription);
+              long compensationHandlerInstanceKey = NONE_COMPENSATION_HANDLER_INSTANCE_KEY;
 
               // invoke the compensation handler if present
               if (!subscription.getRecord().getCompensationHandlerId().isEmpty()) {
-                activateCompensationHandler(
-                    context, subscription.getRecord().getCompensableActivityId());
+                compensationHandlerInstanceKey =
+                    activateCompensationHandler(
+                        context, subscription.getRecord().getCompensableActivityId());
               }
+
+              // mark the subscription as triggered
+              appendCompensationSubscriptionTriggerEvent(
+                  context, subscription, compensationHandlerInstanceKey);
 
               // propagate the compensation to subprocesses
               triggerCompensationFromTopToBottom(
@@ -171,19 +177,22 @@ public class BpmnCompensationSubscriptionBehaviour {
   }
 
   private void appendCompensationSubscriptionTriggerEvent(
-      final BpmnElementContext context, final CompensationSubscription subscription) {
+      final BpmnElementContext context,
+      final CompensationSubscription subscription,
+      final long compensationHandlerInstanceKey) {
 
     final var key = subscription.getKey();
     final var compensationRecord = subscription.getRecord();
     compensationRecord
         .setThrowEventId(BufferUtil.bufferAsString(context.getElementId()))
-        .setThrowEventInstanceKey(context.getElementInstanceKey());
+        .setThrowEventInstanceKey(context.getElementInstanceKey())
+        .setCompensationHandlerInstanceKey(compensationHandlerInstanceKey);
 
     stateWriter.appendFollowUpEvent(
         key, CompensationSubscriptionIntent.TRIGGERED, compensationRecord);
   }
 
-  private void activateCompensationHandler(
+  private long activateCompensationHandler(
       final BpmnElementContext context, final String elementId) {
 
     final var boundaryEvent = getCompensationBoundaryEvent(context, elementId);
@@ -199,8 +208,13 @@ public class BpmnCompensationSubscriptionBehaviour {
         .setBpmnElementType(compensationHandler.getElementType())
         .setBpmnEventType(BpmnEventType.COMPENSATION);
 
-    commandWriter.appendNewCommand(
-        ProcessInstanceIntent.ACTIVATE_ELEMENT, compensationHandlerRecord);
+    final long compensationHandlerInstanceKey = keyGenerator.nextKey();
+    commandWriter.appendFollowUpCommand(
+        compensationHandlerInstanceKey,
+        ProcessInstanceIntent.ACTIVATE_ELEMENT,
+        compensationHandlerRecord);
+
+    return compensationHandlerInstanceKey;
   }
 
   private ExecutableBoundaryEvent getCompensationBoundaryEvent(
@@ -250,18 +264,13 @@ public class BpmnCompensationSubscriptionBehaviour {
         boundaryEventKey, ProcessInstanceIntent.ELEMENT_COMPLETED, boundaryEventRecord);
   }
 
-  public void completeCompensationHandler(
-      final ExecutableActivity element, final BpmnElementContext context) {
+  public void completeCompensationHandler(final BpmnElementContext context) {
 
     if (BpmnEventType.COMPENSATION != context.getBpmnEventType()) {
       return; // avoid accessing the state for non-compensation handlers
     }
 
-    final var compensationHandlerId = BufferUtil.bufferAsString(element.getId());
-
     // complete the subscription of the compensation handler
-    // - if there are multiple subscriptions for the same compensation handler then we may
-    // complete the wrong subscription
     compensationSubscriptionState
         .findSubscriptionsByProcessInstanceKey(
             context.getTenantId(), context.getProcessInstanceKey())
@@ -269,8 +278,10 @@ public class BpmnCompensationSubscriptionBehaviour {
         .filter(BpmnCompensationSubscriptionBehaviour::isCompensationTriggered)
         .filter(
             subscription ->
-                subscription.getRecord().getCompensationHandlerId().equals(compensationHandlerId))
-        .forEach(compensation -> completeSubscription(context, compensation));
+                subscription.getRecord().getCompensationHandlerInstanceKey()
+                    == context.getElementInstanceKey())
+        .findFirst()
+        .ifPresent(compensation -> completeSubscription(context, compensation));
   }
 
   private void completeSubscription(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/JobWorkerTaskProcessor.java
@@ -78,7 +78,7 @@ public final class JobWorkerTaskProcessor implements BpmnElementProcessor<Execut
             })
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
+              compensationSubscriptionBehaviour.completeCompensationHandler(completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/ScriptTaskProcessor.java
@@ -97,7 +97,7 @@ public final class ScriptTaskProcessor
             })
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
+              compensationSubscriptionBehaviour.completeCompensationHandler(completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UndefinedTaskProcessor.java
@@ -53,7 +53,7 @@ public class UndefinedTaskProcessor implements BpmnElementProcessor<ExecutableAc
         .transitionToCompleted(element, context)
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
+              compensationSubscriptionBehaviour.completeCompensationHandler(completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/task/UserTaskProcessor.java
@@ -91,7 +91,7 @@ public final class UserTaskProcessor extends JobWorkerTaskSupportingProcessor<Ex
             })
         .thenDo(
             completed -> {
-              compensationSubscriptionBehaviour.completeCompensationHandler(element, completed);
+              compensationSubscriptionBehaviour.completeCompensationHandler(completed);
               stateTransitionBehavior.takeOutgoingSequenceFlows(element, completed);
             });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -41,6 +41,9 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
     copy.recordProp.getValue().setCompensationHandlerId(getRecord().getCompensationHandlerId());
     copy.recordProp
         .getValue()
+        .setCompensationHandlerInstanceKey(getRecord().getCompensationHandlerInstanceKey());
+    copy.recordProp
+        .getValue()
         .setCompensableActivityScopeKey(getRecord().getCompensableActivityScopeKey());
     copy.recordProp
         .getValue()

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscription.java
@@ -28,29 +28,12 @@ public class CompensationSubscription extends UnpackedObject implements DbValue 
 
   public CompensationSubscription copy() {
     final var copy = new CompensationSubscription();
-    copy.keyProp.setValue(getKey());
-    copy.recordProp.getValue().setTenantId(getRecord().getTenantId());
-    copy.recordProp.getValue().setProcessInstanceKey(getRecord().getProcessInstanceKey());
-    copy.recordProp.getValue().setProcessDefinitionKey(getRecord().getProcessDefinitionKey());
-    copy.recordProp.getValue().setCompensableActivityId(getRecord().getCompensableActivityId());
-    copy.recordProp
-        .getValue()
-        .setCompensableActivityScopeId(getRecord().getCompensableActivityScopeId());
-    copy.recordProp.getValue().setThrowEventId(getRecord().getThrowEventId());
-    copy.recordProp.getValue().setThrowEventInstanceKey(getRecord().getThrowEventInstanceKey());
-    copy.recordProp.getValue().setCompensationHandlerId(getRecord().getCompensationHandlerId());
-    copy.recordProp
-        .getValue()
-        .setCompensationHandlerInstanceKey(getRecord().getCompensationHandlerInstanceKey());
-    copy.recordProp
-        .getValue()
-        .setCompensableActivityScopeKey(getRecord().getCompensableActivityScopeKey());
-    copy.recordProp
-        .getValue()
-        .setCompensableActivityInstanceKey(getRecord().getCompensableActivityInstanceKey());
-    copy.recordProp
-        .getValue()
-        .setVariables(BufferUtil.cloneBuffer(getRecord().getVariablesBuffer()));
+    copy.setKey(getKey());
+
+    final CompensationSubscriptionRecord original = getRecord();
+    copy.getRecord().wrap(original);
+    copy.getRecord().setVariables(BufferUtil.cloneBuffer(original.getVariablesBuffer()));
+
     return copy;
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -203,7 +203,6 @@ public class CompensationEventExecutionTest {
             CompensationSubscriptionRecordValue::getProcessDefinitionKey,
             CompensationSubscriptionRecordValue::getCompensableActivityId,
             CompensationSubscriptionRecordValue::getCompensableActivityInstanceKey,
-            CompensationSubscriptionRecordValue::getCompensableActivityScopeId,
             CompensationSubscriptionRecordValue::getCompensableActivityScopeKey,
             CompensationSubscriptionRecordValue::getCompensationHandlerId)
         .containsOnly(
@@ -213,7 +212,6 @@ public class CompensationEventExecutionTest {
                 compensationActivityActivated.getValue().getProcessDefinitionKey(),
                 "ActivityToCompensate",
                 compensationActivityActivated.getKey(),
-                PROCESS_ID,
                 compensationActivityActivated.getValue().getFlowScopeKey(),
                 "CompensationHandler"));
 
@@ -778,19 +776,10 @@ public class CompensationEventExecutionTest {
             RecordingExporter.compensationSubscriptionRecords()
                 .withProcessInstanceKey(processInstanceKey)
                 .limit(5))
-        .extracting(
-            Record::getIntent,
-            r -> r.getValue().getCompensableActivityScopeId(),
-            r -> r.getValue().getCompensationHandlerId())
+        .extracting(Record::getIntent, r -> r.getValue().getCompensationHandlerId())
         .containsSubsequence(
-            tuple(
-                CompensationSubscriptionIntent.COMPLETED,
-                "embedded-subprocess",
-                "CompensationHandler2"),
-            tuple(
-                CompensationSubscriptionIntent.DELETED,
-                "compensation-process",
-                "CompensationHandler"));
+            tuple(CompensationSubscriptionIntent.COMPLETED, "CompensationHandler2"),
+            tuple(CompensationSubscriptionIntent.DELETED, "CompensationHandler"));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -26,7 +26,6 @@ public class CompensationSubscriptionStateTest {
   private static final long PROCESS_DEFINITION_KEY = 2L;
   private static final String COMPENSABLE_ACTIVITY_ID = "compensableActivityId";
   private static final long COMPENSABLE_ACTIVITY_INSTANCE_KEY = 3L;
-  private static final String COMPENSABLE_ACTIVITY_SCOPE_ID = "compensableActivityScopeId";
   private static final long COMPENSABLE_ACTIVITY_SCOPE_KEY = 4L;
   private static final String THROW_EVENT_ID = "throwEventId";
   private static final long THROW_EVENT_INSTANCE_KEY = 5L;
@@ -55,8 +54,6 @@ public class CompensationSubscriptionStateTest {
     assertThat(storedCompensation.getCompensableActivityId()).isEqualTo(COMPENSABLE_ACTIVITY_ID);
     assertThat(storedCompensation.getCompensableActivityInstanceKey())
         .isEqualTo(COMPENSABLE_ACTIVITY_INSTANCE_KEY);
-    assertThat(storedCompensation.getCompensableActivityScopeId())
-        .isEqualTo(COMPENSABLE_ACTIVITY_SCOPE_ID);
     assertThat(storedCompensation.getCompensableActivityScopeKey())
         .isEqualTo(COMPENSABLE_ACTIVITY_SCOPE_KEY);
     assertThat(storedCompensation.getThrowEventId()).isEqualTo(THROW_EVENT_ID);
@@ -80,7 +77,6 @@ public class CompensationSubscriptionStateTest {
             .setProcessInstanceKey(PROCESS_INSTANCE_KEY)
             .setProcessDefinitionKey(PROCESS_DEFINITION_KEY)
             .setCompensableActivityId(COMPENSABLE_ACTIVITY_ID)
-            .setCompensableActivityScopeId(COMPENSABLE_ACTIVITY_SCOPE_ID)
             .setCompensableActivityInstanceKey(10L)
             .setCompensableActivityScopeKey(11L)
             .setThrowEventId("updateThrowEventId")
@@ -214,7 +210,6 @@ public class CompensationSubscriptionStateTest {
         .setProcessDefinitionKey(PROCESS_DEFINITION_KEY)
         .setCompensableActivityId(COMPENSABLE_ACTIVITY_ID)
         .setCompensableActivityInstanceKey(COMPENSABLE_ACTIVITY_INSTANCE_KEY)
-        .setCompensableActivityScopeId(COMPENSABLE_ACTIVITY_SCOPE_ID)
         .setCompensableActivityScopeKey(COMPENSABLE_ACTIVITY_SCOPE_KEY)
         .setThrowEventId(THROW_EVENT_ID)
         .setThrowEventInstanceKey(THROW_EVENT_INSTANCE_KEY)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/compensation/CompensationSubscriptionStateTest.java
@@ -25,10 +25,13 @@ public class CompensationSubscriptionStateTest {
   private static final long PROCESS_INSTANCE_KEY = 1L;
   private static final long PROCESS_DEFINITION_KEY = 2L;
   private static final String COMPENSABLE_ACTIVITY_ID = "compensableActivityId";
+  private static final long COMPENSABLE_ACTIVITY_INSTANCE_KEY = 3L;
   private static final String COMPENSABLE_ACTIVITY_SCOPE_ID = "compensableActivityScopeId";
+  private static final long COMPENSABLE_ACTIVITY_SCOPE_KEY = 4L;
   private static final String THROW_EVENT_ID = "throwEventId";
-  private static final long THROW_EVENT_INSTANCE_KEY = 4L;
-  private static final String COMPENSATION_ACTIVITY_ELEMENT_ID = "compensationActivityElementId";
+  private static final long THROW_EVENT_INSTANCE_KEY = 5L;
+  private static final String COMPENSATION_HANDLER_ID = "compensationHandlerId";
+  private static final long COMPENSATION_HANDLER_INSTANCE_KEY = 6L;
 
   private MutableCompensationSubscriptionState state;
   private MutableProcessingState processingState;
@@ -50,12 +53,17 @@ public class CompensationSubscriptionStateTest {
     assertThat(storedCompensation.getProcessInstanceKey()).isEqualTo(PROCESS_INSTANCE_KEY);
     assertThat(storedCompensation.getProcessDefinitionKey()).isEqualTo(PROCESS_DEFINITION_KEY);
     assertThat(storedCompensation.getCompensableActivityId()).isEqualTo(COMPENSABLE_ACTIVITY_ID);
+    assertThat(storedCompensation.getCompensableActivityInstanceKey())
+        .isEqualTo(COMPENSABLE_ACTIVITY_INSTANCE_KEY);
     assertThat(storedCompensation.getCompensableActivityScopeId())
         .isEqualTo(COMPENSABLE_ACTIVITY_SCOPE_ID);
+    assertThat(storedCompensation.getCompensableActivityScopeKey())
+        .isEqualTo(COMPENSABLE_ACTIVITY_SCOPE_KEY);
     assertThat(storedCompensation.getThrowEventId()).isEqualTo(THROW_EVENT_ID);
     assertThat(storedCompensation.getThrowEventInstanceKey()).isEqualTo(THROW_EVENT_INSTANCE_KEY);
-    assertThat(storedCompensation.getCompensationHandlerId())
-        .isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
+    assertThat(storedCompensation.getCompensationHandlerId()).isEqualTo(COMPENSATION_HANDLER_ID);
+    assertThat(storedCompensation.getCompensationHandlerInstanceKey())
+        .isEqualTo(COMPENSATION_HANDLER_INSTANCE_KEY);
   }
 
   @Test
@@ -73,8 +81,11 @@ public class CompensationSubscriptionStateTest {
             .setProcessDefinitionKey(PROCESS_DEFINITION_KEY)
             .setCompensableActivityId(COMPENSABLE_ACTIVITY_ID)
             .setCompensableActivityScopeId(COMPENSABLE_ACTIVITY_SCOPE_ID)
+            .setCompensableActivityInstanceKey(10L)
+            .setCompensableActivityScopeKey(11L)
             .setThrowEventId("updateThrowEventId")
-            .setThrowEventInstanceKey(2L);
+            .setThrowEventInstanceKey(2L)
+            .setCompensationHandlerInstanceKey(12L);
 
     state.update(1L, updatedCompensationInfo);
 
@@ -95,14 +106,23 @@ public class CompensationSubscriptionStateTest {
             .getRecord();
 
     assertThat(updatedCompensation.getCompensableActivityId()).isEqualTo(COMPENSABLE_ACTIVITY_ID);
+    assertThat(updatedCompensation.getCompensableActivityInstanceKey()).isEqualTo(10L);
+    assertThat(updatedCompensation.getCompensableActivityScopeKey()).isEqualTo(11L);
     assertThat(updatedCompensation.getThrowEventId()).isEqualTo("updateThrowEventId");
     assertThat(updatedCompensation.getThrowEventInstanceKey()).isEqualTo(2L);
+    assertThat(updatedCompensation.getCompensationHandlerInstanceKey()).isEqualTo(12L);
 
     assertThat(notUpdatedCompensation.getCompensableActivityId())
         .isEqualTo(COMPENSABLE_ACTIVITY_ID);
+    assertThat(notUpdatedCompensation.getCompensableActivityInstanceKey())
+        .isEqualTo(COMPENSABLE_ACTIVITY_INSTANCE_KEY);
+    assertThat(notUpdatedCompensation.getCompensableActivityScopeKey())
+        .isEqualTo(COMPENSABLE_ACTIVITY_SCOPE_KEY);
     assertThat(notUpdatedCompensation.getThrowEventId()).isEqualTo(THROW_EVENT_ID);
     assertThat(notUpdatedCompensation.getThrowEventInstanceKey())
         .isEqualTo(THROW_EVENT_INSTANCE_KEY);
+    assertThat(notUpdatedCompensation.getCompensationHandlerInstanceKey())
+        .isEqualTo(COMPENSATION_HANDLER_INSTANCE_KEY);
   }
 
   @Test
@@ -164,10 +184,10 @@ public class CompensationSubscriptionStateTest {
 
     final var retrievedCompensation =
         state.findSubscriptionByCompensationHandlerId(
-            TENANT_ID, PROCESS_INSTANCE_KEY, COMPENSATION_ACTIVITY_ELEMENT_ID);
+            TENANT_ID, PROCESS_INSTANCE_KEY, COMPENSATION_HANDLER_ID);
     assertThat(retrievedCompensation.isPresent()).isTrue();
     assertThat(retrievedCompensation.get().getRecord().getCompensationHandlerId())
-        .isEqualTo(COMPENSATION_ACTIVITY_ELEMENT_ID);
+        .isEqualTo(COMPENSATION_HANDLER_ID);
   }
 
   @Test
@@ -193,9 +213,12 @@ public class CompensationSubscriptionStateTest {
         .setProcessInstanceKey(key)
         .setProcessDefinitionKey(PROCESS_DEFINITION_KEY)
         .setCompensableActivityId(COMPENSABLE_ACTIVITY_ID)
+        .setCompensableActivityInstanceKey(COMPENSABLE_ACTIVITY_INSTANCE_KEY)
         .setCompensableActivityScopeId(COMPENSABLE_ACTIVITY_SCOPE_ID)
+        .setCompensableActivityScopeKey(COMPENSABLE_ACTIVITY_SCOPE_KEY)
         .setThrowEventId(THROW_EVENT_ID)
         .setThrowEventInstanceKey(THROW_EVENT_INSTANCE_KEY)
-        .setCompensationHandlerId(COMPENSATION_ACTIVITY_ELEMENT_ID);
+        .setCompensationHandlerId(COMPENSATION_HANDLER_ID)
+        .setCompensationHandlerInstanceKey(COMPENSATION_HANDLER_INSTANCE_KEY);
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -31,9 +31,6 @@
             "compensableActivityId": {
               "type": "keyword"
             },
-            "compensableActivityScopeId": {
-              "type": "keyword"
-            },
             "throwEventId": {
               "type": "keyword"
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -43,6 +43,9 @@
             "compensationHandlerId": {
               "type": "keyword"
             },
+            "compensationHandlerInstanceKey": {
+              "type": "long"
+            },
             "compensableActivityScopeKey":{
               "type": "long"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -31,9 +31,6 @@
             "compensableActivityId": {
               "type": "keyword"
             },
-            "compensableActivityScopeId": {
-              "type": "keyword"
-            },
             "throwEventId": {
               "type": "keyword"
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-compensation-subscription-template.json
@@ -43,6 +43,9 @@
             "compensationHandlerId": {
               "type": "keyword"
             },
+            "compensationHandlerInstanceKey": {
+              "type": "long"
+            },
             "compensableActivityScopeKey":{
               "type": "long"
             },

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -32,8 +32,6 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
       new LongProperty("processDefinitionKey", -1);
   private final StringProperty compensableActivityIdProperty =
       new StringProperty("compensableActivityId", EMPTY_STRING);
-  private final StringProperty compensableActivityScopeIdProperty =
-      new StringProperty("compensableActivityScopeId", EMPTY_STRING);
   private final StringProperty throwEventIdProperty =
       new StringProperty("throwEventId", EMPTY_STRING);
   private final LongProperty throwEventInstanceKeyProperty =
@@ -52,12 +50,11 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
-    super(12);
+    super(11);
     declareProperty(tenantIdProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
         .declareProperty(compensableActivityIdProperty)
-        .declareProperty(compensableActivityScopeIdProperty)
         .declareProperty(throwEventIdProperty)
         .declareProperty(throwEventInstanceKeyProperty)
         .declareProperty(compensationHandlerIdProperty)
@@ -72,7 +69,6 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     processInstanceKeyProperty.setValue(record.getProcessInstanceKey());
     processDefinitionKeyProperty.setValue(record.getProcessDefinitionKey());
     compensableActivityIdProperty.setValue(record.getCompensableActivityId());
-    compensableActivityScopeIdProperty.setValue(record.getCompensableActivityScopeId());
     throwEventIdProperty.setValue(record.getThrowEventId());
     throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
     compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
@@ -115,11 +111,6 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   @Override
   public String getCompensableActivityId() {
     return BufferUtil.bufferAsString(compensableActivityIdProperty.getValue());
-  }
-
-  @Override
-  public String getCompensableActivityScopeId() {
-    return BufferUtil.bufferAsString(compensableActivityScopeIdProperty.getValue());
   }
 
   @Override
@@ -174,7 +165,8 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     return this;
   }
 
-  public CompensationSubscriptionRecord setCompensationHandlerInstanceKey(final long compensationHandlerInstanceKey) {
+  public CompensationSubscriptionRecord setCompensationHandlerInstanceKey(
+      final long compensationHandlerInstanceKey) {
     compensationHandlerInstanceKeyProperty.setValue(compensationHandlerInstanceKey);
     return this;
   }
@@ -192,12 +184,6 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
 
   public CompensationSubscriptionRecord setThrowEventId(final String throwEventId) {
     throwEventIdProperty.setValue(throwEventId);
-    return this;
-  }
-
-  public CompensationSubscriptionRecord setCompensableActivityScopeId(
-      final String compensableActivityScopeId) {
-    compensableActivityScopeIdProperty.setValue(compensableActivityScopeId);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/compensation/CompensationSubscriptionRecord.java
@@ -40,16 +40,19 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
       new LongProperty("throwEventInstanceKey", -1);
   private final StringProperty compensationHandlerIdProperty =
       new StringProperty("compensationHandlerId", EMPTY_STRING);
+  private final LongProperty compensationHandlerInstanceKeyProperty =
+      new LongProperty("compensationHandlerInstanceKey", -1L);
 
   private final LongProperty compensableActivityScopeKeyProperty =
       new LongProperty("compensableActivityScopeKey", -1);
 
   private final LongProperty compensableActivityInstanceKeyProperty =
       new LongProperty("compensableActivityInstanceKey", -1);
+
   private final DocumentProperty variablesProperty = new DocumentProperty("variables");
 
   public CompensationSubscriptionRecord() {
-    super(11);
+    super(12);
     declareProperty(tenantIdProperty)
         .declareProperty(processInstanceKeyProperty)
         .declareProperty(processDefinitionKeyProperty)
@@ -58,6 +61,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(throwEventIdProperty)
         .declareProperty(throwEventInstanceKeyProperty)
         .declareProperty(compensationHandlerIdProperty)
+        .declareProperty(compensationHandlerInstanceKeyProperty)
         .declareProperty(compensableActivityScopeKeyProperty)
         .declareProperty(compensableActivityInstanceKeyProperty)
         .declareProperty(variablesProperty);
@@ -72,6 +76,7 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
     throwEventIdProperty.setValue(record.getThrowEventId());
     throwEventInstanceKeyProperty.setValue(record.getThrowEventInstanceKey());
     compensationHandlerIdProperty.setValue(record.getCompensationHandlerId());
+    compensationHandlerInstanceKeyProperty.setValue(record.getCompensationHandlerInstanceKey());
     compensableActivityScopeKeyProperty.setValue(record.getCompensableActivityScopeKey());
     compensableActivityInstanceKeyProperty.setValue(record.getCompensableActivityInstanceKey());
     variablesProperty.setValue(record.getVariablesBuffer());
@@ -133,6 +138,11 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   }
 
   @Override
+  public long getCompensationHandlerInstanceKey() {
+    return compensationHandlerInstanceKeyProperty.getValue();
+  }
+
+  @Override
   public long getCompensableActivityScopeKey() {
     return compensableActivityScopeKeyProperty.getValue();
   }
@@ -161,6 +171,11 @@ public class CompensationSubscriptionRecord extends UnifiedRecordValue
   public CompensationSubscriptionRecord setCompensableActivityScopeKey(
       final long scopeInstanceKey) {
     compensableActivityScopeKeyProperty.setValue(scopeInstanceKey);
+    return this;
+  }
+
+  public CompensationSubscriptionRecord setCompensationHandlerInstanceKey(final long compensationHandlerInstanceKey) {
+    compensationHandlerInstanceKeyProperty.setValue(compensationHandlerInstanceKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2266,7 +2266,6 @@ final class JsonSerializableToJsonTest {
                     .setProcessInstanceKey(123L)
                     .setProcessDefinitionKey(456L)
                     .setCompensableActivityId("elementActivityId")
-                    .setCompensableActivityScopeId("elementActivityScopeId")
                     .setThrowEventId("elementThrowEventId")
                     .setThrowEventInstanceKey(123L)
                     .setCompensationHandlerId("compensationActivityElementId")
@@ -2280,7 +2279,6 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": 123,
           "processDefinitionKey": 456,
           "compensableActivityId": "elementActivityId",
-          "compensableActivityScopeId": "elementActivityScopeId",
           "throwEventId": "elementThrowEventId",
           "throwEventInstanceKey": 123,
           "compensationHandlerId": "compensationActivityElementId",
@@ -2306,7 +2304,6 @@ final class JsonSerializableToJsonTest {
           "processInstanceKey": -1,
           "processDefinitionKey": -1,
           "compensableActivityId": "",
-          "compensableActivityScopeId": "",
           "throwEventId": "",
           "throwEventInstanceKey": -1,
           "compensationHandlerId": "",

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2270,6 +2270,7 @@ final class JsonSerializableToJsonTest {
                     .setThrowEventId("elementThrowEventId")
                     .setThrowEventInstanceKey(123L)
                     .setCompensationHandlerId("compensationActivityElementId")
+                    .setCompensationHandlerInstanceKey(100L)
                     .setCompensableActivityScopeKey(789L)
                     .setCompensableActivityInstanceKey(123L)
                     .setVariables(VARIABLES_MSGPACK),
@@ -2283,6 +2284,7 @@ final class JsonSerializableToJsonTest {
           "throwEventId": "elementThrowEventId",
           "throwEventInstanceKey": 123,
           "compensationHandlerId": "compensationActivityElementId",
+          "compensationHandlerInstanceKey": 100,
           "compensableActivityScopeKey": 789,
           "compensableActivityInstanceKey": 123,
           "variables": {
@@ -2308,6 +2310,7 @@ final class JsonSerializableToJsonTest {
           "throwEventId": "",
           "throwEventInstanceKey": -1,
           "compensationHandlerId": "",
+          "compensationHandlerInstanceKey": -1,
           "compensableActivityScopeKey": -1,
           "compensableActivityInstanceKey": -1,
           "variables": {}

--- a/zeebe/protocol/revapi.json
+++ b/zeebe/protocol/revapi.json
@@ -313,16 +313,14 @@
         },
         {
           "ignore": true,
-          "code": "java.method.returnTypeChanged",
+          "code": "java.method.removed",
           "old": "method long io.camunda.zeebe.protocol.record.value.ImmutableCompensationSubscriptionRecordValue::getCompensableActivityScopeId()",
-          "new": "method java.lang.String io.camunda.zeebe.protocol.record.value.ImmutableCompensationSubscriptionRecordValue::getCompensableActivityScopeId()",
           "justification": "This functionality is not yet released"
         },
         {
           "ignore": true,
-          "code": "java.method.returnTypeChanged",
+          "code": "java.method.removed",
           "old": "method long io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue::getCompensableActivityScopeId()",
-          "new": "method java.lang.String io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue::getCompensableActivityScopeId()",
           "justification": "This functionality is not yet released"
         },
         {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -45,12 +45,6 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   String getCompensableActivityId();
 
   /**
-   * @return the element id of the flow scope that contains the activity with the compensation
-   *     handler
-   */
-  String getCompensableActivityScopeId();
-
-  /**
    * @return the element id of compensation throw event
    */
   String getThrowEventId();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/CompensationSubscriptionRecordValue.java
@@ -66,6 +66,11 @@ public interface CompensationSubscriptionRecordValue extends RecordValue {
   String getCompensationHandlerId();
 
   /**
+   * @return the instance key of the compensation handler
+   */
+  long getCompensationHandlerInstanceKey();
+
+  /**
    * @return the instance key of the flow scope that contains the activity with the compensation
    *     handler
    */


### PR DESCRIPTION
## Description

- Add a new property for the compensation handler instance key to the compensation subscription
- Use the instance key to complete the subscription that belongs to this instance of the compensation
handler.
- Remove the compensation activity scope id property from the compensation subscription record. 

## Related issues

closes #16809 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
