### PR TITLE
[Backport stable/8.4] test: stabilize flaky test by increasing timeout

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -536,7 +536,7 @@ final class ReconfigurationTest {
       assertThat(m2.leave())
           .describedAs(
               "Should fail to leave because quorum not available for the new configuration")
-          .failsWithin(Duration.ofSeconds(2))
+          .failsWithin(Duration.ofSeconds(10))
           .withThrowableOfType(ExecutionException.class);
     }
 


### PR DESCRIPTION
# Description
Backport of #17001 to `stable/8.4`.

relates to #16719
original author: @oleschoenburg