### PR TITLE
feat: Reject compensation event subprocesses

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/SubProcessValidator.java
@@ -40,8 +40,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           MessageEventDefinition.class,
           ErrorEventDefinition.class,
           SignalEventDefinition.class,
-          EscalationEventDefinition.class,
-          CompensateEventDefinition.class);
+          EscalationEventDefinition.class);
 
   @Override
   public Class<SubProcess> getElementType() {
@@ -89,7 +88,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
     if (eventDefinitions.isEmpty()) {
       validationResultCollector.addError(
           0,
-          "Start events in event subprocesses must be one of: message, timer, error, signal, escalation or compensation");
+          "Start events in event subprocesses must be one of: message, timer, error, signal or escalation");
     }
 
     if (eventDefinitions.stream().anyMatch(CompensateEventDefinition.class::isInstance)
@@ -103,7 +102,7 @@ public class SubProcessValidator implements ModelElementValidator<SubProcess> {
           if (SUPPORTED_START_TYPES.stream().noneMatch(type -> type.isInstance(def))) {
             validationResultCollector.addError(
                 0,
-                "Start events in event subprocesses must be one of: message, timer, error, signal, escalation or compensation");
+                "Start events in event subprocesses must be one of: message, timer, error, signal or escalation");
           }
         });
 

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/EventSubprocessValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/EventSubprocessValidationTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation;
+
+import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.expect;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.model.bpmn.builder.EventSubProcessBuilder;
+import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
+import io.camunda.zeebe.model.bpmn.instance.ConditionalEventDefinition;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class EventSubprocessValidationTest {
+
+  private static final String PROCESS_ID = "process";
+  private static final String SUBPROCESS_ID = "subprocess";
+
+  @ParameterizedTest
+  @MethodSource("supportedStartEvents")
+  @DisplayName("An event subprocess with a supported start event should be valid")
+  void validStartEvent(final BpmnElementBuilder elementBuilder) {
+    // given
+    final BpmnModelInstance process = process(elementBuilder);
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessIsValid(process);
+  }
+
+  @Test
+  @DisplayName(
+      "An event subprocess with a compensation start event should not be valid on process level")
+  void compensationStartEventOnProcessLevel() {
+    // given
+    final Consumer<EventSubProcessBuilder> eventSubprocessBuilder =
+        eventSubprocess ->
+            eventSubprocess
+                .startEvent()
+                .compensateEventDefinition()
+                .compensateEventDefinitionDone();
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(SUBPROCESS_ID, eventSubprocessBuilder)
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            SUBPROCESS_ID,
+            "Start events in event subprocesses must be one of: message, timer, error, signal or escalation"),
+        expect(
+            SUBPROCESS_ID, "A compensation event subprocess is not allowed on the process level"));
+  }
+
+  @Test
+  @DisplayName(
+      "An event subprocess with a compensation start event should not be valid inside a subprocess")
+  void compensationStartEventInsideSubprocess() {
+    // given
+    final Consumer<EventSubProcessBuilder> eventSubprocessBuilder =
+        eventSubprocess ->
+            eventSubprocess
+                .startEvent()
+                .compensateEventDefinition()
+                .compensateEventDefinitionDone();
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .subProcess()
+            .embeddedSubProcess()
+            .eventSubProcess(SUBPROCESS_ID, eventSubprocessBuilder)
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            SUBPROCESS_ID,
+            "Start events in event subprocesses must be one of: message, timer, error, signal or escalation"));
+  }
+
+  @Test
+  @DisplayName("An event subprocess with a conditional start event should not be valid")
+  void conditionalStartEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                SUBPROCESS_ID, eventSubprocess -> eventSubprocess.startEvent().condition("true"))
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        expect(
+            SUBPROCESS_ID,
+            "Start events in event subprocesses must be one of: message, timer, error, signal or escalation"),
+        expect(ConditionalEventDefinition.class, "Event definition of this type is not supported"));
+  }
+
+  @Test
+  @DisplayName("An event subprocess without a start event should not be valid")
+  void withoutStartEvent() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(SUBPROCESS_ID, eventSubprocess -> {})
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(SUBPROCESS_ID, "Must have exactly one start event"));
+  }
+
+  @Test
+  @DisplayName("An event subprocess with multiple start events should not be valid")
+  void multipleStartEvents() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .eventSubProcess(
+                SUBPROCESS_ID,
+                eventSubprocess -> {
+                  eventSubprocess.startEvent().signal("a").endEvent();
+                  eventSubprocess.startEvent().signal("b").endEvent();
+                })
+            .startEvent()
+            .endEvent()
+            .done();
+
+    // when/then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process, expect(SUBPROCESS_ID, "Must have exactly one start event"));
+  }
+
+  private BpmnModelInstance process(final BpmnElementBuilder elementBuilder) {
+
+    final AbstractFlowNodeBuilder<?, ?> processBuilder =
+        Bpmn.createExecutableProcess(PROCESS_ID).startEvent().endEvent();
+
+    return elementBuilder.build(processBuilder).done();
+  }
+
+  private static StartEventBuilder withEventSubprocess(
+      final AbstractFlowNodeBuilder<?, ?> builder) {
+    return builder.moveToProcess(PROCESS_ID).eventSubProcess(SUBPROCESS_ID).startEvent();
+  }
+
+  private static Stream<BpmnElementBuilder> supportedStartEvents() {
+    return Stream.of(
+        BpmnElementBuilder.of(
+            "timer start event", builder -> withEventSubprocess(builder).timerWithDuration("P1D")),
+        BpmnElementBuilder.of(
+            "message start event",
+            builder ->
+                withEventSubprocess(builder)
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))),
+        BpmnElementBuilder.of("error start event", builder -> withEventSubprocess(builder).error()),
+        BpmnElementBuilder.of(
+            "signal start event", builder -> withEventSubprocess(builder).signal("signal")),
+        BpmnElementBuilder.of(
+            "escalation start event", builder -> withEventSubprocess(builder).escalation()));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/compensation/CompensationEventTest.java
@@ -138,7 +138,7 @@ public class CompensationEventTest {
   }
 
   @Test
-  public void shouldDeployCompensationEventSubprocess() {
+  public void shouldNotDeployCompensationEventSubprocess() {
     final var process =
         Bpmn.createExecutableProcess("compensation-process")
             .startEvent()
@@ -169,7 +169,11 @@ public class CompensationEventTest {
                 end -> end.compensateEventDefinition().compensateEventDefinitionDone())
             .done();
 
-    ProcessValidationUtil.validateProcess(process);
+    ProcessValidationUtil.validateProcess(
+        process,
+        ExpectedValidationResult.expect(
+            SubProcess.class,
+            "Start events in event subprocesses must be one of: message, timer, error, signal or escalation"));
   }
 
   @Test


### PR DESCRIPTION
## Description

- Adjust process validation to reject compensation event subprocesses
- Add missing test cases for the validation of event subprocesses

## Related issues

closes #16970 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
