### PR TITLE
Revert "Add merge_group event to Operate CI"

### DIFF
--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -17,7 +17,6 @@ on:
       - '.github/workflows/zeebe-*'
       - 'dist/**'
       - 'zeebe/**'
-  merge_group: { }
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).
 # If a new commits occurs, the current run will be canceled to save costs.


### PR DESCRIPTION
Reverts camunda/zeebe#17066

We realized that it is rather dangerous to have the merge queue triggered by Operate CI as all PRs are immediately merged. 

Since the merge queue don't allow to specify any path filtering, we run Zeebe CI all the time. Likely it was an issue with the Zeebe CI that we have seen before (PRs stuck in merge queue).

Related thread https://camunda.slack.com/archives/C06HTSPD5AP/p1711103050546939