### PR TITLE
Allow loading beans exclusively on the non-management context

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -302,6 +302,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ConditionalOnNonManagementContext.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ConditionalOnNonManagementContext.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.zeebe.shared.management;
 
-import io.camunda.zeebe.shared.management.ConditionalOnManagementContext.OnManagementContextCondition;
+import static io.camunda.zeebe.shared.management.ConditionalOnManagementContext.OnManagementContextCondition.MANAGEMENT_ONLY_BEAN_NAME;
+
+import io.camunda.zeebe.shared.management.ConditionalOnNonManagementContext.OnNonManagementContextCondition;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -20,37 +22,29 @@ import org.springframework.context.annotation.ConditionContext;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.core.type.AnnotatedTypeMetadata;
 
-/**
- * This conditional annotation only works for {@link
- * org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration} factories
- * registered in {@code
- * /META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports}.
- */
+/** This annotation provides the inverse of {@link ConditionalOnManagementContext} */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
 @Documented
-@Conditional(OnManagementContextCondition.class)
-public @interface ConditionalOnManagementContext {
-
+@Conditional(OnNonManagementContextCondition.class)
+public @interface ConditionalOnNonManagementContext {
   /**
-   * A condition which matches if the management context is the same as the base server context or
-   * if it's a different one, and we're currently configuring it.
+   * A condition which matches if the management context is disabled or the same as the base server
+   * context. If the management context is on a different server, it will match iff for the absence
+   * of a management specific bean on the current context.
    */
-  final class OnManagementContextCondition extends SpringBootCondition {
-
-    static final String MANAGEMENT_ONLY_BEAN_NAME = "ManagementContextWebServerFactory";
+  final class OnNonManagementContextCondition extends SpringBootCondition {
 
     @Override
     public ConditionOutcome getMatchOutcome(
         final ConditionContext context, final AnnotatedTypeMetadata metadata) {
       final var managementPortType = ManagementPortType.get(context.getEnvironment());
       return switch (managementPortType) {
-        case DISABLED -> ConditionOutcome.noMatch("no management application defined");
-        case SAME -> ConditionOutcome.match();
+        case DISABLED, SAME -> ConditionOutcome.match();
         case DIFFERENT ->
             context.getRegistry().containsBeanDefinition(MANAGEMENT_ONLY_BEAN_NAME)
-                ? ConditionOutcome.match()
-                : ConditionOutcome.noMatch("not the management context");
+                ? ConditionOutcome.noMatch("management context")
+                : ConditionOutcome.match();
       };
     }
   }

--- a/dist/src/test/java/io/camunda/zeebe/ForbidWebStereotypeTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/ForbidWebStereotypeTest.java
@@ -57,6 +57,8 @@ public final class ForbidWebStereotypeTest {
               "io.camunda.zeebe.broker..",
               "io.camunda.zeebe.gateway..",
               "io.camunda.zeebe.shared..")
+          .and()
+          .resideOutsideOfPackage("io.camunda.zeebe.gateway.rest")
           .should()
           .beAnnotatedWith(WEB_STEREOTYPES)
           .orShould()


### PR DESCRIPTION
## Description

This PR adds the inverse annotation to `ConditionalOnManagementContext`, allowing us to load beans exclusively on the non-management context. This will allow us to specify authentication and other security options _only_ for the REST API and not for the management server using annotations.

At the same time, I fixed two testing issues:

1. We were only running ArchUnit tests :upside_down_face: Now both ArchUnit and junit tests will run
2. The ArchUnit test was failing for me and also flagging classes in the `gateway-rest` module as using the web stereotypes. This is valid. We just didn't want them used in the main dist module.

## Related issues

related to #16835 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
