### PR TITLE
fix: ignore distribution folders of Operate/Zeebe for the other component's CI

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,5 +6,6 @@ component/zeebe:
 component/operate:
   - changed-files:
     - all-globs-to-any-file:
-      - '!zeebe/**'
       - '!.github/workflows/zeebe-*'
+      - '!dist/**'
+      - '!zeebe/**'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,8 +1,9 @@
 component/zeebe:
   - changed-files:
-    - all-globs-to-any-file: 
-      - '!operate/**'
+    - all-globs-to-any-file:
       - '!.github/workflows/operate-*'
+      - '!distro/**'
+      - '!operate/**'
 component/operate:
   - changed-files:
     - all-globs-to-any-file:

--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths-ignore:
       - '.github/workflows/zeebe-*'
+      - 'dist/**'
       - 'zeebe/**'
 
 jobs:

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -10,10 +10,12 @@ on:
       - 'stable/**'
     paths-ignore:
       - '.github/workflows/zeebe-*'
+      - 'dist/**'
       - 'zeebe/**'
   pull_request:
     paths-ignore:
       - '.github/workflows/zeebe-*'
+      - 'dist/**'
       - 'zeebe/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/workflows/zeebe-*'
+      - 'dist/**'
       - 'zeebe/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/workflows/zeebe-*'
+      - 'dist/**'
       - 'zeebe/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - 'operate/client/**'
       - '!.github/workflows/zeebe-*'
+      - '!dist/**'
       - '!zeebe/**'
   pull_request:
     paths:
       - 'operate/client/**'
       - '!.github/workflows/zeebe-*'
+      - '!dist/**'
       - '!zeebe/**'
 
 jobs:

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths-ignore:
       - '.github/workflows/zeebe-*'
+      - 'dist/**'
       - 'zeebe/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -10,10 +10,12 @@ on:
       - staging
     paths-ignore:
       - '.github/workflows/operate-*'
+      - 'distro/**'
       - 'operate/**'
   pull_request:
     paths-ignore:
       - '.github/workflows/operate-*'
+      - 'distro/**'
       - 'operate/**'
   merge_group: { }
   workflow_dispatch: { }

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -186,6 +186,7 @@
             </includes>
             <excludes>
               <exclude>zeebe/benchmarks/project/**/*</exclude>
+              <exclude>distro/**/*</exclude>
               <exclude>operate/**/*</exclude>
             </excludes>
             <mapping>


### PR DESCRIPTION
## Description

Triggered [from the discussion here](https://camunda.slack.com/archives/C06HTSPD5AP/p1710432404768699) we realized that the `dist` folder should not trigger the Zeebe CI and the `distro` folder shouldn't trigger Operate CI.

## Related issues

Related to https://github.com/camunda/team-infrastructure/issues/616