### PR TITLE
feat: support EL job `type` and `retries` configuration via expressions

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractServiceTaskBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
+import java.util.function.Consumer;
 
 /**
  * @author Sebastian Menski
@@ -63,5 +64,11 @@ public abstract class AbstractServiceTaskBuilder<B extends AbstractServiceTaskBu
   @Override
   public B zeebeEndExecutionListener(final String type) {
     return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type);
+  }
+
+  @Override
+  public B zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
+    return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ExecutionListenerBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ExecutionListenerBuilder.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+
+public class ExecutionListenerBuilder {
+  private final ZeebeExecutionListener element;
+  private final AbstractBaseElementBuilder<?, ?> elementBuilder;
+
+  protected ExecutionListenerBuilder(
+      final ZeebeExecutionListener element, final AbstractBaseElementBuilder<?, ?> elementBuilder) {
+    this.element = element;
+    this.elementBuilder = elementBuilder;
+  }
+
+  public ExecutionListenerBuilder eventType(final ZeebeExecutionListenerEventType eventType) {
+    element.setEventType(eventType);
+    return this;
+  }
+
+  public ExecutionListenerBuilder start() {
+    return eventType(ZeebeExecutionListenerEventType.start);
+  }
+
+  public ExecutionListenerBuilder end() {
+    return eventType(ZeebeExecutionListenerEventType.end);
+  }
+
+  public ExecutionListenerBuilder type(final String type) {
+    element.setType(type);
+    return this;
+  }
+
+  public ExecutionListenerBuilder typeExpression(final String typeExpression) {
+    return type(elementBuilder.asZeebeExpression(typeExpression));
+  }
+
+  public ExecutionListenerBuilder retries(final String retries) {
+    element.setRetries(retries);
+    return this;
+  }
+
+  public ExecutionListenerBuilder retriesExpression(final String retriesExpression) {
+    return retries(elementBuilder.asZeebeExpression(retriesExpression));
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilder.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.model.bpmn.builder;
 
+import java.util.function.Consumer;
+
 /** A fluent builder for elements with execution listeners. */
 public interface ZeebeExecutionListenersBuilder<B> {
 
@@ -25,4 +27,7 @@ public interface ZeebeExecutionListenersBuilder<B> {
   B zeebeEndExecutionListener(String type, String retries);
 
   B zeebeEndExecutionListener(String type);
+
+  B zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeExecutionListenersBuilderImpl.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
+import java.util.function.Consumer;
 
 public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBuilder<?, ?>>
     implements ZeebeExecutionListenersBuilder<B> {
@@ -30,10 +31,7 @@ public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBui
 
   @Override
   public B zeebeStartExecutionListener(final String type, final String retries) {
-    final ZeebeExecutionListeners executionListeners =
-        elementBuilder.getCreateSingleExtensionElement(ZeebeExecutionListeners.class);
-    final ZeebeExecutionListener listener =
-        elementBuilder.createChild(executionListeners, ZeebeExecutionListener.class);
+    final ZeebeExecutionListener listener = createZeebeExecutionListener();
     listener.setEventType(ZeebeExecutionListenerEventType.start);
     listener.setType(type);
     listener.setRetries(retries);
@@ -48,10 +46,7 @@ public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBui
 
   @Override
   public B zeebeEndExecutionListener(final String type, final String retries) {
-    final ZeebeExecutionListeners executionListeners =
-        elementBuilder.getCreateSingleExtensionElement(ZeebeExecutionListeners.class);
-    final ZeebeExecutionListener listener =
-        elementBuilder.createChild(executionListeners, ZeebeExecutionListener.class);
+    final ZeebeExecutionListener listener = createZeebeExecutionListener();
     listener.setEventType(ZeebeExecutionListenerEventType.end);
     listener.setType(type);
     listener.setRetries(retries);
@@ -62,5 +57,22 @@ public class ZeebeExecutionListenersBuilderImpl<B extends AbstractBaseElementBui
   @Override
   public B zeebeEndExecutionListener(final String type) {
     return zeebeEndExecutionListener(type, ZeebeExecutionListener.DEFAULT_RETRIES);
+  }
+
+  @Override
+  public B zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
+    final ZeebeExecutionListener listener = createZeebeExecutionListener();
+    final ExecutionListenerBuilder builder = new ExecutionListenerBuilder(listener, elementBuilder);
+
+    executionListenerBuilderConsumer.accept(builder);
+
+    return elementBuilder;
+  }
+
+  private ZeebeExecutionListener createZeebeExecutionListener() {
+    final ZeebeExecutionListeners executionListeners =
+        elementBuilder.getCreateSingleExtensionElement(ZeebeExecutionListeners.class);
+    return elementBuilder.createChild(executionListeners, ZeebeExecutionListener.class);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/IncidentResolvedApplier.java
@@ -9,13 +9,14 @@ package io.camunda.zeebe.engine.state.appliers;
 
 import io.camunda.zeebe.engine.processing.job.JobThrowErrorProcessor;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
-import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
 import io.camunda.zeebe.engine.state.mutable.MutableIncidentState;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -26,12 +27,12 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
 
   private final MutableIncidentState incidentState;
   private final MutableJobState jobState;
-  private final ElementInstanceState elementInstanceState;
+  private final MutableElementInstanceState elementInstanceState;
 
   public IncidentResolvedApplier(
       final MutableIncidentState incidentState,
       final MutableJobState jobState,
-      final ElementInstanceState elementInstanceState) {
+      final MutableElementInstanceState elementInstanceState) {
     this.incidentState = incidentState;
     this.jobState = jobState;
     this.elementInstanceState = elementInstanceState;
@@ -39,8 +40,13 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
 
   @Override
   public void applyState(final long incidentKey, final IncidentRecord value) {
+    if (value.getErrorType() == ErrorType.EXTRACT_VALUE_ERROR) {
+      resetExecutionListenerIndex(value);
+    }
+
     final var jobKey = value.getJobKey();
     final boolean isJobRelatedIncident = jobKey > 0;
+
     if (isJobRelatedIncident) {
       final var stateOfJob = jobState.getState(jobKey);
       if (RESOLVABLE_JOB_STATES.contains(stateOfJob)) {
@@ -50,6 +56,14 @@ final class IncidentResolvedApplier implements TypedEventApplier<IncidentIntent,
       }
     }
     incidentState.deleteIncident(incidentKey);
+  }
+
+  private void resetExecutionListenerIndex(final IncidentRecord value) {
+    final var elementInstance = elementInstanceState.getInstance(value.getElementInstanceKey());
+    if (elementInstance != null) {
+      elementInstance.resetExecutionListenerIndex();
+      elementInstanceState.updateInstance(elementInstance);
+    }
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 
 class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
@@ -37,7 +38,9 @@ class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
       final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
 
       if (scopeInstance != null && scopeInstance.isActive()) {
-
+        if (value.getJobKind() == JobKind.EXECUTION_LISTENER) {
+          elementInstance.incrementExecutionListenerIndex();
+        }
         elementInstance.setJobKey(-1);
         elementInstanceState.updateInstance(elementInstance);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.value.JobKind;
 
 final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
@@ -35,10 +34,6 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
       final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
       if (elementInstance != null) {
-        if (value.getJobKind() == JobKind.EXECUTION_LISTENER) {
-          elementInstance.setExecutionListenerType(value.getType());
-        }
-
         elementInstance.setJobKey(key);
         elementInstanceState.updateInstance(elementInstance);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatedApplier.java
@@ -26,6 +26,10 @@ final class ProcessInstanceElementActivatedApplier
   @Override
   public void applyState(final long key, final ProcessInstanceRecord value) {
     elementInstanceState.updateInstance(
-        key, instance -> instance.setState(ProcessInstanceIntent.ELEMENT_ACTIVATED));
+        key,
+        instance -> {
+          instance.setState(ProcessInstanceIntent.ELEMENT_ACTIVATED);
+          instance.resetExecutionListenerIndex();
+        });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import org.agrona.DirectBuffer;
 
 public final class ElementInstance extends UnpackedObject implements DbValue {
@@ -41,8 +40,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final IntegerProperty activeSequenceFlowsProp =
       new IntegerProperty("activeSequenceFlows", 0);
   private final LongProperty userTaskKeyProp = new LongProperty("userTaskKey", -1L);
-  private final StringProperty executionListenerTypeProp =
-      new StringProperty("executionListenerType", "");
+  private final IntegerProperty executionListenerIndexProp =
+      new IntegerProperty("executionListenerIndex", 0);
 
   public ElementInstance() {
     super(13);
@@ -58,7 +57,7 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(recordProp)
         .declareProperty(activeSequenceFlowsProp)
         .declareProperty(userTaskKeyProp)
-        .declareProperty(executionListenerTypeProp);
+        .declareProperty(executionListenerIndexProp);
   }
 
   public ElementInstance(
@@ -235,11 +234,15 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
     userTaskKeyProp.setValue(userTaskKey);
   }
 
-  public String getExecutionListenerType() {
-    return BufferUtil.bufferAsString(executionListenerTypeProp.getValue());
+  public int getExecutionListenerIndex() {
+    return executionListenerIndexProp.getValue();
   }
 
-  public void setExecutionListenerType(final String executionListenerType) {
-    executionListenerTypeProp.setValue(executionListenerType);
+  public void incrementExecutionListenerIndex() {
+    executionListenerIndexProp.increment();
+  }
+
+  public void resetExecutionListenerIndex() {
+    executionListenerIndexProp.setValue(0);
   }
 }


### PR DESCRIPTION
## Description
This pull request introduces the ability to configure Execution Listener job `types` and `retry` counts dynamically using expressions.

Key features:
- Users can now specify expressions for EL job types and retries, evaluated at runtime.
- Enhance Zeebe's process modeling API to accept expressions for EL configurations:
   ```java
        Bpmn.createExecutableProcess("process")
         .startEvent("start")
         .serviceTask(
             "task",
             t ->
                 t.zeebeJobType("service_task")
                     .zeebeExecutionListener(
                         b ->
                             b.start().type("startListener1").retriesExpression("defaultRetries + 5"))
                     .zeebeExecutionListener(
                         b -> b.start().typeExpression("listenerVarName").retries("5"))
                     .zeebeExecutionListener(b -> b.end().type("endListener").retries("4")))
         .endEvent("end")
         .done();
   ```
- Includes tests verifying expression evaluation, proper execution based on evaluated results, and error handling for failed evaluations.

This feature allows for more adaptive and context-aware setups for ELs within various workflow scenarios.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16210 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Operate](https://github.com/camunda/operate/issues)
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
