### PR TITLE
fix: do not fail retry of member join operation

### DIFF
--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberJoinApplier.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/changes/MemberJoinApplier.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.topology.changes.TopologyChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.topology.state.ClusterTopology;
 import io.camunda.zeebe.topology.state.MemberState;
+import io.camunda.zeebe.topology.state.MemberState.State;
 import io.camunda.zeebe.util.Either;
 import java.util.function.UnaryOperator;
 
@@ -37,12 +38,21 @@ final class MemberJoinApplier implements MemberOperationApplier {
   @Override
   public Either<Exception, UnaryOperator<MemberState>> initMemberState(
       final ClusterTopology currentClusterTopology) {
-    if (currentClusterTopology.hasMember(memberId)) {
+    if (currentClusterTopology.hasMember(memberId)
+        && !currentClusterTopology.getMember(memberId).state().equals(State.JOINING)) {
       return Either.left(
           new IllegalStateException(
               String.format(
                   "Expected to join member %s, but the member is already part of the topology",
                   memberId)));
+    }
+
+    if (currentClusterTopology.hasMember(memberId)
+        && currentClusterTopology.getMember(memberId).state().equals(State.JOINING)) {
+      // If member is already joining, then we don't need to set it again. This can happen if the
+      // node restarted while applying the join operation. To ensure that the topology change can
+      // make progress, we do not treat this as an error.
+      return Either.right(UnaryOperator.identity());
     }
 
     return Either.right(

--- a/zeebe/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
+++ b/zeebe/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
@@ -42,7 +42,7 @@ final class MemberJoinApplierTest {
   }
 
   @Test
-  void shouldFailMemberJoinOnInitIfMemberExistsInJoiningState() {
+  void shouldNotFailMemberJoinOnInitIfMemberExistsInJoiningState() {
     final MemberId memberId = MemberId.from("1");
     final var memberJoinApplier = new MemberJoinApplier(memberId, null);
 
@@ -53,10 +53,9 @@ final class MemberJoinApplierTest {
     final var result = memberJoinApplier.init(clusterTopologyWithMember);
 
     // then
-    EitherAssert.assertThat(result).isLeft();
-    assertThat(result.getLeft())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("but the member is already part of the topology");
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get().apply(clusterTopologyWithMember).getMember(memberId).state())
+        .isEqualTo(JOINING);
   }
 
   @Test


### PR DESCRIPTION
## Description

If the broker restarts while applying the operation, it might be in state joining. When the operation is reapplied after restart, it should not fail.

## Related issues

closes #16870 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
