### PR TITLE
Camunda Spring SDK - Add support for new Zeebe REST properties

### DIFF
--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/CamundaAutoConfiguration.java
@@ -15,12 +15,9 @@
  */
 package io.camunda.zeebe.spring.client;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.common.json.SdkObjectMapper;
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.JsonMapper;
-import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.spring.client.configuration.CommonClientConfiguration;
+import io.camunda.zeebe.spring.client.configuration.JsonMapperConfiguration;
 import io.camunda.zeebe.spring.client.configuration.MetricsDefaultConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeActuatorConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientAllAutoConfiguration;
@@ -41,12 +38,12 @@ import org.springframework.context.annotation.Configuration;
   ZeebeClientProdAutoConfiguration.class,
   ZeebeClientAllAutoConfiguration.class,
   CommonClientConfiguration.class,
+  JsonMapperConfiguration.class,
   ZeebeActuatorConfiguration.class,
   MetricsDefaultConfiguration.class
 })
-@AutoConfigureAfter(
-    JacksonAutoConfiguration
-        .class) // make sure Spring created ObjectMapper is preferred if available
+// make sure Spring created ObjectMapper is preferred if available
+@AutoConfigureAfter(JacksonAutoConfiguration.class)
 public class CamundaAutoConfiguration {
 
   @Bean
@@ -57,29 +54,5 @@ public class CamundaAutoConfiguration {
   public ZeebeLifecycleEventProducer zeebeLifecycleEventProducer(
       final ZeebeClient client, final ApplicationEventPublisher publisher) {
     return new ZeebeLifecycleEventProducer(client, publisher);
-  }
-
-  /**
-   * Registering a JsonMapper bean when there is none already exists in {@link
-   * org.springframework.beans.factory.BeanFactory}.
-   *
-   * <p>NOTE: This method SHOULD NOT be explicitly called as it might lead to unexpected behaviour
-   * due to the {@link ConditionalOnMissingBean} annotation. i.e. Calling this method when another
-   * JsonMapper bean is defined in the context might throw {@link
-   * org.springframework.beans.factory.NoSuchBeanDefinitionException}
-   *
-   * @return a new JsonMapper bean if none already exists in {@link
-   *     org.springframework.beans.factory.BeanFactory}
-   */
-  @Bean(name = "zeebeJsonMapper")
-  @ConditionalOnMissingBean
-  public JsonMapper jsonMapper(final ObjectMapper objectMapper) {
-    return new ZeebeObjectMapper(objectMapper);
-  }
-
-  @Bean(name = "commonJsonMapper")
-  @ConditionalOnMissingBean
-  public io.camunda.common.json.JsonMapper commonJsonMapper(final ObjectMapper objectMapper) {
-    return new SdkObjectMapper(objectMapper);
   }
 }

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/JsonMapperConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.common.json.SdkObjectMapper;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonMapperConfiguration {
+  private final ObjectMapper objectMapper;
+
+  @Autowired
+  public JsonMapperConfiguration(@Autowired(required = false) final ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Bean(name = "zeebeJsonMapper")
+  @ConditionalOnMissingBean
+  public JsonMapper jsonMapper() {
+    if (objectMapper == null) {
+      return new ZeebeObjectMapper();
+    }
+    return new ZeebeObjectMapper(objectMapper);
+  }
+
+  @Bean(name = "commonJsonMapper")
+  @ConditionalOnMissingBean
+  public io.camunda.common.json.JsonMapper commonJsonMapper() {
+    if (objectMapper == null) {
+      return new SdkObjectMapper();
+    }
+    return new SdkObjectMapper(objectMapper);
+  }
+}

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationSpringImpl.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationSpringImpl.java
@@ -32,7 +32,6 @@ import io.grpc.ClientInterceptor;
 import io.grpc.Status.Code;
 import jakarta.annotation.PostConstruct;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
@@ -73,22 +72,12 @@ public class ZeebeClientConfigurationSpringImpl implements ZeebeClientConfigurat
 
   @Override
   public URI getRestAddress() {
-    // TODO implement
-    try {
-      return new URI("http://localhost:1235");
-    } catch (final URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
+    return properties.getRestAddress();
   }
 
   @Override
   public URI getGrpcAddress() {
-    // TODO implement
-    try {
-      return new URI(properties.getGatewayAddress());
-    } catch (final URISyntaxException e) {
-      throw new RuntimeException(e);
-    }
+    return properties.getGrpcAddress();
   }
 
   @Override

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -16,10 +16,12 @@
 package io.camunda.zeebe.spring.client.properties;
 
 import io.camunda.zeebe.client.ClientProperties;
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.util.Environment;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import jakarta.annotation.PostConstruct;
+import java.net.URI;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -217,87 +219,60 @@ public class ZeebeClientConfigurationProperties {
     return ownsJobWorkerExecutor;
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(broker, cloud, worker, message, security, job, requestTimeout);
-  }
-
-  @Override
-  public boolean equals(final Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ZeebeClientConfigurationProperties that = (ZeebeClientConfigurationProperties) o;
-    return Objects.equals(broker, that.broker)
-        && Objects.equals(cloud, that.cloud)
-        && Objects.equals(worker, that.worker)
-        && Objects.equals(message, that.message)
-        && Objects.equals(security, that.security)
-        && Objects.equals(job, that.job)
-        && Objects.equals(requestTimeout, that.requestTimeout);
-  }
-
-  @Override
-  public String toString() {
-    return "ZeebeClientConfigurationProperties{"
-        + "environment="
-        + environment
-        + ", connectionMode='"
-        + connectionMode
-        + '\''
-        + ", defaultTenantId='"
-        + defaultTenantId
-        + '\''
-        + ", defaultJobWorkerTenantIds="
-        + defaultJobWorkerTenantIds
-        + ", applyEnvironmentVariableOverrides="
-        + applyEnvironmentVariableOverrides
-        + ", enabled="
-        + enabled
-        + ", broker="
-        + broker
-        + ", cloud="
-        + cloud
-        + ", worker="
-        + worker
-        + ", message="
-        + message
-        + ", security="
-        + security
-        + ", job="
-        + job
-        + ", ownsJobWorkerExecutor="
-        + ownsJobWorkerExecutor
-        + ", defaultJobWorkerStreamEnabled="
-        + defaultJobWorkerStreamEnabled
-        + ", requestTimeout="
-        + requestTimeout
-        + '}';
-  }
-
+  /**
+   * @deprecated since 8.5 for removal with 8.8, replaced by {@link
+   *     ZeebeClientConfigurationProperties#getGrpcAddress()}
+   * @see ZeebeClientConfiguration#getGatewayAddress()
+   */
+  @Deprecated
   public String getGatewayAddress() {
-    if (connectionMode != null && connectionMode.length() > 0) {
+    if (connectionMode != null && !connectionMode.isEmpty()) {
       LOGGER.info("Using connection mode '{}' to connect to Zeebe", connectionMode);
       if (CONNECTION_MODE_CLOUD.equalsIgnoreCase(connectionMode)) {
         return cloud.getGatewayAddress();
       } else if (CONNECTION_MODE_ADDRESS.equalsIgnoreCase(connectionMode)) {
         return broker.getGatewayAddress();
       } else {
-        throw new RuntimeException(
-            "Value '"
-                + connectionMode
-                + "' for ConnectionMode is invalid, valid values are "
-                + CONNECTION_MODE_CLOUD
-                + " or "
-                + CONNECTION_MODE_ADDRESS);
+        throw new RuntimeException(createInvalidConnectionModeErrorMessage());
       }
     } else if (cloud.isConfigured()) {
       return cloud.getGatewayAddress();
     } else {
       return broker.getGatewayAddress();
+    }
+  }
+
+  public URI getGrpcAddress() {
+    if (connectionMode != null && !connectionMode.isEmpty()) {
+      LOGGER.info("Using connection mode '{}' to connect to Zeebe GRPC", connectionMode);
+      if (CONNECTION_MODE_CLOUD.equalsIgnoreCase(connectionMode)) {
+        return cloud.getGrpcAddress();
+      } else if (CONNECTION_MODE_ADDRESS.equalsIgnoreCase(connectionMode)) {
+        return broker.getGrpcAddress();
+      } else {
+        throw new RuntimeException(createInvalidConnectionModeErrorMessage());
+      }
+    } else if (cloud.isConfigured()) {
+      return cloud.getGrpcAddress();
+    } else {
+      return broker.getGrpcAddress();
+    }
+  }
+
+  public URI getRestAddress() {
+    if (connectionMode != null && !connectionMode.isEmpty()) {
+      LOGGER.info("Using connection mode '{}' to connect to Zeebe REST", connectionMode);
+      if (CONNECTION_MODE_CLOUD.equalsIgnoreCase(connectionMode)) {
+        return cloud.getRestAddress();
+      } else if (CONNECTION_MODE_ADDRESS.equalsIgnoreCase(connectionMode)) {
+        return broker.getRestAddress();
+      } else {
+        throw new RuntimeException(createInvalidConnectionModeErrorMessage());
+      }
+    } else if (cloud.isConfigured()) {
+      return cloud.getRestAddress();
+    } else {
+      return broker.getRestAddress();
     }
   }
 
@@ -389,31 +364,92 @@ public class ZeebeClientConfigurationProperties {
     return message.getMaxMessageSize();
   }
 
-  public static class Broker {
+  @Override
+  public int hashCode() {
+    return Objects.hash(broker, cloud, worker, message, security, job, requestTimeout);
+  }
 
-    private String gatewayAddress;
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ZeebeClientConfigurationProperties that = (ZeebeClientConfigurationProperties) o;
+    return Objects.equals(broker, that.broker)
+        && Objects.equals(cloud, that.cloud)
+        && Objects.equals(worker, that.worker)
+        && Objects.equals(message, that.message)
+        && Objects.equals(security, that.security)
+        && Objects.equals(job, that.job)
+        && Objects.equals(requestTimeout, that.requestTimeout);
+  }
+
+  @Override
+  public String toString() {
+    return "ZeebeClientConfigurationProperties{"
+        + "environment="
+        + environment
+        + ", connectionMode='"
+        + connectionMode
+        + '\''
+        + ", defaultTenantId='"
+        + defaultTenantId
+        + '\''
+        + ", defaultJobWorkerTenantIds="
+        + defaultJobWorkerTenantIds
+        + ", applyEnvironmentVariableOverrides="
+        + applyEnvironmentVariableOverrides
+        + ", enabled="
+        + enabled
+        + ", broker="
+        + broker
+        + ", cloud="
+        + cloud
+        + ", worker="
+        + worker
+        + ", message="
+        + message
+        + ", security="
+        + security
+        + ", job="
+        + job
+        + ", ownsJobWorkerExecutor="
+        + ownsJobWorkerExecutor
+        + ", defaultJobWorkerStreamEnabled="
+        + defaultJobWorkerStreamEnabled
+        + ", requestTimeout="
+        + requestTimeout
+        + '}';
+  }
+
+  private String createInvalidConnectionModeErrorMessage() {
+    return "Value '"
+        + connectionMode
+        + "' for ConnectionMode is invalid, valid values are "
+        + CONNECTION_MODE_CLOUD
+        + " or "
+        + CONNECTION_MODE_ADDRESS;
+  }
+
+  public static class Broker {
+    /**
+     * @deprecated since 8.5 for removal with 8.8, replaced by {@link Broker#getGrpcAddress()}
+     * @see ZeebeClientConfiguration#getGatewayAddress()
+     */
+    @Deprecated private String gatewayAddress;
+
+    private URI grpcAddress;
+    private URI restAddress;
     private Duration keepAlive = DEFAULT.getKeepAlive();
 
     /**
-     * Use gatewayAddress. It's deprecated since 0.25.0, and will be removed in 0.26.0
-     *
-     * @return gatewayAddress
+     * @deprecated since 8.5 for removal with 8.8, replaced by {@link Broker#getGrpcAddress()}
+     * @see ZeebeClientConfiguration#getGatewayAddress()
      */
     @Deprecated
-    public String getContactPoint() {
-      return getGatewayAddress();
-    }
-
-    /**
-     * Use gatewayAddress. It's deprecated since 0.25.0, and will be removed in 0.26.0
-     *
-     * @param contactPoint
-     */
-    @Deprecated
-    public void setContactPoint(final String contactPoint) {
-      setGatewayAddress(contactPoint);
-    }
-
     public String getGatewayAddress() {
       if (gatewayAddress != null) {
         return gatewayAddress;
@@ -422,8 +458,37 @@ public class ZeebeClientConfigurationProperties {
       }
     }
 
+    /**
+     * @deprecated since 8.5 for removal with 8.8, replaced by {@link Broker#getGrpcAddress()}
+     * @see ZeebeClientConfiguration#getGatewayAddress()
+     */
+    @Deprecated
     public void setGatewayAddress(final String gatewayAddress) {
       this.gatewayAddress = gatewayAddress;
+    }
+
+    public URI getGrpcAddress() {
+      if (grpcAddress != null) {
+        return grpcAddress;
+      } else {
+        return DEFAULT.getGrpcAddress();
+      }
+    }
+
+    public void setGrpcAddress(final URI grpcAddress) {
+      this.grpcAddress = grpcAddress;
+    }
+
+    public URI getRestAddress() {
+      if (restAddress != null) {
+        return restAddress;
+      } else {
+        return DEFAULT.getRestAddress();
+      }
+    }
+
+    public void setRestAddress(final URI restAddress) {
+      this.restAddress = restAddress;
     }
 
     public Duration getKeepAlive() {
@@ -436,7 +501,7 @@ public class ZeebeClientConfigurationProperties {
 
     @Override
     public int hashCode() {
-      return Objects.hash(gatewayAddress, keepAlive);
+      return Objects.hash(gatewayAddress, grpcAddress, restAddress, keepAlive);
     }
 
     @Override
@@ -449,6 +514,8 @@ public class ZeebeClientConfigurationProperties {
       }
       final Broker broker = (Broker) o;
       return Objects.equals(gatewayAddress, broker.gatewayAddress)
+          && Objects.equals(grpcAddress, broker.grpcAddress)
+          && Objects.equals(restAddress, broker.restAddress)
           && Objects.equals(keepAlive, broker.keepAlive);
     }
 
@@ -457,7 +524,10 @@ public class ZeebeClientConfigurationProperties {
       return "Broker{"
           + "gatewayAddress='"
           + gatewayAddress
-          + '\''
+          + ", grpcAddress="
+          + grpcAddress
+          + ", restAddress="
+          + restAddress
           + ", keepAlive="
           + keepAlive
           + '}';
@@ -475,38 +545,6 @@ public class ZeebeClientConfigurationProperties {
     private String authUrl = "https://login.cloud.camunda.io/oauth/token";
     private int port = 443;
     private String credentialsCachePath;
-
-    @Override
-    public String toString() {
-      return "Cloud{"
-          + "clusterId='"
-          + clusterId
-          + '\''
-          + ", clientId='"
-          + "***"
-          + '\''
-          + ", clientSecret='"
-          + "***"
-          + '\''
-          + ", region='"
-          + region
-          + '\''
-          + ", scope='"
-          + scope
-          + '\''
-          + ", baseUrl='"
-          + baseUrl
-          + '\''
-          + ", authUrl='"
-          + authUrl
-          + '\''
-          + ", port="
-          + port
-          + ", credentialsCachePath='"
-          + credentialsCachePath
-          + '\''
-          + '}';
-    }
 
     public String getClusterId() {
       return clusterId;
@@ -588,8 +626,87 @@ public class ZeebeClientConfigurationProperties {
       return (clusterId != null);
     }
 
+    /**
+     * @deprecated since 8.5 for removal with 8.8, replaced by {@link Cloud#getGrpcAddress()}
+     * @see ZeebeClientConfiguration#getGatewayAddress()
+     */
+    @Deprecated
     public String getGatewayAddress() {
       return String.format("%s.%s.%s:%d", clusterId, region, baseUrl, port);
+    }
+
+    public URI getGrpcAddress() {
+      return URI.create(String.format("https://%s.%s.%s:%d", clusterId, region, baseUrl, port));
+    }
+
+    public URI getRestAddress() {
+      return URI.create(String.format("https://%s.%s:%d/%s", region, baseUrl, port, clusterId));
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(
+          clusterId,
+          clientId,
+          clientSecret,
+          region,
+          scope,
+          baseUrl,
+          authUrl,
+          port,
+          credentialsCachePath);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final Cloud cloud = (Cloud) o;
+      return port == cloud.port
+          && Objects.equals(clusterId, cloud.clusterId)
+          && Objects.equals(clientId, cloud.clientId)
+          && Objects.equals(clientSecret, cloud.clientSecret)
+          && Objects.equals(region, cloud.region)
+          && Objects.equals(scope, cloud.scope)
+          && Objects.equals(baseUrl, cloud.baseUrl)
+          && Objects.equals(authUrl, cloud.authUrl)
+          && Objects.equals(credentialsCachePath, cloud.credentialsCachePath);
+    }
+
+    @Override
+    public String toString() {
+      return "Cloud{"
+          + "clusterId='"
+          + clusterId
+          + '\''
+          + ", clientId='"
+          + clientId
+          + '\''
+          + ", clientSecret='"
+          + clientSecret
+          + '\''
+          + ", region='"
+          + region
+          + '\''
+          + ", scope='"
+          + scope
+          + '\''
+          + ", baseUrl='"
+          + baseUrl
+          + '\''
+          + ", authUrl='"
+          + authUrl
+          + '\''
+          + ", port="
+          + port
+          + ", credentialsCachePath='"
+          + credentialsCachePath
+          + '\''
+          + '}';
     }
   }
 

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCloudTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCloudTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@TestPropertySource(
+    properties = {
+      "zeebe.client.cloud.clusterId=123-abc-456-def",
+    })
+@ContextConfiguration(
+    classes = {
+      CamundaAutoConfiguration.class,
+      ZeebeClientStarterAutoConfigurationCloudTest.TestConfig.class
+    })
+public class ZeebeClientStarterAutoConfigurationCloudTest {
+
+  @Autowired private ApplicationContext applicationContext;
+
+  @Test
+  void testClientConfiguration() {
+    final ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
+    assertThat(client.getConfiguration().getGatewayAddress())
+        .isEqualTo("123-abc-456-def.bru-2.zeebe.camunda.io:443");
+    assertThat(client.getConfiguration().getGrpcAddress().toString())
+        .isEqualTo("https://123-abc-456-def.bru-2.zeebe.camunda.io:443");
+    assertThat(client.getConfiguration().getRestAddress().toString())
+        .isEqualTo("https://bru-2.zeebe.camunda.io:443/123-abc-456-def");
+  }
+
+  public static class TestConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+  }
+}

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCustomJsonMapperTest.java
@@ -41,7 +41,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
     properties = {
-      "zeebe.client.broker.gatewayAddress=http://localhost:1234",
+      "zeebe.client.broker.gatewayAddress=localhost:1234",
+      "zeebe.client.broker.grpcAddress=https://localhost:1234",
+      "zeebe.client.broker.restAddress=https://localhost:8080",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",
       "zeebe.client.job.pollInterval=99s",
@@ -95,14 +97,17 @@ public class ZeebeClientStarterAutoConfigurationCustomJsonMapperTest {
   }
 
   @Test
-  void testBuilder() {
+  void testClientConfiguration() {
     final ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
     final io.camunda.zeebe.client.api.JsonMapper clientJsonMapper =
         AopTestUtils.getUltimateTargetObject(client.getConfiguration().getJsonMapper());
     assertThat(clientJsonMapper).isSameAs(jsonMapper);
     assertThat(clientJsonMapper).isSameAs(applicationContext.getBean("overridingJsonMapper"));
+    assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost:1234");
     assertThat(client.getConfiguration().getGrpcAddress().toString())
-        .isEqualTo("http://localhost:1234");
+        .isEqualTo("https://localhost:1234");
+    assertThat(client.getConfiguration().getRestAddress().toString())
+        .isEqualTo("https://localhost:8080");
     assertThat(client.getConfiguration().getDefaultRequestTimeout())
         .isEqualTo(Duration.ofSeconds(99));
     assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
@@ -19,9 +19,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
+import java.time.Duration;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +38,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(SpringExtension.class)
 @TestPropertySource(
     properties = {
-      "zeebe.client.broker.gatewayAddress=http://localhost:1234",
+      "zeebe.client.broker.gatewayAddress=localhost:1234",
+      "zeebe.client.broker.grpcAddress=https://localhost:1234",
+      "zeebe.client.broker.restAddress=https://localhost:8080",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",
       "zeebe.client.job.pollInterval=99s",
@@ -85,6 +89,23 @@ public class ZeebeClientStarterAutoConfigurationTest {
                 .getDeserializationConfig()
                 .isEnabled(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES))
         .isFalse();
+  }
+
+  @Test
+  void testClientConfiguration() {
+    final ZeebeClient client = applicationContext.getBean(ZeebeClient.class);
+    assertThat(client.getConfiguration().getGatewayAddress()).isEqualTo("localhost:1234");
+    assertThat(client.getConfiguration().getGrpcAddress().toString())
+        .isEqualTo("https://localhost:1234");
+    assertThat(client.getConfiguration().getRestAddress().toString())
+        .isEqualTo("https://localhost:8080");
+    assertThat(client.getConfiguration().getDefaultRequestTimeout())
+        .isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getCaCertificatePath()).isEqualTo("aPath");
+    assertThat(client.getConfiguration().isPlaintextConnectionEnabled()).isTrue();
+    assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
+    assertThat(client.getConfiguration().getDefaultJobPollInterval())
+        .isEqualTo(Duration.ofSeconds(99));
   }
 
   public static class TestConfig {

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
@@ -34,6 +34,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @TestPropertySource(
     properties = {
       "zeebe.client.gateway.address=localhost12345",
+      "zeebe.client.broker.grpcAddress=https://localhost:1234",
+      "zeebe.client.broker.restAddress=https://localhost:8080",
       "zeebe.client.job.pollinterval=99s",
       "zeebe.client.worker.name=testName",
       "zeebe.client.cloud.secret=processOrchestration"
@@ -44,8 +46,16 @@ public class JavaClientPropertiesTest {
   @Autowired private ZeebeClientConfigurationProperties properties;
 
   @Test
-  public void hasBrokerContactPoint() throws Exception {
+  public void hasDeprecatedGatewayAddress() throws Exception {
     assertThat(properties.getGatewayAddress()).isEqualTo("localhost12345");
+  }
+
+  public void hasGrpcAddress() throws Exception {
+    assertThat(properties.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
+  }
+
+  public void hasRestAddress() throws Exception {
+    assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8080");
   }
 
   @Test

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
@@ -46,30 +46,30 @@ public class JavaClientPropertiesTest {
   @Autowired private ZeebeClientConfigurationProperties properties;
 
   @Test
-  public void hasDeprecatedGatewayAddress() throws Exception {
+  public void hasDeprecatedGatewayAddress() {
     assertThat(properties.getGatewayAddress()).isEqualTo("localhost12345");
   }
 
-  public void hasGrpcAddress() throws Exception {
+  public void hasGrpcAddress() {
     assertThat(properties.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
   }
 
-  public void hasRestAddress() throws Exception {
+  public void hasRestAddress() {
     assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8080");
   }
 
   @Test
-  public void hasWorkerName() throws Exception {
+  public void hasWorkerName() {
     assertThat(properties.getDefaultJobWorkerName()).isEqualTo("testName");
   }
 
   @Test
-  public void hasJobPollInterval() throws Exception {
+  public void hasJobPollInterval() {
     assertThat(properties.getJob().getPollInterval()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
-  public void hasCloudSecret() throws Exception {
+  public void hasCloudSecret() {
     assertThat(properties.getCloud().getClientSecret()).isEqualTo("processOrchestration");
   }
 

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/PropertyBasedZeebeWorkerValueCustomizerTest.java
@@ -76,7 +76,7 @@ public class PropertyBasedZeebeWorkerValueCustomizerTest {
   }
 
   @Test
-  void shouldSetDefaultName() throws NoSuchMethodException {
+  void shouldSetDefaultName() {
     // given
     final ZeebeClientConfigurationProperties properties = properties();
     properties.getWorker().setDefaultName("defaultName");

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
@@ -33,62 +33,62 @@ public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
   @Autowired private ZeebeClientConfigurationProperties properties;
 
   @Test
-  public void hasDeprecatedGatewayAddress() throws Exception {
+  public void hasDeprecatedGatewayAddress() {
     assertThat(properties.getGatewayAddress()).isEqualTo("0.0.0.0:26500");
   }
 
   @Test
-  public void hasGrpcAddress() throws Exception {
+  public void hasGrpcAddress() {
     assertThat(properties.getGrpcAddress().toString()).isEqualTo("https://0.0.0.0:26500");
   }
 
   @Test
-  public void hasRestAddress() throws Exception {
+  public void hasRestAddress() {
     assertThat(properties.getRestAddress().toString()).isEqualTo("https://0.0.0.0:8080");
   }
 
   @Test
-  public void hasRequestTimeout() throws Exception {
+  public void hasRequestTimeout() {
     assertThat(properties.getRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
   }
 
   @Test
-  public void hasNoWorkerName() throws Exception {
+  public void hasNoWorkerName() {
     assertThat(properties.getDefaultJobWorkerName()).isNull();
   }
 
   @Test
-  public void hasJobTimeout() throws Exception {
+  public void hasJobTimeout() {
     assertThat(properties.getDefaultJobTimeout()).isEqualTo(Duration.ofSeconds(300));
   }
 
   @Test
-  public void hasWorkerMaxJobsActive() throws Exception {
+  public void hasWorkerMaxJobsActive() {
     assertThat(properties.getDefaultJobWorkerMaxJobsActive()).isEqualTo(32);
   }
 
   @Test
-  public void hasJobPollInterval() throws Exception {
+  public void hasJobPollInterval() {
     assertThat(properties.getDefaultJobPollInterval()).isEqualTo(Duration.ofNanos(100000000));
   }
 
   @Test
-  public void hasWorkerThreads() throws Exception {
+  public void hasWorkerThreads() {
     assertThat(properties.getNumJobWorkerExecutionThreads()).isEqualTo(1);
   }
 
   @Test
-  public void hasMessageTimeToLeave() throws Exception {
+  public void hasMessageTimeToLeave() {
     assertThat(properties.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofSeconds(3600));
   }
 
   @Test
-  public void isSecurityPlainTextDisabled() throws Exception {
+  public void isSecurityPlainTextDisabled() {
     assertThat(properties.isPlaintextConnectionEnabled()).isFalse();
   }
 
   @Test
-  public void hasSecurityCertificatePath() throws Exception {
+  public void hasSecurityCertificatePath() {
     assertThat(properties.getCaCertificatePath()).isNull();
   }
 

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
@@ -33,8 +33,18 @@ public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
   @Autowired private ZeebeClientConfigurationProperties properties;
 
   @Test
-  public void hasGatewayAddress() throws Exception {
+  public void hasDeprecatedGatewayAddress() throws Exception {
     assertThat(properties.getGatewayAddress()).isEqualTo("0.0.0.0:26500");
+  }
+
+  @Test
+  public void hasGrpcAddress() throws Exception {
+    assertThat(properties.getGrpcAddress().toString()).isEqualTo("https://0.0.0.0:26500");
+  }
+
+  @Test
+  public void hasRestAddress() throws Exception {
+    assertThat(properties.getRestAddress().toString()).isEqualTo("https://0.0.0.0:8080");
   }
 
   @Test

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -55,67 +55,67 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   @Autowired private JsonMapper jsonMapper;
 
   @Test
-  public void hasDeprecatedGatewayAddress() throws Exception {
+  public void hasDeprecatedGatewayAddress() {
     assertThat(properties.getGatewayAddress()).isEqualTo("localhost12345");
   }
 
   @Test
-  public void hasGrpcAddress() throws Exception {
+  public void hasGrpcAddress() {
     assertThat(properties.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
   }
 
   @Test
-  public void hasRestAddress() throws Exception {
+  public void hasRestAddress() {
     assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8080");
   }
 
   @Test
-  public void hasRequestTimeout() throws Exception {
+  public void hasRequestTimeout() {
     assertThat(properties.getRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
-  public void hasWorkerName() throws Exception {
+  public void hasWorkerName() {
     assertThat(properties.getDefaultJobWorkerName()).isEqualTo("testName");
   }
 
   @Test
-  public void hasWorkerType() throws Exception {
+  public void hasWorkerType() {
     assertThat(properties.getDefaultJobWorkerType()).isEqualTo("testType");
   }
 
   @Test
-  public void hasJobTimeout() throws Exception {
+  public void hasJobTimeout() {
     assertThat(properties.getJob().getTimeout()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
-  public void hasWorkerMaxJobsActive() throws Exception {
+  public void hasWorkerMaxJobsActive() {
     assertThat(properties.getWorker().getMaxJobsActive()).isEqualTo(99);
   }
 
   @Test
-  public void hasJobPollInterval() throws Exception {
+  public void hasJobPollInterval() {
     assertThat(properties.getJob().getPollInterval()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
-  public void hasWorkerThreads() throws Exception {
+  public void hasWorkerThreads() {
     assertThat(properties.getWorker().getThreads()).isEqualTo(99);
   }
 
   @Test
-  public void hasMessageTimeToLeave() throws Exception {
+  public void hasMessageTimeToLeave() {
     assertThat(properties.getMessage().getTimeToLive()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
-  public void isSecurityPlainTextDisabled() throws Exception {
+  public void isSecurityPlainTextDisabled() {
     assertThat(properties.getSecurity().isPlaintext()).isTrue();
   }
 
   @Test
-  public void hasSecurityCertificatePath() throws Exception {
+  public void hasSecurityCertificatePath() {
     assertThat(properties.getSecurity().getCertPath()).isEqualTo("aPath");
   }
 

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -34,6 +34,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @TestPropertySource(
     properties = {
       "zeebe.client.broker.gatewayAddress=localhost12345",
+      "zeebe.client.broker.grpcAddress=https://localhost:1234",
+      "zeebe.client.broker.restAddress=https://localhost:8080",
       "zeebe.client.requestTimeout=99s",
       "zeebe.client.job.timeout=99s",
       "zeebe.client.job.pollInterval=99s",
@@ -53,8 +55,18 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   @Autowired private JsonMapper jsonMapper;
 
   @Test
-  public void hasBrokerContactPoint() throws Exception {
+  public void hasDeprecatedGatewayAddress() throws Exception {
     assertThat(properties.getGatewayAddress()).isEqualTo("localhost12345");
+  }
+
+  @Test
+  public void hasGrpcAddress() throws Exception {
+    assertThat(properties.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
+  }
+
+  @Test
+  public void hasRestAddress() throws Exception {
+    assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8080");
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds new grpcAddress and restAddress support to the Camunda Spring SDK.

The cloud endpoint config is based off the different URI as described [here](https://camunda.slack.com/archives/C069H0BDB3R/p1710922836223999).

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #17073
