### PR TITLE
Remove compensation subscription when terminating subprocess 

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/SubProcessProcessor.java
@@ -93,6 +93,7 @@ public final class SubProcessProcessor
 
     eventSubscriptionBehavior.unsubscribeFromEvents(terminating);
     incidentBehavior.resolveIncidents(terminating);
+    compensationSubscriptionBehaviour.deleteSubscriptionsOfSubprocess(terminating);
 
     final var noActiveChildInstances = stateTransitionBehavior.terminateChildInstances(terminating);
     if (noActiveChildInstances) {

--- a/zeebe/engine/src/test/resources/compensation/compensation-multiinstance-subprocess-terminated.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-multiinstance-subprocess-terminated.bpmn
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ooqdwl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_09xy41x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="subprocess">
+      <bpmn:incoming>Flow_09xy41x</bpmn:incoming>
+      <bpmn:outgoing>Flow_01z009g</bpmn:outgoing>
+      <bpmn:multiInstanceLoopCharacteristics>
+        <bpmn:extensionElements>
+          <zeebe:loopCharacteristics inputCollection="=[1,2,3]" />
+        </bpmn:extensionElements>
+      </bpmn:multiInstanceLoopCharacteristics>
+      <bpmn:startEvent id="Event_0tx7iii">
+        <bpmn:outgoing>Flow_02s4q60</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_02s4q60" sourceRef="Event_0tx7iii" targetRef="A" />
+      <bpmn:sequenceFlow id="Flow_1vvcwbh" sourceRef="A" targetRef="Event_1rsduv6" />
+      <bpmn:serviceTask id="A" name="A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="A" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_02s4q60</bpmn:incoming>
+        <bpmn:outgoing>Flow_1vvcwbh</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_1wtb45q" attachedToRef="A">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1vrx9w9" />
+      </bpmn:boundaryEvent>
+      <bpmn:endEvent id="Event_0loo0x6">
+        <bpmn:incoming>Flow_0dotdo1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:serviceTask id="undoA" name="undo A" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="undoA" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_0dotdo1" sourceRef="Event_1rsduv6" targetRef="Event_0loo0x6" />
+      <bpmn:intermediateThrowEvent id="Event_1rsduv6">
+        <bpmn:incoming>Flow_1vvcwbh</bpmn:incoming>
+        <bpmn:outgoing>Flow_0dotdo1</bpmn:outgoing>
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1renh4q" />
+      </bpmn:intermediateThrowEvent>
+      <bpmn:association id="Association_0x6ydnr" associationDirection="One" sourceRef="Event_1wtb45q" targetRef="undoA" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_09xy41x" sourceRef="StartEvent_1" targetRef="subprocess" />
+    <bpmn:endEvent id="Event_176evt4">
+      <bpmn:incoming>Flow_01z009g</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_01z009g" sourceRef="subprocess" targetRef="Event_176evt4" />
+    <bpmn:sequenceFlow id="Flow_0benk2b" sourceRef="timer" targetRef="Event_1p03anv" />
+    <bpmn:endEvent id="Event_1p03anv">
+      <bpmn:incoming>Flow_0benk2b</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="timer" attachedToRef="subprocess">
+      <bpmn:outgoing>Flow_0benk2b</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_01vz515">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p03anv_di" bpmnElement="Event_1p03anv">
+        <dc:Bounds x="872" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_176evt4_di" bpmnElement="Event_176evt4">
+        <dc:Bounds x="902" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hx27gq_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="310" y="100" width="540" height="290" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tx7iii_di" bpmnElement="Event_0tx7iii">
+        <dc:Bounds x="350" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hsnw7f_di" bpmnElement="A">
+        <dc:Bounds x="440" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0m18tth_di" bpmnElement="undoA">
+        <dc:Bounds x="580" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1j5bpz5_di" bpmnElement="Event_1rsduv6">
+        <dc:Bounds x="642" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0loo0x6_di" bpmnElement="Event_0loo0x6">
+        <dc:Bounds x="772" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xe0s1s_di" bpmnElement="Event_1wtb45q">
+        <dc:Bounds x="492" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02s4q60_di" bpmnElement="Flow_02s4q60">
+        <di:waypoint x="386" y="177" />
+        <di:waypoint x="440" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vvcwbh_di" bpmnElement="Flow_1vvcwbh">
+        <di:waypoint x="540" y="177" />
+        <di:waypoint x="642" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dotdo1_di" bpmnElement="Flow_0dotdo1">
+        <di:waypoint x="678" y="177" />
+        <di:waypoint x="772" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0x6ydnr_di" bpmnElement="Association_0x6ydnr">
+        <di:waypoint x="510" y="235" />
+        <di:waypoint x="510" y="300" />
+        <di:waypoint x="580" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ldd7il_di" bpmnElement="timer">
+        <dc:Bounds x="818" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09xy41x_di" bpmnElement="Flow_09xy41x">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="310" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01z009g_di" bpmnElement="Flow_01z009g">
+        <di:waypoint x="850" y="177" />
+        <di:waypoint x="902" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0benk2b_di" bpmnElement="Flow_0benk2b">
+        <di:waypoint x="836" y="408" />
+        <di:waypoint x="836" y="470" />
+        <di:waypoint x="872" y="470" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-subprocess-terminated-multiscope.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-subprocess-terminated-multiscope.bpmn
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ooqdwl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_09xy41x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="subprocess">
+      <bpmn:incoming>Flow_1408u0j</bpmn:incoming>
+      <bpmn:outgoing>Flow_1mpayaj</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0tx7iii">
+        <bpmn:outgoing>Flow_02s4q60</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_02s4q60" sourceRef="Event_0tx7iii" targetRef="B" />
+      <bpmn:serviceTask id="B" name="B">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="B" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_02s4q60</bpmn:incoming>
+        <bpmn:outgoing>Flow_0zu2ohp</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_1wtb45q" attachedToRef="B">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1vrx9w9" />
+      </bpmn:boundaryEvent>
+      <bpmn:serviceTask id="undoB" name="undo B" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="undoB" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:subProcess id="subprocess2">
+        <bpmn:incoming>Flow_0zu2ohp</bpmn:incoming>
+        <bpmn:outgoing>Flow_11x05lj</bpmn:outgoing>
+        <bpmn:startEvent id="Event_1058f5t">
+          <bpmn:outgoing>Flow_0rjsu5z</bpmn:outgoing>
+        </bpmn:startEvent>
+        <bpmn:sequenceFlow id="Flow_0rjsu5z" sourceRef="Event_1058f5t" targetRef="C" />
+        <bpmn:serviceTask id="C" name="C">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="C" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_0rjsu5z</bpmn:incoming>
+          <bpmn:outgoing>Flow_1epod0k</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:sequenceFlow id="Flow_1epod0k" sourceRef="C" targetRef="D" />
+        <bpmn:serviceTask id="D" name="D">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="D" />
+          </bpmn:extensionElements>
+          <bpmn:incoming>Flow_1epod0k</bpmn:incoming>
+          <bpmn:outgoing>Flow_07qboz7</bpmn:outgoing>
+        </bpmn:serviceTask>
+        <bpmn:boundaryEvent id="Event_0p52a5i" attachedToRef="C">
+          <bpmn:compensateEventDefinition id="CompensateEventDefinition_08rk35k" />
+        </bpmn:boundaryEvent>
+        <bpmn:serviceTask id="undoC" name="undo C" isForCompensation="true">
+          <bpmn:extensionElements>
+            <zeebe:taskDefinition type="undoC" />
+          </bpmn:extensionElements>
+        </bpmn:serviceTask>
+        <bpmn:endEvent id="Event_12za3f3">
+          <bpmn:incoming>Flow_07qboz7</bpmn:incoming>
+        </bpmn:endEvent>
+        <bpmn:sequenceFlow id="Flow_07qboz7" sourceRef="D" targetRef="Event_12za3f3" />
+        <bpmn:association id="Association_0hz9crr" associationDirection="One" sourceRef="Event_0p52a5i" targetRef="undoC" />
+      </bpmn:subProcess>
+      <bpmn:sequenceFlow id="Flow_0zu2ohp" sourceRef="B" targetRef="subprocess2" />
+      <bpmn:endEvent id="Event_04z0ymk">
+        <bpmn:incoming>Flow_11x05lj</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_11x05lj" sourceRef="subprocess2" targetRef="Event_04z0ymk" />
+      <bpmn:association id="Association_0x6ydnr" associationDirection="One" sourceRef="Event_1wtb45q" targetRef="undoB" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_09xy41x" sourceRef="StartEvent_1" targetRef="A" />
+    <bpmn:endEvent id="Event_176evt4">
+      <bpmn:incoming>Flow_1mpayaj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0benk2b" sourceRef="timer" targetRef="Event_0zirey3" />
+    <bpmn:endEvent id="Event_1p03anv">
+      <bpmn:incoming>Flow_1q9vwol</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="timer" attachedToRef="subprocess">
+      <bpmn:outgoing>Flow_0benk2b</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_01vz515">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_1mpayaj" sourceRef="subprocess" targetRef="Event_176evt4" />
+    <bpmn:sequenceFlow id="Flow_1q9vwol" sourceRef="Event_0zirey3" targetRef="Event_1p03anv" />
+    <bpmn:intermediateThrowEvent id="Event_0zirey3">
+      <bpmn:incoming>Flow_0benk2b</bpmn:incoming>
+      <bpmn:outgoing>Flow_1q9vwol</bpmn:outgoing>
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1oyiz4g" />
+    </bpmn:intermediateThrowEvent>
+    <bpmn:serviceTask id="undoA" name="undo A" isForCompensation="true">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="undoA" />
+      </bpmn:extensionElements>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="A" name="A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="A" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_09xy41x</bpmn:incoming>
+      <bpmn:outgoing>Flow_1408u0j</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1408u0j" sourceRef="A" targetRef="subprocess" />
+    <bpmn:boundaryEvent id="Event_1fwzi2u" attachedToRef="A">
+      <bpmn:compensateEventDefinition id="CompensateEventDefinition_1f57xeq" />
+    </bpmn:boundaryEvent>
+    <bpmn:association id="Association_0af3ziy" associationDirection="One" sourceRef="Event_1fwzi2u" targetRef="undoA" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="219" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wkc1r5_di" bpmnElement="A">
+        <dc:Bounds x="220" y="197" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0x3lz7a_di" bpmnElement="undoA">
+        <dc:Bounds x="340" y="480" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_176evt4_di" bpmnElement="Event_176evt4">
+        <dc:Bounds x="1492" y="247" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p03anv_di" bpmnElement="Event_1p03anv">
+        <dc:Bounds x="1572" y="492" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1ffdhla_di" bpmnElement="Event_0zirey3">
+        <dc:Bounds x="1482" y="492" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hx27gq_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="360" y="80" width="1070" height="370" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tx7iii_di" bpmnElement="Event_0tx7iii">
+        <dc:Bounds x="400" y="219" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hsnw7f_di" bpmnElement="B">
+        <dc:Bounds x="490" y="197" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0m18tth_di" bpmnElement="undoB">
+        <dc:Bounds x="630" y="320" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04z0ymk_di" bpmnElement="Event_04z0ymk">
+        <dc:Bounds x="1362" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0atw4g9_di" bpmnElement="subprocess2" isExpanded="true">
+        <dc:Bounds x="800" y="137" width="520" height="263" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1058f5t_di" bpmnElement="Event_1058f5t">
+        <dc:Bounds x="840" y="219" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_06y28k7_di" bpmnElement="C">
+        <dc:Bounds x="930" y="197" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dfisz2_di" bpmnElement="D">
+        <dc:Bounds x="1090" y="197" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04okpbl_di" bpmnElement="undoC">
+        <dc:Bounds x="1030" y="300" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_12za3f3_di" bpmnElement="Event_12za3f3">
+        <dc:Bounds x="1252" y="219" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Association_0hz9crr_di" bpmnElement="Association_0hz9crr">
+        <di:waypoint x="970" y="295" />
+        <di:waypoint x="970" y="340" />
+        <di:waypoint x="1030" y="340" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1j9y111_di" bpmnElement="Event_0p52a5i">
+        <dc:Bounds x="952" y="259" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0rjsu5z_di" bpmnElement="Flow_0rjsu5z">
+        <di:waypoint x="876" y="237" />
+        <di:waypoint x="930" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1epod0k_di" bpmnElement="Flow_1epod0k">
+        <di:waypoint x="1030" y="237" />
+        <di:waypoint x="1090" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07qboz7_di" bpmnElement="Flow_07qboz7">
+        <di:waypoint x="1190" y="237" />
+        <di:waypoint x="1252" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0x6ydnr_di" bpmnElement="Association_0x6ydnr">
+        <di:waypoint x="560" y="295" />
+        <di:waypoint x="560" y="360" />
+        <di:waypoint x="630" y="360" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1xe0s1s_di" bpmnElement="Event_1wtb45q">
+        <dc:Bounds x="542" y="259" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02s4q60_di" bpmnElement="Flow_02s4q60">
+        <di:waypoint x="436" y="237" />
+        <di:waypoint x="490" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zu2ohp_di" bpmnElement="Flow_0zu2ohp">
+        <di:waypoint x="590" y="237" />
+        <di:waypoint x="800" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11x05lj_di" bpmnElement="Flow_11x05lj">
+        <di:waypoint x="1320" y="260" />
+        <di:waypoint x="1362" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0af3ziy_di" bpmnElement="Association_0af3ziy">
+        <di:waypoint x="270" y="295" />
+        <di:waypoint x="270" y="520" />
+        <di:waypoint x="340" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0ldd7il_di" bpmnElement="timer">
+        <dc:Bounds x="1412" y="432" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1m8ibn4_di" bpmnElement="Event_1fwzi2u">
+        <dc:Bounds x="252" y="259" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0benk2b_di" bpmnElement="Flow_0benk2b">
+        <di:waypoint x="1430" y="468" />
+        <di:waypoint x="1430" y="510" />
+        <di:waypoint x="1482" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1mpayaj_di" bpmnElement="Flow_1mpayaj">
+        <di:waypoint x="1430" y="265" />
+        <di:waypoint x="1492" y="265" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09xy41x_di" bpmnElement="Flow_09xy41x">
+        <di:waypoint x="188" y="237" />
+        <di:waypoint x="220" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1408u0j_di" bpmnElement="Flow_1408u0j">
+        <di:waypoint x="320" y="237" />
+        <di:waypoint x="360" y="237" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q9vwol_di" bpmnElement="Flow_1q9vwol">
+        <di:waypoint x="1518" y="510" />
+        <di:waypoint x="1572" y="510" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/engine/src/test/resources/compensation/compensation-subprocess-terminated.bpmn
+++ b/zeebe/engine/src/test/resources/compensation/compensation-subprocess-terminated.bpmn
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1ooqdwl" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.19.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.4.0">
+  <bpmn:process id="compensation-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_09xy41x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:subProcess id="subprocess">
+      <bpmn:incoming>Flow_09xy41x</bpmn:incoming>
+      <bpmn:outgoing>Flow_01z009g</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0tx7iii">
+        <bpmn:outgoing>Flow_02s4q60</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:sequenceFlow id="Flow_02s4q60" sourceRef="Event_0tx7iii" targetRef="CompensableActivity" />
+      <bpmn:sequenceFlow id="Flow_1vvcwbh" sourceRef="CompensableActivity" targetRef="CompensableActivity2" />
+      <bpmn:serviceTask id="CompensableActivity" name="A">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensableActivity" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_02s4q60</bpmn:incoming>
+        <bpmn:outgoing>Flow_1vvcwbh</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:serviceTask id="CompensableActivity2" name="B">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensableActivity2" />
+        </bpmn:extensionElements>
+        <bpmn:incoming>Flow_1vvcwbh</bpmn:incoming>
+        <bpmn:outgoing>Flow_1nqqcn9</bpmn:outgoing>
+      </bpmn:serviceTask>
+      <bpmn:boundaryEvent id="Event_1wtb45q" attachedToRef="CompensableActivity">
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1vrx9w9" />
+      </bpmn:boundaryEvent>
+      <bpmn:endEvent id="Event_0loo0x6">
+        <bpmn:incoming>Flow_0dotdo1</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_1nqqcn9" sourceRef="CompensableActivity2" targetRef="Event_1rsduv6" />
+      <bpmn:serviceTask id="CompensationHandler" name="undo A" isForCompensation="true">
+        <bpmn:extensionElements>
+          <zeebe:taskDefinition type="compensationHandler" />
+        </bpmn:extensionElements>
+      </bpmn:serviceTask>
+      <bpmn:sequenceFlow id="Flow_0dotdo1" sourceRef="Event_1rsduv6" targetRef="Event_0loo0x6" />
+      <bpmn:intermediateThrowEvent id="Event_1rsduv6">
+        <bpmn:incoming>Flow_1nqqcn9</bpmn:incoming>
+        <bpmn:outgoing>Flow_0dotdo1</bpmn:outgoing>
+        <bpmn:compensateEventDefinition id="CompensateEventDefinition_1renh4q" />
+      </bpmn:intermediateThrowEvent>
+      <bpmn:association id="Association_0x6ydnr" associationDirection="One" sourceRef="Event_1wtb45q" targetRef="CompensationHandler" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_09xy41x" sourceRef="StartEvent_1" targetRef="subprocess" />
+    <bpmn:endEvent id="Event_176evt4">
+      <bpmn:incoming>Flow_01z009g</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_01z009g" sourceRef="subprocess" targetRef="Event_176evt4" />
+    <bpmn:sequenceFlow id="Flow_0benk2b" sourceRef="timer" targetRef="Event_1p03anv" />
+    <bpmn:endEvent id="Event_1p03anv">
+      <bpmn:incoming>Flow_0benk2b</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="timer" attachedToRef="subprocess">
+      <bpmn:outgoing>Flow_0benk2b</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_01vz515">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">PT1S</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:boundaryEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="compensation-process">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hx27gq_di" bpmnElement="subprocess" isExpanded="true">
+        <dc:Bounds x="310" y="77" width="750" height="313" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0tx7iii_di" bpmnElement="Event_0tx7iii">
+        <dc:Bounds x="350" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hsnw7f_di" bpmnElement="CompensableActivity">
+        <dc:Bounds x="440" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hcx97u_di" bpmnElement="CompensableActivity2">
+        <dc:Bounds x="710" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0loo0x6_di" bpmnElement="Event_0loo0x6">
+        <dc:Bounds x="1002" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0m18tth_di" bpmnElement="CompensationHandler">
+        <dc:Bounds x="580" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1j5bpz5_di" bpmnElement="Event_1rsduv6">
+        <dc:Bounds x="882" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1xe0s1s_di" bpmnElement="Event_1wtb45q">
+        <dc:Bounds x="492" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_02s4q60_di" bpmnElement="Flow_02s4q60">
+        <di:waypoint x="386" y="177" />
+        <di:waypoint x="440" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vvcwbh_di" bpmnElement="Flow_1vvcwbh">
+        <di:waypoint x="540" y="177" />
+        <di:waypoint x="710" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nqqcn9_di" bpmnElement="Flow_1nqqcn9">
+        <di:waypoint x="810" y="177" />
+        <di:waypoint x="882" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0dotdo1_di" bpmnElement="Flow_0dotdo1">
+        <di:waypoint x="918" y="177" />
+        <di:waypoint x="1002" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Association_0x6ydnr_di" bpmnElement="Association_0x6ydnr">
+        <di:waypoint x="510" y="235" />
+        <di:waypoint x="510" y="300" />
+        <di:waypoint x="580" y="300" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_176evt4_di" bpmnElement="Event_176evt4">
+        <dc:Bounds x="1142" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p03anv_di" bpmnElement="Event_1p03anv">
+        <dc:Bounds x="1102" y="452" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0ldd7il_di" bpmnElement="timer">
+        <dc:Bounds x="1022" y="372" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_09xy41x_di" bpmnElement="Flow_09xy41x">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="310" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01z009g_di" bpmnElement="Flow_01z009g">
+        <di:waypoint x="1060" y="177" />
+        <di:waypoint x="1142" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0benk2b_di" bpmnElement="Flow_0benk2b">
+        <di:waypoint x="1040" y="408" />
+        <di:waypoint x="1040" y="470" />
+        <di:waypoint x="1102" y="470" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

If a subprocess is terminated, all the compensation subscriptions inside the subprocess scope must be deleted from the state

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16808 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
