### PR TITLE
feat: Support compensation for call activities

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -104,6 +104,7 @@ public final class CallActivityProcessor
         .flatMap(
             ok -> {
               eventSubscriptionBehavior.unsubscribeFromEvents(context);
+              compensationSubscriptionBehaviour.createCompensationSubscription(element, context);
               return stateTransitionBehavior.transitionToCompleted(element, context);
             })
         .thenDo(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventExecutionTest.java
@@ -2309,6 +2309,191 @@ public class CompensationEventExecutionTest {
   }
 
   @Test
+  public void shouldCompensateCallActivity() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity(
+                "A",
+                callActivity ->
+                    callActivity
+                        .zeebeProcessId(CHILD_PROCESS_ID)
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .endEvent()
+            .compensateEventDefinition()
+            .done();
+
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess(CHILD_PROCESS_ID).startEvent().endEvent().done();
+
+    ENGINE.deployment().withXmlResource(process).withXmlResource(childProcess).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-A").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            r -> r.getValue().getBpmnElementType(),
+            r -> r.getValue().getBpmnEventType(),
+            Record::getIntent)
+        .containsSubsequence(
+            tuple(
+                BpmnElementType.CALL_ACTIVITY,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                BpmnElementType.SERVICE_TASK,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                BpmnElementType.END_EVENT,
+                BpmnEventType.COMPENSATION,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                BpmnElementType.PROCESS,
+                BpmnEventType.UNSPECIFIED,
+                ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldNotTriggerCompensationIfCallActivityIsActive() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .parallelGateway("fork")
+            .callActivity(
+                "A",
+                callActivity ->
+                    callActivity
+                        .zeebeProcessId(CHILD_PROCESS_ID)
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .parallelGateway("join")
+            .endEvent()
+            .moveToNode("fork")
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .intermediateThrowEvent(
+                "compensation-throw-event", AbstractThrowEventBuilder::compensateEventDefinition)
+            .connectTo("join")
+            .endEvent()
+            .done();
+
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+            .startEvent()
+            .serviceTask("A", task -> task.zeebeJobType("A"))
+            .endEvent()
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).withXmlResource(childProcess).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when
+    ENGINE.job().ofInstance(processInstanceKey).withType("B").complete();
+
+    // then
+    final long childProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getKey();
+
+    ENGINE.job().ofInstance(childProcessInstanceKey).withType("A").complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getElementId(), Record::getIntent)
+        .containsSubsequence(
+            tuple("A", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple("A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(tuple("Undo-A", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
+  public void shouldNotTriggerCompensationForChildProcess() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .callActivity(
+                "A",
+                callActivity ->
+                    callActivity
+                        .zeebeProcessId(CHILD_PROCESS_ID)
+                        .boundaryEvent()
+                        .compensation(
+                            compensation ->
+                                compensation.serviceTask("Undo-A").zeebeJobType("Undo-A")))
+            .endEvent("compensation-throw-event")
+            .compensateEventDefinition()
+            .done();
+
+    final BpmnModelInstance childProcess =
+        Bpmn.createExecutableProcess(CHILD_PROCESS_ID)
+            .startEvent()
+            .serviceTask("B", task -> task.zeebeJobType("B"))
+            .boundaryEvent()
+            .compensation(compensation -> compensation.serviceTask("Undo-B").zeebeJobType("Undo-B"))
+            .done();
+
+    ENGINE.deployment().withXmlResource(process).withXmlResource(childProcess).deploy();
+
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final long childProcessInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(processInstanceKey)
+            .withElementType(BpmnElementType.PROCESS)
+            .getFirst()
+            .getKey();
+
+    // when
+    ENGINE.job().ofInstance(childProcessInstanceKey).withType("B").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType("Undo-A").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .limit(PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .extracting(
+            r -> r.getValue().getBpmnProcessId(),
+            r -> r.getValue().getElementId(),
+            Record::getIntent)
+        .containsSubsequence(
+            tuple(CHILD_PROCESS_ID, "B", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, "A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, "compensation-throw-event", ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(PROCESS_ID, "Undo-A", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, "compensation-throw-event", ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, PROCESS_ID, ProcessInstanceIntent.ELEMENT_COMPLETED))
+        .doesNotContain(tuple(CHILD_PROCESS_ID, "Undo-B", ProcessInstanceIntent.ELEMENT_ACTIVATED));
+  }
+
+  @Test
   public void shouldDeleteSubscriptionForTerminatedSubprocess() {
     // given
     final var process =


### PR DESCRIPTION
## Description

- Invoke a compensation handler for a completed call activity
- Invoke a call activity as a compensation handler 

## Related issues

closes #16600 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
