### PR TITLE
[Backport stable/8.1] ci: don't cache results of building zeebe docker image

### DIFF
--- a/.github/actions/build-zeebe-docker/action.yml
+++ b/.github/actions/build-zeebe-docker/action.yml
@@ -81,8 +81,6 @@ runs:
         tags: ${{ steps.get-images.outputs.result }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}
-        cache-from: type=gha,ignore-error=true
-        cache-to: type=gha,mode=max,ignore-error=true
         build-args: |
           DISTBALL=${{ steps.get-distball.outputs.result }}
           DATE=${{ steps.get-date.outputs.result }}


### PR DESCRIPTION
# Description
Backport of #17064 to `stable/8.4`.

relates to 
original author: @oleschoenburg