### PR TITLE
test: await identity readiness

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -27,16 +27,10 @@ import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
 import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -98,12 +92,15 @@ public class GatewayAuthenticationIdentityIT {
           .withEnv("KEYCLOAK_CLIENTS_0_PERMISSIONS_0_DEFINITION", "write:*")
           .withEnv("IDENTITY_RETRY_ATTEMPTS", "90")
           .withEnv("IDENTITY_RETRY_DELAY_SECONDS", "1")
+          // this will enable readiness checks by spring to await ApplicationRunner completion
+          .withEnv("MANAGEMENT_ENDPOINT_HEALTH_PROBES_ENABLED", "true")
+          .withEnv("MANAGEMENT_HEALTH_READINESSSTATE_ENABLED", "true")
           .withNetwork(NETWORK)
           .withExposedPorts(8080, 8082)
           .waitingFor(
               new HttpWaitStrategy()
                   .forPort(8082)
-                  .forPath("/actuator/health")
+                  .forPath("/actuator/health/readiness")
                   .allowInsecure()
                   .forStatusCode(200))
           .withNetworkAliases("identity");
@@ -118,8 +115,6 @@ public class GatewayAuthenticationIdentityIT {
 
   @BeforeAll
   static void beforeAll() {
-    awaitCamundaRealmAvailabilityOnKeycloak();
-
     ZEEBE
         .withBrokerConfig(
             cfg -> {
@@ -205,29 +200,6 @@ public class GatewayAuthenticationIdentityIT {
       assertThat(client.newTopologyRequest().send().toCompletableFuture())
           .succeedsWithin(Duration.ofSeconds(1));
     }
-  }
-
-  /**
-   * Awaits the presence of the Camunda realm and openid keys on the keycloak container. Once
-   * Keycloak and Identity booted up, Identity will eventually configure the Camunda Realm on
-   * Keycloak.
-   */
-  private static void awaitCamundaRealmAvailabilityOnKeycloak() {
-    final var httpClient = HttpClient.newHttpClient();
-    final HttpRequest request =
-        HttpRequest.newBuilder()
-            .uri(URI.create(getKeycloakRealmAddress() + "/protocol/openid-connect/certs"))
-            .build();
-    Awaitility.await()
-        .atMost(Duration.ofSeconds(120))
-        .pollInterval(Duration.ofSeconds(5))
-        .ignoreExceptions()
-        .untilAsserted(
-            () -> {
-              final HttpResponse<String> response =
-                  httpClient.send(request, BodyHandlers.ofString());
-              assertThat(response.statusCode()).isEqualTo(200);
-            });
   }
 
   private static String getKeycloakRealmAddress() {


### PR DESCRIPTION
## Description

Previous await of keycloak realm availability wasn't suffice, as identity runs several ApplicationRunners that may still run concurrently once the realm was created see e.g. [KeycloakUserInitializer]( https://github.com/camunda-cloud/identity/blob/main/management-api/src/main/java/io/camunda/identity/impl/keycloak/initializer/KeycloakUserInitializer.java) and others. Before these are completed we can't be sure identity is ready to be used and may experience failures on auth.

These config changes instruct identity to expose the spring readiness state which is bound to finished ApplicationRunners, see [Readiness State](https://docs.spring.io/spring-boot/docs/current/reference/html/features.html#features.spring-application.application-availability.readiness).

I checked the difference via the logs of testcontainers, with this change we can see that locally the identity startup takes ~8s instead of 4s and we see readiness returns 503 for a while within that period, while previously it was healthy (but not ready) on first request.

W/O readiness change
```
07:31:21.759 [] [] [main] INFO  org.testcontainers.containers.wait.strategy.HttpWaitStrategy - /nervous_rubin: Waiting for 60 seconds for URL: http://localhost:33357/actuator/health (where port 33357 maps to container port 8082)
07:31:25.706 [] [] [ducttape-0] TRACE org.testcontainers.containers.wait.strategy.HttpWaitStrategy - Get response code 200
07:31:25.708 [] [] [main] INFO  tc.camunda/identity:8.4.5 - Container camunda/identity:8.4.5 started in PT4.175705S
```

With readiness change
```
07:30:13.766 [] [] [main] INFO  org.testcontainers.containers.wait.strategy.HttpWaitStrategy - /vigorous_neumann: Waiting for 60 seconds for URL: http://localhost:33348/actuator/health/readiness (where port 33348 maps to container port 8082)
07:30:17.762 [] [] [ducttape-0] TRACE org.testcontainers.containers.wait.strategy.HttpWaitStrategy - Get response code 503
07:30:18.776 [] [] [ducttape-0] TRACE org.testcontainers.containers.wait.strategy.HttpWaitStrategy - Get response code 503
07:30:19.786 [] [] [ducttape-0] TRACE org.testcontainers.containers.wait.strategy.HttpWaitStrategy - Get response code 503
07:30:20.793 [] [] [ducttape-0] TRACE org.testcontainers.containers.wait.strategy.HttpWaitStrategy - Get response code 503
07:30:21.809 [] [] [ducttape-0] TRACE org.testcontainers.containers.wait.strategy.HttpWaitStrategy - Get response code 200
07:30:21.809 [] [] [main] INFO  tc.camunda/identity:8.4.5 - Container camunda/identity:8.4.5 started in PT8.238064S
```

See also
https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints.kubernetes-probes
https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.actuator.management.endpoint.health.probes.enabled
https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.actuator.management.health.readinessstate.enabled

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #15429
closes #15827

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
