### PR TITLE
[Backport stable/8.4] fix: do not fail retry of member join operation

### DIFF
--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
@@ -54,7 +54,7 @@ final class MemberJoinApplierTest {
 
     // then
     EitherAssert.assertThat(result).isRight();
-    assertThat(result.get().apply(clusterTopologyWithMember).getMember(memberId).state())
+    assertThat(result.get().apply(clusterTopologyWithMember.getMember(memberId)).state())
         .isEqualTo(JOINING);
   }
 

--- a/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
+++ b/topology/src/test/java/io/camunda/zeebe/topology/changes/MemberJoinApplierTest.java
@@ -42,7 +42,7 @@ final class MemberJoinApplierTest {
   }
 
   @Test
-  void shouldFailMemberJoinOnInitIfMemberExistsInJoiningState() {
+  void shouldNotFailMemberJoinOnInitIfMemberExistsInJoiningState() {
     final MemberId memberId = MemberId.from("1");
     final var memberJoinApplier = new MemberJoinApplier(memberId, null);
 
@@ -53,10 +53,9 @@ final class MemberJoinApplierTest {
     final var result = memberJoinApplier.init(clusterTopologyWithMember);
 
     // then
-    EitherAssert.assertThat(result).isLeft();
-    assertThat(result.getLeft())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("but the member is already part of the topology");
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get().apply(clusterTopologyWithMember).getMember(memberId).state())
+        .isEqualTo(JOINING);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #16907 to `stable/8.4`.

relates to #16870
original author: @deepthidevaki