### PR TITLE
fix(operate): Error calling Prometheus endpoint with multitenancy enabled 

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchDecisionStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchDecisionStore.java
@@ -72,7 +72,7 @@ public class ElasticsearchDecisionStore implements DecisionStore {
                             .precisionThreshold(1_000)
                             .field(fieldName)));
     try {
-      final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
+      final SearchResponse searchResponse = esClient.search(searchRequest, RequestOptions.DEFAULT);
       final Cardinality distinctFieldCounts =
           searchResponse.getAggregations().get(DISTINCT_FIELD_COUNTS);
       return Optional.of(distinctFieldCounts.getValue());

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -161,7 +161,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
                             .precisionThreshold(1_000)
                             .field(fieldName)));
     try {
-      final SearchResponse searchResponse = tenantAwareClient.search(searchRequest);
+      final SearchResponse searchResponse = esClient.search(searchRequest, RequestOptions.DEFAULT);
       final Cardinality distinctFieldCounts =
           searchResponse.getAggregations().get(DISTINCT_FIELD_COUNTS);
       return Optional.of(distinctFieldCounts.getValue());
@@ -365,6 +365,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
     }
   }
 
+  @Override
   public ProcessInstanceForListViewEntity getProcessInstanceListViewByKey(Long processInstanceKey) {
     try {
       final QueryBuilder query =

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchDecisionStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchDecisionStore.java
@@ -18,7 +18,6 @@ package io.camunda.operate.store.opensearch;
 
 import static io.camunda.operate.store.opensearch.dsl.AggregationDSL.cardinalityAggregation;
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.matchAll;
-import static io.camunda.operate.store.opensearch.dsl.QueryDSL.withTenantCheck;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
 import static io.camunda.operate.util.ExceptionHelper.withIOException;
 
@@ -54,7 +53,7 @@ public class OpensearchDecisionStore implements DecisionStore {
     var indexAlias = decisionIndex.getAlias();
     var searchRequestBuilder =
         searchRequestBuilder(indexAlias)
-            .query(withTenantCheck(matchAll()))
+            .query(matchAll())
             .size(0)
             .aggregations(
                 DISTINCT_FIELD_COUNTS, cardinalityAggregation(fieldName, 1_000)._toAggregation());

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchProcessStore.java
@@ -84,7 +84,7 @@ public class OpensearchProcessStore implements ProcessStore {
     final SearchResponse<Void> response;
     var searchRequestBuilder =
         searchRequestBuilder(processIndex.getAlias())
-            .query(withTenantCheck(matchAll()))
+            .query(matchAll())
             .aggregations(
                 DISTINCT_FIELD_COUNTS, cardinalityAggregation(fieldName, 1_000)._toAggregation())
             .size(0);

--- a/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStoreTest.java
@@ -83,7 +83,7 @@ public class ElasticsearchProcessStoreTest {
 
   @Test
   public void testExceptionDuringGetDistinctCountFor() throws IOException {
-    when(tenantAwareClient.search(any())).thenThrow(new IOException());
+    when(esClient.search(any(), any())).thenThrow(new IOException());
     when(processIndex.getAlias()).thenReturn("processIndexAlias");
 
     Optional<Long> result = underTest.getDistinctCountFor("foo");


### PR DESCRIPTION
- removed tenant check in ProcessStore calls
- changed used client from tenant aware to high level client in DecisionStores
- adjusted related test to mock high level client
## Description

<!-- Please explain the changes you made here. -->
Removed tenant awareness from client calls in ProcessStore and DecisionStore for method getDistinctCountFor(...). The method is only called by the ModelMetricsProvider and metrics access does not require authentication.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes https://github.com/camunda/operate/issues/6448

Migrated Pull-Request from the Operate repository. Original: https://github.com/camunda/operate/pull/6632

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
