### PR TITLE
ci: release Operate with prefixed Git tag

### DIFF
--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -67,6 +67,7 @@ env:
   JAVA_VERSION: 17
   LIMITS_CPU: 2
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
+  TAG_VERSION: operate-${{ inputs.releaseVersion }}
   GITHUB_UPLOAD_RELEASE: ${{ inputs.githubUploadRelease }}
   DRY_RUN: ${{ inputs.dryRun }}
   CREATE_A_RELEASE: ${{ inputs.dryRun == false && inputs.branch != 'stable/opensearch-8.2' && inputs.fromCommit != '' }}
@@ -156,7 +157,7 @@ jobs:
           -DlocalCheckout=true \
           -DskipTests=true -B -T$LIMITS_CPU --fail-at-end \
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
-          -Dtag=$RELEASE_VERSION \
+          -Dtag=$TAG_VERSION \
           -DreleaseVersion=$RELEASE_VERSION \
           -DdevelopmentVersion=$NEXT_DEVELOPMENT_VERSION \
           -Darguments='-Dmaven.deploy.skip=$SKIP_DEPLOY -P -docker -DskipTests=true -DskipNexusStagingDeployMojo=$SKIP_DEPLOY -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn'
@@ -167,10 +168,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
         uses: octokit/request-action@v2.1.9
         with:
-          route: POST /repos/camunda/operate/releases
+          route: POST /repos/camunda/zeebe/releases
           draft: false
-          name: ${{ inputs.releaseVersion }}
-          tag_name: ${{ inputs.releaseVersion }}
+          name: ${{ env.TAG_VERSION }}
+          tag_name: ${{ env.TAG_VERSION }}
           body: ${{ toJSON(format('{0}', steps.changelog.outputs.body)) }}
 
       # Upload: Upload to GitHub Release
@@ -179,7 +180,6 @@ jobs:
           GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
         run: |
           ARTIFACT="camunda-operate"
-          ZEEBE_VERSION=$(mvn -f operate help:evaluate -Dexpression=version.zeebe -q -DforceStdout)
 
           cd target/checkout/distro/target
 
@@ -195,8 +195,8 @@ jobs:
             if $DRY_RUN; then
               echo "'${f}' file was created, skip upload in dryRun mode"
             elif $GITHUB_UPLOAD_RELEASE; then
-              echo "Uploading '${f}' file to operate repo on GitHub"
-              ./github-release upload --user camunda --repo operate --tag ${ZEEBE_VERSION} --name "${f}" --file "${f}"
+              echo "Uploading '${f}' file to zeebe repo on GitHub"
+              ./github-release upload --user camunda --repo zeebe --tag ${TAG_VERSION} --name "${f}" --file "${f}"
             else
               echo "'${f}' file was created, skip upload"
             fi
@@ -294,7 +294,7 @@ jobs:
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",
-              "github_run_url": "https://github.com/camunda/operate/actions/runs/${{ github.run_id }}",
+              "github_run_url": "https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}",
               "dry_run": "${{ inputs.dryRun }}",
               "release_version": "${{ inputs.releaseVersion }}",
               "branch": "${{ inputs.branch }}"


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
As discussed in https://camunda.slack.com/archives/C06HTSPD5AP/p1710335238406509
in 8.5 minor and patch releases , Zeebe and Operate will continue to be released separately

- Operate will be released with `operate-8.5.X` Git Tags, matching Operate 8.5.X POM version
- New `operate-8.5.X` releases will be created in https://github.com/camunda/zeebe/releases containing Operate release notes + artifacts (assets)

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
