### PR TITLE
Add merge_group event to Operate CI

### DIFF
--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -17,6 +17,7 @@ on:
       - '.github/workflows/zeebe-*'
       - 'dist/**'
       - 'zeebe/**'
+  merge_group: { }
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).
 # If a new commits occurs, the current run will be canceled to save costs.


### PR DESCRIPTION
## Description

Operate PRs could not be merged with the merge queue, as they are not listening to the merge_group event.