### PR TITLE
feat: open links to other C8 apps in the same tab

### DIFF
--- a/operate/client/src/App/Layout/AppHeader/index.tsx
+++ b/operate/client/src/App/Layout/AppHeader/index.tsx
@@ -161,7 +161,6 @@ const AppHeader: React.FC = observer(() => {
                 key: appName,
                 label: capitalize(appName),
                 href: c8Links[appName],
-                target: '_blank',
                 active: appName === 'operate',
                 routeProps:
                   appName === 'operate' ? {to: Paths.dashboard()} : undefined,

--- a/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
@@ -70,23 +70,27 @@ describe('App switcher', () => {
       }),
     );
 
-    expect(
-      await withinAppPanel.findByRole('link', {name: 'Console'}),
-    ).toHaveAttribute('href', 'https://link-to-console');
-    expect(withinAppPanel.getByRole('link', {name: 'Modeler'})).toHaveAttribute(
-      'href',
-      'https://link-to-modeler',
-    );
-    expect(
-      withinAppPanel.getByRole('link', {name: 'Tasklist'}),
-    ).toHaveAttribute('href', 'https://link-to-tasklist');
-    expect(withinAppPanel.getByRole('link', {name: 'Operate'})).toHaveAttribute(
-      'href',
-      '/',
-    );
-    expect(
-      withinAppPanel.getByRole('link', {name: 'Optimize'}),
-    ).toHaveAttribute('href', 'https://link-to-optimize');
+    const consoleLink = await withinAppPanel.findByRole('link', {
+      name: 'Console',
+    });
+    expect(consoleLink).toHaveAttribute('href', 'https://link-to-console');
+    expect(consoleLink).not.toHaveAttribute('target');
+
+    const modelerLink = withinAppPanel.getByRole('link', {name: 'Modeler'});
+    expect(modelerLink).toHaveAttribute('href', 'https://link-to-modeler');
+    expect(modelerLink).not.toHaveAttribute('target');
+
+    const tasklistLink = withinAppPanel.getByRole('link', {name: 'Tasklist'});
+    expect(tasklistLink).toHaveAttribute('href', 'https://link-to-tasklist');
+    expect(tasklistLink).not.toHaveAttribute('target');
+
+    const operateLink = withinAppPanel.getByRole('link', {name: 'Operate'});
+    expect(operateLink).toHaveAttribute('href', '/');
+    expect(operateLink).not.toHaveAttribute('target');
+
+    const optimizeLink = withinAppPanel.getByRole('link', {name: 'Optimize'});
+    expect(optimizeLink).toHaveAttribute('href', 'https://link-to-optimize');
+    expect(optimizeLink).not.toHaveAttribute('target');
   });
 
   it('should not render links for CCSM', async () => {


### PR DESCRIPTION
## Description

- Remove target=_blank from the app switcher of the app header component
- update tests

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #17122 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [x] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
