### PR TITLE
Add code blocks to save actions

### DIFF
--- a/.idea/saveactions_settings.xml
+++ b/.idea/saveactions_settings.xml
@@ -11,6 +11,7 @@
         <option value="localCanBeFinal" />
         <option value="missingOverrideAnnotation" />
         <option value="unnecessaryThis" />
+        <option value="useBlocks" />
       </set>
     </option>
     <option name="configurationPath" value="" />

--- a/operate/.idea/saveactions_settings.xml
+++ b/operate/.idea/saveactions_settings.xml
@@ -11,6 +11,7 @@
         <option value="localCanBeFinal" />
         <option value="missingOverrideAnnotation" />
         <option value="unnecessaryThis" />
+        <option value="useBlocks" />
       </set>
     </option>
     <option name="configurationPath" value="" />


### PR DESCRIPTION


## Description
Add useBlocks option to the save action plugin,
such that it generates brackets for new code.

This is useful especially when generating equals/hashcode


See related slack thread https://camunda.slack.com/archives/C05DH1F5TAR/p1710928704042159?thread_ts=1710928203.030479&cid=C05DH1F5TAR