### PR TITLE
[Backport stable/8.2] feat: makes job timeout resolution configurable

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -58,6 +58,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setMessagesTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit())
         .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval())
         .setDrgCacheCapacity(caches.getDrgCacheCapacity())
-        .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval());
+        .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
+        .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -15,11 +15,13 @@ public final class EngineCfg implements ConfigurationEntry {
 
   private MessagesCfg messages = new MessagesCfg();
   private CachesCfg caches = new CachesCfg();
+  private JobsCfg jobs = new JobsCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     messages.init(globalConfig, brokerBase);
     caches.init(globalConfig, brokerBase);
+    jobs.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -38,15 +40,24 @@ public final class EngineCfg implements ConfigurationEntry {
     this.caches = caches;
   }
 
+  public JobsCfg getJobs() {
+    return jobs;
+  }
+
+  public void setJobs(final JobsCfg jobs) {
+    this.jobs = jobs;
+  }
+
   @Override
   public String toString() {
-    return "EngineCfg{" + "messages=" + messages + ", caches=" + caches + '}';
+    return "EngineCfg{" + "messages=" + messages + ", caches=" + caches + ", jobs=" + jobs + '}';
   }
 
   public EngineConfiguration createEngineConfiguration() {
     return new EngineConfiguration()
         .setMessagesTtlCheckerBatchLimit(messages.getTtlCheckerBatchLimit())
         .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval())
-        .setDrgCacheCapacity(caches.getDrgCacheCapacity());
+        .setDrgCacheCapacity(caches.getDrgCacheCapacity())
+        .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/JobsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/JobsCfg.java
@@ -14,6 +14,8 @@ import java.time.Duration;
 public class JobsCfg implements ConfigurationEntry {
   private Duration timeoutCheckerPollingInterval =
       EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
+  private int timeoutCheckerBatchLimit =
+      EngineConfiguration.DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
 
   public Duration getTimeoutCheckerPollingInterval() {
     return timeoutCheckerPollingInterval;
@@ -23,8 +25,21 @@ public class JobsCfg implements ConfigurationEntry {
     this.timeoutCheckerPollingInterval = timeoutCheckerPollingInterval;
   }
 
+  public int getTimeoutCheckerBatchLimit() {
+    return timeoutCheckerBatchLimit;
+  }
+
+  public void setTimeoutCheckerBatchLimit(final int timeoutCheckerBatchLimit) {
+    this.timeoutCheckerBatchLimit = timeoutCheckerBatchLimit;
+  }
+
   @Override
   public String toString() {
-    return "JobsCfg{" + "timeoutCheckerPollingInterval=" + timeoutCheckerPollingInterval + '}';
+    return "JobsCfg{"
+        + "timeoutCheckerPollingInterval="
+        + timeoutCheckerPollingInterval
+        + ", timeoutCheckerBatchLimit="
+        + timeoutCheckerBatchLimit
+        + '}';
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/JobsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/JobsCfg.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+import java.time.Duration;
+
+public class JobsCfg implements ConfigurationEntry {
+  private Duration timeoutCheckerPollingInterval =
+      EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
+
+  public Duration getTimeoutCheckerPollingInterval() {
+    return timeoutCheckerPollingInterval;
+  }
+
+  public void setTimeoutCheckerPollingInterval(final Duration timeoutCheckerPollingInterval) {
+    this.timeoutCheckerPollingInterval = timeoutCheckerPollingInterval;
+  }
+
+  @Override
+  public String toString() {
+    return "JobsCfg{" + "timeoutCheckerPollingInterval=" + timeoutCheckerPollingInterval + '}';
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -30,6 +30,8 @@ final class EngineCfgTest {
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofMinutes(1));
     assertThat(configuration.getDrgCacheCapacity()).isEqualTo(1000L);
+    assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
+        .isEqualTo(Duration.ofSeconds(1));
   }
 
   @Test
@@ -44,5 +46,7 @@ final class EngineCfgTest {
     assertThat(configuration.getMessagesTtlCheckerBatchLimit()).isEqualTo(1000);
     assertThat(configuration.getMessagesTtlCheckerInterval()).isEqualTo(Duration.ofSeconds(15));
     assertThat(configuration.getDrgCacheCapacity()).isEqualTo(2000L);
+    assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
+        .isEqualTo(Duration.ofSeconds(15));
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -32,6 +32,7 @@ final class EngineCfgTest {
     assertThat(configuration.getDrgCacheCapacity()).isEqualTo(1000L);
     assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
         .isEqualTo(Duration.ofSeconds(1));
+    assertThat(configuration.getJobsTimeoutCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
   }
 
   @Test
@@ -48,5 +49,6 @@ final class EngineCfgTest {
     assertThat(configuration.getDrgCacheCapacity()).isEqualTo(2000L);
     assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
         .isEqualTo(Duration.ofSeconds(15));
+    assertThat(configuration.getJobsTimeoutCheckerBatchLimit()).isEqualTo(1000);
   }
 }

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -9,3 +9,4 @@ zeebe:
           drgCacheCapacity: 2000
         jobs:
           timeoutCheckerPollingInterval: 15s
+          timeoutCheckerBatchLimit: 1000

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -7,3 +7,5 @@ zeebe:
           ttlCheckerInterval: 15s
         caches:
           drgCacheCapacity: 2000
+        jobs:
+          timeoutCheckerPollingInterval: 15s

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1071,6 +1071,13 @@
           # decision is evaluated. If the cache is full, the least used DRG gets evicted.
           # drgCacheCapacity: 1000
 
+        # jobs:
+          # Allows to configure the Job Timeout Checker's polling interval. This is the period during
+          # which the checker is idle in between two of its executions. Note that it can mark multiple jobs
+          # as timed-out in a single execution. See `timeoutTriggerBatchLimit` to configure the size of these batches.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERPOLLINGINTERVAL
+          # timeoutCheckerPollingInterval: 1s
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1078,6 +1078,11 @@
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERPOLLINGINTERVAL
           # timeoutCheckerPollingInterval: 1s
 
+          # Allows to configure the Job Timeout Checker's batch limit. This is the number of jobs
+          # that could be marked as timed-out in a single trigger run.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERBATCHLIMIT
+          # timeoutCheckerBatchLimit: 0x7fffffff
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -987,6 +987,11 @@
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERPOLLINGINTERVAL
           # timeoutCheckerPollingInterval: 1s
 
+          # Allows to configure the Job Timeout Checker's batch limit. This is the number of jobs
+          # that could be marked as timed-out in a single trigger run.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERBATCHLIMIT
+          # timeoutCheckerBatchLimit: 0x7fffffff
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -980,6 +980,13 @@
           # decision is evaluated. If the cache is full, the least used DRG gets evicted.
           # drgCacheCapacity: 1000
 
+        # jobs:
+          # Allows to configure the Job Timeout Checker's polling interval. This is the period during
+          # which the checker is idle in between two of its executions. Note that it can mark multiple jobs
+          # as timed-out in a single execution. See `timeoutTriggerBatchLimit` to configure the size of these batches.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERPOLLINGINTERVAL
+          # timeoutCheckerPollingInterval: 1s
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -21,10 +21,12 @@ public final class EngineConfiguration {
   public static final int BATCH_SIZE_CALCULATION_BUFFER = 1024 * 8;
 
   public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
+  public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
   private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
+  private Duration jobsTimeoutCheckerPollingInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -52,6 +54,16 @@ public final class EngineConfiguration {
 
   public EngineConfiguration setDrgCacheCapacity(final int drgCacheCapacity) {
     this.drgCacheCapacity = drgCacheCapacity;
+    return this;
+  }
+
+  public Duration getJobsTimeoutCheckerPollingInterval() {
+    return jobsTimeoutCheckerPollingInterval;
+  }
+
+  public EngineConfiguration setJobsTimeoutCheckerPollingInterval(
+      final Duration jobsTimeoutCheckerPollingInterval) {
+    this.jobsTimeoutCheckerPollingInterval = jobsTimeoutCheckerPollingInterval;
     return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -22,11 +22,13 @@ public final class EngineConfiguration {
 
   public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
+  public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = 1000;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
   private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
   private Duration jobsTimeoutCheckerPollingInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
+  private int jobsTimeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -64,6 +66,16 @@ public final class EngineConfiguration {
   public EngineConfiguration setJobsTimeoutCheckerPollingInterval(
       final Duration jobsTimeoutCheckerPollingInterval) {
     this.jobsTimeoutCheckerPollingInterval = jobsTimeoutCheckerPollingInterval;
+    return this;
+  }
+
+  public int getJobsTimeoutCheckerBatchLimit() {
+    return jobsTimeoutCheckerBatchLimit;
+  }
+
+  public EngineConfiguration setJobsTimeoutCheckerBatchLimit(
+      final int jobsTimeoutCheckerBatchLimit) {
+    this.jobsTimeoutCheckerBatchLimit = jobsTimeoutCheckerBatchLimit;
     return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -22,7 +22,7 @@ public final class EngineConfiguration {
 
   public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
-  public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = 1000;
+  public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -147,8 +147,7 @@ public final class EngineProcessors {
     addDecisionProcessors(typedRecordProcessors, decisionBehavior, writers, processingState);
 
     JobEventProcessors.addJobProcessors(
-        typedRecordProcessors, processingState, bpmnBehaviors, writers, jobMetrics,
-        config);
+        typedRecordProcessors, processingState, bpmnBehaviors, writers, jobMetrics, config);
 
     addIncidentProcessors(processingState, bpmnStreamProcessor, typedRecordProcessors, writers);
     addResourceDeletionProcessors(typedRecordProcessors, writers, processingState);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -147,7 +147,8 @@ public final class EngineProcessors {
     addDecisionProcessors(typedRecordProcessors, decisionBehavior, writers, processingState);
 
     JobEventProcessors.addJobProcessors(
-        typedRecordProcessors, processingState, bpmnBehaviors, writers, jobMetrics);
+        typedRecordProcessors, processingState, bpmnBehaviors, writers, jobMetrics,
+        config);
 
     addIncidentProcessors(processingState, bpmnStreamProcessor, typedRecordProcessors, writers);
     addResourceDeletionProcessors(typedRecordProcessors, writers, processingState);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobs.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobs.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.scheduler.clock.ActorClock.currentTimeMillis;
+
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.JobState.DeadlineIndex;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResult;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import org.agrona.collections.MutableInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class DeactivateTimeOutJobs implements Task {
+  private static final Logger LOG = LoggerFactory.getLogger(DeactivateTimeOutJobs.class);
+
+  private boolean shouldReschedule = false;
+
+  /** Keeps track of the timestamp to compare the message deadlines against. */
+  private long executionTimestamp = -1;
+
+  /** Keeps track of where to continue between iterations. */
+  private DeadlineIndex startAtIndex = null;
+
+  private final JobState state;
+  private ReadonlyStreamProcessorContext processingContext;
+  private final Duration pollingInterval;
+  private final int batchLimit;
+
+  public DeactivateTimeOutJobs(
+      final JobState state, final Duration pollingInterval, final int batchLimit) {
+    this.state = state;
+    this.pollingInterval = pollingInterval;
+    this.batchLimit = batchLimit;
+  }
+
+  public void schedule(final Duration idleInterval) {
+    if (shouldReschedule) {
+      processingContext.getScheduleService().runDelayed(idleInterval, this);
+    }
+  }
+
+  @Override
+  public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    LOG.trace("Job timout checker running...");
+    if (executionTimestamp == -1) {
+      executionTimestamp = currentTimeMillis();
+    }
+
+    final var counter = new MutableInteger(0);
+
+    final DeadlineIndex nextIndex =
+        state.forEachTimedOutEntry(
+            executionTimestamp,
+            startAtIndex,
+            (key, record) -> {
+              if (counter.getAndIncrement() >= batchLimit) {
+                return false;
+              }
+
+              return taskResultBuilder.appendCommandRecord(key, JobIntent.TIME_OUT, record);
+            });
+
+    if (nextIndex != null) {
+      LOG.trace(
+          "Job timout checker yielded early. will reschedule immediately from where it left of.");
+      startAtIndex = nextIndex;
+      schedule(Duration.ZERO);
+    } else {
+      executionTimestamp = -1;
+      startAtIndex = null;
+      schedule(pollingInterval);
+    }
+
+    LOG.trace("{} jobs has been marked to timeout", counter.get());
+
+    return taskResultBuilder.build();
+  }
+
+  public void setProcessingContext(final ReadonlyStreamProcessorContext processingContext) {
+    this.processingContext = processingContext;
+  }
+
+  public void setShouldReschedule(final boolean shouldReschedule) {
+    this.shouldReschedule = shouldReschedule;
+  }
+}

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobs.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobs.java
@@ -52,7 +52,7 @@ final class DeactivateTimeOutJobs implements Task {
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    LOG.trace("Job timout checker running...");
+    LOG.trace("Job timeout checker running...");
     if (executionTimestamp == -1) {
       executionTimestamp = currentTimeMillis();
     }
@@ -73,7 +73,7 @@ final class DeactivateTimeOutJobs implements Task {
 
     if (nextIndex != null) {
       LOG.trace(
-          "Job timout checker yielded early. will reschedule immediately from where it left of.");
+          "Job timeout checker yielded early. Will reschedule immediately from {}", nextIndex);
       startAtIndex = nextIndex;
       schedule(Duration.ZERO);
     } else {
@@ -82,7 +82,7 @@ final class DeactivateTimeOutJobs implements Task {
       schedule(pollingInterval);
     }
 
-    LOG.trace("{} jobs has been marked to timeout", counter.get());
+    LOG.trace("{} timeout job commands appended to task result builder", counter.get());
 
     return taskResultBuilder.build();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
@@ -24,7 +25,8 @@ public final class JobEventProcessors {
       final MutableProcessingState processingState,
       final BpmnBehaviors bpmnBehaviors,
       final Writers writers,
-      final JobMetrics jobMetrics) {
+      final JobMetrics jobMetrics,
+      final EngineConfiguration config) {
 
     final var jobState = processingState.getJobState();
     final var keyGenerator = processingState.getKeyGenerator();
@@ -79,7 +81,10 @@ public final class JobEventProcessors {
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
                 writers, processingState, processingState.getKeyGenerator(), jobMetrics))
-        .withListener(new JobTimeoutChecker(jobState))
+        .withListener(
+            new JobTimeoutChecker(
+                jobState,
+                config.getJobsTimeoutCheckerPollingInterval()))
         .withListener(jobBackoffChecker);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -84,7 +84,8 @@ public final class JobEventProcessors {
         .withListener(
             new JobTimeoutChecker(
                 jobState,
-                config.getJobsTimeoutCheckerPollingInterval()))
+                config.getJobsTimeoutCheckerPollingInterval(),
+                config.getJobsTimeoutCheckerBatchLimit()))
         .withListener(jobBackoffChecker);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -82,7 +82,7 @@ public final class JobEventProcessors {
             new JobBatchActivateProcessor(
                 writers, processingState, processingState.getKeyGenerator(), jobMetrics))
         .withListener(
-            new JobTimeoutChecker(
+            new JobTimeoutCheckerScheduler(
                 jobState,
                 config.getJobsTimeoutCheckerPollingInterval(),
                 config.getJobsTimeoutCheckerBatchLimit()))

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -79,7 +79,7 @@ public final class JobEventProcessors {
             JobBatchIntent.ACTIVATE,
             new JobBatchActivateProcessor(
                 writers, processingState, processingState.getKeyGenerator(), jobMetrics))
-        .withListener(new JobTimeoutTrigger(jobState))
+        .withListener(new JobTimeoutChecker(jobState))
         .withListener(jobBackoffChecker);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
 
-public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
+public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
   public static final Duration TIME_OUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   private final JobState state;
 
@@ -27,7 +27,7 @@ public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
   private ReadonlyStreamProcessorContext processingContext;
   private final Task deactivateTimedOutJobs;
 
-  public JobTimeoutTrigger(final JobState state) {
+  public JobTimeoutChecker(final JobState state) {
     this.state = state;
     deactivateTimedOutJobs = new DeactivateTimeOutJobs();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -21,8 +21,8 @@ import org.agrona.collections.MutableInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-final class DeactivateTimeOutJobs implements Task {
-  private static final Logger LOG = LoggerFactory.getLogger(DeactivateTimeOutJobs.class);
+final class JobTimeoutChecker implements Task {
+  private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutChecker.class);
 
   private boolean shouldReschedule = false;
 
@@ -37,7 +37,7 @@ final class DeactivateTimeOutJobs implements Task {
   private final Duration pollingInterval;
   private final int batchLimit;
 
-  public DeactivateTimeOutJobs(
+  public JobTimeoutChecker(
       final JobState state, final Duration pollingInterval, final int batchLimit) {
     this.state = state;
     this.pollingInterval = pollingInterval;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import static io.camunda.zeebe.scheduler.clock.ActorClock.currentTimeMillis;
 
 import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.JobState.DeadlineIndex;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
@@ -17,15 +18,23 @@ import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
+import org.agrona.collections.MutableInteger;
 
 public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
   private final JobState state;
   private final Duration pollingInterval;
+  private final int batchLimit = 1000;
 
   private boolean shouldReschedule = false;
 
   private ReadonlyStreamProcessorContext processingContext;
   private final Task deactivateTimedOutJobs;
+
+  /** Keeps track of the timestamp to compare the message deadlines against. */
+  private long executionTimestamp = -1;
+
+  /** Keeps track of where to continue between iterations. */
+  private DeadlineIndex startAtIndex = null;
 
   public JobTimeoutChecker(final JobState state, final Duration pollingInterval) {
     this.state = state;
@@ -38,7 +47,7 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
     this.processingContext = processingContext;
     shouldReschedule = true;
 
-    scheduleDeactivateTimedOutJobsTask();
+    scheduleDeactivateTimedOutJobsTask(pollingInterval);
   }
 
   @Override
@@ -59,11 +68,11 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onResumed() {
     shouldReschedule = true;
-    scheduleDeactivateTimedOutJobsTask();
+    scheduleDeactivateTimedOutJobsTask(pollingInterval);
   }
 
-  private void scheduleDeactivateTimedOutJobsTask() {
-    processingContext.getScheduleService().runDelayed(pollingInterval, deactivateTimedOutJobs);
+  private void scheduleDeactivateTimedOutJobsTask(final Duration idleInterval) {
+    processingContext.getScheduleService().runDelayed(idleInterval, deactivateTimedOutJobs);
   }
 
   private void cancelTimer() {
@@ -74,12 +83,33 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
 
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-      final long now = currentTimeMillis();
-      state.forEachTimedOutEntry(
-          now,
-          (key, record) -> taskResultBuilder.appendCommandRecord(key, JobIntent.TIME_OUT, record));
+      if (executionTimestamp == -1) {
+        executionTimestamp = currentTimeMillis();
+      }
+
+      final var counter = new MutableInteger(0);
+
+      final DeadlineIndex nextIndex =
+          state.forEachTimedOutEntry(
+              executionTimestamp,
+              startAtIndex,
+              (key, record) -> {
+                if (counter.getAndIncrement() >= batchLimit) {
+                  return false;
+                }
+
+                return taskResultBuilder.appendCommandRecord(key, JobIntent.TIME_OUT, record);
+              });
+
       if (shouldReschedule) {
-        scheduleDeactivateTimedOutJobsTask();
+        if (nextIndex != null) {
+          startAtIndex = nextIndex;
+          scheduleDeactivateTimedOutJobsTask(Duration.ZERO);
+        } else {
+          executionTimestamp = -1;
+          startAtIndex = null;
+          scheduleDeactivateTimedOutJobsTask(pollingInterval);
+        }
       }
       return taskResultBuilder.build();
     }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -19,8 +19,11 @@ import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
 import org.agrona.collections.MutableInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
+  private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutChecker.class);
   private final JobState state;
   private final Duration pollingInterval;
   private final int batchLimit;
@@ -79,12 +82,14 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
 
   private void cancelTimer() {
     shouldReschedule = false;
+    LOG.trace("Job timout checker canceled!");
   }
 
   private final class DeactivateTimeOutJobs implements Task {
 
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+      LOG.trace("Job timout checker running...");
       if (executionTimestamp == -1) {
         executionTimestamp = currentTimeMillis();
       }
@@ -105,6 +110,8 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
 
       if (shouldReschedule) {
         if (nextIndex != null) {
+          LOG.trace(
+              "Job timout checker yielded early. will reschedule immediately from where it left of.");
           startAtIndex = nextIndex;
           scheduleDeactivateTimedOutJobsTask(Duration.ZERO);
         } else {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -23,7 +23,7 @@ import org.agrona.collections.MutableInteger;
 public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
   private final JobState state;
   private final Duration pollingInterval;
-  private final int batchLimit = 1000;
+  private final int batchLimit;
 
   private boolean shouldReschedule = false;
 
@@ -36,9 +36,11 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
   /** Keeps track of where to continue between iterations. */
   private DeadlineIndex startAtIndex = null;
 
-  public JobTimeoutChecker(final JobState state, final Duration pollingInterval) {
+  public JobTimeoutChecker(
+      final JobState state, final Duration pollingInterval, final int batchLimit) {
     this.state = state;
     this.pollingInterval = pollingInterval;
+    this.batchLimit = batchLimit;
     deactivateTimedOutJobs = new DeactivateTimeOutJobs();
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -59,7 +59,7 @@ final class JobTimeoutChecker implements Task {
 
     final var counter = new MutableInteger(0);
 
-    final DeadlineIndex nextIndex =
+    final DeadlineIndex lastVisitedIndex =
         state.forEachTimedOutEntry(
             executionTimestamp,
             startAtIndex,
@@ -71,10 +71,11 @@ final class JobTimeoutChecker implements Task {
               return taskResultBuilder.appendCommandRecord(key, JobIntent.TIME_OUT, record);
             });
 
-    if (nextIndex != null) {
+    if (lastVisitedIndex != null) {
       LOG.trace(
-          "Job timeout checker yielded early. Will reschedule immediately from {}", nextIndex);
-      startAtIndex = nextIndex;
+          "Job timeout checker yielded early. Will reschedule immediately from {}",
+          lastVisitedIndex);
+      startAtIndex = lastVisitedIndex;
       schedule(Duration.ZERO);
     } else {
       executionTimestamp = -1;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -120,6 +120,9 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
           scheduleDeactivateTimedOutJobsTask(pollingInterval);
         }
       }
+
+      LOG.trace("{} jobs has been marked to timeout", counter.get());
+
       return taskResultBuilder.build();
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -55,6 +55,6 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
 
   private void cancelTimer() {
     deactivateTimedOutJobs.setShouldReschedule(false);
-    LOG.trace("Job timout checker canceled!");
+    LOG.trace("Job timeout checker canceled!");
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -19,7 +19,6 @@ import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
 
 public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
-  public static final Duration TIME_OUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   private final JobState state;
   private final Duration pollingInterval;
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -21,14 +21,16 @@ import java.time.Duration;
 public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
   public static final Duration TIME_OUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   private final JobState state;
+  private final Duration pollingInterval;
 
   private boolean shouldReschedule = false;
 
   private ReadonlyStreamProcessorContext processingContext;
   private final Task deactivateTimedOutJobs;
 
-  public JobTimeoutChecker(final JobState state) {
+  public JobTimeoutChecker(final JobState state, final Duration pollingInterval) {
     this.state = state;
+    this.pollingInterval = pollingInterval;
     deactivateTimedOutJobs = new DeactivateTimeOutJobs();
   }
 
@@ -62,9 +64,7 @@ public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
   }
 
   private void scheduleDeactivateTimedOutJobsTask() {
-    processingContext
-        .getScheduleService()
-        .runDelayed(TIME_OUT_POLLING_INTERVAL, deactivateTimedOutJobs);
+    processingContext.getScheduleService().runDelayed(pollingInterval, deactivateTimedOutJobs);
   }
 
   private void cancelTimer() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
@@ -17,19 +17,19 @@ import org.slf4j.LoggerFactory;
 public final class JobTimeoutCheckerScheduler implements StreamProcessorLifecycleAware {
   private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutCheckerScheduler.class);
   private final Duration pollingInterval;
-  private final DeactivateTimeOutJobs deactivateTimedOutJobs;
+  private final JobTimeoutChecker jobTimeoutChecker;
 
   public JobTimeoutCheckerScheduler(
       final JobState state, final Duration pollingInterval, final int batchLimit) {
     this.pollingInterval = pollingInterval;
-    deactivateTimedOutJobs = new DeactivateTimeOutJobs(state, pollingInterval, batchLimit);
+    jobTimeoutChecker = new JobTimeoutChecker(state, pollingInterval, batchLimit);
   }
 
   @Override
   public void onRecovered(final ReadonlyStreamProcessorContext processingContext) {
-    deactivateTimedOutJobs.setProcessingContext(processingContext);
-    deactivateTimedOutJobs.setShouldReschedule(true);
-    deactivateTimedOutJobs.schedule(pollingInterval);
+    jobTimeoutChecker.setProcessingContext(processingContext);
+    jobTimeoutChecker.setShouldReschedule(true);
+    jobTimeoutChecker.schedule(pollingInterval);
   }
 
   @Override
@@ -49,12 +49,12 @@ public final class JobTimeoutCheckerScheduler implements StreamProcessorLifecycl
 
   @Override
   public void onResumed() {
-    deactivateTimedOutJobs.setShouldReschedule(true);
-    deactivateTimedOutJobs.schedule(pollingInterval);
+    jobTimeoutChecker.setShouldReschedule(true);
+    jobTimeoutChecker.schedule(pollingInterval);
   }
 
   private void cancelTimer() {
-    deactivateTimedOutJobs.setShouldReschedule(false);
+    jobTimeoutChecker.setShouldReschedule(false);
     LOG.trace("Job timeout checker canceled!");
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
@@ -14,12 +14,12 @@ import java.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class JobTimeoutChecker implements StreamProcessorLifecycleAware {
-  private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutChecker.class);
+public final class JobTimeoutCheckerScheduler implements StreamProcessorLifecycleAware {
+  private static final Logger LOG = LoggerFactory.getLogger(JobTimeoutCheckerScheduler.class);
   private final Duration pollingInterval;
   private final DeactivateTimeOutJobs deactivateTimedOutJobs;
 
-  public JobTimeoutChecker(
+  public JobTimeoutCheckerScheduler(
       final JobState state, final Duration pollingInterval, final int batchLimit) {
     this.pollingInterval = pollingInterval;
     deactivateTimedOutJobs = new DeactivateTimeOutJobs(state, pollingInterval, batchLimit);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutTrigger.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
 
 public final class JobTimeoutTrigger implements StreamProcessorLifecycleAware {
-  public static final Duration TIME_OUT_POLLING_INTERVAL = Duration.ofSeconds(30);
+  public static final Duration TIME_OUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   private final JobState state;
 
   private boolean shouldReschedule = false;

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
@@ -23,8 +23,8 @@ public interface JobState {
    *     startAt is {@code null}
    * @param callback A callback method to be applied to each job entry. It must return a boolean
    *     that when {@code true} allows the loop to continue, or when {@code false} stops iteration.
-   * @return The next index to start iteration from if the iteration has stopped because the {@code
-   *     callback} method returned false or {@code null} if it was not the case.
+   * @return The last visited index where the iteration has stopped because the {@code callback}
+   *     method returned false or {@code null} if it was not the case.
    */
   DeadlineIndex forEachTimedOutEntry(
       long executionTimestamp, final DeadlineIndex startAt, BiPredicate<Long, JobRecord> callback);

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/JobState.java
@@ -14,7 +14,20 @@ import org.agrona.DirectBuffer;
 
 public interface JobState {
 
-  void forEachTimedOutEntry(long upperBound, BiPredicate<Long, JobRecord> callback);
+  /**
+   * Loops over all timed-out job entries and applies the provided callback.
+   *
+   * @param executionTimestamp Timestamp against which it's determined whether the deadline has
+   *     expired
+   * @param startAt Index used to start the iteration at; looping starts at the beginning when
+   *     startAt is {@code null}
+   * @param callback A callback method to be applied to each job entry. It must return a boolean
+   *     that when {@code true} allows the loop to continue, or when {@code false} stops iteration.
+   * @return The next index to start iteration from if the iteration has stopped because the {@code
+   *     callback} method returned false or {@code null} if it was not the case.
+   */
+  DeadlineIndex forEachTimedOutEntry(
+      long executionTimestamp, final DeadlineIndex startAt, BiPredicate<Long, JobRecord> callback);
 
   boolean exists(long jobKey);
 
@@ -27,6 +40,9 @@ public interface JobState {
   JobRecord getJob(long key);
 
   long findBackedOffJobs(final long timestamp, final BiPredicate<Long, JobRecord> callback);
+
+  /** Index to point to a specific position in the jobs with deadline column family. */
+  record DeadlineIndex(long deadline, long key) {}
 
   enum State {
     ACTIVATABLE((byte) 0),

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -313,7 +313,7 @@ public final class DbJobState implements JobState, MutableJobState {
       startAtKey = null;
     }
 
-    final var nextIndex = new AtomicReference<DeadlineIndex>();
+    final var lastVisitedIndex = new AtomicReference<DeadlineIndex>();
     deadlinesColumnFamily.whileTrue(
         startAtKey,
         (key, value) -> {
@@ -324,14 +324,14 @@ public final class DbJobState implements JobState, MutableJobState {
           }
           final var jobKey = key.second().inner().getValue();
           if (!visitJob(jobKey, callback)) {
-            nextIndex.set(
+            lastVisitedIndex.set(
                 new DeadlineIndex(key.first().getValue(), key.second().inner().getValue()));
             return false;
           }
           return true;
         });
 
-    return nextIndex.get();
+    return lastVisitedIndex.get();
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
@@ -105,7 +105,7 @@ public class JobMetricsTest {
 
     // when
     // We need to add 1 ms as the deadline needs to be < the current time. Without the extra 1 ms
-    // it could be that the JobTimeoutTrigger is triggered at the exact same time as the job
+    // it could be that the JobTimeoutChecker is triggered at the exact same time as the job
     // deadline resulting in the Job activation not being expired yet.
     ENGINE
         .getClock()

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsNotificationTests.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsNotificationTests.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.job;
 import static io.camunda.zeebe.protocol.record.intent.JobIntent.TIMED_OUT;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -105,7 +106,7 @@ public final class ActivatableJobsNotificationTests {
     activateJobs(1, Duration.ofMillis(10));
 
     // when
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
     RecordingExporter.jobRecords(TIMED_OUT).withType(taskType).getFirst();
 
     // then
@@ -117,7 +118,7 @@ public final class ActivatableJobsNotificationTests {
     // given
     createProcessInstanceAndJobs(1);
     final long jobKey = activateJobs(1, Duration.ofMillis(10)).getValue().getJobKeys().get(0);
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
     RecordingExporter.jobRecords(TIMED_OUT).withType(taskType).getFirst();
 
     // when

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsNotificationTests.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsNotificationTests.java
@@ -105,7 +105,7 @@ public final class ActivatableJobsNotificationTests {
     activateJobs(1, Duration.ofMillis(10));
 
     // when
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
     RecordingExporter.jobRecords(TIMED_OUT).withType(taskType).getFirst();
 
     // then
@@ -117,7 +117,7 @@ public final class ActivatableJobsNotificationTests {
     // given
     createProcessInstanceAndJobs(1);
     final long jobKey = activateJobs(1, Duration.ofMillis(10)).getValue().getJobKeys().get(0);
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
     RecordingExporter.jobRecords(TIMED_OUT).withType(taskType).getFirst();
 
     // when

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobsTest.java
@@ -124,6 +124,18 @@ public class DeactivateTimeOutJobsTest {
     verifyNoMoreInteractions(mockTaskResultBuilder);
 
     verify(mockScheduleService, times(1)).runDelayed(eq(Duration.ZERO), any(Task.class));
+
+    /* TEST verify next execute will start where left off */
+
+    // When
+    task.execute(mockTaskResultBuilder);
+
+    // then
+    for (long i = batchLimit + 1; i <= 2 * batchLimit; i++) {
+      inOrder.verify(mockTaskResultBuilder).appendCommandRecord(eq(i), eq(TIME_OUT), any());
+    }
+    inOrder.verify(mockTaskResultBuilder).build();
+    verifyNoMoreInteractions(mockTaskResultBuilder);
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobsTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/DeactivateTimeOutJobsTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static io.camunda.zeebe.protocol.record.intent.JobIntent.TIME_OUT;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.state.mutable.MutableJobState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class DeactivateTimeOutJobsTest {
+  public static final int NUMBER_OF_ACTIVE_JOBS = 10;
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+
+  private MutableProcessingState processingState;
+  private MutableJobState jobState;
+  private ReadonlyStreamProcessorContext mockContext;
+  private ProcessingScheduleService mockScheduleService;
+  private TaskResultBuilder mockTaskResultBuilder;
+
+  @Before
+  public void setUp() {
+    processingState = stateRule.getProcessingState();
+    jobState = processingState.getJobState();
+
+    for (int i = 1; i <= NUMBER_OF_ACTIVE_JOBS; i++) {
+      createAndActivateJobRecord(i, newJobRecord().setDeadline(i));
+    }
+
+    mockContext = mock(ReadonlyStreamProcessorContext.class);
+    mockScheduleService = mock(ProcessingScheduleService.class);
+    when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
+    mockTaskResultBuilder = mock(TaskResultBuilder.class);
+  }
+
+  private void createAndActivateJobRecord(final long key, final JobRecord record) {
+    jobState.create(key, record);
+    jobState.activate(key, record);
+  }
+
+  private JobRecord newJobRecord() {
+    return newJobRecord(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  private JobRecord newJobRecord(final String tenantId) {
+    final JobRecord jobRecord = new JobRecord();
+
+    jobRecord.setRetries(2).setDeadline(256L).setType("test").setTenantId(tenantId);
+
+    return jobRecord;
+  }
+
+  @Test
+  public void shouldRescheduleWithPollingIntervalAfterSuccessfulExecution() {
+    // Given
+    when(mockTaskResultBuilder.appendCommandRecord(anyLong(), any(), any())).thenReturn(true);
+
+    final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
+    final int batchLimit = Integer.MAX_VALUE;
+
+    final var task = new DeactivateTimeOutJobs(jobState, pollingInterval, batchLimit);
+    task.setProcessingContext(mockContext);
+    task.setShouldReschedule(true);
+
+    // When
+    task.execute(mockTaskResultBuilder);
+
+    // then
+    final var inOrder = inOrder(mockTaskResultBuilder);
+    for (long i = 1; i <= NUMBER_OF_ACTIVE_JOBS; i++) {
+      inOrder.verify(mockTaskResultBuilder).appendCommandRecord(eq(i), eq(TIME_OUT), any());
+    }
+    inOrder.verify(mockTaskResultBuilder).build();
+    verifyNoMoreInteractions(mockTaskResultBuilder);
+
+    verify(mockScheduleService, times(1)).runDelayed(eq(pollingInterval), any(Task.class));
+  }
+
+  @Test
+  public void shouldRescheduleImmediatelyIfYieldedDueToBatchLimit() {
+    // Given
+    when(mockTaskResultBuilder.appendCommandRecord(anyLong(), any(), any())).thenReturn(true);
+
+    final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
+    final int batchLimit = 3;
+
+    final var task = new DeactivateTimeOutJobs(jobState, pollingInterval, batchLimit);
+    task.setProcessingContext(mockContext);
+    task.setShouldReschedule(true);
+
+    // When
+    task.execute(mockTaskResultBuilder);
+
+    // then
+    final var inOrder = inOrder(mockTaskResultBuilder);
+    for (long i = 1; i <= batchLimit; i++) {
+      inOrder.verify(mockTaskResultBuilder).appendCommandRecord(eq(i), eq(TIME_OUT), any());
+    }
+    inOrder.verify(mockTaskResultBuilder).build();
+    verifyNoMoreInteractions(mockTaskResultBuilder);
+
+    verify(mockScheduleService, times(1)).runDelayed(eq(Duration.ZERO), any(Task.class));
+  }
+
+  @Test
+  public void shouldRescheduleImmediatelyIfFailedToAppendTimeoutCommand() {
+    // Given
+    when(mockTaskResultBuilder.appendCommandRecord(anyLong(), any(), any()))
+        .thenReturn(true)
+        .thenReturn(false);
+
+    final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
+    final int batchLimit = Integer.MAX_VALUE;
+
+    final var task = new DeactivateTimeOutJobs(jobState, pollingInterval, batchLimit);
+    task.setProcessingContext(mockContext);
+    task.setShouldReschedule(true);
+
+    // When
+    task.execute(mockTaskResultBuilder);
+
+    // then
+    final var inOrder = inOrder(mockTaskResultBuilder);
+
+    inOrder.verify(mockTaskResultBuilder).appendCommandRecord(eq(1L), eq(TIME_OUT), any());
+    inOrder.verify(mockTaskResultBuilder).appendCommandRecord(eq(2L), eq(TIME_OUT), any());
+    inOrder.verify(mockTaskResultBuilder).build();
+
+    verifyNoMoreInteractions(mockTaskResultBuilder);
+
+    verify(mockScheduleService, times(1)).runDelayed(eq(Duration.ZERO), any(Task.class));
+  }
+}

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -81,7 +81,8 @@ public final class JobTimeOutTest {
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
 
     final long jobKey2 = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    ENGINE.jobs().withType(jobType).activate();
+    ENGINE.jobs().withTimeout(timeout.toMillis()).withType(jobType).activate();
+
     ENGINE.job().withKey(jobKey).complete();
 
     // when

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -87,7 +87,6 @@ public final class JobTimeOutTest {
 
     // when
     ENGINE.reprocess();
-    ENGINE.jobs().withType(jobType).activate();
 
     // then
     ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.awaitility.Awaitility;
@@ -73,9 +74,9 @@ public final class JobTimeOutTest {
   public void shouldTimeOutAfterReprocessing() {
     // given
     final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    final long timeout = 10L;
+    final Duration timeout = Duration.ofSeconds(10);
 
-    ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
+    ENGINE.jobs().withType(jobType).withTimeout(timeout.toMillis()).activate();
     ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -52,7 +52,7 @@ public final class JobTimeOutTest {
     final long timeout = 10L;
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
 
     // when expired
     jobRecords(TIME_OUT).withType(jobType).getFirst();
@@ -75,7 +75,7 @@ public final class JobTimeOutTest {
     final long timeout = 10L;
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
 
     final long jobKey2 = ENGINE.createJob(jobType, PROCESS_ID).getKey();
@@ -87,7 +87,7 @@ public final class JobTimeOutTest {
     ENGINE.jobs().withType(jobType).activate();
 
     // then
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
     jobRecords(TIME_OUT).withRecordKey(jobKey2).getFirst();
   }
 
@@ -95,15 +95,15 @@ public final class JobTimeOutTest {
   public void shouldTimeOutAfterResumed() {
     // given
     final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    final long timeout = JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL.toMillis() * 2;
+    final long timeout = JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL.toMillis() * 2;
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
     ENGINE.pauseProcessing(1);
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
 
     // when
     ENGINE.resumeProcessing(1);
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
 
     // then
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
@@ -113,14 +113,14 @@ public final class JobTimeOutTest {
   public void shouldActivateAndTimeOutAfterResumed() {
     // given
     final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    final long timeout = JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL.toMillis();
+    final long timeout = JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL.toMillis();
     ENGINE.pauseProcessing(1);
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
 
     // when
     ENGINE.resumeProcessing(1);
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
 
     // then
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
@@ -151,7 +151,7 @@ public final class JobTimeOutTest {
     // when
     jobBatchRecords(JobBatchIntent.ACTIVATED).withType(jobType).getFirst();
 
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
     jobRecords(JobIntent.TIMED_OUT).withProcessInstanceKey(instanceKey1).getFirst();
     ENGINE.jobs().withType(jobType).activate();
 
@@ -201,7 +201,7 @@ public final class JobTimeOutTest {
 
     // when
     jobBatchRecords(JobBatchIntent.ACTIVATED).withType(jobType).getFirst();
-    ENGINE.increaseTime(JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
     final Record<JobRecordValue> timedOutRecord =
         jobRecords(TIME_OUT).withProcessInstanceKey(processInstanceKey).getFirst();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import static io.camunda.zeebe.protocol.record.intent.JobIntent.TIMED_OUT;
 import static io.camunda.zeebe.protocol.record.intent.JobIntent.TIME_OUT;
 import static io.camunda.zeebe.test.util.record.RecordingExporter.jobBatchRecords;
 import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
@@ -57,7 +58,7 @@ public final class JobTimeOutTest {
     ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // when expired
-    jobRecords(TIME_OUT).withType(jobType).getFirst();
+    jobRecords(TIMED_OUT).withType(jobType).getFirst();
     ENGINE.jobs().withType(jobType).activate();
 
     // then activated again
@@ -78,7 +79,7 @@ public final class JobTimeOutTest {
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout.toMillis()).activate();
     ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
-    jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
+    jobRecords(TIMED_OUT).withRecordKey(jobKey).getFirst();
 
     final long jobKey2 = ENGINE.createJob(jobType, PROCESS_ID).getKey();
     ENGINE.jobs().withTimeout(timeout.toMillis()).withType(jobType).activate();
@@ -90,7 +91,7 @@ public final class JobTimeOutTest {
 
     // then
     ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
-    jobRecords(TIME_OUT).withRecordKey(jobKey2).getFirst();
+    jobRecords(TIMED_OUT).withRecordKey(jobKey2).getFirst();
   }
 
   @Test
@@ -108,7 +109,7 @@ public final class JobTimeOutTest {
     ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // then
-    jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
+    jobRecords(TIMED_OUT).withRecordKey(jobKey).getFirst();
   }
 
   @Test
@@ -125,7 +126,7 @@ public final class JobTimeOutTest {
     ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // then
-    jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
+    jobRecords(TIMED_OUT).withRecordKey(jobKey).getFirst();
   }
 
   @Test
@@ -154,7 +155,7 @@ public final class JobTimeOutTest {
     jobBatchRecords(JobBatchIntent.ACTIVATED).withType(jobType).getFirst();
 
     ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
-    jobRecords(JobIntent.TIMED_OUT).withProcessInstanceKey(instanceKey1).getFirst();
+    jobRecords(TIMED_OUT).withProcessInstanceKey(instanceKey1).getFirst();
     ENGINE.jobs().withType(jobType).activate();
 
     // then

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.test.util.record.RecordingExporter.jobBatchRecord
 import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -52,7 +53,7 @@ public final class JobTimeOutTest {
     final long timeout = 10L;
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // when expired
     jobRecords(TIME_OUT).withType(jobType).getFirst();
@@ -75,7 +76,7 @@ public final class JobTimeOutTest {
     final long timeout = 10L;
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
 
     final long jobKey2 = ENGINE.createJob(jobType, PROCESS_ID).getKey();
@@ -87,7 +88,7 @@ public final class JobTimeOutTest {
     ENGINE.jobs().withType(jobType).activate();
 
     // then
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
     jobRecords(TIME_OUT).withRecordKey(jobKey2).getFirst();
   }
 
@@ -95,15 +96,15 @@ public final class JobTimeOutTest {
   public void shouldTimeOutAfterResumed() {
     // given
     final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    final long timeout = JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL.toMillis() * 2;
+    final long timeout = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL.toMillis() * 2;
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
     ENGINE.pauseProcessing(1);
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // when
     ENGINE.resumeProcessing(1);
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // then
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
@@ -113,14 +114,14 @@ public final class JobTimeOutTest {
   public void shouldActivateAndTimeOutAfterResumed() {
     // given
     final long jobKey = ENGINE.createJob(jobType, PROCESS_ID).getKey();
-    final long timeout = JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL.toMillis();
+    final long timeout = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL.toMillis();
     ENGINE.pauseProcessing(1);
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // when
     ENGINE.resumeProcessing(1);
     ENGINE.jobs().withType(jobType).withTimeout(timeout).activate();
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
 
     // then
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
@@ -151,7 +152,7 @@ public final class JobTimeOutTest {
     // when
     jobBatchRecords(JobBatchIntent.ACTIVATED).withType(jobType).getFirst();
 
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
     jobRecords(JobIntent.TIMED_OUT).withProcessInstanceKey(instanceKey1).getFirst();
     ENGINE.jobs().withType(jobType).activate();
 
@@ -201,7 +202,7 @@ public final class JobTimeOutTest {
 
     // when
     jobBatchRecords(JobBatchIntent.ACTIVATED).withType(jobType).getFirst();
-    ENGINE.increaseTime(JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
     final Record<JobRecordValue> timedOutRecord =
         jobRecords(TIME_OUT).withProcessInstanceKey(processInstanceKey).getFirst();
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeOutTest.java
@@ -77,7 +77,7 @@ public final class JobTimeOutTest {
     final Duration timeout = Duration.ofSeconds(10);
 
     ENGINE.jobs().withType(jobType).withTimeout(timeout.toMillis()).activate();
-    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
     jobRecords(TIME_OUT).withRecordKey(jobKey).getFirst();
 
     final long jobKey2 = ENGINE.createJob(jobType, PROCESS_ID).getKey();
@@ -90,7 +90,7 @@ public final class JobTimeOutTest {
     ENGINE.jobs().withType(jobType).activate();
 
     // then
-    ENGINE.increaseTime(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL);
+    ENGINE.increaseTime(timeout.plus(EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL));
     jobRecords(TIME_OUT).withRecordKey(jobKey2).getFirst();
   }
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
@@ -63,13 +62,9 @@ public class JobTimeoutCheckerTest {
   }
 
   private JobRecord newJobRecord() {
-    return newJobRecord(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
-  }
-
-  private JobRecord newJobRecord(final String tenantId) {
     final JobRecord jobRecord = new JobRecord();
 
-    jobRecord.setRetries(2).setDeadline(256L).setType("test").setTenantId(tenantId);
+    jobRecord.setRetries(2).setDeadline(256L).setType("test");
 
     return jobRecord;
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
@@ -32,7 +32,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class DeactivateTimeOutJobsTest {
+public class JobTimeoutCheckerTest {
   public static final int NUMBER_OF_ACTIVE_JOBS = 10;
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
@@ -82,7 +82,7 @@ public class DeactivateTimeOutJobsTest {
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = Integer.MAX_VALUE;
 
-    final var task = new DeactivateTimeOutJobs(jobState, pollingInterval, batchLimit);
+    final var task = new JobTimeoutChecker(jobState, pollingInterval, batchLimit);
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 
@@ -108,7 +108,7 @@ public class DeactivateTimeOutJobsTest {
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = 3;
 
-    final var task = new DeactivateTimeOutJobs(jobState, pollingInterval, batchLimit);
+    final var task = new JobTimeoutChecker(jobState, pollingInterval, batchLimit);
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 
@@ -148,7 +148,7 @@ public class DeactivateTimeOutJobsTest {
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = Integer.MAX_VALUE;
 
-    final var task = new DeactivateTimeOutJobs(jobState, pollingInterval, batchLimit);
+    final var task = new JobTimeoutChecker(jobState, pollingInterval, batchLimit);
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.JobState.DeadlineIndex;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
@@ -504,17 +505,20 @@ public final class JobStateTest {
     // when
     final List<Long> timedOutKeys = new ArrayList<>();
     final long since = 65536L;
-    jobState.forEachTimedOutEntry(
-        since,
-        null,
-        (k, e) -> {
-          timedOutKeys.add(k);
-          return k.longValue() < 3;
-        });
+    final DeadlineIndex nextIndex =
+        jobState.forEachTimedOutEntry(
+            since,
+            null,
+            (k, e) -> {
+              timedOutKeys.add(k);
+              return k.longValue() < 3;
+            });
 
     // then
     assertThat(timedOutKeys).hasSize(3);
     assertThat(timedOutKeys).containsExactly(1L, 2L, 3L);
+    assertThat(nextIndex).isNotNull();
+    assertThat(nextIndex.key()).isEqualTo(3);
   }
 
   @Test
@@ -527,17 +531,19 @@ public final class JobStateTest {
     // when
     final List<Long> timedOutKeys = new ArrayList<>();
     final long since = 65536L;
-    jobState.forEachTimedOutEntry(
-        since,
-        null,
-        (k, e) -> {
-          timedOutKeys.add(k);
-          return true;
-        });
+    final DeadlineIndex nextIndex =
+        jobState.forEachTimedOutEntry(
+            since,
+            null,
+            (k, e) -> {
+              timedOutKeys.add(k);
+              return true;
+            });
 
     // then
     assertThat(timedOutKeys).hasSize(1);
     assertThat(timedOutKeys).containsExactly(2L);
+    assertThat(nextIndex).isNull();
   }
 
   @Test

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/instance/JobStateTest.java
@@ -506,6 +506,7 @@ public final class JobStateTest {
     final long since = 65536L;
     jobState.forEachTimedOutEntry(
         since,
+        null,
         (k, e) -> {
           timedOutKeys.add(k);
           return k.longValue() < 3;
@@ -528,6 +529,7 @@ public final class JobStateTest {
     final long since = 65536L;
     jobState.forEachTimedOutEntry(
         since,
+        null,
         (k, e) -> {
           timedOutKeys.add(k);
           return true;
@@ -783,7 +785,7 @@ public final class JobStateTest {
   private List<Long> getTimedOutKeys(final long since) {
     final List<Long> timedOutKeys = new ArrayList<>();
 
-    jobState.forEachTimedOutEntry(since, (k, e) -> timedOutKeys.add(k));
+    jobState.forEachTimedOutEntry(since, null, (k, e) -> timedOutKeys.add(k));
     return timedOutKeys;
   }
 

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerReprocessingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerReprocessingTest.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.engine.processing.job.JobTimeoutChecker;
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -683,7 +683,7 @@ public final class BrokerReprocessingTest {
 
     final ControlledActorClock clock = brokerRule.getClock();
     final Duration pollingInterval =
-        JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL
+        EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL
             // this shouldn't be needed but is caused by the fact hat on reprocessing without
             // a snapshot a new deadline is set for the job
             // https://github.com/zeebe-io/zeebe/issues/1800

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerReprocessingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/BrokerReprocessingTest.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.response.DeploymentEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
-import io.camunda.zeebe.engine.processing.job.JobTimeoutTrigger;
+import io.camunda.zeebe.engine.processing.job.JobTimeoutChecker;
 import io.camunda.zeebe.it.util.GrpcClientRule;
 import io.camunda.zeebe.it.util.ZeebeAssertHelper;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -683,7 +683,7 @@ public final class BrokerReprocessingTest {
 
     final ControlledActorClock clock = brokerRule.getClock();
     final Duration pollingInterval =
-        JobTimeoutTrigger.TIME_OUT_POLLING_INTERVAL
+        JobTimeoutChecker.TIME_OUT_POLLING_INTERVAL
             // this shouldn't be needed but is caused by the fact hat on reprocessing without
             // a snapshot a new deadline is set for the job
             // https://github.com/zeebe-io/zeebe/issues/1800


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe/pull/16889 to stable/8.2.

The conflicts were only about the file renames and changes in a test class that didn't exist in the base branch `ActivatableJobsPushTest`. I only accepted the upstream changes, skipped the test class.

Also removed tenantId from backported tests. didn't exist in this version

## Related issues

relates to https://github.com/camunda/zeebe/issues/5073