### PR TITLE
feat: gracefully shut down gRPC server

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/StandaloneBroker.java
@@ -86,7 +86,12 @@ public class StandaloneBroker
   public void run(final String... args) throws IOException {
     final SystemContext systemContext =
         new SystemContext(
-            configuration.config(), identityConfiguration, actorScheduler, cluster, brokerClient);
+            configuration.shutdownTimeout(),
+            configuration.config(),
+            identityConfiguration,
+            actorScheduler,
+            cluster,
+            brokerClient);
 
     springBrokerBridge.registerShutdownHelper(
         errorCode -> shutdownHelper.initiateShutdown(errorCode));

--- a/dist/src/main/java/io/camunda/zeebe/broker/shared/BrokerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/shared/BrokerConfiguration.java
@@ -11,8 +11,10 @@ import io.camunda.zeebe.broker.shared.BrokerConfiguration.BrokerProperties;
 import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled.RestGatewayDisabled;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.context.LifecycleProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -24,12 +26,16 @@ public final class BrokerConfiguration {
 
   private final WorkingDirectory workingDirectory;
   private final BrokerCfg properties;
+  private final LifecycleProperties lifecycle;
 
   @Autowired
   public BrokerConfiguration(
-      final WorkingDirectory workingDirectory, final BrokerProperties properties) {
+      final WorkingDirectory workingDirectory,
+      final BrokerProperties properties,
+      final LifecycleProperties lifecycle) {
     this.workingDirectory = workingDirectory;
     this.properties = properties;
+    this.lifecycle = lifecycle;
 
     properties.init(workingDirectory.path().toAbsolutePath().toString());
   }
@@ -50,6 +56,10 @@ public final class BrokerConfiguration {
   @Bean
   public RestGatewayDisabled disableRestGateway() {
     return new RestGatewayDisabled();
+  }
+
+  public Duration shutdownTimeout() {
+    return lifecycle.getTimeoutPerShutdownPhase();
   }
 
   @ConfigurationProperties("zeebe.broker")

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayConfiguration.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.gateway;
 
 import io.camunda.zeebe.gateway.GatewayConfiguration.GatewayProperties;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.context.LifecycleProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
@@ -19,15 +21,22 @@ import org.springframework.context.annotation.Configuration;
 public final class GatewayConfiguration {
 
   private final GatewayProperties config;
+  private final LifecycleProperties lifecycleProperties;
 
   @Autowired
-  public GatewayConfiguration(final GatewayProperties config) {
+  public GatewayConfiguration(
+      final GatewayProperties config, final LifecycleProperties lifecycleProperties) {
     this.config = config;
+    this.lifecycleProperties = lifecycleProperties;
     config.init();
   }
 
   public GatewayProperties config() {
     return config;
+  }
+
+  public Duration shutdownTimeout() {
+    return lifecycleProperties.getTimeoutPerShutdownPhase();
   }
 
   @ConfigurationProperties("zeebe.gateway")

--- a/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/StandaloneGateway.java
@@ -104,6 +104,7 @@ public class StandaloneGateway
 
     gateway =
         new Gateway(
+            configuration.shutdownTimeout(),
             configuration.config(),
             identityConfiguration,
             brokerClient,

--- a/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/gateway/StandaloneGatewaySecurityTest.java
@@ -29,6 +29,7 @@ import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.context.LifecycleProperties;
 
 final class StandaloneGatewaySecurityTest {
   private SelfSignedCertificate certificate;
@@ -135,7 +136,7 @@ final class StandaloneGatewaySecurityTest {
   }
 
   private StandaloneGateway buildGateway(final GatewayProperties gatewayCfg) {
-    final var config = new GatewayConfiguration(gatewayCfg);
+    final var config = new GatewayConfiguration(gatewayCfg, new LifecycleProperties());
     final var clusterConfig = new GatewayClusterConfiguration();
     atomixCluster =
         new GatewayClusterConfiguration().atomixCluster(clusterConfig.clusterConfig(config));
@@ -152,7 +153,7 @@ final class StandaloneGatewaySecurityTest {
     jobStreamClient = new JobStreamComponent().jobStreamClient(actorScheduler, atomixCluster);
 
     return new StandaloneGateway(
-        new GatewayConfiguration(gatewayCfg),
+        config,
         null, // identity is disabled by default
         new SpringGatewayBridge(),
         actorScheduler,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -71,7 +71,8 @@ public final class Broker implements AutoCloseable {
             buildExporterRepository(getConfig()),
             new ClusterServicesImpl(systemContext.getCluster()),
             systemContext.getBrokerClient(),
-            additionalPartitionListeners);
+            additionalPartitionListeners,
+            systemContext.getShutdownTimeout());
 
     brokerStartupActor = new BrokerStartupActor(startupContext);
     scheduler.submitActor(brokerStartupActor);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import java.time.Duration;
 import java.util.List;
 
 /**
@@ -109,4 +110,6 @@ public interface BrokerStartupContext {
   void setClusterTopology(ClusterTopologyService clusterTopologyService);
 
   BrokerClient getBrokerClient();
+
+  Duration getShutdownTimeout();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -32,6 +32,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -49,6 +50,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private final BrokerClient brokerClient;
   private final List<PartitionListener> partitionListeners = new ArrayList<>();
   private final List<PartitionRaftListener> partitionRaftListeners = new ArrayList<>();
+  private final Duration shutdownTimeout;
 
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
@@ -72,7 +74,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final ExporterRepository exporterRepository,
       final ClusterServicesImpl clusterServices,
       final BrokerClient brokerClient,
-      final List<PartitionListener> additionalPartitionListeners) {
+      final List<PartitionListener> additionalPartitionListeners,
+      final Duration shutdownTimeout) {
 
     this.brokerInfo = requireNonNull(brokerInfo);
     this.configuration = requireNonNull(configuration);
@@ -83,6 +86,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
     this.clusterServices = requireNonNull(clusterServices);
     this.identityConfiguration = identityConfiguration;
     this.brokerClient = brokerClient;
+    this.shutdownTimeout = shutdownTimeout;
     partitionListeners.addAll(additionalPartitionListeners);
   }
 
@@ -95,7 +99,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
       final ExporterRepository exporterRepository,
       final ClusterServicesImpl clusterServices,
       final BrokerClient brokerClient,
-      final List<PartitionListener> additionalPartitionListeners) {
+      final List<PartitionListener> additionalPartitionListeners,
+      final Duration shutdownTimeout) {
 
     this(
         brokerInfo,
@@ -107,7 +112,8 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
         exporterRepository,
         clusterServices,
         brokerClient,
-        additionalPartitionListeners);
+        additionalPartitionListeners,
+        shutdownTimeout);
   }
 
   @Override
@@ -297,5 +303,10 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public BrokerClient getBrokerClient() {
     return brokerClient;
+  }
+
+  @Override
+  public Duration getShutdownTimeout() {
+    return shutdownTimeout;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStep.java
@@ -34,6 +34,7 @@ class EmbeddedGatewayServiceStep extends AbstractBrokerStartupStep {
 
     final var embeddedGatewayService =
         new EmbeddedGatewayService(
+            brokerStartupContext.getShutdownTimeout(),
             brokerStartupContext.getBrokerConfiguration(),
             brokerStartupContext.getIdentityConfiguration(),
             scheduler,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/EmbeddedGatewayService.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.gateway.impl.stream.JobStreamClient;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.time.Duration;
 import org.agrona.CloseHelper;
 
 public final class EmbeddedGatewayService implements AutoCloseable {
@@ -25,6 +26,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
   private final ConcurrencyControl concurrencyControl;
 
   public EmbeddedGatewayService(
+      final Duration shutdownTimeout,
       final BrokerCfg configuration,
       final IdentityConfiguration identityConfiguration,
       final ActorSchedulingService actorScheduler,
@@ -36,6 +38,7 @@ public final class EmbeddedGatewayService implements AutoCloseable {
     this.jobStreamClient = jobStreamClient;
     gateway =
         new Gateway(
+            shutdownTimeout,
             configuration.getGateway(),
             identityConfiguration,
             brokerClient,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -39,12 +40,14 @@ import org.slf4j.Logger;
 public final class SystemContext {
 
   public static final Logger LOG = Loggers.SYSTEM_LOGGER;
+  public static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
   private static final String BROKER_ID_LOG_PROPERTY = "broker-id";
   private static final String SNAPSHOT_PERIOD_ERROR_MSG =
       "Snapshot period %s needs to be larger then or equals to one minute.";
   private static final String MAX_BATCH_SIZE_ERROR_MSG =
       "Expected to have an append batch size maximum which is non negative and smaller then '%d', but was '%s'.";
 
+  private final Duration shutdownTimeout;
   private final BrokerCfg brokerCfg;
   private final IdentityConfiguration identityConfiguration;
   private Map<String, String> diagnosticContext;
@@ -53,11 +56,13 @@ public final class SystemContext {
   private final BrokerClient brokerClient;
 
   public SystemContext(
+      final Duration shutdownTimeout,
       final BrokerCfg brokerCfg,
       final IdentityConfiguration identityConfiguration,
       final ActorScheduler scheduler,
       final AtomixCluster cluster,
       final BrokerClient brokerClient) {
+    this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
     this.identityConfiguration = identityConfiguration;
     this.scheduler = scheduler;
@@ -71,7 +76,7 @@ public final class SystemContext {
       final ActorScheduler scheduler,
       final AtomixCluster cluster,
       final BrokerClient brokerClient) {
-    this(brokerCfg, null, scheduler, cluster, brokerClient);
+    this(DEFAULT_SHUTDOWN_TIMEOUT, brokerCfg, null, scheduler, cluster, brokerClient);
   }
 
   private void initSystemContext() {
@@ -278,5 +283,9 @@ public final class SystemContext {
 
   public BrokerClient getBrokerClient() {
     return brokerClient;
+  }
+
+  public Duration getShutdownTimeout() {
+    return shutdownTimeout;
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/ApiMessagingServiceStepTest.java
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class ApiMessagingServiceStepTest {
+
+  public static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final BrokerInfo TEST_BROKER_INFO = new BrokerInfo(0, "localhost");
@@ -66,7 +68,8 @@ class ApiMessagingServiceStepTest {
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
             mock(BrokerClient.class),
-            Collections.emptyList());
+            Collections.emptyList(),
+            TEST_SHUTDOWN_TIMEOUT);
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/CommandApiServiceStepTest.java
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class CommandApiServiceStepTest {
+  public static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final BrokerInfo TEST_BROKER_INFO = new BrokerInfo(0, "localhost");
@@ -68,7 +69,8 @@ class CommandApiServiceStepTest {
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
             mock(BrokerClient.class),
-            Collections.emptyList());
+            Collections.emptyList(),
+            TEST_SHUTDOWN_TIMEOUT);
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
     testBrokerStartupContext.setDiskSpaceUsageMonitor(mock(DiskSpaceUsageMonitorActor.class));
     testBrokerStartupContext.setGatewayBrokerTransport(mock(AtomixServerTransport.class));

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/EmbeddedGatewayServiceStepTest.java
@@ -37,6 +37,7 @@ class EmbeddedGatewayServiceStepTest {
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
+  private static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
 
   static {
     final var networkCfg = TEST_BROKER_CONFIG.getGateway().getNetwork();
@@ -78,7 +79,8 @@ class EmbeddedGatewayServiceStepTest {
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
               mock(BrokerClient.class),
-              Collections.emptyList());
+              Collections.emptyList(),
+              TEST_SHUTDOWN_TIMEOUT);
 
       final var port = SocketUtil.getNextAddress().getPort();
       final var commandApiCfg = TEST_BROKER_CONFIG.getGateway().getNetwork();
@@ -146,7 +148,8 @@ class EmbeddedGatewayServiceStepTest {
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
               mock(BrokerClient.class),
-              Collections.emptyList());
+              Collections.emptyList(),
+              TEST_SHUTDOWN_TIMEOUT);
 
       testBrokerStartupContext.setEmbeddedGatewayService(mockEmbeddedGatewayService);
       shutdownFuture = CONCURRENCY_CONTROL.createFuture();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStepTest.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 class GatewayBrokerTransportStepTest {
+  private static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final BrokerInfo TEST_BROKER_INFO = new BrokerInfo(0, "localhost");
@@ -59,7 +60,8 @@ class GatewayBrokerTransportStepTest {
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
             mock(BrokerClient.class),
-            Collections.emptyList());
+            Collections.emptyList(),
+            TEST_SHUTDOWN_TIMEOUT);
     testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStepTest.java
@@ -46,6 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class PartitionManagerStepTest {
+  public static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
   private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
@@ -90,7 +91,8 @@ class PartitionManagerStepTest {
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
               mock(BrokerClient.class),
-              Collections.emptyList());
+              Collections.emptyList(),
+              TEST_SHUTDOWN_TIMEOUT);
       testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
       testBrokerStartupContext.setAdminApiService(mock(AdminApiRequestHandler.class));
       testBrokerStartupContext.setBrokerAdminService(mock(BrokerAdminServiceImpl.class));
@@ -186,7 +188,8 @@ class PartitionManagerStepTest {
               mock(ExporterRepository.class),
               mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
               mock(BrokerClient.class),
-              Collections.emptyList());
+              Collections.emptyList(),
+              TEST_SHUTDOWN_TIMEOUT);
 
       testBrokerStartupContext.setPartitionManager(mockPartitionManager);
       final ClusterTopologyService mockClusterTopology = mock(ClusterTopologyService.class);

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -324,6 +324,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GracefulShutdownIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GracefulShutdownIT.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.gateway;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.Strings;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+final class GracefulShutdownIT {
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(1)
+          .withGatewaysCount(1)
+          .withEmbeddedGateway(false)
+          .withGatewayConfig(
+              cfg -> cfg.withProperty("spring.lifecycle.timeout-per-shutdown-phase", "20s"))
+          .build();
+
+  @Test
+  void shouldShutdownGracefully() {
+    // given -- an open job stream that needs to wait for an activated job
+    final var jobType = Strings.newRandomValidBpmnId();
+    final var activatedJob = new AtomicReference<ActivatedJob>();
+    final var model =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent("timer", e -> e.timerWithDuration(Duration.ofSeconds(5)))
+            .serviceTask("task", task -> task.zeebeJobType(jobType))
+            .endEvent()
+            .done();
+    try (final var client = cluster.newClientBuilder().build()) {
+      client.newDeployResourceCommand().addProcessModel(model, "process.bpmn").send().join();
+      client.newStreamJobsCommand().jobType(jobType).consumer(activatedJob::set).send();
+      client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
+
+      assertThat(activatedJob).hasNullValue();
+
+      // when -- shutting down the gateways
+      cluster.gateways().values().forEach(TestApplication::close);
+
+      // then -- job is still activated because gateway is maintaining the connection
+      Awaitility.await("job is activated")
+          .untilAsserted(() -> assertThat(activatedJob).doesNotHaveNullValue());
+    }
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -46,6 +46,7 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     // randomize ports to allow multiple concurrent instances
     overridePropertyIfAbsent("server.port", SocketUtil.getNextAddress().getPort());
     overridePropertyIfAbsent("management.server.port", SocketUtil.getNextAddress().getPort());
+    overridePropertyIfAbsent("spring.lifecycle.timeout-per-shutdown-phase", "1s");
 
     if (!beans.containsKey("collectorRegistry")) {
       beans.put(


### PR DESCRIPTION
Uses the spring property `spring.lifecycle.timeout-per-shutdown-phase` to determine a timeout for graceful shutdown of the gRPC server in the gateway.
If the server can't be closed within this timeout, for example because there are open job streams, the server is closed forcefully instead, falling back to the old behavior.

closes #16024