### PR TITLE
Fix context path set up for management health routes

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerHealthRoutes.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerHealthRoutes.java
@@ -9,8 +9,10 @@ package io.camunda.zeebe.broker.health;
 
 import io.camunda.zeebe.shared.management.ConditionalOnManagementContext;
 import java.net.URI;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextType;
+import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
@@ -24,12 +26,20 @@ import reactor.core.publisher.Mono;
 @ManagementContextConfiguration(value = ManagementContextType.ANY, proxyBeanMethods = false)
 public class BrokerHealthRoutes {
 
+  private final ManagementServerProperties properties;
+
+  @Autowired
+  public BrokerHealthRoutes(final ManagementServerProperties properties) {
+    this.properties = properties;
+  }
+
   @Bean
   public RouterFunction<ServerResponse> routes() {
+    final String basePath = properties.getBasePath();
     return RouterFunctions.route()
-        .GET("/health", req -> movedPermanently("/actuator/health/status"))
-        .GET("/ready", req -> movedPermanently("/actuator/health/readiness"))
-        .GET("/startup", req -> movedPermanently("/actuator/health/startup"))
+        .GET("/health", req -> movedPermanently(basePath + "/actuator/health/status"))
+        .GET("/ready", req -> movedPermanently(basePath + "/actuator/health/readiness"))
+        .GET("/startup", req -> movedPermanently(basePath + "/actuator/health/startup"))
         .build();
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerHealthRoutes.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerHealthRoutes.java
@@ -8,8 +8,8 @@
 package io.camunda.zeebe.broker.health;
 
 import io.camunda.zeebe.shared.management.ConditionalOnManagementContext;
-import java.net.URI;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration;
 import org.springframework.boot.actuate.autoconfigure.web.ManagementContextType;
 import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServerProperties;
@@ -19,6 +19,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.reactive.function.server.RouterFunction;
 import org.springframework.web.reactive.function.server.RouterFunctions;
 import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.util.DefaultUriBuilderFactory;
+import org.springframework.web.util.UriBuilderFactory;
 import reactor.core.publisher.Mono;
 
 @Profile("broker")
@@ -26,24 +28,41 @@ import reactor.core.publisher.Mono;
 @ManagementContextConfiguration(value = ManagementContextType.ANY, proxyBeanMethods = false)
 public class BrokerHealthRoutes {
 
-  private final ManagementServerProperties properties;
+  private final UriBuilderFactory uriBuilderFactory = new DefaultUriBuilderFactory();
+
+  private final ManagementServerProperties serverProperties;
+  private final WebEndpointProperties actuatorProperties;
 
   @Autowired
-  public BrokerHealthRoutes(final ManagementServerProperties properties) {
-    this.properties = properties;
+  public BrokerHealthRoutes(
+      final ManagementServerProperties serverProperties,
+      final WebEndpointProperties actuatorProperties) {
+    this.serverProperties = serverProperties;
+    this.actuatorProperties = actuatorProperties;
   }
 
   @Bean
   public RouterFunction<ServerResponse> routes() {
-    final String basePath = properties.getBasePath();
+    final var serverBasePath = serverProperties.getBasePath();
+    final var actuatorBasePath = actuatorProperties.getBasePath();
+
     return RouterFunctions.route()
-        .GET("/health", req -> movedPermanently(basePath + "/actuator/health/status"))
-        .GET("/ready", req -> movedPermanently(basePath + "/actuator/health/readiness"))
-        .GET("/startup", req -> movedPermanently(basePath + "/actuator/health/startup"))
+        .GET("/health", req -> movedPermanently(serverBasePath, actuatorBasePath, "/health/status"))
+        .GET(
+            "/ready",
+            req -> movedPermanently(serverBasePath, actuatorBasePath, "/health/readiness"))
+        .GET(
+            "/startup",
+            req -> movedPermanently(serverBasePath, actuatorBasePath, "/health/startup"))
         .build();
   }
 
-  private Mono<ServerResponse> movedPermanently(final String path) {
-    return ServerResponse.status(HttpStatus.MOVED_PERMANENTLY).location(URI.create(path)).build();
+  private Mono<ServerResponse> movedPermanently(final String... paths) {
+    final var builder = uriBuilderFactory.builder();
+    for (final var path : paths) {
+      builder.path(path);
+    }
+
+    return ServerResponse.status(HttpStatus.MOVED_PERMANENTLY).location(builder.build()).build();
   }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -93,7 +93,7 @@ public class HttpClientFactory {
 
   private URI buildGatewayAddress() {
     try {
-      final URIBuilder builder = new URIBuilder(config.getRestAddress()).setPath(REST_API_PATH);
+      final URIBuilder builder = new URIBuilder(config.getRestAddress()).appendPath(REST_API_PATH);
       builder.setScheme(config.isPlaintextConnectionEnabled() ? "http" : "https");
 
       return builder.build();

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -92,8 +92,16 @@ public class HttpClientFactory {
   }
 
   private URI buildGatewayAddress() {
+    String basePath = config.getRestAddress().toString();
+
+    // we need to strip the last / otherwise we'll have an empty path segment which Spring
+    // interprets as a different route
+    if (basePath.endsWith("/")) {
+      basePath = basePath.substring(0, basePath.length() - 1);
+    }
+
     try {
-      final URIBuilder builder = new URIBuilder(config.getRestAddress()).appendPath(REST_API_PATH);
+      final URIBuilder builder = new URIBuilder(basePath).appendPath(REST_API_PATH);
       builder.setScheme(config.isPlaintextConnectionEnabled() ? "http" : "https");
 
       return builder.build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/BackupAcceptance.java
@@ -37,7 +37,7 @@ public interface BackupAcceptance {
   default void shouldTakeBackup() {
     // given
     final TestCluster cluster = getTestCluster();
-    final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
+    final var actuator = BackupActuator.of(cluster.availableGateway());
     try (final var client = cluster.newClientBuilder().build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
@@ -54,7 +54,7 @@ public interface BackupAcceptance {
   default void shouldListBackups() {
     // given
     final TestCluster cluster = getTestCluster();
-    final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
+    final var actuator = BackupActuator.of(cluster.availableGateway());
     try (final var client = cluster.newClientBuilder().build()) {
       client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
     }
@@ -79,7 +79,7 @@ public interface BackupAcceptance {
   default void shouldDeleteBackup() {
     // given
     final TestCluster cluster = getTestCluster();
-    final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
+    final var actuator = BackupActuator.of(cluster.availableGateway());
     final long backupId = 1;
     actuator.take(backupId);
     waitUntilBackupIsCompleted(actuator, backupId);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/ClusteredBackupRestoreTest.java
@@ -68,7 +68,7 @@ public class ClusteredBackupRestoreTest {
             .build()
             .start()
             .awaitCompleteTopology()) {
-      final var actuator = BackupActuator.ofAddress(cluster.availableGateway().monitoringAddress());
+      final var actuator = BackupActuator.of(cluster.availableGateway());
 
       try (final var client = cluster.newClientBuilder().build()) {
         IntStream.range(0, 30)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
@@ -51,7 +51,7 @@ public interface RestoreAcceptance {
             .withBrokerConfig(this::configureBackupStore)
             .start()
             .awaitCompleteTopology()) {
-      final var actuator = BackupActuator.ofAddress(zeebe.monitoringAddress());
+      final var actuator = BackupActuator.of(zeebe);
 
       try (final var client = zeebe.newClientBuilder().build()) {
         client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -44,7 +44,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringAddress())
+              .setBaseUri(gateway.monitoringUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -79,7 +79,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringAddress())
+              .setBaseUri("http://" + gateway.monitoringUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -124,7 +124,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringAddress())
+              .setBaseUri("http://" + gateway.monitoringUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -139,7 +139,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringAddress())
+              .setBaseUri("http://" + gateway.monitoringUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -173,7 +173,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringAddress())
+              .setBaseUri("http://" + gateway.monitoringUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -27,9 +27,9 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 public class GatewayHealthProbeIntegrationTest {
 
-  private static final String PATH_LIVENESS_PROBE = "/actuator/health/liveness";
-  private static final String PATH_READINESS_PROBE = "/actuator/health/readiness";
-  private static final String PATH_TO_HEALTH_PROBE = "/actuator/health";
+  private static final String PATH_LIVENESS_PROBE = "/health/liveness";
+  private static final String PATH_READINESS_PROBE = "/health/readiness";
+  private static final String PATH_TO_HEALTH_PROBE = "/health";
 
   @Nested
   final class WithBrokerTest {
@@ -44,7 +44,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri(gateway.monitoringUri())
+              .setBaseUri(gateway.actuatorUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -79,7 +79,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringUri())
+              .setBaseUri(gateway.actuatorUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -124,7 +124,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringUri())
+              .setBaseUri(gateway.actuatorUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -139,7 +139,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringUri())
+              .setBaseUri(gateway.actuatorUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();
@@ -173,7 +173,7 @@ public class GatewayHealthProbeIntegrationTest {
       final var gatewayServerSpec =
           new RequestSpecBuilder()
               .setContentType(ContentType.JSON)
-              .setBaseUri("http://" + gateway.monitoringUri())
+              .setBaseUri(gateway.actuatorUri())
               .addFilter(new ResponseLoggingFilter())
               .addFilter(new RequestLoggingFilter())
               .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/BrokerMonitoringEndpointTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/health/BrokerMonitoringEndpointTest.java
@@ -11,6 +11,7 @@ import static io.restassured.RestAssured.given;
 import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.restassured.builder.RequestSpecBuilder;
@@ -26,14 +27,18 @@ import org.junit.jupiter.api.Test;
 public final class BrokerMonitoringEndpointTest {
 
   static RequestSpecification brokerServerSpec;
-  @TestZeebe private static final TestStandaloneBroker BROKER = new TestStandaloneBroker();
+
+  @TestZeebe
+  private static final TestStandaloneBroker BROKER =
+      new TestStandaloneBroker().withProperty("management.server.base-path", "/foo");
 
   @BeforeAll
   static void setUpClass() {
     brokerServerSpec =
         new RequestSpecBuilder()
             .setContentType(ContentType.TEXT)
-            .setBaseUri("http://" + BROKER.monitoringAddress())
+            // set URL explicitly since we want to ensure the mapping is correct
+            .setBaseUri("http://localhost:" + BROKER.mappedPort(TestZeebePort.MONITORING) + "/foo")
             .addFilter(new ResponseLoggingFilter())
             .addFilter(new RequestLoggingFilter())
             .build();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -119,7 +119,7 @@ final class ControlledActorClockEndpointIT {
 
   private Builder buildRequest(final String operation) {
     return HttpRequest.newBuilder(
-            URI.create("http://" + broker.monitoringAddress() + "/actuator/clock/" + operation))
+            URI.create("http://" + broker.monitoringUri() + "/actuator/clock/" + operation))
         .headers("Content-Type", "application/json", "Accept", "application/json");
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ControlledActorClockEndpointIT.java
@@ -26,7 +26,6 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
-import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -118,8 +117,7 @@ final class ControlledActorClockEndpointIT {
   }
 
   private Builder buildRequest(final String operation) {
-    return HttpRequest.newBuilder(
-            URI.create("http://" + broker.monitoringUri() + "/actuator/clock/" + operation))
+    return HttpRequest.newBuilder(broker.actuatorUri("clock", operation))
         .headers("Content-Type", "application/json", "Accept", "application/json");
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
@@ -21,16 +21,19 @@ import org.junit.jupiter.api.Test;
 @ZeebeIntegration
 public final class RestAPIContextPathIT {
   @TestZeebe
-  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withProperty("spring.webflux.base-path", "/zeebe");
+  private final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker().withProperty("spring.webflux.base-path", "/zeebe");
 
   @Test
   void shouldConnectWithContextPath() {
     // given
     //noinspection resource
-    final var client = zeebe.newClientBuilder()
-        .preferRestOverGrpc(true)
-        .restAddress(zeebe.uri("http", TestZeebePort.REST, "zeebe"))
-        .build();
+    final var client =
+        zeebe
+            .newClientBuilder()
+            .preferRestOverGrpc(true)
+            .restAddress(zeebe.uri("http", TestZeebePort.REST, "zeebe"))
+            .build();
 
     // when
     final Future<Topology> topology = client.newTopologyRequest().send();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.startup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.cluster.TestZeebePort;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public final class RestAPIContextPathIT {
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withProperty("spring.webflux.base-path", "/zeebe");
+
+  @Test
+  void shouldConnectWithContextPath() {
+    // given
+    //noinspection resource
+    final var client = zeebe.newClientBuilder()
+        .preferRestOverGrpc(true)
+        .restAddress(zeebe.uri("http", TestZeebePort.REST, "zeebe"))
+        .build();
+
+    // when
+    final Future<Topology> topology = client.newTopologyRequest().send();
+
+    // then
+    assertThat(topology).succeedsWithin(Duration.ofSeconds(10));
+  }
+}

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -173,5 +173,10 @@
       <artifactId>swagger-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+
   </dependencies>
 </project>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BackupActuator.java
@@ -71,8 +71,7 @@ public interface BackupActuator {
    * @return a new instance of {@link BackupActuator}
    */
   static BackupActuator of(final TestApplication<?> node) {
-    final var endpoint = String.format("http://%s/actuator/backups", node.monitoringAddress());
-    return of(endpoint);
+    return of(node.actuatorUri("backups").toString());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BanningActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BanningActuator.java
@@ -26,8 +26,7 @@ public interface BanningActuator {
   }
 
   static BanningActuator of(final TestApplication<?> node) {
-    final var endpoint = String.format("http://%s/actuator/banning", node.monitoringAddress());
-    return of(endpoint);
+    return of(node.actuatorUri("banning").toString());
   }
 
   static BanningActuator of(final String endpoint) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BrokerHealthActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BrokerHealthActuator.java
@@ -45,7 +45,7 @@ public interface BrokerHealthActuator extends HealthActuator {
    * @return a new instance of {@link BrokerHealthActuator}
    */
   static BrokerHealthActuator of(final TestStandaloneBroker node) {
-    return of(node.monitoringAddress());
+    return of(node.monitoringUri().toString());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BrokerHealthActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/BrokerHealthActuator.java
@@ -15,6 +15,7 @@ import feign.Retryer;
 import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.zeebe.containers.ZeebeNode;
 import java.util.List;
 
@@ -33,17 +34,18 @@ public interface BrokerHealthActuator extends HealthActuator {
    * @return a new instance of {@link BrokerHealthActuator}
    */
   static BrokerHealthActuator of(final ZeebeNode<?> node) {
-    return ofAddress(node.getExternalMonitoringAddress());
+    final String address = node.getExternalMonitoringAddress();
+    return of("http://" + address);
   }
 
   /**
-   * Returns a {@link BrokerHealthActuator} instance using the given base monitoring address.
+   * Returns a {@link BrokerHealthActuator} instance using the given node as upstream.
    *
-   * @param address the base monitoring address
+   * @param node the node to connect to
    * @return a new instance of {@link BrokerHealthActuator}
    */
-  static BrokerHealthActuator ofAddress(final String address) {
-    return of("http://" + address);
+  static BrokerHealthActuator of(final TestStandaloneBroker node) {
+    return of(node.monitoringAddress());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ClusterActuator.java
@@ -44,7 +44,7 @@ public interface ClusterActuator {
    * @return a new instance of {@link ClusterActuator}
    */
   static ClusterActuator of(final TestApplication<?> node) {
-    return ofAddress(node.monitoringAddress());
+    return of(node.actuatorUri("cluster").toString());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
@@ -25,8 +25,7 @@ public interface ExportingActuator {
   }
 
   static ExportingActuator of(final TestApplication<?> node) {
-    final var endpoint = String.format("http://%s/actuator/exporting", node.monitoringAddress());
-    return of(endpoint);
+    return of(node.actuatorUri("exporting").toString());
   }
 
   static ExportingActuator of(final String endpoint) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/GatewayHealthActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/GatewayHealthActuator.java
@@ -15,6 +15,7 @@ import feign.Retryer;
 import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.qa.util.cluster.TestGateway;
 import io.zeebe.containers.ZeebeNode;
 import java.util.List;
 
@@ -33,17 +34,18 @@ public interface GatewayHealthActuator extends HealthActuator {
    * @return a new instance of {@link GatewayHealthActuator}
    */
   static GatewayHealthActuator of(final ZeebeNode<?> node) {
-    return ofAddress(node.getExternalMonitoringAddress());
+    final String address = node.getExternalMonitoringAddress();
+    return of("http://" + address);
   }
 
   /**
-   * Returns a {@link GatewayHealthActuator} instance using the given base monitoring address.
+   * Returns a {@link GatewayHealthActuator} instance using the given node as upstream.
    *
-   * @param address the base monitoring address
+   * @param node the node to connect to
    * @return a new instance of {@link GatewayHealthActuator}
    */
-  static GatewayHealthActuator ofAddress(final String address) {
-    return of("http://" + address);
+  static GatewayHealthActuator of(final TestGateway<?> node) {
+    return of(node.monitoringAddress());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/GatewayHealthActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/GatewayHealthActuator.java
@@ -35,7 +35,7 @@ public interface GatewayHealthActuator extends HealthActuator {
    */
   static GatewayHealthActuator of(final ZeebeNode<?> node) {
     final String address = node.getExternalMonitoringAddress();
-    return of("http://" + address);
+    return of("http://" + address + "/actuator/health");
   }
 
   /**
@@ -45,7 +45,7 @@ public interface GatewayHealthActuator extends HealthActuator {
    * @return a new instance of {@link GatewayHealthActuator}
    */
   static GatewayHealthActuator of(final TestGateway<?> node) {
-    return of(node.monitoringAddress());
+    return of(node.actuatorUri("health").toString());
   }
 
   /**
@@ -68,14 +68,14 @@ public interface GatewayHealthActuator extends HealthActuator {
   }
 
   @Override
-  @RequestLine("GET /actuator/health")
+  @RequestLine("GET /")
   void ready();
 
   @Override
-  @RequestLine("GET /actuator/health/startup")
+  @RequestLine("GET /startup")
   void startup();
 
   @Override
-  @RequestLine("GET /actuator/health/liveness")
+  @RequestLine("GET /liveness")
   void live();
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/JobStreamActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/JobStreamActuator.java
@@ -50,8 +50,7 @@ public interface JobStreamActuator {
    * @return a new instance of {@link JobStreamActuator}
    */
   static JobStreamActuator of(final TestApplication<?> node) {
-    final var endpoint = String.format("http://%s/actuator/jobstreams", node.monitoringAddress());
-    return of(endpoint);
+    return of(node.actuatorUri("jobstreams").toString());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/LoggersActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/LoggersActuator.java
@@ -55,8 +55,7 @@ public interface LoggersActuator {
    * @return a new instance of {@link LoggersActuator}
    */
   static LoggersActuator of(final TestApplication<?> node) {
-    final var endpoint = String.format("http://%s/actuator/loggers", node.monitoringAddress());
-    return of(endpoint);
+    return of(node.actuatorUri("loggers").toString());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -58,8 +58,7 @@ public interface PartitionsActuator {
    * @return a new instance of {@link PartitionsActuator}
    */
   static PartitionsActuator of(final TestStandaloneBroker node) {
-    final var endpoint = String.format("http://%s/actuator/partitions", node.monitoringAddress());
-    return of(endpoint);
+    return of(node.actuatorUri("partitions").toString());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/RebalanceActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/RebalanceActuator.java
@@ -50,8 +50,7 @@ public interface RebalanceActuator {
    * @return a new instance of {@link RebalanceActuator}
    */
   static RebalanceActuator of(final TestApplication<?> node) {
-    final var endpoint = String.format("http://%s/actuator/rebalance", node.monitoringAddress());
-    return of(endpoint);
+    return of(node.actuatorUri("rebalance").toString());
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestApplication.java
@@ -114,7 +114,8 @@ public interface TestApplication<T extends TestApplication<T>> extends AutoClose
    * @param port the target port
    * @return externally accessible address for {@code port}
    */
-  default URI uri(final String scheme, final TestZeebePort port, final SequencedCollection<String> paths) {
+  default URI uri(
+      final String scheme, final TestZeebePort port, final SequencedCollection<String> paths) {
     try {
       final var path =
           paths.stream()
@@ -138,7 +139,10 @@ public interface TestApplication<T extends TestApplication<T>> extends AutoClose
   default URI monitoringUri(final String... paths) {
     final var serverBasePath = property("management.server.base-path", String.class, "");
     final var sslEnabled = property("management.server.ssl.enabled", Boolean.class, false);
-    return uri(sslEnabled ? "https" : "http", TestZeebePort.MONITORING, ObjectArrays.concat(serverBasePath, paths));
+    return uri(
+        sslEnabled ? "https" : "http",
+        TestZeebePort.MONITORING,
+        ObjectArrays.concat(serverBasePath, paths));
   }
 
   /**
@@ -149,7 +153,8 @@ public interface TestApplication<T extends TestApplication<T>> extends AutoClose
    * @return the external actuator address
    */
   default URI actuatorUri(final String... paths) {
-    final var actuatorBasePath = property("management.endpoints.web.base-path", String.class, "/actuator");
+    final var actuatorBasePath =
+        property("management.endpoints.web.base-path", String.class, "/actuator");
     return monitoringUri(ObjectArrays.concat(actuatorBasePath, paths));
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -96,7 +96,8 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
     final var builder =
         ZeebeClient.newClientBuilder().grpcAddress(grpcAddress()).restAddress(restAddress());
     final var security = gatewayConfig().getSecurity();
-    if (security.isEnabled()) {
+    final var restSSL = property("server.ssl.enabled", Boolean.class, false);
+    if (security.isEnabled() || restSSL) {
       builder.caCertificatePath(security.getCertificateChainPath().getAbsolutePath());
     } else {
       builder.usePlaintext();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -41,7 +41,7 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
    */
   default URI grpcAddress() {
     final var scheme = gatewayConfig().getSecurity().isEnabled() ? "https" : "http";
-    return parsedAddress(scheme, TestZeebePort.GATEWAY);
+    return uri(scheme, TestZeebePort.GATEWAY);
   }
 
   /**
@@ -61,7 +61,7 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
   default URI restAddress() {
     final var basePath = property("spring.webflux.base-path", String.class, "");
     final var sslEnabled = property("server.ssl.enabled", Boolean.class, false);
-    return parsedAddress(sslEnabled ? "https" : "http", TestZeebePort.REST, basePath);
+    return uri(sslEnabled ? "https" : "http", TestZeebePort.REST, basePath);
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -128,6 +128,16 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
   }
 
   @Override
+  public <V> V property(final String property, final Class<V> type, final V fallback) {
+    if (springContext == null) {
+      //noinspection unchecked
+      return (V) propertyOverrides.getOrDefault(property, fallback);
+    }
+
+    return springContext.getEnvironment().getProperty(property, type, fallback);
+  }
+
+  @Override
   public T withProperty(final String key, final Object value) {
     propertyOverrides.put(key, value);
     return self();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -63,6 +63,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     };
   }
 
+  @Override
   protected SpringApplicationBuilder createSpringBuilder() {
     // because @ConditionalOnRestGatewayEnabled relies on the zeebe.broker.gateway.enable property,
     // we need to hook in at the last minute and set the property as it won't resolve from the
@@ -151,7 +152,7 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
    * and startup.
    */
   public BrokerHealthActuator brokerHealth() {
-    return BrokerHealthActuator.ofAddress(monitoringAddress());
+    return BrokerHealthActuator.of(this);
   }
 
   /**

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneGateway.java
@@ -11,8 +11,6 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.gateway.GatewayConfiguration.GatewayProperties;
 import io.camunda.zeebe.gateway.StandaloneGateway;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
-import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
-import io.camunda.zeebe.qa.util.actuator.HealthActuator;
 import io.camunda.zeebe.shared.Profile;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.util.function.Consumer;
@@ -47,11 +45,6 @@ public final class TestStandaloneGateway extends TestSpringApplication<TestStand
   @Override
   public String host() {
     return config.getNetwork().getHost();
-  }
-
-  @Override
-  public HealthActuator healthActuator() {
-    return GatewayHealthActuator.ofAddress(monitoringAddress());
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR fixes deployments where a context path is set for the management context with the deprecated redirect routes. At the same time, it adds support to our test infrastructure and tests to verify this works as expected.

This is useful in the future as context path deployments are an important feature for the Helm charts, and include not only the main server but also the management server.

## Related issues

related to camunda/camunda-platform-helm#1392

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
