### PR TITLE
Fix duplicate timer schedules

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -86,19 +86,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
   }
 
-  private void scheduleInitialExecution() {
-    if (!shouldRescheduleChecker) {
-      return;
-    }
-
-    // ensure that the checker is scheduled only once. No execution is expected, but we want to
-    // cover all edge cases.
-    cancelNextExecution();
-
-    final var task = scheduleService.runDelayed(Duration.ZERO, this::execute);
-    nextExecution = new NextExecution(-1, task);
-  }
-
   /**
    * Calculates the delay for the next run so that it occurs at (or close to) due date. If due date
    * is in the future, the delay will be precise. If due date is in the past, now or in the very
@@ -123,7 +110,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
 
     shouldRescheduleChecker = true;
-    scheduleInitialExecution();
+    schedule(-1);
   }
 
   @Override
@@ -147,7 +134,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onResumed() {
     shouldRescheduleChecker = true;
-    scheduleInitialExecution();
+    schedule(-1);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -57,6 +57,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     // already scheduled. While we try to avoid this, we can't prevent it entirely anyway because
     // cancellation of scheduled executions is best-effort and does not reliably prevent execution.
     nextExecution.set(null);
+
     final long nextDueDate = visitor.apply(taskResultBuilder);
 
     // reschedule the runnable if there are timers left
@@ -72,7 +73,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       return;
     }
     final var replacedExecution =
-        AtomicUtil.update(
+        AtomicUtil.replace(
             nextExecution,
             currentlyScheduled -> {
               if (currentlyScheduled == null

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -14,7 +14,10 @@ import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService.Sc
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import io.camunda.zeebe.util.AtomicUtil;
 import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 public final class DueDateChecker implements StreamProcessorLifecycleAware {
@@ -34,7 +37,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
    * Keeps track of the next execution of the checker. It is set to null when the checker has no
    * need to reschedule itself anymore.
    */
-  private NextExecution nextExecution = null;
+  private AtomicReference<NextExecution> nextExecution = new AtomicReference<>(null);
 
   public DueDateChecker(
       final long timerResolution,
@@ -71,18 +74,23 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       return;
     }
 
-    if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
-      cancelNextExecution();
-      final var delay = calculateDelayForNextRun(dueDate);
-      final var task = scheduleService.runDelayed(delay, this::execute);
-      nextExecution = new NextExecution(dueDate, task);
-    }
-  }
+    final var previouslyScheduled =
+        AtomicUtil.update(
+            nextExecution,
+            currentlyScheduled -> {
+              if (currentlyScheduled == null
+                  || currentlyScheduled.nextDueDate() - dueDate > timerResolution) {
+                final var delay = calculateDelayForNextRun(dueDate);
+                final var task = scheduleService.runDelayed(delay, this::execute);
+                return Optional.of(new NextExecution(dueDate, task));
+              }
+              return Optional.empty();
+            },
+            newlyScheduled -> newlyScheduled.task().cancel());
 
-  private void cancelNextExecution() {
-    if (nextExecution != null) {
-      nextExecution.task().cancel();
-      nextExecution = null;
+    if (previouslyScheduled != null) {
+      // cancel the execution that we just replaced
+      previouslyScheduled.task().cancel();
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -18,8 +18,12 @@ import java.time.Duration;
 import java.util.function.Function;
 
 public final class DueDateChecker implements StreamProcessorLifecycleAware {
-  private ScheduleDelayed scheduleService;
   private final boolean scheduleAsync;
+  private final long timerResolution;
+  private final Function<TaskResultBuilder, Long> visitor;
+  private final TriggerEntitiesTask triggerEntitiesTask = new TriggerEntitiesTask();
+
+  private ScheduleDelayed scheduleService;
 
   /**
    * Indicates whether the checker should reschedule itself. Controlled by the stream processor's
@@ -33,11 +37,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
    */
   private NextExecution nextExecution = null;
 
-  private final long timerResolution;
-
-  private final Function<TaskResultBuilder, Long> visitor;
-  private final TriggerEntitiesTask triggerEntitiesTask;
-
   public DueDateChecker(
       final long timerResolution,
       final boolean scheduleAsync,
@@ -45,7 +44,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     this.timerResolution = timerResolution;
     this.scheduleAsync = scheduleAsync;
     this.visitor = visitor;
-    triggerEntitiesTask = new TriggerEntitiesTask();
   }
 
   public void schedule(final long dueDate) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -48,10 +48,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     // - Otherwise, we don't need to cancel the runnable. It will be rescheduled when it is
     // executed.
 
-    final Duration delay = calculateDelayForNextRun(dueDate);
-
     if (shouldRescheduleChecker) {
       if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
+        final var delay = calculateDelayForNextRun(dueDate);
         final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
         nextExecution = new NextExecution(dueDate, task);
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -34,16 +34,17 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private NextExecution nextExecution = null;
 
   private final long timerResolution;
-  private final Function<TaskResultBuilder, Long> nextDueDateSupplier;
+
+  private final Function<TaskResultBuilder, Long> visitor;
   private final TriggerEntitiesTask triggerEntitiesTask;
 
   public DueDateChecker(
       final long timerResolution,
       final boolean scheduleAsync,
-      final Function<TaskResultBuilder, Long> nextDueDateFunction) {
+      final Function<TaskResultBuilder, Long> visitor) {
     this.timerResolution = timerResolution;
     this.scheduleAsync = scheduleAsync;
-    nextDueDateSupplier = nextDueDateFunction;
+    this.visitor = visitor;
     triggerEntitiesTask = new TriggerEntitiesTask();
   }
 
@@ -148,7 +149,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
       if (shouldRescheduleChecker) {
-        final long nextDueDate = nextDueDateSupplier.apply(taskResultBuilder);
+        final long nextDueDate = visitor.apply(taskResultBuilder);
 
         // reschedule the runnable if there are timers left
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -73,7 +73,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       return;
     }
 
-    final var previouslyScheduled =
+    final var replacedExecution =
         AtomicUtil.update(
             nextExecution,
             currentlyScheduled -> {
@@ -87,9 +87,8 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
             },
             newlyScheduled -> newlyScheduled.task().cancel());
 
-    if (previouslyScheduled != null) {
-      // cancel the execution that we just replaced
-      previouslyScheduled.task().cancel();
+    if (replacedExecution != null) {
+      replacedExecution.task().cancel();
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -21,7 +21,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private final boolean scheduleAsync;
   private final long timerResolution;
   private final Function<TaskResultBuilder, Long> visitor;
-  private final TriggerEntitiesTask triggerEntitiesTask = new TriggerEntitiesTask();
 
   private ScheduleDelayed scheduleService;
 
@@ -46,6 +45,22 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     this.visitor = visitor;
   }
 
+  private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    nextExecution = null;
+
+    if (shouldRescheduleChecker) {
+      final long nextDueDate = visitor.apply(taskResultBuilder);
+
+      // reschedule the runnable if there are timers left
+
+      if (nextDueDate > 0) {
+        schedule(nextDueDate);
+      }
+    }
+
+    return taskResultBuilder.build();
+  }
+
   public void schedule(final long dueDate) {
 
     // We schedule only one runnable for all timers.
@@ -62,7 +77,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
       cancelNextExecution();
       final var delay = calculateDelayForNextRun(dueDate);
-      final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
+      final var task = scheduleService.runDelayed(delay, this::execute);
       nextExecution = new NextExecution(dueDate, task);
     }
   }
@@ -83,7 +98,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     // cover all edge cases.
     cancelNextExecution();
 
-    final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
+    final var task = scheduleService.runDelayed(Duration.ZERO, this::execute);
     nextExecution = new NextExecution(-1, task);
   }
 
@@ -161,25 +176,5 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
      * Task)}
      */
     ScheduledTask runDelayed(final Duration delay, final Task task);
-  }
-
-  private final class TriggerEntitiesTask implements Task {
-
-    @Override
-    public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-      nextExecution = null;
-
-      if (shouldRescheduleChecker) {
-        final long nextDueDate = visitor.apply(taskResultBuilder);
-
-        // reschedule the runnable if there are timers left
-
-        if (nextDueDate > 0) {
-          schedule(nextDueDate);
-        }
-      }
-
-      return taskResultBuilder.build();
-    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -34,11 +34,10 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private boolean shouldRescheduleChecker;
 
   /**
-   * Keeps track of the next execution of the checker. As it's not set to null, it could refer to
-   * the last execution. We can always use its due date to determine whether it is in the past.
+   * Keeps track of the next execution of the checker. Value can be null if there is no scheduled
+   * execution known.
    */
-  private final AtomicReference<NextExecution> nextExecution =
-      new AtomicReference<>(new NextExecution(-1, () -> {}));
+  private final AtomicReference<NextExecution> nextExecution = new AtomicReference<>(null);
 
   public DueDateChecker(
       final long timerResolution,
@@ -50,6 +49,14 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   }
 
   TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+    // There is a benign edge case where we are not supposed to set nextExecution to null here.
+    // If this execution was supposed to be cancelled because an earlier execution was scheduled
+    // instead, nextExecution would hold that earlier execution. We still overwrite it with null and
+    // thus forget that we planned an execution. The next time something is scheduled, we will
+    // observe the null value and thus decide to schedule something new without cancelling what's
+    // already scheduled. While we try to avoid this, we can't prevent it entirely anyway because
+    // cancellation of scheduled executions is best-effort and does not reliably prevent execution.
+    nextExecution.set(null);
     final long nextDueDate = visitor.apply(taskResultBuilder);
 
     // reschedule the runnable if there are timers left
@@ -61,23 +68,14 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   }
 
   public void schedule(final long dueDate) {
-
-    // We schedule only one runnable for all timers.
-    // - The runnable is scheduled when the first timer is scheduled.
-    // - If a new timer is scheduled which should be triggered before the current runnable is
-    // executed then the runnable is canceled and re-scheduled with the new delay.
-    // - Otherwise, we don't need to cancel the runnable. It will be rescheduled when it is
-    // executed.
-
     if (!shouldRescheduleChecker) {
       return;
     }
-
     final var replacedExecution =
         AtomicUtil.update(
             nextExecution,
             currentlyScheduled -> {
-              if (currentlyScheduled.nextDueDate() < ActorClock.currentTimeMillis()
+              if (currentlyScheduled == null
                   || currentlyScheduled.nextDueDate() - dueDate > timerResolution) {
                 final var delay = calculateDelayForNextRun(dueDate);
                 final var task = scheduleService.runDelayed(delay, this::execute);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -167,9 +167,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
         // reschedule the runnable if there are timers left
 
         if (nextDueDate > 0) {
-          final Duration delay = calculateDelayForNextRun(nextDueDate);
-          final var task = scheduleService.runDelayed(delay, this);
-          nextExecution = new NextExecution(nextDueDate, task);
+          schedule(nextDueDate);
         }
       }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -81,9 +81,10 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       return;
     }
 
-    if (nextExecution != null) {
-      return;
-    }
+    // ensure that the checker is scheduled only once. No execution is expected, but we want to
+    // cover all edge cases.
+    cancelNextExecution();
+
     final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
     nextExecution = new NextExecution(-1, task);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -48,12 +48,14 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     // - Otherwise, we don't need to cancel the runnable. It will be rescheduled when it is
     // executed.
 
-    if (shouldRescheduleChecker) {
-      if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
-        final var delay = calculateDelayForNextRun(dueDate);
-        final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
-        nextExecution = new NextExecution(dueDate, task);
-      }
+    if (!shouldRescheduleChecker) {
+      return;
+    }
+
+    if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
+      final var delay = calculateDelayForNextRun(dueDate);
+      final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
+      nextExecution = new NextExecution(dueDate, task);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -45,7 +45,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     this.visitor = visitor;
   }
 
-  private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+  TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     nextExecution = null;
 
     final long nextDueDate = visitor.apply(taskResultBuilder);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -103,8 +103,19 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
 
     shouldRescheduleChecker = true;
-    // check if timers are due after restart
     scheduleInitialExecution();
+  }
+
+  @Override
+  public void onClose() {
+    shouldRescheduleChecker = false;
+    nextExecution = null;
+  }
+
+  @Override
+  public void onFailed() {
+    shouldRescheduleChecker = false;
+    nextExecution = null;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -51,10 +51,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     final Duration delay = calculateDelayForNextRun(dueDate);
 
     if (shouldRescheduleChecker) {
-      if (nextExecution == null) {
-        final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
-        nextExecution = new NextExecution(dueDate, task);
-      } else if (nextExecution.nextDueDate() - dueDate > timerResolution) {
+      if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
         final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
         nextExecution = new NextExecution(dueDate, task);
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -111,6 +111,22 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
   }
 
+  /**
+   * Abstracts over async and sync scheduling methods of {@link
+   * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService}.
+   */
+  @FunctionalInterface
+  interface ScheduleDelayed {
+    /**
+     * Implemented by either {@link
+     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runDelayed(Duration, Task)}
+     * or {@link
+     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runDelayedAsync(Duration,
+     * Task)}
+     */
+    void runDelayed(final Duration delay, final Task task);
+  }
+
   private final class TriggerEntitiesTask implements Task {
 
     @Override
@@ -132,21 +148,5 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       }
       return taskResultBuilder.build();
     }
-  }
-
-  /**
-   * Abstracts over async and sync scheduling methods of {@link
-   * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService}.
-   */
-  @FunctionalInterface
-  interface ScheduleDelayed {
-    /**
-     * Implemented by either {@link
-     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runDelayed(Duration, Task)}
-     * or {@link
-     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runDelayedAsync(Duration,
-     * Task)}
-     */
-    void runDelayed(final Duration delay, final Task task);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -61,12 +61,13 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
   }
 
-  private void scheduleTriggerEntitiesTask() {
+  private void scheduleInitialExecution() {
+    if (nextExecution != null) {
+      return;
+    }
     if (shouldRescheduleChecker) {
       final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
       nextExecution = new NextExecution(-1, task);
-    } else {
-      nextExecution = null;
     }
   }
 
@@ -95,9 +96,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
 
     shouldRescheduleChecker = true;
     // check if timers are due after restart
-    if (nextExecution == null) {
-      scheduleTriggerEntitiesTask();
-    }
+    scheduleInitialExecution();
   }
 
   @Override
@@ -109,9 +108,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onResumed() {
     shouldRescheduleChecker = true;
-    if (nextExecution == null) {
-      scheduleTriggerEntitiesTask();
-    }
+    scheduleInitialExecution();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -48,14 +48,11 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     nextExecution = null;
 
-    if (shouldRescheduleChecker) {
-      final long nextDueDate = visitor.apply(taskResultBuilder);
+    final long nextDueDate = visitor.apply(taskResultBuilder);
 
-      // reschedule the runnable if there are timers left
-
-      if (nextDueDate > 0) {
-        schedule(nextDueDate);
-      }
+    // reschedule the runnable if there are timers left
+    if (nextDueDate > 0) {
+      schedule(nextDueDate);
     }
 
     return taskResultBuilder.build();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -21,8 +21,16 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private ScheduleDelayed scheduleService;
   private final boolean scheduleAsync;
 
+  /**
+   * Indicates whether the checker should reschedule itself. Controlled by the stream processor's
+   * lifecycle events, e.g. {@link #onPaused()} and {@link #onResumed()}.
+   */
   private boolean shouldRescheduleChecker;
 
+  /**
+   * Keeps track of the next execution of the checker. It is set to null when the checker has no
+   * need to reschedule itself anymore.
+   */
   private NextExecution nextExecution = null;
 
   private final long timerResolution;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -34,10 +34,11 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private boolean shouldRescheduleChecker;
 
   /**
-   * Keeps track of the next execution of the checker. It is set to null when the checker has no
-   * need to reschedule itself anymore.
+   * Keeps track of the next execution of the checker. As it's not set to null, it could refer to
+   * the last execution. We can always use its due date to determine whether it is in the past.
    */
-  private AtomicReference<NextExecution> nextExecution = new AtomicReference<>(null);
+  private final AtomicReference<NextExecution> nextExecution =
+      new AtomicReference<>(new NextExecution(-1, () -> {}));
 
   public DueDateChecker(
       final long timerResolution,
@@ -49,8 +50,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   }
 
   TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    nextExecution = null;
-
     final long nextDueDate = visitor.apply(taskResultBuilder);
 
     // reschedule the runnable if there are timers left
@@ -78,7 +77,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
         AtomicUtil.update(
             nextExecution,
             currentlyScheduled -> {
-              if (currentlyScheduled == null
+              if (currentlyScheduled.nextDueDate() < ActorClock.currentTimeMillis()
                   || currentlyScheduled.nextDueDate() - dueDate > timerResolution) {
                 final var delay = calculateDelayForNextRun(dueDate);
                 final var task = scheduleService.runDelayed(delay, this::execute);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -60,13 +60,14 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   }
 
   private void scheduleInitialExecution() {
+    if (!shouldRescheduleChecker) {
+      return;
+    }
     if (nextExecution != null) {
       return;
     }
-    if (shouldRescheduleChecker) {
-      final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
-      nextExecution = new NextExecution(-1, task);
-    }
+    final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
+    nextExecution = new NextExecution(-1, task);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -95,7 +95,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
 
     shouldRescheduleChecker = true;
     // check if timers are due after restart
-    scheduleTriggerEntitiesTask();
+    if (nextExecution == null) {
+      scheduleTriggerEntitiesTask();
+    }
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -76,11 +76,13 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
         AtomicUtil.replace(
             nextExecution,
             currentlyScheduled -> {
+              final var now = ActorClock.currentTimeMillis();
+              final var scheduleFor = now + Math.max(dueDate - now, timerResolution);
               if (currentlyScheduled == null
-                  || currentlyScheduled.nextDueDate() - dueDate > timerResolution) {
-                final var delay = calculateDelayForNextRun(dueDate);
+                  || currentlyScheduled.scheduledFor() - scheduleFor > timerResolution) {
+                final var delay = Duration.ofMillis(scheduleFor - now);
                 final var task = scheduleService.runDelayed(delay, this::execute);
-                return Optional.of(new NextExecution(dueDate, task));
+                return Optional.of(new NextExecution(scheduleFor, task));
               }
               return Optional.empty();
             },
@@ -89,20 +91,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     if (replacedExecution != null) {
       replacedExecution.task().cancel();
     }
-  }
-
-  /**
-   * Calculates the delay for the next run so that it occurs at (or close to) due date. If due date
-   * is in the future, the delay will be precise. If due date is in the past, now or in the very
-   * near future, then a lower floor is applied to the delay. The lower floor is {@code
-   * timerResolution}. This is to prevent the checker from being immediately rescheduled and thus
-   * not giving any other tasks a chance to run.
-   *
-   * @param dueDate due date for which a scheduling delay is calculated
-   * @return delay to hit the next due date; will be {@code >= timerResolution}
-   */
-  private Duration calculateDelayForNextRun(final long dueDate) {
-    return Duration.ofMillis(Math.max(dueDate - ActorClock.currentTimeMillis(), timerResolution));
   }
 
   @Override
@@ -142,11 +130,10 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   /**
    * Keeps track of the next execution of the checker.
    *
-   * @param nextDueDate The due date of the next timer to be checked or -1 on the first execution,
-   *     i.e. we don't know the next due date yet.
+   * @param scheduledFor The deadline in ms for when this execution is scheduled.
    * @param task The scheduled task for the next execution, can be used for canceling the task.
    */
-  private record NextExecution(long nextDueDate, ScheduledTask task) {}
+  private record NextExecution(long scheduledFor, ScheduledTask task) {}
 
   /**
    * Abstracts over async and sync scheduling methods of {@link

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -159,6 +159,8 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
 
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+      nextExecution = null;
+
       if (shouldRescheduleChecker) {
         final long nextDueDate = visitor.apply(taskResultBuilder);
 
@@ -168,12 +170,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
           final Duration delay = calculateDelayForNextRun(nextDueDate);
           final var task = scheduleService.runDelayed(delay, this);
           nextExecution = new NextExecution(nextDueDate, task);
-        } else {
-          nextExecution = null;
         }
-      } else {
-        nextExecution = null;
       }
+
       return taskResultBuilder.build();
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -116,19 +116,16 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onClose() {
     shouldRescheduleChecker = false;
-    cancelNextExecution();
   }
 
   @Override
   public void onFailed() {
     shouldRescheduleChecker = false;
-    cancelNextExecution();
   }
 
   @Override
   public void onPaused() {
     shouldRescheduleChecker = false;
-    cancelNextExecution();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -62,9 +62,17 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
 
     if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
+      cancelNextExecution();
       final var delay = calculateDelayForNextRun(dueDate);
       final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
       nextExecution = new NextExecution(dueDate, task);
+    }
+  }
+
+  private void cancelNextExecution() {
+    if (nextExecution != null) {
+      nextExecution.task().cancel();
+      nextExecution = null;
     }
   }
 
@@ -72,6 +80,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     if (!shouldRescheduleChecker) {
       return;
     }
+
     if (nextExecution != null) {
       return;
     }
@@ -109,19 +118,19 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onClose() {
     shouldRescheduleChecker = false;
-    nextExecution = null;
+    cancelNextExecution();
   }
 
   @Override
   public void onFailed() {
     shouldRescheduleChecker = false;
-    nextExecution = null;
+    cancelNextExecution();
   }
 
   @Override
   public void onPaused() {
     shouldRescheduleChecker = false;
-    nextExecution = null;
+    cancelNextExecution();
   }
 
   @Override

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -30,13 +30,14 @@ public class DueDateCheckerTest {
   @Test
   public void shouldNotScheduleTwoTasks() {
     // given
-    final var dueDateChecker = new DueDateChecker(100, false, (builder) -> 0L);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -52,7 +53,8 @@ public class DueDateCheckerTest {
   @Test
   public void shouldScheduleForAnEarlierTasks() {
     // given
-    final var dueDateChecker = new DueDateChecker(100, false, (builder) -> 0L);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -61,7 +63,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -81,7 +83,8 @@ public class DueDateCheckerTest {
     final Function<TaskResultBuilder, Long> visitor =
         (builder) -> ActorClock.currentTimeMillis() + 1000L;
 
-    final var dueDateChecker = new DueDateChecker(100, false, visitor);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, visitor);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -90,7 +93,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
@@ -106,7 +109,8 @@ public class DueDateCheckerTest {
     final Function<TaskResultBuilder, Long> visitor =
         (builder) -> ActorClock.currentTimeMillis() + 1000L;
 
-    final var dueDateChecker = new DueDateChecker(100, false, visitor);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, visitor);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -115,7 +119,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     dueDateChecker.execute(mock(TaskResultBuilder.class));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.timer;
+package io.camunda.zeebe.engine.processing.scheduled;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -14,12 +14,14 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService.ScheduledTask;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
+import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
@@ -70,6 +72,62 @@ public class DueDateCheckerTest {
 
     // then
     verify(mockScheduleService, times(2)).runDelayed(any(), any(Task.class));
+    verify(mockScheduledTask).cancel();
+  }
+
+  @Test
+  public void shouldRescheduleAutomatically() {
+    // given
+    final Function<TaskResultBuilder, Long> visitor =
+        (builder) -> ActorClock.currentTimeMillis() + 1000L;
+
+    final var dueDateChecker = new DueDateChecker(100, false, visitor);
+    final var mockContext = mock(ReadonlyStreamProcessorContext.class);
+    final var mockScheduleService = mock(ProcessingScheduleService.class);
+    final var mockScheduledTask = mock(ScheduledTask.class);
+    when(mockScheduleService.runDelayed(any(Duration.class), any(Task.class)))
+        .thenReturn(mockScheduledTask);
+
+    when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
+    dueDateChecker.onRecovered(mockContext);
+    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    Mockito.clearInvocations(mockScheduleService);
+
+    // when
+    dueDateChecker.execute(mock(TaskResultBuilder.class));
+
+    // then
+    verify(mockScheduleService).runDelayed(any(), any(Task.class));
+  }
+
+  @Test
+  public void shouldScheduleEarlierIfRescheduledAutomatically() {
+    // given
+    final Function<TaskResultBuilder, Long> visitor =
+        (builder) -> ActorClock.currentTimeMillis() + 1000L;
+
+    final var dueDateChecker = new DueDateChecker(100, false, visitor);
+    final var mockContext = mock(ReadonlyStreamProcessorContext.class);
+    final var mockScheduleService = mock(ProcessingScheduleService.class);
+    final var mockScheduledTask = mock(ScheduledTask.class);
+    when(mockScheduleService.runDelayed(any(Duration.class), any(Task.class)))
+        .thenReturn(mockScheduledTask);
+
+    when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
+    dueDateChecker.onRecovered(mockContext);
+    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    Mockito.clearInvocations(mockScheduleService);
+
+    dueDateChecker.execute(mock(TaskResultBuilder.class));
+    // expect that there is a next execution scheduled after execution
+    verify(mockScheduleService).runDelayed(any(), any(Task.class));
+    Mockito.clearInvocations(mockScheduleService);
+
+    // when
+    dueDateChecker.schedule(ActorClock.currentTimeMillis() + 100); // in one second
+
+    // then
+    verify(mockScheduleService).runDelayed(any(), any(Task.class));
     verify(mockScheduledTask).cancel();
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -10,13 +10,15 @@ package io.camunda.zeebe.engine.processing.scheduled;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService.ScheduledTask;
 import io.camunda.zeebe.stream.api.scheduling.Task;
+import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -32,7 +34,8 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService, timeout(1000)).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
@@ -41,7 +44,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 1000); // in one second
 
     // then
-    verify(mockScheduleService, timeout(1000)).runDelayed(any(), any(Task.class));
+    verify(mockScheduleService).runDelayed(any(), any(Task.class));
   }
 
   @Test
@@ -50,10 +53,14 @@ public class DueDateCheckerTest {
     final var dueDateChecker = new DueDateChecker(100, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
+    final var mockScheduledTask = mock(ScheduledTask.class);
+    when(mockScheduleService.runDelayed(any(Duration.class), any(Task.class)))
+        .thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService, timeout(1000)).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
@@ -62,6 +69,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 100); // in 100 millis
 
     // then
-    verify(mockScheduleService, timeout(1000).times(2)).runDelayed(any(), any(Task.class));
+    verify(mockScheduleService, times(2)).runDelayed(any(), any(Task.class));
+    verify(mockScheduledTask).cancel();
   }
 }

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/TimerTriggerSchedulingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/TimerTriggerSchedulingTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.processing;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class TimerTriggerSchedulingTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static final RuleChain RULE_CHAIN = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  /**
+   * Regression test against issue <a href="https://github.com/camunda/zeebe/issues/17128">17128</a>
+   *
+   * <p>Given a process with a timer event that triggers some time in the future, and a process that
+   * schedules a timer event every second, we should not produce many Timer TRIGGER commands for any
+   * of these timers.
+   *
+   * <p>This was a problem previously because every time the DueDateChecker ran, it would reschedule
+   * another execution for the next timer (the one further in the future). This would cause the
+   * DueDateChecker to run many times in a row for this same timer, and not benefit from the command
+   * cache because executions are scheduled beforehand and executed before the cache is persisted.
+   */
+  @Test
+  public void shouldTriggerTimerOnlyOnce() {
+    // given
+    final long processDefinitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess("PROCESS")
+                .startEvent()
+                .intermediateCatchEvent("timer", t -> t.timerWithDurationExpression("duration"))
+                .endEvent()
+                .done());
+    final long processInstanceKey =
+        CLIENT_RULE.createProcessInstance(
+            processDefinitionKey,
+            """
+            {
+              "duration": "PT1H"
+            }
+            """);
+
+    // when
+    for (int i = 0; i < 10; i++) {
+      final long shortProcessInstanceKey =
+          CLIENT_RULE.createProcessInstance(
+              processDefinitionKey,
+              """
+              {
+                "duration": "PT1S"
+              }
+              """);
+      RecordingExporter.timerRecords(TimerIntent.CREATED)
+          .withProcessInstanceKey(shortProcessInstanceKey)
+          .await();
+      BROKER_RULE.getClock().addTime(Duration.ofSeconds(2));
+      RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+          .withProcessInstanceKey(shortProcessInstanceKey)
+          .await();
+    }
+
+    BROKER_RULE.getClock().addTime(Duration.ofHours(2));
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.timerRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(t -> t.getIntent() == TimerIntent.TRIGGERED)
+                .filter(t -> t.getIntent() == TimerIntent.TRIGGER)
+                .onlyCommands())
+        .describedAs("We only expect a single TRIGGER command")
+        .hasSize(1);
+  }
+}

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ScheduledTimer.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ScheduledTimer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.scheduler;
 
+@FunctionalInterface
 public interface ScheduledTimer {
   void cancel();
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -40,6 +40,8 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *
    * @param delay The delay to wait before executing the task
    * @param task The task to execute after the delay
+   * @implNote If the delay is short, cancellation via {@link ScheduledTask} may happen after
+   *     execution and have no effect.
    */
-  void runDelayedAsync(final Duration delay, final Task task);
+  ScheduledTask runDelayedAsync(final Duration delay, final Task task);
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
@@ -11,9 +11,21 @@ import java.time.Duration;
 
 public interface SimpleProcessingScheduleService {
 
-  void runDelayed(Duration delay, Runnable task);
+  /**
+   * Schedules the task to run after the given delay.
+   *
+   * @implNote Can be silently ignored if the scheduling service is not ready.
+   * @return A representation of the scheduled task.
+   */
+  ScheduledTask runDelayed(Duration delay, Runnable task);
 
-  void runDelayed(Duration delay, Task task);
+  /**
+   * Schedules the task to run after the given delay.
+   *
+   * @implNote Can be silently ignored if the scheduling service is not ready.
+   * @return A representation of the scheduled task.
+   */
+  ScheduledTask runDelayed(Duration delay, Task task);
 
   /**
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
@@ -40,4 +52,20 @@ public interface SimpleProcessingScheduleService {
   }
 
   void runAtFixedRate(final Duration delay, final Task task);
+
+  /***
+   * A task scheduled by {@link SimpleProcessingScheduleService} to give the caller control over the
+   * task, i.e. for cancellation.
+   */
+  @FunctionalInterface
+  interface ScheduledTask {
+
+    /**
+     * Cancels the scheduled execution of this task.
+     *
+     * @implNote can be a noop if the task already ran or if the task scheduling was silently
+     *     ignored.
+     */
+    void cancel();
+  }
 }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
@@ -63,8 +63,9 @@ public interface SimpleProcessingScheduleService {
     /**
      * Cancels the scheduled execution of this task.
      *
-     * @implNote can be a noop if the task already ran or if the task scheduling was silently
-     *     ignored.
+     * @implNote can be a noop if the task scheduling was silently ignored or cancellation can no
+     *     longer prevent execution, e.g. because the task already ran or due to asynchronous
+     *     scheduling.
      */
     void cancel();
   }

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -47,13 +47,13 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public void runDelayed(final Duration delay, final Runnable task) {
-    processorActorService.runDelayed(delay, task);
+  public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
+    return processorActorService.runDelayed(delay, task);
   }
 
   @Override
-  public void runDelayed(final Duration delay, final Task task) {
-    processorActorService.runDelayed(delay, task);
+  public ScheduledTask runDelayed(final Duration delay, final Task task) {
+    return processorActorService.runDelayed(delay, task);
   }
 
   @Override

--- a/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -51,7 +51,11 @@ public class ProcessingScheduleServiceImpl
 
   @Override
   public void runDelayed(final Duration delay, final Runnable followUpTask) {
-    useActorControl(() -> actorControl.runDelayed(delay, followUpTask));
+    if (actorControl == null) {
+      LOG.debug("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
+      return;
+    }
+    actorControl.runDelayed(delay, followUpTask);
   }
 
   @Override
@@ -71,14 +75,6 @@ public class ProcessingScheduleServiceImpl
                 runAtFixedRate(delay, task);
               }
             }));
-  }
-
-  private void useActorControl(final Runnable task) {
-    if (actorControl == null) {
-      LOG.debug("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
-      return;
-    }
-    task.run();
   }
 
   public ActorFuture<Void> open(final ActorControl control) {

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -378,13 +378,35 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
-    public void runDelayed(final Duration delay, final Runnable task) {
-      actor.submit(() -> processingScheduleService.runDelayed(delay, task));
+    public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
+      final var futureScheduledTask =
+          actor.call(() -> processingScheduleService.runDelayed(delay, task));
+      return () ->
+          actor.run(
+              () ->
+                  actor.runOnCompletion(
+                      futureScheduledTask,
+                      (scheduledTask, throwable) -> {
+                        if (scheduledTask != null) {
+                          scheduledTask.cancel();
+                        }
+                      }));
     }
 
     @Override
-    public void runDelayed(final Duration delay, final Task task) {
-      actor.submit(() -> processingScheduleService.runDelayed(delay, task));
+    public ScheduledTask runDelayed(final Duration delay, final Task task) {
+      final var futureScheduledTask =
+          actor.call(() -> processingScheduleService.runDelayed(delay, task));
+      return () ->
+          actor.run(
+              () ->
+                  actor.runOnCompletion(
+                      futureScheduledTask,
+                      (scheduledTask, throwable) -> {
+                        if (scheduledTask != null) {
+                          scheduledTask.cancel();
+                        }
+                      }));
     }
 
     @Override

--- a/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -359,6 +359,25 @@ class ProcessingScheduleServiceTest {
     assertThat(commandCache.contains(ACTIVATE_ELEMENT, 1)).isFalse();
   }
 
+  @Test
+  void shouldNotExecuteCancelledDelayedTask() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+
+    final var scheduledTask = scheduleService.runDelayed(Duration.ofMinutes(1), mockedTask);
+    actorScheduler.workUntilDone(); // Ensure task is scheduled
+
+    scheduledTask.cancel();
+    actorScheduler.workUntilDone(); // Ensure task is cancelled
+
+    // when
+    actorScheduler.updateClock(Duration.ofMinutes(2));
+    actorScheduler.workUntilDone(); // Would execute task if not cancelled
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
   /**
    * This decorator is an actor and implements {@link ProcessingScheduleService} and delegates to
    * {@link ProcessingScheduleServiceImpl}, on each call it will submit an extra job to the related

--- a/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
@@ -32,7 +32,7 @@ public final class AtomicUtil {
    *     {@code empty} the atomic reference is not updated
    * @param rollback The rollback function used to revert any side effect produced by the update
    *     function
-   * @return The previous value of the atomic reference
+   * @return The previous value of the atomic reference, or null if the value was left unchanged
    * @param <T> The type of the atomic reference
    */
   public static <T> T update(
@@ -49,7 +49,7 @@ public final class AtomicUtil {
       currentVal = ref.get();
       final var result = update.apply(currentVal);
       if (result.isEmpty()) {
-        return currentVal;
+        return null;
       }
       newVal = result.get();
     } while (!ref.compareAndSet(currentVal, newVal));

--- a/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/** Utility class for common tasks with {@link AtomicReference} instances. */
+public final class AtomicUtil {
+
+  private AtomicUtil() {}
+
+  /**
+   * Locklessly updates an atomic reference using the provided update function and rollbacks if the
+   * reference changed during the update, e.g. by another thread.
+   *
+   * <p>If the update function returns an empty optional, the atomic reference is not updated.
+   *
+   * <p>If the atomic reference has been updated by another thread in the meantime, the rollback
+   * function is called with the value provided by the update function, and the update function is
+   * called again.
+   *
+   * @param ref The atomic reference to update
+   * @param update The update function used to provide a new value to the atomic reference; if
+   *     {@code empty} the atomic reference is not updated
+   * @param rollback The rollback function used to revert any side effect produced by the update
+   *     function
+   * @return The previous value of the atomic reference
+   * @param <T> The type of the atomic reference
+   */
+  public static <T> T update(
+      final AtomicReference<T> ref,
+      final Function<T, Optional<T>> update,
+      final Consumer<T> rollback) {
+    T currentVal;
+    T newVal = null;
+    do {
+      if (newVal != null) {
+        // another thread appears to have replaced the value in the meantime
+        rollback.accept(newVal);
+      }
+      currentVal = ref.get();
+      final var result = update.apply(currentVal);
+      if (result.isEmpty()) {
+        return currentVal;
+      }
+      newVal = result.get();
+    } while (!ref.compareAndSet(currentVal, newVal));
+    return currentVal;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->

This pull request aims to avoid duplicate timer `TRIGGER` commands and avoids the pathological case where this would deterministically result in #17128.

An integration test reproducing that scenario is provided in `TimerTriggerSchedulingTest`.

This pull request achieves this by introducing two main changes:
- It cancels existing future execution runs of the `DueDateChecker` when scheduling another to avoid many scheduled executions of the checker at any time
- It provides a threadsafe way to schedule, execute, and cancel the executions of the `DueDateChecker`
  - this is to ensure that the bug is also fixed when enabling the async due date checker

> [!NOTE]
> Cancellation in concurrent (or async) scheduling/execution does not guarantee to prevent execution.

This pull request also:
- Implements the `onClose` and `onFailure` lifecycle events for the `DueDateChecker`
- Refactors the `DueDateChecker` for understandability and adds a lot of documentation
- Introduces an `AtomicUtil` class to allow threadsafe lock-free replacing of AtomicReference
- Schedules the initial execution of `DueDateChecker` after 100ms instead of 0ms

## Related issues

<!-- Which issues are closed by this PR or are related -->

This PR:
resolves #17128
resolves #10541

Not sure exactly, but could:
resolves #16884 
resolves #8991 