### PR TITLE
build: jdk 17 support for camunda spring sdk

### DIFF
--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -35,6 +35,7 @@
   </licenses>
 
   <properties>
+    <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
   </properties>
 

--- a/zeebe/clients/zeebe-client-spring/pom.xml
+++ b/zeebe/clients/zeebe-client-spring/pom.xml
@@ -33,8 +33,7 @@
   </licenses>
 
   <properties>
-    <version.spring-aop>6.1.5</version.spring-aop>
-    <version.commons-beanutils>1.9.4</version.commons-beanutils>
+    <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
   </properties>
 

--- a/zeebe/clients/zeebe-client-spring/pom.xml
+++ b/zeebe/clients/zeebe-client-spring/pom.xml
@@ -34,6 +34,7 @@
 
   <properties>
     <version.java>17</version.java>
+    <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
   </properties>
 
@@ -75,7 +76,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>6.1.5</version>
+      <version>${version.spring}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -105,7 +106,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.4</version>
+      <version>${version.commons-beanutils}</version>
       <exclusions>
         <exclusion>
           <groupId>commons-collections</groupId>


### PR DESCRIPTION
## Description

Sets java level to 17 to allow the sdk to be used on JDK >=17.

## Related issues

closes #17077
