### PR TITLE
feat: add polling headers to API requests

### DIFF
--- a/operate/client/src/modules/api/fetchBatchOperations.ts
+++ b/operate/client/src/modules/api/fetchBatchOperations.ts
@@ -17,21 +17,27 @@
 
 import {requestAndParse} from 'modules/request';
 
-const fetchBatchOperations = async ({
-  pageSize,
-  searchAfter,
-}: {
-  pageSize: number;
-  searchAfter?: OperationEntity['sortValues'];
-}) => {
-  return requestAndParse<OperationEntity[]>({
-    url: '/api/batch-operations',
-    method: 'POST',
-    body: {
-      pageSize,
-      searchAfter,
+const fetchBatchOperations = async (
+  {
+    pageSize,
+    searchAfter,
+  }: {
+    pageSize: number;
+    searchAfter?: OperationEntity['sortValues'];
+  },
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<OperationEntity[]>(
+    {
+      url: '/api/batch-operations',
+      method: 'POST',
+      body: {
+        pageSize,
+        searchAfter,
+      },
     },
-  });
+    options,
+  );
 };
 
 export {fetchBatchOperations};

--- a/operate/client/src/modules/api/fetchFlowNodeInstances.ts
+++ b/operate/client/src/modules/api/fetchFlowNodeInstances.ts
@@ -45,12 +45,18 @@ type FlowNodeInstancesDto<T> = {
   };
 };
 
-const fetchFlowNodeInstances = async (queries: Query[]) => {
-  return requestAndParse<FlowNodeInstancesDto<FlowNodeInstanceDto>>({
-    url: '/api/flow-node-instances',
-    method: 'POST',
-    body: {queries},
-  });
+const fetchFlowNodeInstances = async (
+  queries: Query[],
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<FlowNodeInstancesDto<FlowNodeInstanceDto>>(
+    {
+      url: '/api/flow-node-instances',
+      method: 'POST',
+      body: {queries},
+    },
+    options,
+  );
 };
 
 export {fetchFlowNodeInstances};

--- a/operate/client/src/modules/api/getOperation.ts
+++ b/operate/client/src/modules/api/getOperation.ts
@@ -17,10 +17,16 @@
 
 import {requestAndParse} from 'modules/request';
 
-const getOperation = async (batchOperationId: string) => {
-  return requestAndParse<InstanceOperationEntity[]>({
-    url: `/api/operations?batchOperationId=${batchOperationId}`,
-  });
+const getOperation = async (
+  batchOperationId: string,
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<InstanceOperationEntity[]>(
+    {
+      url: `/api/operations?batchOperationId=${batchOperationId}`,
+    },
+    options,
+  );
 };
 
 export {getOperation};

--- a/operate/client/src/modules/api/incidents/fetchIncidentsByError.ts
+++ b/operate/client/src/modules/api/incidents/fetchIncidentsByError.ts
@@ -34,10 +34,15 @@ type IncidentByErrorDto = {
   processes: ProcessDto[];
 };
 
-const fetchIncidentsByError = async () => {
-  return requestAndParse<IncidentByErrorDto[]>({
-    url: '/api/incidents/byError',
-  });
+const fetchIncidentsByError = async (
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<IncidentByErrorDto[]>(
+    {
+      url: '/api/incidents/byError',
+    },
+    options,
+  );
 };
 
 export {fetchIncidentsByError};

--- a/operate/client/src/modules/api/incidents/fetchProcessInstancesByName.ts
+++ b/operate/client/src/modules/api/incidents/fetchProcessInstancesByName.ts
@@ -36,10 +36,15 @@ type ProcessInstanceByNameDto = {
   processes: ProcessDto[];
 };
 
-const fetchProcessInstancesByName = async () => {
-  return requestAndParse<ProcessInstanceByNameDto[]>({
-    url: '/api/incidents/byProcess',
-  });
+const fetchProcessInstancesByName = async (
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<ProcessInstanceByNameDto[]>(
+    {
+      url: '/api/incidents/byProcess',
+    },
+    options,
+  );
 };
 
 export {fetchProcessInstancesByName};

--- a/operate/client/src/modules/api/processInstances/fetchProcessCoreStatistics.ts
+++ b/operate/client/src/modules/api/processInstances/fetchProcessCoreStatistics.ts
@@ -23,10 +23,15 @@ type CoreStatisticsDto = {
   withIncidents: number;
 };
 
-const fetchProcessCoreStatistics = async () => {
-  return requestAndParse<CoreStatisticsDto>({
-    url: '/api/process-instances/core-statistics',
-  });
+const fetchProcessCoreStatistics = async (
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<CoreStatisticsDto>(
+    {
+      url: '/api/process-instances/core-statistics',
+    },
+    options,
+  );
 };
 
 export {fetchProcessCoreStatistics};

--- a/operate/client/src/modules/api/processInstances/fetchProcessInstance.ts
+++ b/operate/client/src/modules/api/processInstances/fetchProcessInstance.ts
@@ -19,10 +19,14 @@ import {requestAndParse} from 'modules/request';
 
 const fetchProcessInstance = async (
   processInstanceId: ProcessInstanceEntity['id'],
+  options?: Parameters<typeof requestAndParse>[1],
 ) => {
-  return requestAndParse<ProcessInstanceEntity>({
-    url: `/api/process-instances/${processInstanceId}`,
-  });
+  return requestAndParse<ProcessInstanceEntity>(
+    {
+      url: `/api/process-instances/${processInstanceId}`,
+    },
+    options,
+  );
 };
 
 export {fetchProcessInstance};

--- a/operate/client/src/modules/api/processInstances/fetchProcessInstanceDetailStatistics.ts
+++ b/operate/client/src/modules/api/processInstances/fetchProcessInstanceDetailStatistics.ts
@@ -27,10 +27,14 @@ type ProcessInstanceDetailStatisticsDto = {
 
 const fetchProcessInstanceDetailStatistics = async (
   processInstanceId: ProcessInstanceEntity['id'],
+  options?: Parameters<typeof requestAndParse>[1],
 ) => {
-  return requestAndParse<ProcessInstanceDetailStatisticsDto[]>({
-    url: `/api/process-instances/${processInstanceId}/statistics`,
-  });
+  return requestAndParse<ProcessInstanceDetailStatisticsDto[]>(
+    {
+      url: `/api/process-instances/${processInstanceId}/statistics`,
+    },
+    options,
+  );
 };
 
 export {fetchProcessInstanceDetailStatistics};

--- a/operate/client/src/modules/api/processInstances/fetchProcessInstanceIncidents.ts
+++ b/operate/client/src/modules/api/processInstances/fetchProcessInstanceIncidents.ts
@@ -55,10 +55,14 @@ type ProcessInstanceIncidentsDto = {
 
 const fetchProcessInstanceIncidents = async (
   processInstanceId: ProcessInstanceEntity['id'],
+  options?: Parameters<typeof requestAndParse>[1],
 ) => {
-  return requestAndParse<ProcessInstanceIncidentsDto>({
-    url: `/api/process-instances/${processInstanceId}/incidents`,
-  });
+  return requestAndParse<ProcessInstanceIncidentsDto>(
+    {
+      url: `/api/process-instances/${processInstanceId}/incidents`,
+    },
+    options,
+  );
 };
 
 export {fetchProcessInstanceIncidents};

--- a/operate/client/src/modules/api/processInstances/fetchProcessInstances.ts
+++ b/operate/client/src/modules/api/processInstances/fetchProcessInstances.ts
@@ -37,25 +37,33 @@ type ProcessInstancesQuery = {
 const fetchProcessInstances = async ({
   payload,
   signal,
+  options,
 }: {
   payload: ProcessInstancesQuery;
   signal?: AbortSignal;
+  options?: Parameters<typeof requestAndParse>[1];
 }) => {
-  return requestAndParse<ProcessInstancesDto>({
-    url: '/api/process-instances',
-    method: 'POST',
-    body: payload,
-    signal,
-  });
+  return requestAndParse<ProcessInstancesDto>(
+    {
+      url: '/api/process-instances',
+      method: 'POST',
+      body: payload,
+      signal,
+    },
+    options,
+  );
 };
 
-async function fetchProcessInstancesByIds({
-  ids,
-  signal,
-}: {
-  ids: ProcessInstanceEntity['id'][];
-  signal?: AbortSignal;
-}) {
+async function fetchProcessInstancesByIds(
+  {
+    ids,
+    signal,
+  }: {
+    ids: ProcessInstanceEntity['id'][];
+    signal?: AbortSignal;
+  },
+  options?: Parameters<typeof requestAndParse>[1],
+) {
   return fetchProcessInstances({
     payload: {
       pageSize: ids.length,
@@ -70,6 +78,7 @@ async function fetchProcessInstancesByIds({
       },
     },
     signal,
+    options,
   });
 }
 

--- a/operate/client/src/modules/api/processInstances/fetchVariables.ts
+++ b/operate/client/src/modules/api/processInstances/fetchVariables.ts
@@ -26,21 +26,27 @@ type VariablePayload = {
   searchBeforeOrEqual?: ReadonlyArray<string>;
 };
 
-const fetchVariables = async ({
-  instanceId,
-  payload,
-  signal,
-}: {
-  instanceId: ProcessInstanceEntity['id'];
-  payload: VariablePayload;
-  signal?: AbortSignal;
-}) => {
-  return requestAndParse<VariableEntity[]>({
-    url: `/api/process-instances/${instanceId}/variables`,
-    method: 'POST',
-    body: payload,
+const fetchVariables = async (
+  {
+    instanceId,
+    payload,
     signal,
-  });
+  }: {
+    instanceId: ProcessInstanceEntity['id'];
+    payload: VariablePayload;
+    signal?: AbortSignal;
+  },
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<VariableEntity[]>(
+    {
+      url: `/api/process-instances/${instanceId}/variables`,
+      method: 'POST',
+      body: payload,
+      signal,
+    },
+    options,
+  );
 };
 
 export {fetchVariables};

--- a/operate/client/src/modules/api/processInstances/sequenceFlows.ts
+++ b/operate/client/src/modules/api/processInstances/sequenceFlows.ts
@@ -24,10 +24,16 @@ type SequenceFlowDto = {
 
 type SequenceFlowsDto = SequenceFlowDto[];
 
-const fetchSequenceFlows = async (processInstanceId: string) => {
-  return requestAndParse<SequenceFlowsDto>({
-    url: `/api/process-instances/${processInstanceId}/sequence-flows`,
-  });
+const fetchSequenceFlows = async (
+  processInstanceId: string,
+  options?: Parameters<typeof requestAndParse>[1],
+) => {
+  return requestAndParse<SequenceFlowsDto>(
+    {
+      url: `/api/process-instances/${processInstanceId}/sequence-flows`,
+    },
+    options,
+  );
 };
 
 export {fetchSequenceFlows};

--- a/operate/client/src/modules/request/index.ts
+++ b/operate/client/src/modules/request/index.ts
@@ -56,12 +56,23 @@ async function request({url, method, body, headers, signal}: RequestParams) {
 
 async function requestAndParse<T>(
   params: RequestParams,
-  options?: {onFailure?: () => void; onException?: () => void},
+  options?: {
+    onFailure?: () => void;
+    onException?: () => void;
+    isPolling?: boolean;
+  },
 ) {
   const {url} = params;
 
+  const extendedParams = {
+    ...params,
+    headers: {...params.headers, 'x-is-polling': 'true'},
+  };
+
   try {
-    const response = await request(params);
+    const response = await request(
+      options?.isPolling ? extendedParams : params,
+    );
 
     if (!response.ok) {
       options?.onFailure?.();

--- a/operate/client/src/modules/stores/flowNodeInstance/index.tsx
+++ b/operate/client/src/modules/stores/flowNodeInstance/index.tsx
@@ -132,7 +132,7 @@ class FlowNodeInstance extends NetworkReconnectionHandler {
     }
 
     this.isPollRequestRunning = true;
-    const response = await fetchFlowNodeInstances(queries);
+    const response = await fetchFlowNodeInstances(queries, {isPolling: true});
 
     if (response.isSuccess) {
       if (this.intervalId !== null) {

--- a/operate/client/src/modules/stores/incidents.test.ts
+++ b/operate/client/src/modules/stores/incidents.test.ts
@@ -28,7 +28,9 @@ describe('stores/incidents', () => {
     incidentsStore.reset();
   });
   beforeEach(() => {
-    mockFetchProcessInstanceIncidents().withSuccess(mockIncidents);
+    mockFetchProcessInstanceIncidents().withSuccess(mockIncidents, {
+      expectPolling: false,
+    });
   });
 
   it('should poll for incidents if instance state is incident', async () => {
@@ -43,10 +45,13 @@ describe('stores/incidents', () => {
       expect(incidentsStore.state.response).toEqual(mockIncidents),
     );
 
-    mockFetchProcessInstanceIncidents().withSuccess({
-      ...mockIncidents,
-      count: 2,
-    });
+    mockFetchProcessInstanceIncidents().withSuccess(
+      {
+        ...mockIncidents,
+        count: 2,
+      },
+      {expectPolling: true},
+    );
 
     jest.runOnlyPendingTimers();
 
@@ -57,10 +62,13 @@ describe('stores/incidents', () => {
       }),
     );
 
-    mockFetchProcessInstanceIncidents().withSuccess({
-      ...mockIncidents,
-      count: 3,
-    });
+    mockFetchProcessInstanceIncidents().withSuccess(
+      {
+        ...mockIncidents,
+        count: 3,
+      },
+      {expectPolling: true},
+    );
 
     jest.runOnlyPendingTimers();
 

--- a/operate/client/src/modules/stores/incidents.ts
+++ b/operate/client/src/modules/stores/incidents.ts
@@ -147,7 +147,7 @@ class Incidents extends NetworkReconnectionHandler {
 
   handlePolling = async (id: string) => {
     this.isPollRequestRunning = true;
-    const response = await fetchProcessInstanceIncidents(id);
+    const response = await fetchProcessInstanceIncidents(id, {isPolling: true});
 
     if (this.intervalId !== null && response.isSuccess) {
       this.setIncidents(response.data);

--- a/operate/client/src/modules/stores/incidentsByError.test.ts
+++ b/operate/client/src/modules/stores/incidentsByError.test.ts
@@ -71,7 +71,9 @@ describe('stores/incidentsByError', () => {
   ];
 
   beforeEach(() => {
-    mockFetchIncidentsByError().withSuccess(mockIncidentsByError);
+    mockFetchIncidentsByError().withSuccess(mockIncidentsByError, {
+      expectPolling: false,
+    });
   });
 
   afterEach(() => {
@@ -91,6 +93,9 @@ describe('stores/incidentsByError', () => {
   });
 
   it('should start polling on init', async () => {
+    mockFetchIncidentsByError().withSuccess(mockIncidentsByError, {
+      expectPolling: true,
+    });
     jest.useFakeTimers();
     incidentsByErrorStore.init();
     await waitFor(() =>
@@ -99,7 +104,7 @@ describe('stores/incidentsByError', () => {
 
     expect(incidentsByErrorStore.state.incidents).toEqual(mockIncidentsByError);
 
-    mockFetchIncidentsByError().withSuccess([]);
+    mockFetchIncidentsByError().withSuccess([], {expectPolling: true});
 
     jest.runOnlyPendingTimers();
 

--- a/operate/client/src/modules/stores/incidentsByError.ts
+++ b/operate/client/src/modules/stores/incidentsByError.ts
@@ -86,7 +86,7 @@ class IncidentsByError extends NetworkReconnectionHandler {
 
   handlePolling = async () => {
     this.isPollRequestRunning = true;
-    const response = await fetchIncidentsByError();
+    const response = await fetchIncidentsByError({isPolling: true});
 
     if (this.intervalId !== null) {
       if (response.isSuccess) {

--- a/operate/client/src/modules/stores/operations/index.tsx
+++ b/operate/client/src/modules/stores/operations/index.tsx
@@ -222,9 +222,12 @@ class Operations extends NetworkReconnectionHandler {
 
   handlePolling = async () => {
     this.isPollRequestRunning = true;
-    const response = await fetchBatchOperations({
-      pageSize: MAX_OPERATIONS_PER_REQUEST * this.state.page,
-    });
+    const response = await fetchBatchOperations(
+      {
+        pageSize: MAX_OPERATIONS_PER_REQUEST * this.state.page,
+      },
+      {isPolling: true},
+    );
 
     if (this.intervalId !== null && response.isSuccess) {
       this.setOperations(response.data);

--- a/operate/client/src/modules/stores/processInstanceDetails.test.ts
+++ b/operate/client/src/modules/stores/processInstanceDetails.test.ts
@@ -246,4 +246,38 @@ describe('stores/currentInstance', () => {
 
     window.addEventListener = originalEventListener;
   });
+
+  it('should poll with polling header', async () => {
+    jest.useFakeTimers();
+
+    // expect the first request not to be a polling request
+    mockFetchProcessInstance().withSuccess(currentInstanceMock, {
+      expectPolling: false,
+    });
+
+    processInstanceDetailsStore.init({id: '1'});
+    await waitFor(() =>
+      expect(processInstanceDetailsStore.state.processInstance).toEqual(
+        currentInstanceMock,
+      ),
+    );
+
+    const secondCurrentInstanceMock = createInstance();
+
+    // expect the second request to be a polling request
+    mockFetchProcessInstance().withSuccess(secondCurrentInstanceMock, {
+      expectPolling: true,
+    });
+
+    jest.runOnlyPendingTimers();
+
+    await waitFor(() =>
+      expect(processInstanceDetailsStore.state.processInstance).toEqual(
+        secondCurrentInstanceMock,
+      ),
+    );
+
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
 });

--- a/operate/client/src/modules/stores/processInstanceDetails.ts
+++ b/operate/client/src/modules/stores/processInstanceDetails.ts
@@ -235,7 +235,7 @@ class ProcessInstanceDetails extends NetworkReconnectionHandler {
 
   handlePolling = async (instanceId: any) => {
     this.isPollRequestRunning = true;
-    const response = await fetchProcessInstance(instanceId);
+    const response = await fetchProcessInstance(instanceId, {isPolling: true});
 
     if (this.intervalId !== null) {
       if (response.isSuccess) {

--- a/operate/client/src/modules/stores/processInstanceDetailsStatistic.test.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsStatistic.test.ts
@@ -83,6 +83,7 @@ describe('stores/processInstanceDetailsStatistics', () => {
   beforeEach(async () => {
     mockFetchProcessInstanceDetailStatistics().withSuccess(
       mockProcessInstanceDetailsStatistics,
+      {expectPolling: false},
     );
     mockFetchProcessInstance().withSuccess(
       createInstance({id: PROCESS_INSTANCE_ID, state: 'INCIDENT'}),
@@ -170,16 +171,19 @@ describe('stores/processInstanceDetailsStatistics', () => {
       );
     });
 
-    mockFetchProcessInstanceDetailStatistics().withSuccess([
-      ...mockProcessInstanceDetailsStatistics,
-      {
-        activityId: 'anotherNode',
-        active: 1,
-        canceled: 0,
-        incidents: 0,
-        completed: 0,
-      },
-    ]);
+    mockFetchProcessInstanceDetailStatistics().withSuccess(
+      [
+        ...mockProcessInstanceDetailsStatistics,
+        {
+          activityId: 'anotherNode',
+          active: 1,
+          canceled: 0,
+          incidents: 0,
+          completed: 0,
+        },
+      ],
+      {expectPolling: true},
+    );
 
     jest.runOnlyPendingTimers();
 

--- a/operate/client/src/modules/stores/processInstanceDetailsStatistics.ts
+++ b/operate/client/src/modules/stores/processInstanceDetailsStatistics.ts
@@ -100,8 +100,10 @@ class ProcessInstanceDetailsStatistics extends NetworkReconnectionHandler {
 
   handlePolling = async (processInstanceId: string) => {
     this.isPollRequestRunning = true;
-    const response =
-      await fetchProcessInstanceDetailStatistics(processInstanceId);
+    const response = await fetchProcessInstanceDetailStatistics(
+      processInstanceId,
+      {isPolling: true},
+    );
 
     if (this.intervalId !== null) {
       if (response.isSuccess) {

--- a/operate/client/src/modules/stores/processInstances.ts
+++ b/operate/client/src/modules/stores/processInstances.ts
@@ -289,6 +289,7 @@ class ProcessInstances extends NetworkReconnectionHandler {
         query: {active: true, running: true, incidents: true, processIds},
         pageSize: 0,
       },
+      options: {isPolling: true},
     });
 
     this.setRunningInstancesCount(
@@ -307,6 +308,7 @@ class ProcessInstances extends NetworkReconnectionHandler {
               ? this.state.processInstances.length
               : MAX_INSTANCES_PER_REQUEST,
         },
+        options: {isPolling: true},
       }),
       this.fetchRunningInstancesCount(),
     ]);
@@ -404,10 +406,13 @@ class ProcessInstances extends NetworkReconnectionHandler {
     }
 
     this.isPollRequestRunning = true;
-    const response = await fetchProcessInstancesByIds({
-      ids: this.processInstanceIdsWithActiveOperations,
-      signal: this.pollingAbortController?.signal,
-    });
+    const response = await fetchProcessInstancesByIds(
+      {
+        ids: this.processInstanceIdsWithActiveOperations,
+        signal: this.pollingAbortController?.signal,
+      },
+      {isPolling: true},
+    );
 
     if (response.isSuccess) {
       if (this.intervalId !== null) {

--- a/operate/client/src/modules/stores/processInstancesByName.test.ts
+++ b/operate/client/src/modules/stores/processInstancesByName.test.ts
@@ -72,7 +72,9 @@ describe('stores/processInstancesByName', () => {
   ];
 
   beforeEach(() => {
-    mockFetchProcessInstancesByName().withSuccess(mockInstancesByProcess);
+    mockFetchProcessInstancesByName().withSuccess(mockInstancesByProcess, {
+      expectPolling: false,
+    });
   });
 
   afterEach(() => {
@@ -92,6 +94,9 @@ describe('stores/processInstancesByName', () => {
   });
 
   it('should start polling on init', async () => {
+    mockFetchProcessInstancesByName().withSuccess(mockInstancesByProcess, {
+      expectPolling: true,
+    });
     jest.useFakeTimers();
     processInstancesByNameStore.init();
     await waitFor(() =>
@@ -102,7 +107,7 @@ describe('stores/processInstancesByName', () => {
       mockInstancesByProcess,
     );
 
-    mockFetchProcessInstancesByName().withSuccess([]);
+    mockFetchProcessInstancesByName().withSuccess([], {expectPolling: true});
 
     jest.runOnlyPendingTimers();
 

--- a/operate/client/src/modules/stores/processInstancesByName.ts
+++ b/operate/client/src/modules/stores/processInstancesByName.ts
@@ -85,7 +85,7 @@ class ProcessInstancesByName extends NetworkReconnectionHandler {
 
   handlePolling = async () => {
     this.isPollRequestRunning = true;
-    const response = await fetchProcessInstancesByName();
+    const response = await fetchProcessInstancesByName({isPolling: true});
 
     if (this.intervalId !== null) {
       if (response.isSuccess) {

--- a/operate/client/src/modules/stores/sequenceFlows.test.ts
+++ b/operate/client/src/modules/stores/sequenceFlows.test.ts
@@ -25,7 +25,9 @@ describe('stores/sequenceFlows', () => {
   const mockSequenceFlows = createSequenceFlows();
 
   beforeEach(() => {
-    mockFetchSequenceFlows().withSuccess(mockSequenceFlows);
+    mockFetchSequenceFlows().withSuccess(mockSequenceFlows, {
+      expectPolling: false,
+    });
   });
 
   afterEach(() => {
@@ -67,13 +69,16 @@ describe('stores/sequenceFlows', () => {
       ]),
     );
 
-    mockFetchSequenceFlows().withSuccess([
-      ...mockSequenceFlows,
-      {
-        processInstanceId: '2251799813693731',
-        activityId: 'SequenceFlow_1sz6737',
-      },
-    ]);
+    mockFetchSequenceFlows().withSuccess(
+      [
+        ...mockSequenceFlows,
+        {
+          processInstanceId: '2251799813693731',
+          activityId: 'SequenceFlow_1sz6737',
+        },
+      ],
+      {expectPolling: true},
+    );
 
     jest.runOnlyPendingTimers();
 
@@ -87,17 +92,20 @@ describe('stores/sequenceFlows', () => {
       ]),
     );
 
-    mockFetchSequenceFlows().withSuccess([
-      ...mockSequenceFlows,
-      {
-        processInstanceId: '2251799813693731',
-        activityId: 'SequenceFlow_1sz6737',
-      },
-      {
-        processInstanceId: '2251799813693732',
-        activityId: 'SequenceFlow_1sz6738',
-      },
-    ]);
+    mockFetchSequenceFlows().withSuccess(
+      [
+        ...mockSequenceFlows,
+        {
+          processInstanceId: '2251799813693731',
+          activityId: 'SequenceFlow_1sz6737',
+        },
+        {
+          processInstanceId: '2251799813693732',
+          activityId: 'SequenceFlow_1sz6738',
+        },
+      ],
+      {expectPolling: true},
+    );
 
     jest.runOnlyPendingTimers();
 

--- a/operate/client/src/modules/stores/sequenceFlows.ts
+++ b/operate/client/src/modules/stores/sequenceFlows.ts
@@ -92,7 +92,9 @@ class SequenceFlows extends NetworkReconnectionHandler {
 
   handlePolling = async (instanceId: ProcessInstanceEntity['id']) => {
     this.isPollRequestRunning = true;
-    const {isSuccess, data} = await fetchSequenceFlows(instanceId);
+    const {isSuccess, data} = await fetchSequenceFlows(instanceId, {
+      isPolling: true,
+    });
 
     if (this.intervalId !== null && isSuccess) {
       this.setItems(getProcessedSequenceFlows(data));

--- a/operate/client/src/modules/stores/variables/index.ts
+++ b/operate/client/src/modules/stores/variables/index.ts
@@ -390,18 +390,21 @@ class Variables extends NetworkReconnectionHandler {
 
     this.isPollRequestRunning = true;
 
-    const response = await fetchVariables({
-      instanceId,
-      payload: {
-        scopeId: this.scopeId || instanceId,
-        pageSize:
-          items.length <= MAX_VARIABLES_PER_REQUEST
-            ? MAX_VARIABLES_PER_REQUEST
-            : items.length,
-        searchAfterOrEqual: this.getSortValues('initial'),
+    const response = await fetchVariables(
+      {
+        instanceId,
+        payload: {
+          scopeId: this.scopeId || instanceId,
+          pageSize:
+            items.length <= MAX_VARIABLES_PER_REQUEST
+              ? MAX_VARIABLES_PER_REQUEST
+              : items.length,
+          searchAfterOrEqual: this.getSortValues('initial'),
+        },
+        signal: this.pollingAbortController?.signal,
       },
-      signal: this.pollingAbortController?.signal,
-    });
+      {isPolling: true},
+    );
 
     if (this.intervalId !== null && response.isSuccess) {
       const variables = response.data;


### PR DESCRIPTION
## Description

This PR adds an 'x-is-polling': 'true' header to API requests, in case it is a polling request.

## Related issues

related to https://github.com/camunda/operate/issues/6406
closes https://github.com/camunda/operate/pull/6636

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [x] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
