### PR TITLE
feat(engine): support bpmn converging inclusive gateway

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/InclusiveGatewayValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/InclusiveGatewayValidator.java
@@ -32,15 +32,10 @@ public class InclusiveGatewayValidator implements ModelElementValidator<Inclusiv
       final InclusiveGateway element, final ValidationResultCollector validationResultCollector) {
 
     final SequenceFlow defaultFlow = element.getDefault();
-    final int size = element.getIncoming().size();
     if (defaultFlow != null) {
       if (defaultFlow.getSource() != element) {
         validationResultCollector.addError(0, "Default flow must start at gateway");
       }
-    }
-    if (size > 1) {
-      validationResultCollector.addError(
-          0, "Currently the inclusive gateway can only have one incoming sequence flow");
     }
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeGatewayValidationTest.java
@@ -52,26 +52,6 @@ public class ZeebeGatewayValidationTest extends AbstractZeebeValidationTest {
             .done(),
         singletonList(expect("flow1", "Must have a condition"))
       },
-      {
-        Bpmn.createExecutableProcess("process")
-            .startEvent("start")
-            .inclusiveGateway("fork")
-            .defaultFlow()
-            .sequenceFlowId("flow1")
-            .conditionExpression("= contains(str,\"a\")")
-            .serviceTask("task1", b -> b.zeebeJobType("type1"))
-            .inclusiveGateway("join")
-            .endEvent("end")
-            .moveToNode("fork")
-            .sequenceFlowId("flow2")
-            .conditionExpression("= contains(str,\"b\")")
-            .serviceTask("task2", b -> b.zeebeJobType("type2"))
-            .connectTo("join")
-            .done(),
-        singletonList(
-            expect(
-                "join", "Currently the inclusive gateway can only have one incoming sequence flow"))
-      },
       {"default-flow.bpmn", singletonList(expect("gateway", "Default flow must start at gateway"))},
       {
         "default-flow-inclusive-gateway.bpmn",

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnInclusiveGatewayBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnInclusiveGatewayBehavior.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.behavior;
+
+import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableBoundaryEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElement;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableIntermediateThrowEvent;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableLink;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableProcess;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.agrona.DirectBuffer;
+
+public class BpmnInclusiveGatewayBehavior {
+  private final BpmnStateBehavior stateBehavior;
+
+  public BpmnInclusiveGatewayBehavior(final BpmnStateBehavior stateBehavior) {
+    this.stateBehavior = stateBehavior;
+  }
+
+  public boolean hasActivePathToTheGateway(
+      final BpmnElementContext context,
+      final ExecutableFlowElement inclusiveGateway,
+      final ExecutableProcess process) {
+    final Set<DirectBuffer> takenSequenceFlowIds = stateBehavior.getTakenSequenceFlowIds(context);
+    final var gatewayElementId = inclusiveGateway.getId();
+    final var activateElementIds = findActivateElementInFlowScope(context, gatewayElementId);
+    final boolean hasActiveElementPath =
+        activateElementIds.stream()
+            .anyMatch(
+                elementId ->
+                    hasActivePathToTheGateway(
+                        process, elementId, gatewayElementId, takenSequenceFlowIds));
+    return hasActiveElementPath
+        || hasActiveSequenceFlowToTheGateway(
+            context, process, gatewayElementId, takenSequenceFlowIds);
+  }
+
+  private Set<DirectBuffer> findActivateElementInFlowScope(
+      final BpmnElementContext context, final DirectBuffer targetElementId) {
+    final var flowScopeContext = stateBehavior.getFlowScopeContext(context);
+    final var childInstanceContents = stateBehavior.getChildInstanceContexts(flowScopeContext);
+
+    // activate element in flow scope
+    return childInstanceContents.stream()
+        .map(BpmnElementContext::getElementId)
+        .filter(elementId -> !elementId.equals(targetElementId))
+        .collect(Collectors.toSet());
+  }
+
+  private boolean hasActiveSequenceFlowToTheGateway(
+      final BpmnElementContext context,
+      final ExecutableProcess process,
+      final DirectBuffer targetElementId,
+      final Set<DirectBuffer> takenSequenceFlowIds) {
+    final var flowScopeInstance = stateBehavior.getFlowScopeInstance(context);
+    final var activeSequenceFlowIds = flowScopeInstance.getActiveSequenceFlowIds();
+    // ignore pending incoming sequence flows to the gateway
+    return activeSequenceFlowIds.stream()
+        .anyMatch(
+            flowId -> {
+              final DirectBuffer elementId =
+                  process.getElementById(flowId, ExecutableSequenceFlow.class).getTarget().getId();
+              return !elementId.equals(targetElementId)
+                  && hasActivePathToTheGateway(
+                      process, elementId, targetElementId, takenSequenceFlowIds);
+            });
+  }
+
+  private boolean hasActivePathToTheGateway(
+      final ExecutableProcess process,
+      final DirectBuffer sourceElementId,
+      final DirectBuffer targetElementId,
+      final Set<DirectBuffer> takenSequenceFlowIds) {
+    final Set<ExecutableFlowElement> visited = new HashSet<>();
+    final Deque<ExecutableFlowElement> elementsToVisit = new LinkedList<>();
+
+    elementsToVisit.add(process.getElementById(sourceElementId));
+
+    ExecutableFlowElement currentElement;
+    while ((currentElement = elementsToVisit.poll()) != null) {
+      // found path from sourceElement to targetElement
+      if (currentElement.getId().equals(targetElementId)) {
+        return true;
+      }
+
+      if (!visited.contains(currentElement)) {
+        visited.add(currentElement);
+        switch (currentElement) {
+          case final ExecutableIntermediateThrowEvent throwEvent -> {
+            if (throwEvent.isLinkThrowEvent()) {
+              visitLinkEvent(elementsToVisit, throwEvent.getLink(), visited);
+            } else {
+              visitElement(elementsToVisit, throwEvent, visited, takenSequenceFlowIds);
+            }
+          }
+          case final ExecutableFlowNode element ->
+              visitElement(elementsToVisit, element, visited, takenSequenceFlowIds);
+          default -> {}
+        }
+      }
+    }
+    return false;
+  }
+
+  private void visitLinkEvent(
+      final Deque<ExecutableFlowElement> elementsToVisit,
+      final ExecutableLink linkThrowEvent,
+      final Set<ExecutableFlowElement> visited) {
+    final ExecutableCatchEventElement catchEventElement = linkThrowEvent.getCatchEventElement();
+    if (catchEventElement != null && !visited.contains(catchEventElement)) {
+      elementsToVisit.add(catchEventElement);
+    }
+  }
+
+  private void visitElement(
+      final Deque<ExecutableFlowElement> elementsToVisit,
+      final ExecutableFlowNode sourceElement,
+      final Set<ExecutableFlowElement> visited,
+      final Set<DirectBuffer> takenSequenceFlowIds) {
+    elementsToVisit.addAll(
+        sourceElement.getOutgoing().stream()
+            // exclude paths ending on an incoming sequence flow of the gateway that was already
+            // taken. All incoming flows need to be taken only once.
+            .filter(sequenceFlow -> !takenSequenceFlowIds.contains(sequenceFlow.getId()))
+            .map(ExecutableSequenceFlow::getTarget)
+            .filter(target -> !visited.contains(target))
+            .toList());
+
+    if (sourceElement instanceof ExecutableActivity) {
+      final List<ExecutableBoundaryEvent> boundaryEvents =
+          ((ExecutableActivity) sourceElement).getBoundaryEvents();
+      boundaryEvents.stream().filter(e -> !visited.contains(e)).forEach(elementsToVisit::add);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
 public final class BpmnStateBehavior {
@@ -96,6 +98,20 @@ public final class BpmnStateBehavior {
 
   public ElementInstance getFlowScopeInstance(final BpmnElementContext context) {
     return elementInstanceState.getInstance(context.getFlowScopeKey());
+  }
+
+  public List<BpmnElementContext> getChildInstanceContexts(final BpmnElementContext context) {
+    return elementInstanceState.getChildren(context.getElementInstanceKey()).stream()
+        .map(
+            childInstance ->
+                context.copy(
+                    childInstance.getKey(), childInstance.getValue(), childInstance.getState()))
+        .collect(Collectors.toList());
+  }
+
+  public Set<DirectBuffer> getTakenSequenceFlowIds(final BpmnElementContext context) {
+    return elementInstanceState.getTakenSequenceFlows(
+        context.getFlowScopeKey(), context.getElementId());
   }
 
   public BpmnElementContext getFlowScopeContext(final BpmnElementContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowTakenApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceSequenceFlowTakenApplier.java
@@ -40,10 +40,6 @@ final class ProcessInstanceSequenceFlowTakenApplier
     // path and on the other path the sequence flow is currently active.
     //
     // See discussion in https://github.com/camunda/camunda/pull/6562
-    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
-    flowScopeInstance.incrementActiveSequenceFlows();
-    elementInstanceState.updateInstance(flowScopeInstance);
-
     final var sequenceFlow =
         processState.getFlowElement(
             value.getProcessDefinitionKey(),
@@ -51,6 +47,13 @@ final class ProcessInstanceSequenceFlowTakenApplier
             value.getElementIdBuffer(),
             ExecutableSequenceFlow.class);
     final var target = sequenceFlow.getTarget();
+
+    final var flowScopeInstance = elementInstanceState.getInstance(value.getFlowScopeKey());
+    flowScopeInstance.incrementActiveSequenceFlows();
+    // Stores the pending sequence flow that helps to determine
+    // if an inclusive gateway can be activated or not.
+    flowScopeInstance.addActiveSequenceFlowId(sequenceFlow.getId());
+    elementInstanceState.updateInstance(flowScopeInstance);
 
     if (target.getElementType() == BpmnElementType.PARALLEL_GATEWAY) {
       // stores which sequence flows of the parallel gateway are taken

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ElementInstanceState.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.state.immutable;
 import io.camunda.zeebe.engine.state.instance.AwaitProcessInstanceResultMetadata;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 import org.agrona.DirectBuffer;
 
@@ -38,16 +39,28 @@ public interface ElementInstanceState {
   AwaitProcessInstanceResultMetadata getAwaitResultRequestMetadata(long processInstanceKey);
 
   /**
-   * Returns the number of the taken sequence flows that are connected to the given parallel
-   * (joining) gateway. Each sequence flow counts only as one, even if it is taken multiple times.
+   * Returns the number of the taken sequence flows that are connected to the given (joining)
+   * gateway.
    *
-   * <p>The number helps to determine if a parallel gateway can be activated or not.
+   * <p><b>NOTE</b>: Each sequence flow counts only as one, even if it is taken multiple times.
+   *
+   * <p>The number helps to determine if a gateway can be activated or not.
    *
    * @param flowScopeKey the key of the flow scope that contains the gateway
    * @param gatewayElementId the element id of the gateway
    * @return the number of taken sequence flows of the given gateway
    */
   int getNumberOfTakenSequenceFlows(final long flowScopeKey, final DirectBuffer gatewayElementId);
+
+  /**
+   * Returns the taken sequence flows that are connected to the given (joining) gateway.
+   *
+   * @param flowScopeKey the key of the flow scope that contains the gateway
+   * @param gatewayElementId the element id of the gateway
+   * @return the taken sequence flows of the given gateway
+   */
+  Set<DirectBuffer> getTakenSequenceFlows(
+      final long flowScopeKey, final DirectBuffer gatewayElementId);
 
   /**
    * Returns a list of process instance keys that belong to a specific process definition.

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbElementInstanceState.java
@@ -23,8 +23,11 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -359,6 +362,22 @@ public final class DbElementInstanceState implements MutableElementInstanceState
         });
 
     return count.get();
+  }
+
+  @Override
+  public Set<DirectBuffer> getTakenSequenceFlows(
+      final long flowScopeKey, final DirectBuffer gatewayElementId) {
+    this.flowScopeKey.wrapLong(flowScopeKey);
+    this.gatewayElementId.wrapBuffer(gatewayElementId);
+
+    final Set<DirectBuffer> takenSequenceFlows = new LinkedHashSet<>();
+    numberOfTakenSequenceFlowsColumnFamily.whileEqualPrefix(
+        flowScopeKeyAndElementId,
+        (key, number) -> {
+          takenSequenceFlows.add(BufferUtil.cloneBuffer(key.second().getBuffer()));
+        });
+
+    return takenSequenceFlows;
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.gateway;
 
+import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -24,9 +25,12 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.collection.Maps;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -708,5 +712,599 @@ public final class InclusiveGatewayTest {
             tuple(processInstance, "end1"),
             tuple(processInstance, "end2"),
             tuple(processInstance, "end3"));
+  }
+
+  @Test
+  public void shouldJoinOnInclusiveGateway() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .parallelGateway("fork")
+            .sequenceFlowId("joinFlow1")
+            .inclusiveGateway("join")
+            .endEvent("end")
+            .moveToNode("fork")
+            .sequenceFlowId("joinFlow2")
+            .connectTo("join")
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("joinFlow1", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsSubsequence(
+            tuple("joinFlow2", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsOnlyOnce(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldJoinOnGatewayWithOneIncomingFlowTaken() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .inclusiveGateway("fork")
+            .sequenceFlowId("joinFlow1")
+            .conditionExpression("a > 0")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .conditionExpression("a < 0")
+            .sequenceFlowId("joinFlow2")
+            .connectTo("join")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("a", 10).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsOnlyOnce(
+            tuple("joinFlow1", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(tuple("joinFlow2", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN));
+  }
+
+  @Test
+  public void shouldJoinOnGatewayWhenMultiSatisfiedBranchesAreActivated() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .inclusiveGateway("fork")
+            .sequenceFlowId("joinFlow1")
+            .conditionExpression("a > 0")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .conditionExpression("a > 5")
+            .sequenceFlowId("joinFlow2")
+            .connectTo("join")
+            .moveToNode("fork")
+            .conditionExpression("a > 100")
+            .sequenceFlowId("joinFlow3")
+            .connectTo("join")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("a", 10).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("joinFlow1", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsSubsequence(
+            tuple("joinFlow2", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .doesNotContain(tuple("joinFlow3", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN))
+        .containsOnlyOnce(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldJoinOnGatewayWhenAllSatisfiedBranchesAreActivated() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .sequenceFlowId("joinFlow1")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .serviceTask("task", b -> b.zeebeJobType("type"))
+            .sequenceFlowId("joinFlow2")
+            .connectTo("join")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    // complete the job
+    ENGINE.job().ofInstance(processInstanceKey).withType("type").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("joinFlow1", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("joinFlow2", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .containsOnlyOnce(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldJoinOnGatewayWhenAllSatisfiedBranchesAreActivatedWithBoundaryEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .sequenceFlowId("joinFlow1")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .serviceTask("task", b -> b.zeebeJobType("type"))
+            .boundaryEvent("event", b -> b.timerWithDuration("PT5S"))
+            .sequenceFlowId("joinFlow2")
+            .connectTo("join")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.increaseTime(Duration.ofSeconds(10));
+
+    // then
+    final List<Record<ProcessInstanceRecordValue>> events =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .limitToProcessInstanceCompleted()
+            .collect(Collectors.toList());
+
+    assertThat(events)
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("joinFlow1", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("joinFlow2", ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATED))
+        .containsOnlyOnce(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldMergeAndSplitInOneGateway() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .parallelGateway("fork")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .connectTo("join")
+            .conditionExpression("a > 0")
+            .serviceTask("task1", b -> b.zeebeJobType("type1"))
+            .moveToLastGateway()
+            .conditionExpression("a > 5")
+            .serviceTask("task2", b -> b.zeebeJobType("type2"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("a", 10).create();
+
+    // then
+    final List<Record<ProcessInstanceRecordValue>> elementInstances =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.SERVICE_TASK)
+            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .limit(2)
+            .collect(Collectors.toList());
+
+    assertThat(elementInstances)
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsOnlyOnce(
+            tuple("task1", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("task2", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void shouldMergeAndSplitInOneGatewayWhenSubsetOfTheSequenceFlowsHasBeenTaken() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .exclusiveGateway("fork")
+            .conditionExpression("a >= 0")
+            .task("task1")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .conditionExpression("a < 0")
+            .task("task2")
+            .connectTo("join")
+            .moveToNode("join")
+            .conditionExpression("b > 0")
+            .task("task3")
+            .moveToLastGateway()
+            .conditionExpression("b > 5")
+            .task("task4")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariables(Map.of("a", 10, "b", 10))
+            .create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsOnlyOnce(
+            tuple("task1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("task3", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("task4", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldJoinOnGatewayIfAllIncomingFlowsAreTakenOnce() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .task("task-1")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .parallelGateway("parallel")
+            .exclusiveGateway("exclusive")
+            .connectTo("join")
+            .moveToNode("parallel")
+            .serviceTask("task-3", t -> t.zeebeJobType("type"))
+            .connectTo("exclusive")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withElementType(BpmnElementType.INCLUSIVE_GATEWAY)
+                .limit(1))
+        .extracting(e -> e.getValue().getElementId())
+        .containsOnlyOnce("join");
+  }
+
+  @Test
+  public void shouldJoinOnGatewayIfAnIncomingFlowIsTaken() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .exclusiveGateway("exclusive")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .serviceTask("task-3", t -> t.zeebeJobType("type"))
+            .connectTo("exclusive")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withElementType(BpmnElementType.INCLUSIVE_GATEWAY)
+                .limit(1))
+        .extracting(e -> e.getValue().getElementId())
+        .containsOnlyOnce("join");
+  }
+
+  @Test
+  public void shouldJoinGatewayWithMultipleTokensOnSamePath() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .inclusiveGateway("join")
+            .endEvent()
+            .moveToNode("fork")
+            .parallelGateway("fork-2")
+            .task("task-1")
+            .exclusiveGateway("exclusive")
+            .connectTo("join")
+            .moveToNode("fork-2")
+            .task("task-2")
+            .connectTo("exclusive")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    final List<Record<ProcessInstanceRecordValue>> processInstanceEvents =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .limitToProcessInstanceCompleted()
+            .collect(Collectors.toList());
+
+    assertThat(processInstanceEvents)
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldJoinGatewayIfActiveElementWithLoopHasPathToGateway() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .parallelGateway("fork")
+            .task("task-1")
+            .inclusiveGateway("join")
+            .endEvent()
+            .moveToNode("fork")
+            .serviceTask("task-2", s -> s.zeebeJobType("test"))
+            .exclusiveGateway("exclusive")
+            .conditionExpression("a > 1")
+            .connectTo("join")
+            .moveToNode("exclusive")
+            .conditionExpression("a <= 1")
+            .connectTo("task-2")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("a", 5).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withIntent(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId())
+        .containsOnlyOnce("join");
+  }
+
+  @Test
+  public void shouldJoinGatewayIfActiveElementWithLoopNoPathToGateway() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .parallelGateway("fork")
+            .task("task-1")
+            .inclusiveGateway("join")
+            .endEvent("end-1")
+            .moveToNode("fork")
+            .task("task-2")
+            .connectTo("join")
+            .moveToNode("fork")
+            .serviceTask("task-3")
+            .zeebeJobType("test")
+            .exclusiveGateway("exclusive")
+            .conditionExpression("a > 1")
+            .endEvent("end-2")
+            .moveToNode("exclusive")
+            .conditionExpression("a <= 1")
+            .connectTo("task-3")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("a", 5).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("task-1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsSubsequence(
+            tuple("task-2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsOnlyOnce(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldJoinOnGatewayIfActiveLinkCatchEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .task("task-1")
+            .inclusiveGateway("join")
+            .endEvent()
+            .moveToNode("fork")
+            .serviceTask("task-2", s -> s.zeebeJobType("test"))
+            .intermediateThrowEvent("throw", b -> b.link("link"))
+            .moveToProcess(PROCESS_ID)
+            .linkCatchEvent("catch")
+            .link("link")
+            .connectTo("join")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("test").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("task-1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsSubsequence(
+            tuple("task-2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsOnlyOnce(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldJoinOnGatewayWithNoneThrowEvent() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .task("task-1")
+            .inclusiveGateway("join")
+            .endEvent()
+            .moveToNode("fork")
+            .task("task-2")
+            .intermediateThrowEvent("throw")
+            .connectTo("join")
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("task-1", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsSubsequence(
+            tuple("task-2", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("join", ProcessInstanceIntent.ELEMENT_ACTIVATING))
+        .containsOnlyOnce(
+            tuple("join", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldResolveIncident() {
+    // given
+    final var process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent("start")
+            .parallelGateway("fork")
+            .inclusiveGateway("join")
+            .moveToNode("fork")
+            .connectTo("join")
+            .conditionExpression("foo > 0")
+            .serviceTask("task1", b -> b.zeebeJobType("type1"))
+            .moveToLastGateway()
+            .conditionExpression("foo > 5")
+            .serviceTask("task2", b -> b.zeebeJobType("type2"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.variables().ofScope(processInstanceKey).withDocument(Maps.of(entry("foo", 10))).update();
+    final var incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.SERVICE_TASK)
+                .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .limit(2))
+        .extracting(e -> e.getValue().getElementId(), Record::getIntent)
+        .contains(
+            tuple("task1", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("task2", ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/NumberOfTakenSequenceFlowsStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/NumberOfTakenSequenceFlowsStateTest.java
@@ -96,6 +96,23 @@ public final class NumberOfTakenSequenceFlowsStateTest {
   }
 
   @Test
+  public void shouldReturnTakenSequenceFlows() {
+    // given
+    elementInstanceState.incrementNumberOfTakenSequenceFlows(
+        FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID, SEQUENCE_FLOW_ELEMENT_ID);
+    elementInstanceState.incrementNumberOfTakenSequenceFlows(
+        FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID, SEQUENCE_FLOW_ELEMENT_ID);
+    elementInstanceState.incrementNumberOfTakenSequenceFlows(
+        FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID, OTHER_SEQUENCE_FLOW_ELEMENT_ID);
+
+    // then
+    final var takenSequenceFlows =
+        elementInstanceState.getTakenSequenceFlows(FLOW_SCOPE_KEY, GATEWAY_ELEMENT_ID);
+    assertThat(takenSequenceFlows)
+        .containsExactlyInAnyOrder(SEQUENCE_FLOW_ELEMENT_ID, OTHER_SEQUENCE_FLOW_ELEMENT_ID);
+  }
+
+  @Test
   public void shouldDecrementNumbers() {
     // given
     elementInstanceState.incrementNumberOfTakenSequenceFlows(


### PR DESCRIPTION
## Description
This PR adds support for converging/joining inclusive gateway.

## Related issues
closes #10031

## Definition of Done
Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
