### PR TITLE
fix: sort memberId based on integer value

### DIFF
--- a/zeebe/topology/src/main/java/io/camunda/zeebe/topology/util/RoundRobinPartitionDistributor.java
+++ b/zeebe/topology/src/main/java/io/camunda/zeebe/topology/util/RoundRobinPartitionDistributor.java
@@ -13,7 +13,7 @@ import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.topology.PartitionDistributor;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +45,9 @@ public final class RoundRobinPartitionDistributor implements PartitionDistributo
       final List<PartitionId> sortedPartitionIds,
       final int replicationFactor) {
     final List<MemberId> sorted = new ArrayList<>(clusterMembers);
-    Collections.sort(sorted);
+    // We know that the memberIds are always integer. Sort it based on the integer value instead of
+    // string.
+    sorted.sort(Comparator.comparing(m -> Integer.parseInt(m.id())));
 
     final int length = sorted.size();
     final int count = Math.min(replicationFactor, length);

--- a/zeebe/topology/src/test/java/io/camunda/zeebe/topology/util/RandomizedRoundRobinDistribution2RegionTest.java
+++ b/zeebe/topology/src/test/java/io/camunda/zeebe/topology/util/RandomizedRoundRobinDistribution2RegionTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.topology.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.atomix.primitive.partition.PartitionId;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import net.jqwik.api.ForAll;
+import net.jqwik.api.Property;
+import net.jqwik.api.constraints.IntRange;
+
+public class RandomizedRoundRobinDistribution2RegionTest {
+
+  @Property(tries = 10)
+  void shouldDistributedPartitionsEquallyIn2Regions(
+      @ForAll @IntRange(min = 2, max = 100) final int clusterSizeFactor,
+      @ForAll @IntRange(min = 1, max = 200) final int partitionCount) {
+    // cluster size should be always multiple of 2 for a 2-region deployment
+    final var clusterSize = 2 * clusterSizeFactor;
+    allPartitionHaveTwoReplicasInEachRegion(clusterSize, partitionCount);
+  }
+
+  void allPartitionHaveTwoReplicasInEachRegion(final int clusterSize, final int partitionCount) {
+    final int replicationFactor = 4;
+
+    final var partitionMetadata =
+        new RoundRobinPartitionDistributor()
+            .distributePartitions(
+                getMembers(clusterSize), getSortedPartitionIds(partitionCount), replicationFactor);
+
+    for (final var p : partitionMetadata) {
+      final var members = p.members().stream().map(m -> Integer.parseInt(m.id())).toList();
+      assertThat(members.stream().filter(i -> i % 2 == 0).count())
+          .describedAs("Partition %s has members %s", p.id(), members)
+          .isEqualTo(replicationFactor / 2);
+      assertThat(members.stream().filter(i -> i % 2 == 1).count())
+          .describedAs("Partition %s has members %s", p.id(), members)
+          .isEqualTo(replicationFactor / 2);
+    }
+  }
+
+  private Set<MemberId> getMembers(final int nodeCount) {
+    final Set<MemberId> members = new HashSet<>();
+    for (int i = 0; i < nodeCount; i++) {
+      members.add(MemberId.from(String.valueOf(i)));
+    }
+    return members;
+  }
+
+  private List<PartitionId> getSortedPartitionIds(final int partitionCount) {
+    final List<PartitionId> partitionIds = new ArrayList<>(partitionCount);
+    for (int i = 1; i <= partitionCount; i++) {
+      partitionIds.add(PartitionId.from("test", i));
+    }
+    return partitionIds;
+  }
+}


### PR DESCRIPTION
## Description

When members are sorted based on string id, the partition distribution may not be as expected in a multi-region deployment. We expect that a partition is distributed to brokers with alternating odd and even ids. But when it is sorted as string, this assumption is violated. This is a problem when clusterSize > 20 because until then even if the order is different, the sorted ids alternate between odd and even :  0,1,10,11,12,13,14,15,16,17,18,19,2,3,4,5,6,7,8,9.

This PR changes the Round Robin distribution logic to use member Ids sorted based on the integer values. The partition distribution can change if the cluster size is greater than 20. But this is not breaking updates, because from 8.4 we have the cluster topology which persisted the previous distribution. So even if the distribution logic is changed, since the cluster uses the persisted topology, partition distribution remains the same until we call the scale request explicitly.

DO NOT backport this to 8.4 or lower. 

related to #16126 


