### PR TITLE
Distribute commands to subset of partitions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
-import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
@@ -24,6 +23,7 @@ import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistri
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributionCompleteProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentRedistributor;
 import io.camunda.zeebe.engine.processing.distribution.CommandDistributionAcknowledgeProcessor;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.distribution.CommandRedistributor;
 import io.camunda.zeebe.engine.processing.dmn.DecisionEvaluationEvaluteProcessor;
 import io.camunda.zeebe.engine.processing.incident.IncidentEventProcessors;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -178,7 +178,7 @@ public final class DeploymentCreateProcessor
     final var recordWithoutResource = createDeploymentWithoutResources(deploymentEvent);
     stateWriter.appendFollowUpEvent(
         command.getKey(), DeploymentIntent.CREATED, recordWithoutResource);
-    distributionBehavior.acknowledgeCommand(command.getKey(), command);
+    distributionBehavior.acknowledgeCommand(command);
   }
 
   private void createBpmnResources(final DeploymentRecord deploymentEvent) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -13,13 +13,13 @@ import static java.util.function.Predicate.not;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
-import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationException;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableStartEvent;
 import io.camunda.zeebe.engine.processing.deployment.transform.DeploymentTransformer;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -116,11 +116,10 @@ public final class CommandDistributionBehavior {
   /**
    * Acknowledges that a command was distributed to another partition successfully.
    *
-   * @param distributionKey the key identifying the command distribution
    * @param command the command that was distributed
    */
-  public <T extends UnifiedRecordValue> void acknowledgeCommand(
-      final long distributionKey, final TypedRecord<T> command) {
+  public <T extends UnifiedRecordValue> void acknowledgeCommand(final TypedRecord<T> command) {
+    final long distributionKey = command.getKey();
     final var distributionRecord =
         new CommandDistributionRecord()
             .setPartitionId(currentPartitionId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -36,6 +36,12 @@ public final class CommandDistributionBehavior {
   private final InterPartitionCommandSender interPartitionCommandSender;
   private final int currentPartitionId;
 
+  // Records are expensive to construct, so we create them once and reuse them
+  private final CommandDistributionRecord commandDistributionStarted =
+      new CommandDistributionRecord();
+  private final CommandDistributionRecord commandDistributionDistributing =
+      new CommandDistributionRecord();
+
   public CommandDistributionBehavior(
       final Writers writers,
       final int currentPartition,
@@ -70,7 +76,7 @@ public final class CommandDistributionBehavior {
     }
 
     final var distributionRecord =
-        new CommandDistributionRecord()
+        commandDistributionStarted
             .setPartitionId(currentPartitionId)
             .setValueType(command.getValueType())
             .setIntent(command.getIntent())
@@ -95,7 +101,7 @@ public final class CommandDistributionBehavior {
     stateWriter.appendFollowUpEvent(
         distributionKey,
         CommandDistributionIntent.DISTRIBUTING,
-        new CommandDistributionRecord()
+        commandDistributionDistributing
             .setPartitionId(partition)
             .setValueType(valueType)
             .setIntent(intent));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -45,6 +45,8 @@ public final class CommandDistributionBehavior {
       new CommandDistributionRecord();
   private final CommandDistributionRecord commandDistributionDistributing =
       new CommandDistributionRecord();
+  private final CommandDistributionRecord commandDistributionAcknowledge =
+      new CommandDistributionRecord();
 
   public CommandDistributionBehavior(
       final Writers writers,
@@ -151,7 +153,7 @@ public final class CommandDistributionBehavior {
   public <T extends UnifiedRecordValue> void acknowledgeCommand(final TypedRecord<T> command) {
     final long distributionKey = command.getKey();
     final var distributionRecord =
-        new CommandDistributionRecord()
+        commandDistributionAcknowledge
             .setPartitionId(currentPartitionId)
             .setValueType(command.getValueType())
             .setIntent(command.getIntent());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.engine.processing.common;
+package io.camunda.zeebe.engine.processing.distribution;
 
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -80,17 +80,15 @@ public final class CommandDistributionBehavior {
         distributionKey, CommandDistributionIntent.STARTED, distributionRecord);
 
     otherPartitions.forEach(
-        (partition) ->
-            distributeToPartition(command, partition, distributionRecord, distributionKey));
+        (partition) -> distributeToPartition(partition, distributionRecord, distributionKey));
   }
 
   private <T extends UnifiedRecordValue> void distributeToPartition(
-      final TypedRecord<T> command,
       final int partition,
       final CommandDistributionRecord distributionRecord,
       final long distributionKey) {
     final var valueType = distributionRecord.getValueType();
-    final var intent = command.getIntent();
+    final var intent = distributionRecord.getIntent();
     final var commandValue = distributionRecord.getCommandValue();
 
     // We don't need the actual record in the DISTRIBUTING event applier. In order to prevent

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -98,6 +98,8 @@ public final class CommandDistributionBehavior {
       return;
     }
 
+    commandDistributionStarted.reset();
+
     final var distributionRecord =
         commandDistributionStarted
             .setPartitionId(currentPartitionId)
@@ -118,6 +120,8 @@ public final class CommandDistributionBehavior {
       final long distributionKey) {
     final var valueType = distributionRecord.getValueType();
     final var intent = distributionRecord.getIntent();
+
+    commandDistributionDistributing.reset();
 
     // We don't need the actual record in the DISTRIBUTING event applier. In order to prevent
     // reaching the max message size we don't set the record value here.
@@ -152,6 +156,9 @@ public final class CommandDistributionBehavior {
    */
   public <T extends UnifiedRecordValue> void acknowledgeCommand(final TypedRecord<T> command) {
     final long distributionKey = command.getKey();
+
+    commandDistributionAcknowledge.reset();
+
     final var distributionRecord =
         commandDistributionAcknowledge
             .setPartitionId(currentPartitionId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -90,7 +90,9 @@ public final class CommandDistributionBehavior {
       final CommandDistributionRecord distributionRecord,
       final long distributionKey) {
     final var valueType = distributionRecord.getValueType();
+    final var intent = command.getIntent();
     final var commandValue = distributionRecord.getCommandValue();
+
     // We don't need the actual record in the DISTRIBUTING event applier. In order to prevent
     // reaching the max message size we don't set the record value here.
     stateWriter.appendFollowUpEvent(
@@ -99,16 +101,12 @@ public final class CommandDistributionBehavior {
         new CommandDistributionRecord()
             .setPartitionId(partition)
             .setValueType(valueType)
-            .setIntent(command.getIntent()));
+            .setIntent(intent));
 
     sideEffectWriter.appendSideEffect(
         () -> {
           interPartitionCommandSender.sendCommand(
-              partition,
-              command.getValueType(),
-              command.getIntent(),
-              distributionKey,
-              commandValue);
+              partition, command.getValueType(), intent, distributionKey, commandValue);
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -106,7 +106,7 @@ public final class CommandDistributionBehavior {
     sideEffectWriter.appendSideEffect(
         () -> {
           interPartitionCommandSender.sendCommand(
-              partition, command.getValueType(), intent, distributionKey, commandValue);
+              partition, valueType, intent, distributionKey, commandValue);
           return true;
         });
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -21,9 +21,12 @@ import java.util.List;
 import java.util.stream.IntStream;
 
 /**
- * This behavior allows distributing a command to other partitions, and for those receiving
- * partitions to acknowledge the distributed commands back to the partition that started. This is
- * needed because the communication between partitions is unreliable.
+ * The network communication between the partitions is unreliable. To allow communication between
+ * partitions in a reliable way, we've built command distribution: a way for partitions to send,
+ * receive, and acknowledge (or retry sending) commands between partitions.
+ *
+ * <p>This behavior allows distributing a command to other partitions, and for those receiving
+ * partitions to acknowledge the distributed commands back to the partition that started.
  *
  * @see <a href="https://github.com/camunda/zeebe/blob/main/zeebe/docs/generalized_distribution.md">
  *     generalized_distribution.md</a>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -65,12 +65,12 @@ public final class CommandDistributionBehavior {
   /**
    * Distributes a command to all other partitions.
    *
-   * @param distributionKey the key to identify this unique command distribution. The key is used to
-   *     store the pending distribution, as the key of distributed command, to identify the
-   *     distributing partition when processing the distributed command, and as the key to correlate
-   *     the ACKNOWLEDGE command to the pending distribution. This can be a newly generated key, or
-   *     the key identifying the entity that's being distributed. Please note that it must be unique
-   *     for command distribution. Don't reuse the key to distribute another command.
+   * @param distributionKey the key to identify this unique command distribution. The key used for
+   *     three purposes: storing the pending distribution as the key of distributed command,
+   *     identifying for the distributed command's partition, and correlating the ACKNOWLEDGE
+   *     command to the pending distribution. This can be a newly generated key, or the key
+   *     identifying the entity that's being distributed. Please note that it must be unique for
+   *     command distribution. Don't reuse the key to distribute another command.
    * @param command the command to distribute
    */
   public <T extends UnifiedRecordValue> void distributeCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehavior.java
@@ -126,7 +126,7 @@ public final class CommandDistributionBehavior {
             .setValueType(command.getValueType())
             .setIntent(command.getIntent());
 
-    final int receiverPartitionId = Protocol.decodePartitionId(command.getKey());
+    final int receiverPartitionId = Protocol.decodePartitionId(distributionKey);
     sideEffectWriter.appendSideEffect(
         () -> {
           interPartitionCommandSender.sendCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -12,12 +12,12 @@ import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_IN
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
-import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationException;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.StartEventSubscriptionManager;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -115,7 +115,7 @@ public class ResourceDeletionDeleteProcessor
     tryDeleteResources(command);
 
     stateWriter.appendFollowUpEvent(command.getKey(), ResourceDeletionIntent.DELETED, value);
-    commandDistributionBehavior.acknowledgeCommand(command.getKey(), command);
+    commandDistributionBehavior.acknowledgeCommand(command);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -102,7 +102,7 @@ public class SignalBroadcastProcessor implements DistributedTypedRecordProcessor
         subscription -> activateElement(subscription.getRecord(), value.getVariablesBuffer()));
 
     stateWriter.appendFollowUpEvent(command.getKey(), SignalIntent.BROADCASTED, command.getValue());
-    commandDistributionBehavior.acknowledgeCommand(command.getKey(), command);
+    commandDistributionBehavior.acknowledgeCommand(command);
   }
 
   private void activateElement(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/signal/SignalBroadcastProcessor.java
@@ -8,10 +8,10 @@
 package io.camunda.zeebe.engine.processing.signal;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
-import io.camunda.zeebe.engine.processing.common.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEvent;
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
 import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/distribution/CommandDistributionBehaviorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.distribution;
+
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.appliers.EventAppliers;
+import io.camunda.zeebe.engine.util.MockTypedRecord;
+import io.camunda.zeebe.engine.util.stream.FakeProcessingResultBuilder;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.distribution.CommandDistributionRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * This test differs from most other tests in the engine module. It is a unit test for the
+ * CommandDistributionBehavior class and does not use the EngineRule to start the engine. Instead,
+ * this tests the behavior of the CommandDistributionBehavior in isolation. This is necessary
+ * because the CommandDistributionBehavior is otherwise hard to test.
+ *
+ * <p>Typically, these tests assert that the behavior correctly appends follow-up records to the
+ * ProcessingResultBuilder, and that it correctly sends commands to other partitions through the
+ * InterPartitionCommandSender.
+ *
+ * <p>The command that is distributed in these tests is always the same, because the behavior is
+ * independent of the type of command, although slight coupling exists to the value type.
+ */
+class CommandDistributionBehaviorTest {
+
+  private FakeProcessingResultBuilder<CommandDistributionRecord> fakeProcessingResultBuilder;
+  private InterPartitionCommandSender mockInterpartitionCommandSender;
+  private Writers writers;
+
+  private long key;
+  private ValueType valueType;
+  private DeploymentIntent intent;
+  private MockTypedRecord<DeploymentRecord> command;
+
+  @BeforeEach
+  void setUp() {
+    fakeProcessingResultBuilder = new FakeProcessingResultBuilder<>();
+    mockInterpartitionCommandSender = mock(InterPartitionCommandSender.class);
+    writers = new Writers(() -> fakeProcessingResultBuilder, mock(EventAppliers.class));
+
+    key = Protocol.encodePartitionId(1, 100);
+    valueType = ValueType.DEPLOYMENT;
+    intent = DeploymentIntent.CREATE;
+    command =
+        new MockTypedRecord<>(
+            key, new RecordMetadata().valueType(valueType).intent(intent), new DeploymentRecord());
+  }
+
+  @Test
+  void shouldNotDistributeCommandToThisPartition() {
+    // given 1 partition
+    final var behavior =
+        new CommandDistributionBehavior(writers, 1, 1, mockInterpartitionCommandSender);
+
+    // when distributing to all partitions
+    behavior.distributeCommand(key, command);
+
+    // then no command distribution is started
+    Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords()).isEmpty();
+
+    // then no command is sent to other partitions
+    fakeProcessingResultBuilder.flushPostCommitTasks();
+    verifyNoInteractions(mockInterpartitionCommandSender);
+  }
+
+  @Test
+  void shouldDistributeCommandToAllOtherPartitions() {
+    // given 3 partitions and behavior on partition 1
+    final var behavior =
+        new CommandDistributionBehavior(writers, 1, 3, mockInterpartitionCommandSender);
+
+    // when distributing to all partitions
+    behavior.distributeCommand(key, command);
+
+    // then command distribution is started on partition 1 and distributing to all other partitions
+    Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
+        .extracting(
+            Record::getKey,
+            Record::getIntent,
+            r -> r.getValue().getPartitionId(),
+            r -> r.getValue().getIntent())
+        .containsExactly(
+            tuple(key, CommandDistributionIntent.STARTED, 1, intent),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 2, intent),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 3, intent));
+
+    // then command is sent to all other partitions
+    fakeProcessingResultBuilder.flushPostCommitTasks();
+    verify(mockInterpartitionCommandSender)
+        .sendCommand(eq(2), eq(valueType), eq(intent), eq(key), any());
+    verify(mockInterpartitionCommandSender)
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
+    verifyNoMoreInteractions(mockInterpartitionCommandSender);
+  }
+
+  @Test
+  void shouldDistributeCommandToSpecificPartitions() {
+    // given 4 partitions and behavior on partition 2
+    final var behavior =
+        new CommandDistributionBehavior(writers, 2, 4, mockInterpartitionCommandSender);
+
+    // when distributing to partitions 1 and 3
+    behavior.distributeCommand(key, command, List.of(1, 3));
+
+    // then command distribution is started on partition 2 and distributing to all other partitions
+    Assertions.assertThat(fakeProcessingResultBuilder.getFollowupRecords())
+        .extracting(
+            Record::getKey,
+            Record::getIntent,
+            r -> r.getValue().getPartitionId(),
+            r -> r.getValue().getIntent())
+        .containsExactly(
+            tuple(key, CommandDistributionIntent.STARTED, 2, intent),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 1, intent),
+            tuple(key, CommandDistributionIntent.DISTRIBUTING, 3, intent));
+
+    // then command is sent to partitions 1 and 3
+    fakeProcessingResultBuilder.flushPostCommitTasks();
+    verify(mockInterpartitionCommandSender)
+        .sendCommand(eq(1), eq(valueType), eq(intent), eq(key), any());
+    verify(mockInterpartitionCommandSender)
+        .sendCommand(eq(3), eq(valueType), eq(intent), eq(key), any());
+    verifyNoMoreInteractions(mockInterpartitionCommandSender);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/FakeProcessingResultBuilder.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/FakeProcessingResultBuilder.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.stream;
+
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.stream.api.PostCommitTask;
+import io.camunda.zeebe.stream.api.ProcessingResult;
+import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This processing result builder can be used in unit tests. It allows to capture the records and
+ * the post commit tasks appended to it. Typically, used in combination with {@link
+ * io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers} to tests behavior classes.
+ *
+ * @param <V> the type of the record value expected to be appended to this builder. This can be used
+ *     to reduce the need for casting in tests if you know that only a specific value type is
+ *     appended.
+ */
+public class FakeProcessingResultBuilder<V extends UnifiedRecordValue>
+    implements ProcessingResultBuilder {
+
+  private final List<Record<V>> followupRecords = new ArrayList<>();
+  private final List<PostCommitTask> postCommitTasks = new ArrayList<>();
+
+  /**
+   * Flushes all post commit tasks appended to this builder. This is useful to simulate the
+   * execution of the post commit tasks.
+   */
+  public void flushPostCommitTasks() {
+    postCommitTasks.forEach(PostCommitTask::flush);
+  }
+
+  public List<Record<V>> getFollowupRecords() {
+    return followupRecords;
+  }
+
+  public List<PostCommitTask> getPostCommitTasks() {
+    return postCommitTasks;
+  }
+
+  @Override
+  public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
+      final long key, final RecordValue value, final RecordMetadata metadata) {
+    final int partitionId = Protocol.decodePartitionId(key);
+    final var copiedRecord = new CopiedRecord<>((V) value, metadata, key, partitionId, -1, -1, -1);
+    followupRecords.add(copiedRecord.copyOf());
+    return Either.right(this);
+  }
+
+  @Override
+  public ProcessingResultBuilder withResponse(
+      final RecordType type,
+      final long key,
+      final Intent intent,
+      final UnpackedObject value,
+      final ValueType valueType,
+      final RejectionType rejectionType,
+      final String rejectionReason,
+      final long requestId,
+      final int requestStreamId) {
+    throw new UnsupportedOperationException("Responses are not yet supported by this fake");
+  }
+
+  @Override
+  public ProcessingResultBuilder appendPostCommitTask(final PostCommitTask task) {
+    postCommitTasks.add(task);
+    return this;
+  }
+
+  @Override
+  public ProcessingResultBuilder resetPostCommitTasks() {
+    postCommitTasks.clear();
+    return this;
+  }
+
+  @Override
+  public ProcessingResult build() {
+    throw new UnsupportedOperationException("Build is not yet supported by this fake");
+  }
+
+  @Override
+  public boolean canWriteEventOfLength(final int eventLength) {
+    return true;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adds the ability to distribute a command to a subset of partitions rather than to all partitions.

This PR is mostly a bunch of refactorings that I believe improve the understandability of the concept and code.

I've also introduced a FakeProcessingResultBuilder that we can use when writing unit tests for parts of the engine. While we typically favor integration-style tests using the APIs available to the users, we sometimes have a need for testing something in isolation. This result builder fits really well here to test the command distribution behavior class.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16385

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
