### PR TITLE
fix: change references from master to main branch in Operate CI

### DIFF
--- a/.github/workflows/operate-backend-linting.yml
+++ b/.github/workflows/operate-backend-linting.yml
@@ -2,7 +2,7 @@ name: Operate Backend
 on:
   push:
     branches:
-      - master
+      - main
     paths-ignore:
       - ".github/workflows/zeebe-*"
       - "operate/client/**"

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -29,7 +29,7 @@ defaults:
 # Define environment variables
 env:
   BRANCH_NAME: ${{ inputs.branch }}
-  IS_MASTER_BRANCH: ${{ inputs.branch == 'master' }}
+  IS_DEFAULT_BRANCH: ${{ inputs.branch == 'main' }}
 
 jobs:
   build:
@@ -49,7 +49,7 @@ jobs:
         run: |
           GIT_COMMIT_HASH=$(git rev-parse ${{ inputs.branch }})
           BRANCH_SLUG=$(echo "${{ inputs.branch }}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g')
-          echo "IMAGE_TAG=$(if [ "${{ inputs.branch }}" = "master" ]; then echo $GIT_COMMIT_HASH; else echo "branch-$BRANCH_SLUG"; fi)" >> $GITHUB_ENV
+          echo "IMAGE_TAG=$(if [ "${{ inputs.branch }}" = "main" ]; then echo $GIT_COMMIT_HASH; else echo "branch-$BRANCH_SLUG"; fi)" >> $GITHUB_ENV
           echo "CI_IMAGE_TAG=ci-$GIT_COMMIT_HASH" >> $GITHUB_ENV
           echo "PR_IMAGE_TAG=pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
 
@@ -118,7 +118,7 @@ jobs:
       #########################################################################
       # Docker login for snapshot deployment
       - name: Login to docker hub
-        if: ${{ env.IS_MASTER_BRANCH == 'true' }}
+        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
@@ -127,7 +127,7 @@ jobs:
       #########################################################################
       # Build SNAPSHOT Docker image
       - name: Build SNAPSHOT Docker image
-        if: ${{ env.IS_MASTER_BRANCH == 'true' }}
+        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         uses: ./.github/actions/build-operate-docker
         with:
           tags: |
@@ -137,6 +137,6 @@ jobs:
       #########################################################################
       # Deploy Nexus SNAPSHOT
       - name: Deploy - Nexus SNAPSHOT
-        if: ${{ env.IS_MASTER_BRANCH == 'true' }}
+        if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         run: |
           mvn -f operate org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -P -docker,skipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -1,4 +1,4 @@
-# This GitHub Actions workflow that is triggered on push to `master` and `stable/**` branch or on any pull request creation
+# This GitHub Actions workflow that is triggered on push to `main` and `stable/**` branch or on any pull request creation
 # and invokes `ci-build-reusable` and `ci-test-reusable` workflows.
 ---
 name: Operate CI
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - 'master'
+      - 'main'
       - 'stable/**'
     paths-ignore:
       - '.github/workflows/zeebe-*'
@@ -30,7 +30,7 @@ jobs:
     uses: ./.github/workflows/operate-ci-build-reusable.yml
     secrets: inherit
     with:
-      branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `master` or `stable/**`
+      branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
 
   run-tests:
     name: run-tests

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -38,3 +38,13 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
+
+  test-summary:
+    # Used by the merge queue as a dummy instead of the Zeebe CI in case only Operate files got changed:
+    # https://github.com/orgs/community/discussions/26251
+    # This name is hard-coded in the branch rules; remember to update that if this name changes
+    name: Test summary
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -2,7 +2,7 @@ name: Operate Frontend
 on:
   push:
     branches:
-      - master
+      - main
     paths:
       - 'operate/client/**'
       - '!.github/workflows/zeebe-*'

--- a/.github/workflows/operate-release-dry-run-scheduled.yml
+++ b/.github/workflows/operate-release-dry-run-scheduled.yml
@@ -1,4 +1,4 @@
-# This GitHub Actions (GHA) workflow performs a scheduled dry-run of the release process for `master` and last 3 `stable` branches.
+# This GitHub Actions (GHA) workflow performs a scheduled dry-run of the release process for `main`.
 #
 # The workflow is scheduled to run at 03:00 from Monday through Friday, according to the cron format.
 #
@@ -26,16 +26,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - branch: master
+          - branch: main
             releaseVersion: 99.0.0
-          - branch: stable/8.1
-            releaseVersion: 91.0.0
-          - branch: stable/8.2
-            releaseVersion: 92.0.0
-          - branch: stable/8.3
-            releaseVersion: 93.0.0
-          - branch: stable/8.4
-            releaseVersion: 94.0.0
     with:
       branch: ${{ matrix.branch }}
       releaseVersion: ${{ matrix.releaseVersion }}


### PR DESCRIPTION
## Description

`camunda/operate` has `master` as the default branch so several CI workflows still referred to that instead of `main` in this repo, fixing in this PR.

## Related issues

Related to https://github.com/camunda/team-infrastructure/issues/616