### PR TITLE
test: stabilize flaky test by increasing timeout

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -538,7 +538,7 @@ final class ReconfigurationTest {
       assertThat(m2.leave())
           .describedAs(
               "Should fail to leave because quorum not available for the new configuration")
-          .failsWithin(Duration.ofSeconds(2))
+          .failsWithin(Duration.ofSeconds(10))
           .withThrowableOfType(ExecutionException.class);
     }
 


### PR DESCRIPTION
This test was flaky, especially in CI, because sometimes the leader step down would be delayed by multiple seconds. Instead of first waiting for the leader step down to occur and then checking that the request fails, I've decided to simply increase the time we wait for the request to fail. This is because request failure can only happen on leader step down, and waiting twice for effectively the same thing doesn't improve this test.

Closes #16719