### PR TITLE
build: set project name of zeebe-client-spring

### DIFF
--- a/zeebe/clients/zeebe-client-spring/pom.xml
+++ b/zeebe/clients/zeebe-client-spring/pom.xml
@@ -25,6 +25,8 @@
 
   <artifactId>zeebe-client-spring</artifactId>
 
+  <name>Zeebe Client Spring</name>
+
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>


### PR DESCRIPTION
## Description

Adds missing project name to the module which causes the maven release to fail otherwise with:

```
 Repository "iocamunda-1973" failures
Error: ROR]   Rule "pom-staging" failures
Error: ROR]     * Invalid POM: /io/camunda/zeebe-client-spring/8.5.0-RC2/zeebe-client-spring-8.5.0-RC2.pom: Project name missing
```