### PR TITLE
feat: Trigger compensation from an event subprocess

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCompensateEventDefinitionBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCompensateEventDefinitionBuilder.java
@@ -43,16 +43,6 @@ public abstract class AbstractCompensateEventDefinitionBuilder<
     if (activity == null) {
       throw new BpmnModelException("Activity with id '" + activityId + "' does not exist");
     }
-    final Event event = (Event) element.getParentElement();
-    if (activity.getParentElement() != event.getParentElement()) {
-      throw new BpmnModelException(
-          "Activity with id '"
-              + activityId
-              + "' must be in the same scope as '"
-              + event.getId()
-              + "'");
-    }
-
     element.setActivity(activity);
     return myself;
   }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
@@ -88,9 +88,8 @@ public class CompensationEventDefinitionValidator
   private static boolean isSubprocess(final Activity activity) {
     if (activity instanceof SubProcess) {
       return !((SubProcess) activity).triggeredByEvent();
-    } else {
-      return false;
     }
+    return false;
   }
 
   private static boolean hasCompensationActivityInSameScope(
@@ -106,8 +105,7 @@ public class CompensationEventDefinitionValidator
   private static boolean isEventSubprocess(final BpmnModelElementInstance elementInstance) {
     if (elementInstance instanceof SubProcess) {
       return ((SubProcess) elementInstance).triggeredByEvent();
-    } else {
-      return false;
     }
+    return false;
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/CompensationEventDefinitionValidator.java
@@ -17,6 +17,7 @@ package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.Activity;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
 import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.util.ModelUtil;
@@ -66,7 +67,7 @@ public class CompensationEventDefinitionValidator
               referencedActivity.getId()));
     }
 
-    if (referencedActivity.getScope() != compensateEventDefinition.getScope()) {
+    if (!hasCompensationActivityInSameScope(compensateEventDefinition, referencedActivity)) {
       validationResultCollector.addError(
           0,
           String.format(
@@ -87,6 +88,24 @@ public class CompensationEventDefinitionValidator
   private static boolean isSubprocess(final Activity activity) {
     if (activity instanceof SubProcess) {
       return !((SubProcess) activity).triggeredByEvent();
+    } else {
+      return false;
+    }
+  }
+
+  private static boolean hasCompensationActivityInSameScope(
+      final CompensateEventDefinition compensateEventDefinition,
+      final Activity referencedActivity) {
+    final BpmnModelElementInstance compensationEventScope = compensateEventDefinition.getScope();
+
+    return referencedActivity.getScope() == compensationEventScope
+        || (isEventSubprocess(compensationEventScope)
+            && referencedActivity.getScope() == compensationEventScope.getScope());
+  }
+
+  private static boolean isEventSubprocess(final BpmnModelElementInstance elementInstance) {
+    if (elementInstance instanceof SubProcess) {
+      return ((SubProcess) elementInstance).triggeredByEvent();
     } else {
       return false;
     }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilderTest.java
@@ -1816,24 +1816,14 @@ public class ProcessBuilderTest {
             .userTask("subProcessTask")
             .endEvent()
             .subProcessDone()
-            .endEvent("end")
+            .endEvent("throw")
+            .compensateEventDefinition()
+            .activityRef("subProcessTask")
             .done();
 
-    final UserTask userTask = modelInstance.getModelElementById("userTask");
-    final UserTaskBuilder userTaskBuilder = userTask.builder();
-
-    try {
-      userTaskBuilder
-          .boundaryEvent("boundary")
-          .compensateEventDefinition()
-          .activityRef("subProcessTask")
-          .done();
-      fail("should fail");
-    } catch (final BpmnModelException e) {
-      assertThat(e)
-          .hasMessageContaining(
-              "Activity with id 'subProcessTask' must be in the same scope as 'boundary'");
-    }
+    final CompensateEventDefinition eventDefinition =
+        assertAndGetSingleEventDefinition("throw", CompensateEventDefinition.class);
+    assertThat(eventDefinition.getActivity().getId()).isEqualTo("subProcessTask");
   }
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -172,7 +172,12 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             userTaskBehavior);
 
     compensationSubscriptionBehaviour =
-        new BpmnCompensationSubscriptionBehaviour(processingState, writers);
+        new BpmnCompensationSubscriptionBehaviour(
+            processingState.getKeyGenerator(),
+            processingState.getProcessState(),
+            processingState.getCompensationSubscriptionState(),
+            writers,
+            stateBehavior);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -173,11 +173,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
 
     compensationSubscriptionBehaviour =
         new BpmnCompensationSubscriptionBehaviour(
-            processingState.getKeyGenerator(),
-            processingState.getProcessState(),
-            processingState.getCompensationSubscriptionState(),
-            writers,
-            stateBehavior);
+            processingState.getKeyGenerator(), processingState, writers, stateBehavior);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -41,6 +41,9 @@ public class BpmnCompensationSubscriptionBehaviour {
   /** Default instance key if no compensation handler was activated. */
   private static final long NONE_COMPENSATION_HANDLER_INSTANCE_KEY = -1L;
 
+  private static final Predicate<CompensationSubscription> TRIGGER_ALL_SUBSCRIPTIONS =
+      subscription -> true;
+
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
   private final CompensationSubscriptionState compensationSubscriptionState;
@@ -124,7 +127,7 @@ public class BpmnCompensationSubscriptionBehaviour {
   public boolean triggerCompensation(
       final ExecutableFlowElement element, final BpmnElementContext context) {
     // trigger the compensation in the scope of the compensation throw event
-    return triggerCompensation(element, context, subscription -> true);
+    return triggerCompensationInScope(element, context, TRIGGER_ALL_SUBSCRIPTIONS);
   }
 
   public boolean triggerCompensationForActivity(
@@ -133,14 +136,14 @@ public class BpmnCompensationSubscriptionBehaviour {
       final BpmnElementContext context) {
     final String compensationActivityId = BufferUtil.bufferAsString(compensationActivity.getId());
     // trigger the compensation for the given activity
-    return triggerCompensation(
+    return triggerCompensationInScope(
         element,
         context,
         subscription ->
             subscription.getRecord().getCompensableActivityId().equals(compensationActivityId));
   }
 
-  private boolean triggerCompensation(
+  private boolean triggerCompensationInScope(
       final ExecutableFlowElement element,
       final BpmnElementContext context,
       final Predicate<CompensationSubscription> subscriptionFilter) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.compensation.CompensationSubscription;
 import io.camunda.zeebe.engine.state.immutable.CompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
@@ -53,13 +54,12 @@ public class BpmnCompensationSubscriptionBehaviour {
 
   public BpmnCompensationSubscriptionBehaviour(
       final KeyGenerator keyGenerator,
-      final ProcessState processState,
-      final CompensationSubscriptionState compensationSubscriptionState,
+      final ProcessingState processingState,
       final Writers writers,
       final BpmnStateBehavior stateBehavior) {
     this.keyGenerator = keyGenerator;
-    this.processState = processState;
-    this.compensationSubscriptionState = compensationSubscriptionState;
+    processState = processingState.getProcessState();
+    compensationSubscriptionState = processingState.getCompensationSubscriptionState();
     stateWriter = writers.state();
     commandWriter = writers.command();
     this.stateBehavior = stateBehavior;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnCompensationSubscriptionBehaviour.java
@@ -288,7 +288,9 @@ public class BpmnCompensationSubscriptionBehaviour {
   }
 
   public boolean triggerCompensationForActivity(
-      final ExecutableActivity compensationActivity, final BpmnElementContext context) {
+      final ExecutableFlowElement element,
+      final ExecutableActivity compensationActivity,
+      final BpmnElementContext context) {
     final String compensationActivityId = BufferUtil.bufferAsString(compensationActivity.getId());
 
     // ignore subscriptions that are already triggered
@@ -312,7 +314,10 @@ public class BpmnCompensationSubscriptionBehaviour {
             .filter(
                 subscription ->
                     subscription.getRecord().getCompensableActivityScopeKey()
-                        == context.getFlowScopeKey())
+                            == context.getFlowScopeKey()
+                        || (isElementInsideEventSubprocess(element)
+                            && subscription.getRecord().getCompensableActivityScopeKey()
+                                == stateBehavior.getFlowScopeContext(context).getFlowScopeKey()))
             .toList();
 
     if (subscriptionsForActivity.isEmpty()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -341,7 +341,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
       final var isCompensationTriggered =
           compensation.hasReferenceActivity()
               ? compensationSubscriptionBehaviour.triggerCompensationForActivity(
-                  compensation.getReferenceCompensationActivity(), activated)
+                  element, compensation.getReferenceCompensationActivity(), activated)
               : compensationSubscriptionBehaviour.triggerCompensation(element, activating);
 
       if (isCompensationTriggered) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/EndEventProcessor.java
@@ -342,7 +342,7 @@ public final class EndEventProcessor implements BpmnElementProcessor<ExecutableE
           compensation.hasReferenceActivity()
               ? compensationSubscriptionBehaviour.triggerCompensationForActivity(
                   compensation.getReferenceCompensationActivity(), activated)
-              : compensationSubscriptionBehaviour.triggerCompensation(activating);
+              : compensationSubscriptionBehaviour.triggerCompensation(element, activating);
 
       if (isCompensationTriggered) {
         return SUCCESS;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -319,7 +319,7 @@ public class IntermediateThrowEventProcessor
           compensation.hasReferenceActivity()
               ? compensationSubscriptionBehaviour.triggerCompensationForActivity(
                   compensation.getReferenceCompensationActivity(), activated)
-              : compensationSubscriptionBehaviour.triggerCompensation(activating);
+              : compensationSubscriptionBehaviour.triggerCompensation(element, activating);
 
       if (isCompensationTriggered) {
         return SUCCESS;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -318,7 +318,7 @@ public class IntermediateThrowEventProcessor
       final var isCompensationTriggered =
           compensation.hasReferenceActivity()
               ? compensationSubscriptionBehaviour.triggerCompensationForActivity(
-                  compensation.getReferenceCompensationActivity(), activated)
+                  element, compensation.getReferenceCompensationActivity(), activated)
               : compensationSubscriptionBehaviour.triggerCompensation(element, activating);
 
       if (isCompensationTriggered) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.AbstractThrowEventBuilder;
 import io.camunda.zeebe.model.bpmn.builder.BoundaryEventBuilder;
+import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
 import io.camunda.zeebe.model.bpmn.builder.SubProcessBuilder;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.Assertions;
@@ -2327,6 +2328,295 @@ public class CompensationEventExecutionTest {
         .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
         .containsSubsequence(
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldTriggerCompensationFromEventSubprocess() {
+    // given
+    final Consumer<EventSubProcessBuilder> compensationEventSubprocess =
+        eventSubprocess ->
+            eventSubprocess.startEvent().error().endEvent().compensateEventDefinition();
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess("event-subprocess", compensationEventSubprocess)
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").withErrorCode("error").throwError();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getBpmnEventType(),
+            Record::getIntent)
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.EVENT_SUB_PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SERVICE_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                BpmnElementType.EVENT_SUB_PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                BpmnElementType.PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldTriggerCompensationFromEventSubprocessInsideSubprocess() {
+    // given
+    final Consumer<EventSubProcessBuilder> compensationEventSubprocess =
+        eventSubprocess ->
+            eventSubprocess
+                .startEvent()
+                .error()
+                .endEvent("compensation-throw-event")
+                .compensateEventDefinition();
+
+    final Consumer<SubProcessBuilder> subprocessBuilder =
+        subprocess ->
+            subprocess
+                .embeddedSubProcess()
+                .eventSubProcess("event-subprocess", compensationEventSubprocess)
+                .startEvent()
+                .serviceTask(
+                    "A",
+                    task ->
+                        task.zeebeJobType("A")
+                            .boundaryEvent()
+                            .compensation(
+                                compensation ->
+                                    compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+                .serviceTask("B", task -> task.zeebeJobType("B"));
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .subProcess("subprocess", subprocessBuilder)
+            .parallelGateway("join")
+            .moveToNode("fork")
+            .serviceTask(
+                "C",
+                task ->
+                    task.zeebeJobType("C")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-C").zeebeJobType("Undo-C")))
+            .connectTo("join")
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("C").complete();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").withErrorCode("error").throwError();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("event-subprocess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("event-subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(tuple("Undo-C", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void shouldTriggerCompensationFromEventSubprocessWithCompensationHandlerInside() {
+    // given
+    final Consumer<EventSubProcessBuilder> compensationEventSubprocess =
+        eventSubprocess ->
+            eventSubprocess
+                .startEvent()
+                .error()
+                .serviceTask(
+                    "C",
+                    task ->
+                        task.zeebeJobType("C")
+                            .boundaryEvent()
+                            .compensation(
+                                compensation ->
+                                    compensation.serviceTask("Undo-C").zeebeJobType("Undo-C")))
+                .endEvent("compensation-throw-event")
+                .compensateEventDefinition();
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess("event-subprocess", compensationEventSubprocess)
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").withErrorCode("error").throwError();
+    ENGINE.job().ofInstance(processInstanceKey).withType("C").complete();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-A").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-C").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("event-subprocess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("Undo-C", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("event-subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldNotTriggerCompensationFromEventSubprocessInsideSubprocess() {
+    // given
+    final Consumer<SubProcessBuilder> subprocessBuilder =
+        subprocess ->
+            subprocess
+                .embeddedSubProcess()
+                .startEvent()
+                .serviceTask(
+                    "D",
+                    task ->
+                        task.zeebeJobType("D")
+                            .boundaryEvent()
+                            .compensation(
+                                compensation ->
+                                    compensation.serviceTask("Undo-D").zeebeJobType("Undo-D")))
+                .endEvent("compensation-throw-event")
+                .compensateEventDefinition();
+
+    final Consumer<EventSubProcessBuilder> eventSubprocessBuilder =
+        eventSubprocess ->
+            eventSubprocess
+                .startEvent()
+                .error()
+                .serviceTask(
+                    "C",
+                    task ->
+                        task.zeebeJobType("C")
+                            .boundaryEvent()
+                            .compensation(
+                                compensation ->
+                                    compensation.serviceTask("Undo-C").zeebeJobType("Undo-C")))
+                .subProcess("subprocess", subprocessBuilder);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess("event-subprocess", eventSubprocessBuilder)
+            .startEvent()
+            .serviceTask(
+                "A",
+                task ->
+                    task.zeebeJobType("A")
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("A").complete();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").withErrorCode("error").throwError();
+    ENGINE.job().ofInstance(processInstanceKey).withType("C").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("D").complete();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-D").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("event-subprocess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("Undo-D", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("event-subprocess", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(
+            tuple("Undo-A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("Undo-C", ProcessInstanceIntent.ELEMENT_ACTIVATED));
   }
 
   private BpmnModelInstance createModelFromClasspathResource(final String classpath) {


### PR DESCRIPTION
## Description

- Trigger compensation from an event subprocess
- Invoke all compensation handlers within the event subprocess and outside the event subprocess

## Related issues

closes #15465 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
