### PR TITLE
feat: support sub process mapping in instance migration mode

### DIFF
--- a/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
@@ -1,0 +1,146 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.21.0">
+  <bpmn:process id="orderProcess" name="Order process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Order received">
+      <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="checkPayment" />
+    <bpmn:serviceTask id="checkPayment" name="Check payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="checkPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0j6tsnn</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1q6ade7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="EndEvent_042s0oc">
+      <bpmn:incoming>Flow_14zxms3</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
+      <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:serviceTask id="requestForPayment" name="Request for payment">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="requestPayment" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shippingSubProcess">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:subProcess id="shippingSubProcess" name="Shipping Sub Process">
+      <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
+      <bpmn:outgoing>Flow_14zxms3</bpmn:outgoing>
+      <bpmn:startEvent id="Event_0lv0fih">
+        <bpmn:outgoing>Flow_1iyep4f</bpmn:outgoing>
+      </bpmn:startEvent>
+      <bpmn:userTask id="shipArticles" name="Ship Articles">
+        <bpmn:incoming>Flow_1iyep4f</bpmn:incoming>
+        <bpmn:outgoing>Flow_0n8gs7h</bpmn:outgoing>
+      </bpmn:userTask>
+      <bpmn:endEvent id="Event_0rg692j">
+        <bpmn:incoming>Flow_0n8gs7h</bpmn:incoming>
+      </bpmn:endEvent>
+      <bpmn:sequenceFlow id="Flow_0n8gs7h" sourceRef="shipArticles" targetRef="Event_0rg692j" />
+      <bpmn:sequenceFlow id="Flow_1iyep4f" sourceRef="Event_0lv0fih" targetRef="shipArticles" />
+    </bpmn:subProcess>
+    <bpmn:sequenceFlow id="Flow_14zxms3" sourceRef="shippingSubProcess" targetRef="EndEvent_042s0oc" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="175" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="157" y="156" width="73" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
+        <dc:Bounds x="300" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="469" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="460" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
+        <dc:Bounds x="444" y="260" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
+        <dc:Bounds x="1032" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="385" y="270" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0zhf45a_di" bpmnElement="shippingSubProcess" isExpanded="true">
+        <dc:Bounds x="610" y="38" width="350" height="200" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0lv0fih_di" bpmnElement="Event_0lv0fih">
+        <dc:Bounds x="650" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08ac618_di" bpmnElement="shipArticles">
+        <dc:Bounds x="740" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0rg692j_di" bpmnElement="Event_0rg692j">
+        <dc:Bounds x="892" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1iyep4f_di" bpmnElement="Flow_1iyep4f">
+        <di:waypoint x="686" y="138" />
+        <di:waypoint x="740" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n8gs7h_di" bpmnElement="Flow_0n8gs7h">
+        <di:waypoint x="840" y="138" />
+        <di:waypoint x="892" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
+        <di:waypoint x="211" y="138" />
+        <di:waypoint x="300" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="-169.5" y="227" width="90" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s6g17c_di" bpmnElement="SequenceFlow_1s6g17c">
+        <di:waypoint x="400" y="138" />
+        <di:waypoint x="469" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="54.5" y="227" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jzbqu1_di" bpmnElement="SequenceFlow_0jzbqu1">
+        <di:waypoint x="494" y="163" />
+        <di:waypoint x="494" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="450" y="188" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1q6ade7_di" bpmnElement="SequenceFlow_1q6ade7">
+        <di:waypoint x="444" y="300" />
+        <di:waypoint x="350" y="300" />
+        <di:waypoint x="350" y="178" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="17" y="389" width="0" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dq2rqw_di" bpmnElement="SequenceFlow_1dq2rqw">
+        <di:waypoint x="519" y="138" />
+        <di:waypoint x="610" y="138" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="554" y="117" width="21" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14zxms3_di" bpmnElement="Flow_14zxms3">
+        <di:waypoint x="960" y="138" />
+        <di:waypoint x="1032" y="138" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
@@ -26,7 +26,7 @@ describe('stores/processXml/processXml.list', () => {
   });
 
   it('should filter selectable flow nodes', async () => {
-    mockFetchProcessXML().withSuccess(open('orderProcess.bpmn'));
+    mockFetchProcessXML().withSuccess(open('instanceMigration.bpmn'));
 
     processXmlStore.fetchProcessXml('1');
     expect(processXmlStore.state.status).toBe('fetching');
@@ -34,6 +34,11 @@ describe('stores/processXml/processXml.list', () => {
 
     expect(
       processXmlStore.selectableFlowNodes.map((flowNode) => flowNode.id),
-    ).toEqual(['checkPayment', 'requestForPayment', 'shipArticles']);
+    ).toEqual([
+      'checkPayment',
+      'requestForPayment',
+      'shippingSubProcess',
+      'shipArticles',
+    ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.ts
@@ -32,7 +32,11 @@ class ProcessesXml extends ProcessXmlBase {
   get selectableFlowNodes() {
     return super.selectableFlowNodes
       .filter((flowNode) => {
-        return ['bpmn:ServiceTask', 'bpmn:UserTask'].includes(flowNode.$type);
+        return [
+          'bpmn:ServiceTask',
+          'bpmn:UserTask',
+          'bpmn:SubProcess',
+        ].includes(flowNode.$type);
       })
       .map((flowNode) => {
         return {...flowNode, name: flowNode.name ?? flowNode.id};

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
@@ -26,7 +26,7 @@ describe('stores/processXml/processXml.list', () => {
   });
 
   it('should filter selectable flow nodes', async () => {
-    mockFetchProcessXML().withSuccess(open('orderProcess.bpmn'));
+    mockFetchProcessXML().withSuccess(open('instanceMigration.bpmn'));
 
     processXmlStore.fetchProcessXml('1');
     expect(processXmlStore.state.status).toBe('fetching');
@@ -34,6 +34,11 @@ describe('stores/processXml/processXml.list', () => {
 
     expect(
       processXmlStore.selectableFlowNodes.map((flowNode) => flowNode.id),
-    ).toEqual(['checkPayment', 'requestForPayment', 'shipArticles']);
+    ).toEqual([
+      'checkPayment',
+      'requestForPayment',
+      'shippingSubProcess',
+      'shipArticles',
+    ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.ts
@@ -30,7 +30,11 @@ class ProcessesXml extends ProcessXmlBase {
   get selectableFlowNodes() {
     return super.selectableFlowNodes
       .filter((flowNode) => {
-        return ['bpmn:ServiceTask', 'bpmn:UserTask'].includes(flowNode.$type);
+        return [
+          'bpmn:ServiceTask',
+          'bpmn:UserTask',
+          'bpmn:SubProcess',
+        ].includes(flowNode.$type);
       })
       .map((flowNode) => {
         return {...flowNode, name: flowNode.name ?? flowNode.id};


### PR DESCRIPTION
## Description

Add support for mapping sub processes in instance migration mode in Operate UI

- add sub processes to selectable flow nodes in processXml.migration.source store
- add sub processes to selectable flow nodes in processXml.migration.target store
- The constraint to allow mapping to the same element type already exists
- Add tests to ensure constraints are respected

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #17120 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
