### PR TITLE
Add warning to checkers

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -430,7 +430,7 @@ public final class DbJobState implements JobState, MutableJobState {
   boolean visitJob(final long jobKey, final BiPredicate<Long, JobRecord> callback) {
     final JobRecord job = getJob(jobKey);
     if (job == null) {
-      LOG.error("Expected to find job with key {}, but no job found", jobKey);
+      LOG.warn("Expected to find job with key {}, but no job found", jobKey);
       return true; // we want to continue with the iteration
     }
     return callback.test(jobKey, job);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.db.impl.DbLong;
 import io.camunda.zeebe.db.impl.DbString;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey;
 import io.camunda.zeebe.db.impl.DbTenantAwareKey.PlacementType;
+import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.state.immutable.PendingProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.PendingSubscription;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
@@ -26,12 +27,14 @@ import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
+import org.slf4j.Logger;
 
 public final class DbProcessMessageSubscriptionState
     implements MutableProcessMessageSubscriptionState,
         PendingProcessMessageSubscriptionState,
         StreamProcessorLifecycleAware {
 
+  private static final Logger LOG = Loggers.PROCESS_PROCESSOR_LOGGER;
   // (elementInstanceKey, tenant aware messageName) => ProcessMessageSubscription
   private final DbLong elementInstanceKey;
 
@@ -171,7 +174,14 @@ public final class DbProcessMessageSubscriptionState
               pendingSubscription.elementInstanceKey(),
               BufferUtil.wrapString(pendingSubscription.messageName()),
               pendingSubscription.tenantId());
-
+      if (subscription == null) {
+        LOG.warn(
+            "Expected to find subscription with key {} messageName {} tenantId: {}, but no subscription found",
+            pendingSubscription.elementInstanceKey(),
+            messageName,
+            pendingSubscription.tenantId());
+        continue;
+      }
       visitor.visit(subscription);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -178,7 +178,7 @@ public final class DbProcessMessageSubscriptionState
         LOG.warn(
             "Expected to find subscription with key {} messageName {} tenantId: {}, but no subscription found",
             pendingSubscription.elementInstanceKey(),
-            messageName,
+            pendingSubscription.messageName(),
             pendingSubscription.tenantId());
         continue;
       }


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

Adding a Logger to DbProcessMessageSubscriptionState in order to log warning in cases where the subscription is not found. Please see https://github.com/camunda/zeebe/issues/16609

Changing ERROR log message to WARN in DbJobState to align with other checkers.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/zeebe/issues/16609
closes https://github.com/camunda/zeebe/issues/15733

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
