### PR TITLE
ci: don't cache results of building zeebe docker image

### DIFF
--- a/.github/actions/build-zeebe-docker/action.yml
+++ b/.github/actions/build-zeebe-docker/action.yml
@@ -81,9 +81,6 @@ runs:
         tags: ${{ steps.get-image.outputs.result }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
-        cache-from: type=gha,ignore-error=true
-        cache-to: type=gha,mode=max,ignore-error=true
-        no-cache-filters: build,distball,dist
         platforms: ${{ inputs.platforms }}
         provenance: false
         build-args: |


### PR DESCRIPTION
Cache seems to be overwhelmed and it's unclear how much we benefit from it anyway.