### PR TITLE
feat: add batch modification summary modal (feature-flagged) 

### DIFF
--- a/operate/client/src/App/Processes/ListView/Filters/tests/batchModificationMode.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/batchModificationMode.test.tsx
@@ -80,7 +80,7 @@ describe('Filters', () => {
     await waitFor(() => expect(screen.getByLabelText('Name')).toBeEnabled());
 
     await selectProcess({user, option: 'Big variable process'});
-    await selectFlowNode({user, option: 'StartEvent_1'});
+    await selectFlowNode({user, option: 'Start Event 1'});
 
     expect(screen.getByRole('combobox', {name: /version/i})).toBeEnabled();
     expect(screen.getByRole('combobox', {name: /flow node/i})).toBeEnabled();

--- a/operate/client/src/App/Processes/ListView/Filters/tests/fieldinteractions.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/fieldinteractions.test.tsx
@@ -166,7 +166,7 @@ describe('Interaction with other fields during validation', () => {
 
     expect(screen.getByText(ERRORS.ids)).toBeInTheDocument();
 
-    await selectFlowNode({user, option: 'ServiceTask_0kt6c5i'});
+    await selectFlowNode({user, option: 'Service Task 1'});
 
     expect(screen.getByText(ERRORS.ids)).toBeInTheDocument();
   });

--- a/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/Filters/tests/index.test.tsx
@@ -114,9 +114,7 @@ describe('Filters', () => {
       screen.getByLabelText('Version', {selector: 'button'}),
     ).toHaveTextContent('1');
 
-    expect(screen.getByLabelText('Flow Node')).toHaveValue(
-      MOCK_PARAMS.flowNodeId,
-    );
+    expect(screen.getByLabelText('Flow Node')).toHaveValue('Service Task 1');
 
     expect(screen.getByDisplayValue(MOCK_PARAMS.ids)).toBeInTheDocument();
 
@@ -241,7 +239,7 @@ describe('Filters', () => {
       MOCK_VALUES.errorMessage,
     );
 
-    await selectFlowNode({user, option: MOCK_VALUES.flowNodeId});
+    await selectFlowNode({user, option: 'Service Task 1'});
 
     await user.click(screen.getByRole('button', {name: 'More Filters'}));
     await user.click(screen.getByText('Variable'));

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/styled.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/styled.tsx
@@ -15,43 +15,18 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {Button} from '@carbon/react';
-import {observer} from 'mobx-react';
-import {batchModificationStore} from 'modules/stores/batchModification';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
-import {ModalStateManager} from 'modules/components/ModalStateManager';
-import {BatchModificationSummaryModal} from './BatchModificationSummaryModal';
-import {Stack} from './styled';
+import styled from 'styled-components';
+import {styles} from '@carbon/elements';
+import {DataTable as BaseDataTable} from 'modules/components/DataTable';
 
-const BatchModificationFooter: React.FC = observer(() => {
-  const isButtonDisabled =
-    processInstancesSelectionStore.selectedProcessInstanceCount < 1 ||
-    batchModificationStore.state.selectedTargetFlowNodeId === null;
+const Title = styled.h4`
+  ${styles.productiveHeading01};
+  margin-top: var(--cds-spacing-08);
+  margin-bottom: var(--cds-spacing-06);
+`;
 
-  return (
-    <>
-      <Stack orientation="horizontal" gap={5}>
-        <Button
-          kind="secondary"
-          size="sm"
-          onClick={batchModificationStore.reset}
-        >
-          Exit
-        </Button>
-        <ModalStateManager
-          renderLauncher={({setOpen}) => (
-            <Button size="sm" disabled={isButtonDisabled} onClick={setOpen}>
-              Apply Modification
-            </Button>
-          )}
-        >
-          {({open, setOpen}) => (
-            <BatchModificationSummaryModal open={open} setOpen={setOpen} />
-          )}
-        </ModalStateManager>
-      </Stack>
-    </>
-  );
-});
+const DataTable = styled(BaseDataTable)`
+  max-height: 185px;
+`;
 
-export {BatchModificationFooter};
+export {Title, DataTable};

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.test.tsx
@@ -23,6 +23,12 @@ import {processInstancesStore} from 'modules/stores/processInstances';
 import {batchModificationStore} from 'modules/stores/batchModification';
 import {BatchModificationFooter} from '.';
 
+jest.mock('./BatchModificationSummaryModal', () => ({
+  BatchModificationSummaryModal: () => (
+    <div>MockedBatchModificationSummaryModal</div>
+  ),
+}));
+
 const Wrapper: React.FC<{children?: React.ReactNode}> = observer(
   ({children}) => {
     useEffect(() => {
@@ -148,5 +154,26 @@ describe('BatchModificationFooter', () => {
     expect(
       screen.getByRole('button', {name: /apply modification/i}),
     ).toBeEnabled();
+  });
+
+  it('should render modal on button click', async () => {
+    const {user} = render(<BatchModificationFooter />, {wrapper: Wrapper});
+
+    await user.click(
+      screen.getByRole('button', {name: /select target flow node/i}),
+    );
+    await user.click(
+      screen.getByRole('button', {name: /select single instance/i}),
+    );
+
+    expect(
+      screen.queryByText('MockedBatchModificationSummaryModal'),
+    ).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', {name: /apply modification/i}));
+
+    expect(
+      screen.getByText('MockedBatchModificationSummaryModal'),
+    ).toBeInTheDocument();
   });
 });

--- a/operate/client/src/modules/stores/processInstanceDetailsDiagram/tests/index.test.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsDiagram/tests/index.test.ts
@@ -89,6 +89,7 @@ describe('stores/processInstanceDiagram', () => {
     ).toEqual({
       $type: 'bpmn:StartEvent',
       id: 'StartEvent_1',
+      name: 'Start Event 1',
     });
 
     expect(
@@ -105,6 +106,7 @@ describe('stores/processInstanceDiagram', () => {
         ],
       },
       id: 'ServiceTask_0kt6c5i',
+      name: 'Service Task 1',
     });
 
     expect(
@@ -112,6 +114,7 @@ describe('stores/processInstanceDiagram', () => {
     ).toEqual({
       $type: 'bpmn:EndEvent',
       id: 'EndEvent_0crvjrk',
+      name: 'End Event',
     });
   });
 

--- a/operate/client/src/modules/testUtils.tsx
+++ b/operate/client/src/modules/testUtils.tsx
@@ -377,10 +377,10 @@ export const mockProcessStatistics = [
 export const mockProcessXML = `<?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1771k9d" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.5.0">
   <bpmn:process id="bigVarProcess" isExecutable="true" name="Big variable process">
-    <bpmn:startEvent id="StartEvent_1">
+    <bpmn:startEvent id="StartEvent_1" name="Start Event 1">
       <bpmn:outgoing>SequenceFlow_04ev4jl</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_0kt6c5i">
+    <bpmn:serviceTask id="ServiceTask_0kt6c5i" name="Service Task 1">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="task" />
       </bpmn:extensionElements>
@@ -388,7 +388,7 @@ export const mockProcessXML = `<?xml version="1.0" encoding="UTF-8"?>
       <bpmn:outgoing>SequenceFlow_1njhlr0</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_04ev4jl" sourceRef="StartEvent_1" targetRef="ServiceTask_0kt6c5i" />
-    <bpmn:endEvent id="EndEvent_0crvjrk">
+    <bpmn:endEvent id="EndEvent_0crvjrk" name="End Event">
       <bpmn:incoming>SequenceFlow_1njhlr0</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_1njhlr0" sourceRef="ServiceTask_0kt6c5i" targetRef="EndEvent_0crvjrk" />


### PR DESCRIPTION
## Description

This PR adds a summary modal to the batch modification mode of Operate.

## Related issues

closes https://github.com/camunda/operate/issues/6221
PR was originally opened in Operate repo: https://github.com/camunda/operate/pull/6627

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
