### PR TITLE
[BREAKING CHANGE] Integrate credentials provider with the REST client

### DIFF
--- a/zeebe/clients/java/ignored-changes.json
+++ b/zeebe/clients/java/ignored-changes.json
@@ -1,0 +1,22 @@
+[
+  {
+    "extension": "revapi.differences",
+    "id": "differences",
+    "configuration": {
+      "differences": [
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method void io.camunda.zeebe.client.CredentialsProvider::applyCredentials(io.grpc.Metadata) throws java.io.IOException",
+          "justification": "Replaced by a multi-protocol capable version, and is a known breaking change (as adding REST is a breaking change)"
+        },
+        {
+          "ignore": true,
+          "code": "java.method.removed",
+          "old": "method boolean io.camunda.zeebe.client.CredentialsProvider::shouldRetryRequest(java.lang.Throwable)",
+          "justification": "Replaced by a multi-protocol capable version, and is a known breaking change (as adding REST is a breaking change)"
+        }
+      ]
+    }
+  }
+]

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
@@ -25,24 +25,70 @@ public interface CredentialsProvider {
 
   /**
    * Adds credentials to the headers. For an example of this, see {@link
-   * OAuthCredentialsProvider#applyCredentials(Metadata)}
+   * OAuthCredentialsProvider#applyCredentials(CredentialsApplier)}
    *
-   * @param headers gRPC headers to be modified
+   * @param applier where to headers
    */
-  void applyCredentials(Metadata headers) throws IOException;
+  void applyCredentials(final CredentialsApplier applier) throws IOException;
 
   /**
    * Returns true if the request should be retried; otherwise returns false. For an example of this,
-   * see {@link OAuthCredentialsProvider#shouldRetryRequest(Throwable)}
+   * see {@link OAuthCredentialsProvider#shouldRetryRequest(StatusCode)}.
    *
-   * @param throwable error that caused the request to fail
+   * <p><strong>Only called for REST calls</strong>
+   *
+   * @param statusCode the response code for the failure
    */
-  boolean shouldRetryRequest(Throwable throwable);
+  boolean shouldRetryRequest(final StatusCode statusCode);
 
   /**
    * @return a builder to configure and create a new {@link OAuthCredentialsProvider}.
    */
   static OAuthCredentialsProviderBuilder newCredentialsProviderBuilder() {
     return new OAuthCredentialsProviderBuilder();
+  }
+
+  /**
+   * Used to apply call credentials on a per-request basis, abstracting over gRPC and REST. This
+   * interface is only meant to be consumed, not implemented externally.
+   */
+  interface CredentialsApplier {
+
+    /**
+     * Puts the given header key and value into the request headers (e.g. HTTP headers or gRPC
+     * metadata).
+     *
+     * @param key the header key
+     * @param value the header value
+     */
+    void put(final String key, final String value);
+
+    /**
+     * Helper method to build a credentials applier out of gRPC metadata.
+     *
+     * @param metadata the gRPC metadata on which to apply
+     */
+    static CredentialsApplier ofMetadata(final Metadata metadata) {
+      return (key, value) ->
+          metadata.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+    }
+  }
+
+  /**
+   * Represents the result of a failed call, abstracting over gRPC and standard HTTP status codes.
+   */
+  interface StatusCode {
+
+    /** Returns the raw status code, e.g. HTTP 401 Unauthorized, or gRPC 16 Unauthenticated. */
+    int code();
+
+    /** Returns true if the request was failed because the user cannot be authenticated. */
+    boolean isUnauthorized();
+
+    /**
+     * Returns true if the request was failed because the authenticated user does not have
+     * permissions.
+     */
+    boolean isForbidden();
   }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
@@ -84,11 +84,5 @@ public interface CredentialsProvider {
 
     /** Returns true if the request was failed because the user cannot be authenticated. */
     boolean isUnauthorized();
-
-    /**
-     * Returns true if the request was failed because the authenticated user does not have
-     * permissions.
-     */
-    boolean isForbidden();
   }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/CredentialsProvider.java
@@ -27,7 +27,7 @@ public interface CredentialsProvider {
    * Adds credentials to the headers. For an example of this, see {@link
    * OAuthCredentialsProvider#applyCredentials(CredentialsApplier)}
    *
-   * @param applier where to headers
+   * @param applier where to add the credentials headers
    */
   void applyCredentials(final CredentialsApplier applier) throws IOException;
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/GrpcStatusCode.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/GrpcStatusCode.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl;
+
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
+import io.grpc.Status.Code;
+
+public final class GrpcStatusCode implements StatusCode {
+
+  private final Code code;
+
+  public GrpcStatusCode(final Code code) {
+    this.code = code;
+  }
+
+  @Override
+  public int code() {
+    return code.value();
+  }
+
+  @Override
+  public boolean isUnauthorized() {
+    return code == Code.UNAUTHENTICATED;
+  }
+
+  @Override
+  public boolean isForbidden() {
+    return code == Code.PERMISSION_DENIED;
+  }
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/GrpcStatusCode.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/GrpcStatusCode.java
@@ -35,9 +35,4 @@ public final class GrpcStatusCode implements StatusCode {
   public boolean isUnauthorized() {
     return code == Code.UNAUTHENTICATED;
   }
-
-  @Override
-  public boolean isForbidden() {
-    return code == Code.PERMISSION_DENIED;
-  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/HttpStatusCode.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/HttpStatusCode.java
@@ -35,9 +35,4 @@ public final class HttpStatusCode implements StatusCode {
   public boolean isUnauthorized() {
     return code == HttpStatus.SC_UNAUTHORIZED;
   }
-
-  @Override
-  public boolean isForbidden() {
-    return code == HttpStatus.SC_FORBIDDEN;
-  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/HttpStatusCode.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/HttpStatusCode.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl;
+
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
+import org.apache.hc.core5.http.HttpStatus;
+
+public final class HttpStatusCode implements StatusCode {
+
+  private final int code;
+
+  public HttpStatusCode(final int code) {
+    this.code = code;
+  }
+
+  @Override
+  public int code() {
+    return code;
+  }
+
+  @Override
+  public boolean isUnauthorized() {
+    return code == HttpStatus.SC_UNAUTHORIZED;
+  }
+
+  @Override
+  public boolean isForbidden() {
+    return code == HttpStatus.SC_FORBIDDEN;
+  }
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/NoopCredentialsProvider.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/NoopCredentialsProvider.java
@@ -16,17 +16,16 @@
 package io.camunda.zeebe.client.impl;
 
 import io.camunda.zeebe.client.CredentialsProvider;
-import io.grpc.Metadata;
 
 public final class NoopCredentialsProvider implements CredentialsProvider {
 
   @Override
-  public void applyCredentials(final Metadata headers) {
+  public void applyCredentials(final CredentialsApplier ignored) {
     // Noop
   }
 
   @Override
-  public boolean shouldRetryRequest(final Throwable throwable) {
+  public boolean shouldRetryRequest(final StatusCode statusCode) {
     return false;
   }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeCallCredentials.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.client.impl;
 
 import io.camunda.zeebe.client.CredentialsProvider;
+import io.camunda.zeebe.client.CredentialsProvider.CredentialsApplier;
 import io.grpc.Metadata;
 import io.grpc.SecurityLevel;
 import io.grpc.Status;
@@ -45,7 +46,7 @@ public final class ZeebeCallCredentials extends io.grpc.CallCredentials {
         () -> {
           try {
             final Metadata headers = new Metadata();
-            credentialsProvider.applyCredentials(headers);
+            credentialsProvider.applyCredentials(CredentialsApplier.ofMetadata(headers));
             applier.apply(headers);
           } catch (final IOException e) {
             applier.fail(Status.CANCELLED.withCause(e));

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
@@ -44,7 +45,7 @@ public final class ActivateJobsCommandImpl
   private static final Duration DEADLINE_OFFSET = Duration.ofSeconds(10);
   private final GatewayStub asyncStub;
   private final JsonMapper jsonMapper;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private final Builder builder;
   private Duration requestTimeout;
 
@@ -55,7 +56,7 @@ public final class ActivateJobsCommandImpl
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration config,
       final JsonMapper jsonMapper,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.jsonMapper = jsonMapper;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/BroadcastSignalCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
@@ -37,7 +38,7 @@ public final class BroadcastSignalCommandImpl
     implements BroadcastSignalCommandStep1, BroadcastSignalCommandStep2 {
 
   private final GatewayStub asyncStub;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private final BroadcastSignalRequest.Builder builder;
   private Duration requestTimeout;
 
@@ -45,7 +46,7 @@ public final class BroadcastSignalCommandImpl
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration configuration,
       final JsonMapper jsonMapper,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
@@ -34,14 +35,14 @@ public final class CancelProcessInstanceCommandImpl implements CancelProcessInst
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public CancelProcessInstanceCommandImpl(
       final GatewayStub asyncStub,
       final long processInstanceKey,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CompleteJobCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CompleteJobCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
@@ -36,7 +37,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public CompleteJobCommandImpl(
@@ -44,7 +45,7 @@ public final class CompleteJobCommandImpl extends CommandWithVariables<CompleteJ
       final JsonMapper jsonMapper,
       final long key,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
@@ -44,7 +45,7 @@ public final class CreateProcessInstanceCommandImpl
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private final JsonMapper jsonMapper;
   private Duration requestTimeout;
 
@@ -52,7 +53,7 @@ public final class CreateProcessInstanceCommandImpl
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,
       final ZeebeClientConfiguration config,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     requestTimeout = config.getDefaultRequestTimeout();
@@ -77,7 +78,7 @@ public final class CreateProcessInstanceCommandImpl
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CreateProcessInstanceWithResultCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1.CreateProcessInstanceWithResultCommandStep1;
@@ -42,14 +43,14 @@ public final class CreateProcessInstanceWithResultCommandImpl
   private final GatewayStub asyncStub;
   private final CreateProcessInstanceRequest.Builder createProcessInstanceRequestBuilder;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public CreateProcessInstanceWithResultCommandImpl(
       final JsonMapper jsonMapper,
       final GatewayStub asyncStub,
       final CreateProcessInstanceRequest.Builder builder,
-      final Predicate<Throwable> retryPredicate,
+      final Predicate<StatusCode> retryPredicate,
       final Duration requestTimeout) {
     this.jsonMapper = jsonMapper;
     this.asyncStub = asyncStub;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeleteResourceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeleteResourceCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
@@ -33,13 +34,13 @@ public class DeleteResourceCommandImpl implements DeleteResourceCommandStep1 {
 
   private final DeleteResourceRequest.Builder requestBuilder = DeleteResourceRequest.newBuilder();
   private final GatewayStub asyncStub;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public DeleteResourceCommandImpl(
       final long resourceKey,
       final GatewayStub asyncStub,
-      final Predicate<Throwable> retryPredicate,
+      final Predicate<StatusCode> retryPredicate,
       final Duration requestTimeout) {
     this.asyncStub = asyncStub;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployProcessCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployProcessCommandImpl.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 import static io.camunda.zeebe.client.impl.command.StreamUtil.readInputStream;
 
 import com.google.protobuf.ByteString;
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
@@ -50,13 +51,13 @@ public final class DeployProcessCommandImpl
 
   private final DeployProcessRequest.Builder requestBuilder = DeployProcessRequest.newBuilder();
   private final GatewayStub asyncStub;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public DeployProcessCommandImpl(
       final GatewayStub asyncStub,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeployResourceCommandImpl.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.client.impl.command.ArgumentUtil.ensureNotNull;
 import static io.camunda.zeebe.client.impl.command.StreamUtil.readInputStream;
 
 import com.google.protobuf.ByteString;
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.ClientException;
@@ -52,13 +53,13 @@ public final class DeployResourceCommandImpl
 
   private final DeployResourceRequest.Builder requestBuilder = DeployResourceRequest.newBuilder();
   private final GatewayStub asyncStub;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public DeployResourceCommandImpl(
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration config,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     requestTimeout = config.getDefaultRequestTimeout();
     this.retryPredicate = retryPredicate;
@@ -80,7 +81,7 @@ public final class DeployResourceCommandImpl
   public DeployResourceCommandImpl(
       final GatewayStub asyncStub,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/EvaluateDecisionCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
@@ -39,7 +40,7 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private final JsonMapper jsonMapper;
   private Duration requestTimeout;
 
@@ -47,7 +48,7 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,
       final ZeebeClientConfiguration config,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     requestTimeout = config.getDefaultRequestTimeout();
@@ -72,7 +73,7 @@ public class EvaluateDecisionCommandImpl extends CommandWithVariables<EvaluateDe
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/FailJobCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/FailJobCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FailJobCommandStep1;
@@ -37,7 +38,7 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public FailJobCommandImpl(
@@ -45,7 +46,7 @@ public final class FailJobCommandImpl extends CommandWithVariables<FailJobComman
       final JsonMapper jsonMapper,
       final long key,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
@@ -36,14 +37,14 @@ public final class JobUpdateRetriesCommandImpl
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public JobUpdateRetriesCommandImpl(
       final GatewayStub asyncStub,
       final long jobKey,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateTimeoutCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateTimeoutCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
@@ -37,14 +38,14 @@ public class JobUpdateTimeoutCommandImpl
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public JobUpdateTimeoutCommandImpl(
       final GatewayStub asyncStub,
       final long jobKey,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/MigrateProcessInstanceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/MigrateProcessInstanceCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.command.MigrateProcessInstanceCommandStep1;
@@ -40,14 +41,14 @@ public final class MigrateProcessInstanceCommandImpl
   private final MigrateProcessInstanceRequest.Builder requestBuilder =
       MigrateProcessInstanceRequest.newBuilder();
   private final GatewayStub asyncStub;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public MigrateProcessInstanceCommandImpl(
       final long processInstanceKey,
       final GatewayStub asyncStub,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     requestBuilder.setProcessInstanceKey(processInstanceKey);
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
@@ -46,7 +47,7 @@ public final class ModifyProcessInstanceCommandImpl
       ModifyProcessInstanceRequest.newBuilder();
   private final JsonMapper jsonMapper;
   private final GatewayStub asyncStub;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private ActivateInstruction latestActivateInstruction;
   private Duration requestTimeout;
 
@@ -55,7 +56,7 @@ public final class ModifyProcessInstanceCommandImpl
       final JsonMapper jsonMapper,
       final GatewayStub asyncStub,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     requestBuilder.setProcessInstanceKey(processInstanceKey);
     this.jsonMapper = jsonMapper;
     this.asyncStub = asyncStub;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/PublishMessageCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
@@ -37,7 +38,7 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
     implements PublishMessageCommandStep1, PublishMessageCommandStep2, PublishMessageCommandStep3 {
 
   private final GatewayStub asyncStub;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private final PublishMessageRequest.Builder builder;
   private Duration requestTimeout;
 
@@ -45,7 +46,7 @@ public final class PublishMessageCommandImpl extends CommandWithVariables<Publis
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration configuration,
       final JsonMapper jsonMapper,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     this.retryPredicate = retryPredicate;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ResolveIncidentCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ResolveIncidentCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.command.ResolveIncidentCommandStep1;
@@ -34,14 +35,14 @@ public final class ResolveIncidentCommandImpl implements ResolveIncidentCommandS
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public ResolveIncidentCommandImpl(
       final GatewayStub asyncStub,
       final long incidentKey,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     builder = ResolveIncidentRequest.newBuilder().setIncidentKey(incidentKey);
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/SetVariablesCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/SetVariablesCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
@@ -40,7 +41,7 @@ public final class SetVariablesCommandImpl
   private final GatewayStub asyncStub;
   private final Builder builder;
   private final JsonMapper jsonMapper;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public SetVariablesCommandImpl(
@@ -48,7 +49,7 @@ public final class SetVariablesCommandImpl
       final JsonMapper jsonMapper,
       final long elementInstanceKey,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.jsonMapper = jsonMapper;
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
@@ -47,7 +48,7 @@ public final class StreamJobsCommandImpl
 
   private final GatewayStub asyncStub;
   private final JsonMapper jsonMapper;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private final Builder builder;
 
   private Consumer<ActivatedJob> consumer;
@@ -59,7 +60,7 @@ public final class StreamJobsCommandImpl
   public StreamJobsCommandImpl(
       final GatewayStub asyncStub,
       final JsonMapper jsonMapper,
-      final Predicate<Throwable> retryPredicate,
+      final Predicate<StatusCode> retryPredicate,
       final ZeebeClientConfiguration config) {
     this.asyncStub = asyncStub;
     this.jsonMapper = jsonMapper;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ThrowErrorCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ThrowErrorCommandImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
@@ -35,7 +36,7 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
 
   private final GatewayStub asyncStub;
   private final Builder builder;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
 
   public ThrowErrorCommandImpl(
@@ -43,7 +44,7 @@ public final class ThrowErrorCommandImpl extends CommandWithVariables<ThrowError
       final JsonMapper jsonMapper,
       final long key,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     super(jsonMapper);
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/TopologyRequestImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/TopologyRequestImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.command;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.ZeebeFuture;
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.command.TopologyRequestStep1;
@@ -37,7 +38,7 @@ public final class TopologyRequestImpl implements TopologyRequestStep1 {
   private final GatewayStub asyncStub;
   private final HttpClient httpClient;
   private final RequestConfig.Builder httpRequestConfig;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
   private Duration requestTimeout;
   private boolean useRest;
 
@@ -45,7 +46,7 @@ public final class TopologyRequestImpl implements TopologyRequestStep1 {
       final GatewayStub asyncStub,
       final HttpClient httpClient,
       final Duration requestTimeout,
-      final Predicate<Throwable> retryPredicate,
+      final Predicate<StatusCode> retryPredicate,
       final boolean useRest) {
     this.asyncStub = asyncStub;
     this.requestTimeout = requestTimeout;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -61,7 +61,8 @@ public class HttpClientFactory {
         gatewayAddress,
         defaultRequestConfig,
         config.getMaxMessageSize(),
-        TimeValue.ofSeconds(15));
+        TimeValue.ofSeconds(15),
+        config.getCredentialsProvider());
   }
 
   private URI buildGatewayAddress() {

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -16,7 +16,9 @@
 package io.camunda.zeebe.client.impl.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.impl.NoopCredentialsProvider;
 import io.camunda.zeebe.client.impl.util.VersionUtil;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -54,6 +56,10 @@ public class HttpClientFactory {
     final CloseableHttpAsyncClient client =
         defaultClientBuilder().setDefaultRequestConfig(defaultRequestConfig).build();
     final URI gatewayAddress = buildGatewayAddress();
+    final CredentialsProvider credentialsProvider =
+        config.getCredentialsProvider() != null
+            ? config.getCredentialsProvider()
+            : new NoopCredentialsProvider();
 
     return new HttpClient(
         client,
@@ -62,7 +68,7 @@ public class HttpClientFactory {
         defaultRequestConfig,
         config.getMaxMessageSize(),
         TimeValue.ofSeconds(15),
-        config.getCredentialsProvider());
+        credentialsProvider);
   }
 
   private URI buildGatewayAddress() {

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/JsonAsyncResponseConsumer.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/JsonAsyncResponseConsumer.java
@@ -25,7 +25,7 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 
 /**
  * Consumes either a successful JSON response body of type {@link T} or a {@link
- * io.camunda.zeebe.gateway.protocol.rest.ProblemDetail} returned by the server on error (if the
+ * io.camunda.zeebe.client.protocol.rest.ProblemDetail} returned by the server on error (if the
  * error was generated explicitly by the server, e.g. not a connection error)
  *
  * <p>If there is no body at all, the result will be null (regardless of whether the call was

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
@@ -110,7 +110,7 @@ public final class OAuthCredentialsCache {
     if (optionalCredentials.isPresent()) {
       return Optional.ofNullable(function.apply(optionalCredentials.get()));
     } else {
-      return Optional.empty();
+      return Optional.ofNullable(function.apply(null));
     }
   }
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -96,7 +96,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
   @Override
   public boolean shouldRetryRequest(final StatusCode statusCode) {
     try {
-      return (statusCode.isUnauthorized() || statusCode.isForbidden())
+      return statusCode.isUnauthorized()
           && credentialsCache
               .withCache(
                   endpoint,

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsProvider.java
@@ -23,10 +23,6 @@ import com.fasterxml.jackson.databind.ObjectReader;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.impl.ZeebeClientCredentials;
 import io.camunda.zeebe.client.impl.util.VersionUtil;
-import io.grpc.Metadata;
-import io.grpc.Metadata.Key;
-import io.grpc.Status;
-import io.grpc.Status.Code;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -53,8 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 @ThreadSafe
 public final class OAuthCredentialsProvider implements CredentialsProvider {
-  public static final Key<String> HEADER_AUTH_KEY =
-      Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+  private static final String HEADER_AUTH_KEY = "Authorization";
 
   private static final ObjectMapper JSON_MAPPER =
       new ObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -79,7 +74,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
 
   /** Adds an access token to the Authorization header of a gRPC call. */
   @Override
-  public void applyCredentials(final Metadata headers) throws IOException {
+  public void applyCredentials(final CredentialsApplier applier) throws IOException {
     final ZeebeClientCredentials zeebeClientCredentials =
         credentialsCache.computeIfMissingOrInvalid(endpoint, this::fetchCredentials);
 
@@ -90,18 +85,18 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
     }
 
     type = Character.toUpperCase(type.charAt(0)) + type.substring(1);
-    headers.put(
+    applier.put(
         HEADER_AUTH_KEY, String.format("%s %s", type, zeebeClientCredentials.getAccessToken()));
   }
 
   /**
-   * Returns true if the Throwable was caused by an UNAUTHENTICATED response and a new access token
-   * could be fetched; otherwise returns false.
+   * Returns true if the request failed because it was unauthenticated or unauthorized, and a new
+   * access token could be fetched; otherwise returns false.
    */
   @Override
-  public boolean shouldRetryRequest(final Throwable throwable) {
+  public boolean shouldRetryRequest(final StatusCode statusCode) {
     try {
-      return Status.fromThrowable(throwable).getCode() == Code.UNAUTHENTICATED
+      return (statusCode.isUnauthorized() || statusCode.isForbidden())
           && credentialsCache
               .withCache(
                   endpoint,
@@ -110,7 +105,7 @@ public final class OAuthCredentialsProvider implements CredentialsProvider {
                     credentialsCache.put(endpoint, fetchedCredentials).writeCache();
                     return !fetchedCredentials.equals(value) || !value.isValid();
                   })
-              .orElse(true);
+              .orElse(false);
     } catch (final IOException e) {
       LOG.error("Failed while fetching credentials: ", e);
       return false;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.client.impl.worker;
 
+import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
@@ -37,13 +38,13 @@ public final class JobClientImpl implements JobClient {
   private final GatewayStub asyncStub;
   private final ZeebeClientConfiguration config;
   private final JsonMapper jsonMapper;
-  private final Predicate<Throwable> retryPredicate;
+  private final Predicate<StatusCode> retryPredicate;
 
   public JobClientImpl(
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration config,
       final JsonMapper jsonMapper,
-      final Predicate<Throwable> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.config = config;
     this.jsonMapper = jsonMapper;

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderBuilderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderBuilderTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import java.net.MalformedURLException;
+import java.nio.file.Path;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public final class OAuthCredentialsProviderBuilderTest {
+
+  private final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+  @Test
+  void shouldFailWithNoClientId() {
+    // given
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+    // when
+    builder.audience("a").clientSecret("b").authorizationServerUrl("http://some.url");
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith(
+            String.format(OAuthCredentialsProviderBuilder.INVALID_ARGUMENT_MSG, "client id"));
+  }
+
+  @Test
+  void shouldFailWithNoClientSecret() {
+    // given
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+    // when
+    builder.audience("a").clientId("b").authorizationServerUrl("http://some.url");
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageEndingWith(
+            String.format(OAuthCredentialsProviderBuilder.INVALID_ARGUMENT_MSG, "client secret"));
+  }
+
+  @Test
+  void shouldFailWithMalformedServerUrl() {
+    // given
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+    // when
+    builder.audience("a").clientId("b").clientSecret("c").authorizationServerUrl("someServerUrl");
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasCauseInstanceOf(MalformedURLException.class);
+  }
+
+  @Test
+  void shouldFailIfSpecifiedCacheIsDir(final @TempDir Path tmpDir) {
+    // given
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+    // when
+    builder
+        .audience("a")
+        .clientId("b")
+        .clientSecret("c")
+        .credentialsCachePath(tmpDir.toString())
+        .authorizationServerUrl("http://some.url");
+
+    // then
+    assertThatCode(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Expected specified credentials cache to be a file but found directory instead.");
+  }
+
+  @Test
+  void shouldThrowExceptionIfTimeoutIsZero() {
+    // given
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+    // when
+    builder
+        .audience("a")
+        .clientId("b")
+        .clientSecret("c")
+        .readTimeout(Duration.ZERO)
+        .authorizationServerUrl("http://some.url");
+
+    // then
+    assertThatCode(builder::build)
+        .hasMessageContaining(
+            "ReadTimeout timeout is 0 milliseconds, "
+                + "expected timeout to be a positive number of milliseconds smaller than 2147483647.")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void shouldThrowExceptionIfTimeoutTooLarge() {
+    // given
+    final OAuthCredentialsProviderBuilder builder = new OAuthCredentialsProviderBuilder();
+
+    // when
+    builder
+        .audience("a")
+        .clientId("b")
+        .clientSecret("c")
+        .readTimeout(Duration.ofDays(1_000_000))
+        .authorizationServerUrl("http://some.url");
+
+    // then
+    assertThatCode(builder::build)
+        .hasMessageContaining(
+            "ReadTimeout timeout is 86400000000000 milliseconds, "
+                + "expected timeout to be a positive number of milliseconds smaller than 2147483647.")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -159,7 +159,7 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFilePath.toFile());
-    final TestStatusCode statusCode = new TestStatusCode(0, true, false);
+    final TestStatusCode statusCode = new TestStatusCode(0, true);
 
     // when
     // first, fill in cache, then change mapping, and shouldRetryRequest should also refresh the
@@ -189,7 +189,7 @@ public final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheFilePath.toString())
             .build();
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFilePath.toFile());
-    final TestStatusCode statusCode = new TestStatusCode(0, true, false);
+    final TestStatusCode statusCode = new TestStatusCode(0, true);
 
     // when
     // first, fill in cache, then change mapping, and shouldRetryRequest should also refresh the
@@ -255,7 +255,7 @@ public final class OAuthCredentialsProviderTest {
   void shouldUpdateCacheIfRetried() throws IOException {
     // given
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFilePath.toFile());
-    final StatusCode unauthorizedCode = new TestStatusCode(0, true, false);
+    final StatusCode unauthorizedCode = new TestStatusCode(0, true);
     final OAuthCredentialsProvider provider =
         new OAuthCredentialsProviderBuilder()
             .clientId(CLIENT_ID)
@@ -428,13 +428,10 @@ public final class OAuthCredentialsProviderTest {
   private static final class TestStatusCode implements StatusCode {
     private final int code;
     private final boolean isUnauthorized;
-    private final boolean isForbidden;
 
-    private TestStatusCode(
-        final int code, final boolean isUnauthorized, final boolean isForbidden) {
+    private TestStatusCode(final int code, final boolean isUnauthorized) {
       this.code = code;
       this.isUnauthorized = isUnauthorized;
-      this.isForbidden = isForbidden;
     }
 
     @Override
@@ -445,11 +442,6 @@ public final class OAuthCredentialsProviderTest {
     @Override
     public boolean isUnauthorized() {
       return isUnauthorized;
-    }
-
-    @Override
-    public boolean isForbidden() {
-      return isForbidden;
     }
   }
 

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -15,7 +15,6 @@
  */
 package io.camunda.zeebe.client.impl.oauth;
 
-import static io.camunda.zeebe.client.OAuthCredentialsProviderTest.EXPIRY;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.Assert.assertTrue;
@@ -25,6 +24,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -38,6 +39,8 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 public final class OAuthCredentialsCacheTest {
+  private static final ZonedDateTime EXPIRY =
+      ZonedDateTime.of(3020, 1, 1, 0, 0, 0, 0, ZoneId.of("Z"));
 
   private static final String WOMBAT_ENDPOINT = "wombat.cloud.camunda.io";
   private static final String AARDVARK_ENDPOINT = "aardvark.cloud.camunda.io";

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedGateway.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.mock;
 
 import io.camunda.identity.sdk.Identity;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.zeebe.gateway.EndpointManager;
 import io.camunda.zeebe.gateway.GatewayGrpcService;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
@@ -39,6 +38,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.grpc.CallCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
 import io.grpc.Server;
 import io.grpc.ServerInterceptors;
 import io.grpc.inprocess.InProcessChannelBuilder;
@@ -247,7 +247,8 @@ public final class StubbedGateway {
     public void applyRequestMetadata(
         final RequestInfo requestInfo, final Executor appExecutor, final MetadataApplier applier) {
       final Metadata headers = new Metadata();
-      headers.put(OAuthCredentialsProvider.HEADER_AUTH_KEY, "Bearer " + token);
+      final Key<String> key = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+      headers.put(key, "Bearer " + token);
       applier.apply(headers);
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/OAuthCredentialsProviderTest.java
@@ -9,23 +9,20 @@ package io.camunda.zeebe.it.client;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.identity.sdk.Identity;
+import io.camunda.identity.sdk.IdentityConfiguration;
+import io.camunda.identity.sdk.IdentityConfiguration.Type;
 import io.camunda.zeebe.client.CredentialsProvider;
-import io.grpc.Metadata;
-import io.grpc.Metadata.Key;
+import io.camunda.zeebe.client.CredentialsProvider.CredentialsApplier;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
-import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
 import java.nio.file.Path;
-import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.testcontainers.containers.GenericContainer;
@@ -42,16 +39,23 @@ final class OAuthCredentialsProviderTest {
   private static final Network NETWORK = Network.newNetwork();
 
   @Container
-  private final GenericContainer<?> oauthContainer =
+  private static final GenericContainer<?> OAUTH_CONTAINER =
       new GenericContainer<>(DockerImageName.parse("oryd/hydra:v1.11"))
           .withEnv("DSN", "memory")
+          .withEnv("STRATEGIES_ACCESS_TOKEN", "jwt")
           .withExposedPorts(ADMIN_PORT, PUBLIC_PORT)
           .waitingFor(new HostPortWaitStrategy())
           .withCommand("serve all --dangerous-force-http")
           .withNetwork(NETWORK);
 
-  @BeforeEach
-  void beforeEach() throws IOException, InterruptedException, URISyntaxException {
+  private final TestCredentialsApplier applier = new TestCredentialsApplier();
+  private final Identity identity =
+      new Identity(
+          new IdentityConfiguration(
+              getAuthUrl(""), getAuthUrl(""), "zeebe", "zeebe", "zeebe", Type.AUTH0.name()));
+
+  @BeforeAll
+  static void beforeAll() throws IOException, InterruptedException {
     ensureOAuthClientExists();
   }
 
@@ -61,8 +65,7 @@ final class OAuthCredentialsProviderTest {
   }
 
   @Test
-  void shouldFetchValidOAuthToken(@TempDir final Path cacheDir)
-      throws IOException, InterruptedException {
+  void shouldFetchValidOAuthToken(@TempDir final Path cacheDir) throws IOException {
     // given
     final var credentialsProvider =
         CredentialsProvider.newCredentialsProviderBuilder()
@@ -72,51 +75,24 @@ final class OAuthCredentialsProviderTest {
             .credentialsCachePath(cacheDir.resolve("cache").toString())
             .authorizationServerUrl(getTokenEndpoint())
             .build();
-    final var metadata = new Metadata();
-    final var authHeaderKey = Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
 
     // when
-    credentialsProvider.applyCredentials(metadata);
+    credentialsProvider.applyCredentials(applier);
 
     // then
-    final var authHeaderValue = metadata.get(authHeaderKey);
-    assertThat(authHeaderValue).as("should have authenticated against the provider").isNotNull();
-    assertThatAuthorizationHeaderIsValid(authHeaderValue);
+    assertThat(applier.header()).isEqualTo("Authorization");
+    assertThat(applier.tokenType()).isEqualTo("Bearer");
+    identity.authentication().verifyToken(applier.token());
   }
 
-  private void assertThatAuthorizationHeaderIsValid(final String authHeaderValue)
-      throws IOException, InterruptedException {
-    final HttpResponse<byte[]> response = validateToken(authHeaderValue);
-    final Map<String, Object> payload =
-        new ObjectMapper().readValue(response.body(), new TypeReference<>() {});
-
-    assertThat(response.statusCode()).isEqualTo(200);
-    assertThat(payload).containsEntry("active", true);
-  }
-
-  private HttpResponse<byte[]> validateToken(final String authHeaderValue)
-      throws IOException, InterruptedException {
-    final var httpClient = HttpClient.newHttpClient();
-    final var token = authHeaderValue.replace("Bearer ", "");
-    final var requestBody = BodyPublishers.ofString("token=" + token);
-    final var request =
-        HttpRequest.newBuilder(getAdminEndpoint("oauth2/introspect"))
-            .header("Content-Type", "application/x-www-form-urlencoded")
-            .header("Accept", "application/json")
-            .POST(requestBody)
-            .build();
-
-    return httpClient.send(request, BodyHandlers.ofByteArray());
-  }
-
-  private void ensureOAuthClientExists() throws IOException, InterruptedException {
+  private static void ensureOAuthClientExists() throws IOException, InterruptedException {
     final var httpClient = HttpClient.newHttpClient();
     final var zeebeOauthClient =
         """
         {
           "client_id": "zeebe", "client_secret": "secret", "client_name": "zeebe",
           "grant_types": ["client_credentials"], "audience": ["zeebe"], "response_types": ["code"],
-          "token_endpoint_auth_method": "client_secret_post"
+          "token_endpoint_auth_method": "client_secret_post", "access_token_strategy": "jwt"
         }
         """;
     final var request =
@@ -132,16 +108,43 @@ final class OAuthCredentialsProviderTest {
   }
 
   private String getTokenEndpoint() {
-    return String.format(
-        "http://%s:%d/oauth2/token",
-        oauthContainer.getHost(), oauthContainer.getMappedPort(PUBLIC_PORT));
+    return getAuthUrl("oauth2/token");
   }
 
-  private URI getAdminEndpoint(final String path) {
+  private String getAuthUrl(final String path) {
+    return String.format(
+        "http://%s:%d/%s",
+        OAUTH_CONTAINER.getHost(), OAUTH_CONTAINER.getMappedPort(PUBLIC_PORT), path);
+  }
+
+  private static URI getAdminEndpoint(final String path) {
     final var endpoint =
         String.format(
             "http://%s:%d/%s",
-            oauthContainer.getHost(), oauthContainer.getMappedPort(ADMIN_PORT), path);
+            OAUTH_CONTAINER.getHost(), OAUTH_CONTAINER.getMappedPort(ADMIN_PORT), path);
     return URI.create(endpoint);
+  }
+
+  private static final class TestCredentialsApplier implements CredentialsApplier {
+    private String key;
+    private String value;
+
+    @Override
+    public void put(final String key, final String value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    private String token() {
+      return value.replaceFirst("^Bearer ", "");
+    }
+
+    private String tokenType() {
+      return value.split(" ")[0];
+    }
+
+    private String header() {
+      return key;
+    }
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayAuthenticationIdentityIT.java
@@ -23,8 +23,6 @@ import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.qa.util.testcontainers.DefaultTestContainers;
 import io.camunda.zeebe.test.util.testcontainers.ContainerLogsDumper;
-import io.grpc.Metadata;
-import io.grpc.Metadata.Key;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.time.Duration;
@@ -228,13 +226,12 @@ public class GatewayAuthenticationIdentityIT {
   private static final class InvalidAuthTokenProvider implements CredentialsProvider {
 
     @Override
-    public void applyCredentials(final Metadata headers) {
-      headers.put(
-          Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER), "Bearer youShallNotPass");
+    public void applyCredentials(final CredentialsApplier applier) {
+      applier.put("Authorization", "Bearer youShallNotPass");
     }
 
     @Override
-    public boolean shouldRetryRequest(final Throwable throwable) {
+    public boolean shouldRetryRequest(final StatusCode statusCode) {
       return false;
     }
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -726,7 +726,7 @@ public class MultiTenancyOverIdentityIT {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ofSeconds(10))
+          .failsWithin(Duration.ofHours(10))
           .withThrowableThat()
           .withMessageContaining("PERMISSION_DENIED")
           .withMessageContaining(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -726,7 +726,7 @@ public class MultiTenancyOverIdentityIT {
 
       // then
       assertThat(result)
-          .failsWithin(Duration.ofHours(10))
+          .failsWithin(Duration.ofSeconds(10))
           .withThrowableThat()
           .withMessageContaining("PERMISSION_DENIED")
           .withMessageContaining(


### PR DESCRIPTION
## Description

This PR integrates the `CredentialsProvider` into the REST client, allowing it to use the built-in `OAuthCredentialsProvider`.

To do so, the interface is changed in a breaking manner to support multiple protocols (as we will continue supporting both REST and gRPC in the future).

The previous API was tightly coupled to gRPC by using its own types directly. Instead, we introduced two abstractions:

- `CredentialsApplier`: a functional interface which lets you add headers to a request.
- `StatusCode`: an interface representing a the status of a failed request.

> [!Note]
> `CredentialsApplier` could be renamed to something more like `HeaderMutator` or something like this, as you prefer.
> Similarly, `StatusCode` could be renamed to `FailedStatus` or whatever you want.
>
> Naming is hard, and I'm bad at it :)

So `applyCredentials` now takes a `CredentialsApplier` (properly implemented for REST or gRPC) instead of the gRPC specific type `Metadata`, and `shouldRetryRequest` takes in a `StatusCode` instead of `Throwable`, as we anyway only care to know if it was unauthenticated or not. We couldn't reuse the same `Throwable` because then you'd need to know about library specific types (thus increasing our public API), and we can't just use the code, since gRPC and normal HTTP have different codes.

The bulk of the changes are tests related however, primarily because the previous tests were very tightly coupled to gRPC, so that was fun to change...

The PR could be split to be smaller by having the gRPC changes first, then REST, but considering the time crunch I hope this is OK.

More QA tests will be added with the server part.

## Related issues

closes #16837 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
