### PR TITLE
Report for flakes on slack

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -12,6 +12,11 @@ inputs:
     default: "false"
     required: false
 
+outputs:
+  flakyTests:
+    description: "A collection of flaky tests, if there are any"
+    value: ${{ steps.find-flakes.outputs.FLAKY_TESTS }}
+
 runs:
   using: composite
   steps:
@@ -22,6 +27,43 @@ runs:
       paths: |
         **/target/failsafe-reports/TEST-*.xml
         **/target/surefire-reports/TEST-*.xml
+  - name: Find flaky tests
+    id: find-flakes
+    shell: bash
+    env:
+      BUILD_OUTPUT_FILE_PATH: ${{ inputs.buildOutputFilePath }}
+    run: |
+      if [ ! -s "$BUILD_OUTPUT_FILE_PATH" ]; then
+        echo "::error::Build output file does not exist or is empty!"
+        exit 1
+      fi
+
+      # Extracting flaky tests
+      # Based on old Jenkins script
+      # https://github.com/camunda/zeebe/blob/stable/8.1/.ci/scripts/lib/flaky-tests.sh
+      if grep -q "\[WARNING\] Flakes:" "$BUILD_OUTPUT_FILE_PATH"; then
+        irOutputFile=$(mktemp)
+
+        # Extracting the essential lines
+        awk '/^\[WARNING\] Flakes:.*$/{flag=1}/^\[ERROR\] Tests run:.*Flakes: [0-9]*$/{print;flag=0}flag' "$BUILD_OUTPUT_FILE_PATH" > ${irOutputFile}
+
+        # To cover cases where we use parameterized tests like
+        # [WARNING]  io.camunda.zeebe.engine.state.BanInstanceTest.shouldBanInstance[PROCESS_MESSAGE_SUBSCRIPTION DELETE should ban instance true]
+        # We grep the WARNING line and set the first argument to an empty string
+        flakyTests=$(grep "\[WARNING\] io.camunda" ${irOutputFile} | awk '{$1=""; print $0}')
+
+        # To support multi-line string in output we have to work with EOF delimiter
+        # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+        {
+          echo 'FLAKY_TESTS<<EOF'
+            # echo ${flakyTests[*]}
+            echo $flakyTests
+          echo EOF
+        } >> $GITHUB_OUTPUT
+
+        echo "::error::Found flaky tests!\n ${flakyTests}"
+      fi
+
   - name: Duplicate test runs
     shell: bash
     env:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -34,6 +34,8 @@ jobs:
   integration-tests:
     name: "[IT] ${{ matrix.name }}"
     timeout-minutes: 20
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     runs-on: [ self-hosted, linux, amd64, "16" ]
     strategy:
       fail-fast: false
@@ -118,6 +120,7 @@ jobs:
         with:
           action: terminate
       - name: Analyze Test Runs
+        id: analyze-test-run
         if: always()
         uses: ./.github/actions/analyze-test-runs
         with:
@@ -131,6 +134,8 @@ jobs:
     name: Unit tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
       - uses: actions/checkout@v4
       - name: Install and allow strace tests
@@ -162,6 +167,7 @@ jobs:
       - name: Normalize artifact name
         run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
       - name: Analyze Test Runs
+        id: analyze-test-run
         if: always()
         uses: ./.github/actions/analyze-test-runs
         with:
@@ -491,6 +497,9 @@ jobs:
     name: Test summary
     if: always()
     runs-on: ubuntu-latest
+    outputs:
+      flakyUnitTests: ${{ needs.unit-tests.outputs.flakyTests }}
+      flakyIntegrationTests: ${{ needs.integration-tests.outputs.flakyTests }}
     needs:
       - integration-tests
       - unit-tests

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -662,12 +662,31 @@ jobs:
                     "type": "mrkdwn",
                     "text": "Please check the related commit: ${{ github.event.head_commit.url }}\n \\cc @zeebe-medic"
                   }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Detected flaky unit tests:* \n ${{ env.FLAKY_UNIT_TESTS }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Detected flaky integration tests:* \n ${{ env.FLAKY_INTEGRATION_TESTS }}"
+                  }
                 }
               ]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          FLAKY_UNIT_TESTS: ${{needs.test-summary.outputs.flakyUnitTests}}
+          FLAKY_INTEGRATION_TESTS: ${{needs.test-summary.outputs.flakyIntegrationTests}}
   auto-merge:
     # This workflow will auto merge a PR authored by backport-action or renovate[bot].
     # It runs only on open PRs ready for review.


### PR DESCRIPTION
## Description

As a medic when `main` build fails we often have to check the GHA runs and scroll a long way to find whether a flaky test has failed, etc.

This PR should improve our life a bit to directly see in slack whether a flaky test has occurred and failed the main build. 

Ideally this should allow us also to better track which tests fail more often, as this is currently not really possible.

This means you can see this as a first step to bring back our flaky test statistics.


## Example runs

We distinguish between unit tests and integration tests (in the first iteration) we can always add more or collapse them.

### Flaky parameterized test

When having a parameterized tests, there might be multiple methods and parameters that failed the tests, the new output covers this. Unfortunately we hit here some boundaries of slack messages and line lengths, but I think it is good enough.

![run1](https://github.com/camunda/zeebe/assets/2758593/4cca6c22-ed26-4ac4-ba87-c04feae4e95c)

### No flakes
If there are no flakes for IT, for example but still for unit tests we can see this as well, and the message doesn't break.

![run2](https://github.com/camunda/zeebe/assets/2758593/765f9e7f-c06a-434a-b68f-53ff782d5cbe)


### Only single Unit tests

In most cases it will look like this, where only one unit test has been flaky. The messages is I think good enough to be consumed by a human.

![run3](https://github.com/camunda/zeebe/assets/2758593/b71db865-1b75-42e2-89ec-9aebf159515b)

### Test summary

The summary also shows now always the failed flaky test directly.

![test-results](https://github.com/camunda/zeebe/assets/2758593/06796929-50ea-47a4-9497-8a79a1e65e70)


