### PR TITLE
Write an error record to prevent error loop in ProcessingStateMachine

### DIFF
--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -115,6 +115,7 @@
     <field name="partitionId" id="1" type="uint16"/>
     <field name="key" id="2" type="uint64"/>
     <field name="recordType" id="3" type="RecordType"/>
+    <!-- value type is usually request.ValueType but can also be ERROR if RecordType is COMMAND_REJECTION -->
     <field name="valueType" id="4" type="ValueType"/>
     <field name="intent" id="5" type="uint8"/>
     <!-- populated when RecordType is COMMAND_REJECTION -->

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/CommandRejectionException.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/CommandRejectionException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.stream.impl;
+
+/**
+ * The user command is rejected because RecordProcessor failed to process the command record and
+ * failed to handle the processing error gracefully.
+ */
+public class CommandRejectionException extends RuntimeException {
+
+  public CommandRejectionException(final String message) {
+    super(message);
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -526,7 +526,8 @@ public final class ProcessingStateMachine {
     final ProcessingResultBuilder processingResultBuilder =
         new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
     final var errorRecord = new ErrorRecord();
-    errorRecord.initErrorRecord(new RuntimeException(rejectionReason), currentRecord.getPosition());
+    errorRecord.initErrorRecord(
+        new CommandRejectionException(rejectionReason), currentRecord.getPosition());
 
     final var recordMetadata =
         new RecordMetadata()


### PR DESCRIPTION
## Description

Previously we reset the value and used it to write the follow up rejection record and the rejection response. However, as we saw in https://github.com/camunda/zeebe/issues/16429 not all records are serializable when the value is reset because it may not have a valid value for the properties. 

To ensure all cases can be handled in the error handling logic in `ProcessingStateMachine`, we write an `ErrorRecord`. It is guaranteed that an `ErrorRecord` is always serializable. 

We also send the `ErrorRecord` in the response. However, the gateway do not read the value in a rejection response anyway. So it does not matter. Alternatively, we can also decide not to send any "value" in a rejection response. But this could break several parts of the code as we assume this is not null when serializing or deserializing it. It feels safer to just sent an error record which is currently ignored by the gateway. But can be read if needed if we decide to use it later. 

## Related issues

closes #16107 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
