### PR TITLE
[Backport stable/8.1] Fix duplicate timer schedules

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/ProcessingScheduleService.java
@@ -39,6 +39,8 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *
    * @param delay The delay to wait before executing the task
    * @param task The task to execute after the delay
+   * @implNote If the delay is short, cancellation via {@link ScheduledTask} may happen after
+   *     execution and have no effect.
    */
-  void runDelayedAsync(final Duration delay, final Task task);
+  ScheduledTask runDelayedAsync(final Duration delay, final Task task);
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/SimpleProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/SimpleProcessingScheduleService.java
@@ -11,9 +11,21 @@ import java.time.Duration;
 
 public interface SimpleProcessingScheduleService {
 
-  void runDelayed(Duration delay, Runnable task);
+  /**
+   * Schedules the task to run after the given delay.
+   *
+   * @implNote Can be silently ignored if the scheduling service is not ready.
+   * @return A representation of the scheduled task.
+   */
+  ScheduledTask runDelayed(Duration delay, Runnable task);
 
-  void runDelayed(Duration delay, Task task);
+  /**
+   * Schedules the task to run after the given delay.
+   *
+   * @implNote Can be silently ignored if the scheduling service is not ready.
+   * @return A representation of the scheduled task.
+   */
+  ScheduledTask runDelayed(Duration delay, Task task);
 
   /**
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
@@ -40,4 +52,20 @@ public interface SimpleProcessingScheduleService {
   }
 
   void runAtFixedRate(final Duration delay, final Task task);
+
+  /***
+   * A task scheduled by {@link SimpleProcessingScheduleService} to give the caller control over the
+   * task, i.e. for cancellation.
+   */
+  @FunctionalInterface
+  interface ScheduledTask {
+
+    /**
+     * Cancels the scheduled execution of this task.
+     *
+     * @implNote can be a noop if the task already ran or if the task scheduling was silently
+     *     ignored.
+     */
+    void cancel();
+  }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/api/SimpleProcessingScheduleService.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/api/SimpleProcessingScheduleService.java
@@ -63,8 +63,9 @@ public interface SimpleProcessingScheduleService {
     /**
      * Cancels the scheduled execution of this task.
      *
-     * @implNote can be a noop if the task already ran or if the task scheduling was silently
-     *     ignored.
+     * @implNote can be a noop if the task scheduling was silently ignored or cancellation can no
+     *     longer prevent execution, e.g. because the task already ran or due to asynchronous
+     *     scheduling.
      */
     void cancel();
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -104,8 +104,19 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
 
     shouldRescheduleChecker = true;
-    // check if timers are due after restart
     scheduleInitialExecution();
+  }
+
+  @Override
+  public void onClose() {
+    shouldRescheduleChecker = false;
+    nextExecution = null;
+  }
+
+  @Override
+  public void onFailed() {
+    shouldRescheduleChecker = false;
+    nextExecution = null;
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -46,7 +46,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     this.visitor = visitor;
   }
 
-  private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+  TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     nextExecution = null;
 
     final long nextDueDate = visitor.apply(taskResultBuilder);

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -96,7 +96,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
 
     shouldRescheduleChecker = true;
     // check if timers are due after restart
-    scheduleTriggerEntitiesTask();
+    if (nextExecution == null) {
+      scheduleTriggerEntitiesTask();
+    }
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -62,12 +62,13 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
   }
 
-  private void scheduleTriggerEntitiesTask() {
+  private void scheduleInitialExecution() {
+    if (nextExecution != null) {
+      return;
+    }
     if (shouldRescheduleChecker) {
       final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
       nextExecution = new NextExecution(-1, task);
-    } else {
-      nextExecution = null;
     }
   }
 
@@ -96,9 +97,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
 
     shouldRescheduleChecker = true;
     // check if timers are due after restart
-    if (nextExecution == null) {
-      scheduleTriggerEntitiesTask();
-    }
+    scheduleInitialExecution();
   }
 
   @Override
@@ -110,9 +109,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onResumed() {
     shouldRescheduleChecker = true;
-    if (nextExecution == null) {
-      scheduleTriggerEntitiesTask();
-    }
+    scheduleInitialExecution();
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -112,6 +112,16 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
   }
 
+  /** Abstracts over async and sync scheduling methods of {@link ProcessingScheduleService}. */
+  @FunctionalInterface
+  interface ScheduleDelayed {
+    /**
+     * Implemented by either {@link ProcessingScheduleService#runDelayed(Duration, Task)} or {@link
+     * ProcessingScheduleService#runDelayedAsync(Duration, Task)}
+     */
+    void runDelayed(final Duration delay, final Task task);
+  }
+
   private final class TriggerEntitiesTask implements Task {
 
     @Override
@@ -133,15 +143,5 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       }
       return taskResultBuilder.build();
     }
-  }
-
-  /** Abstracts over async and sync scheduling methods of {@link ProcessingScheduleService}. */
-  @FunctionalInterface
-  interface ScheduleDelayed {
-    /**
-     * Implemented by either {@link ProcessingScheduleService#runDelayed(Duration, Task)} or {@link
-     * ProcessingScheduleService#runDelayedAsync(Duration, Task)}
-     */
-    void runDelayed(final Duration delay, final Task task);
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -162,9 +162,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
         // reschedule the runnable if there are timers left
 
         if (nextDueDate > 0) {
-          final Duration delay = calculateDelayForNextRun(nextDueDate);
-          final var task = scheduleService.runDelayed(delay, this);
-          nextExecution = new NextExecution(nextDueDate, task);
+          schedule(nextDueDate);
         }
       }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -82,9 +82,10 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       return;
     }
 
-    if (nextExecution != null) {
-      return;
-    }
+    // ensure that the checker is scheduled only once. No execution is expected, but we want to
+    // cover all edge cases.
+    cancelNextExecution();
+
     final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
     nextExecution = new NextExecution(-1, task);
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -74,7 +74,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       return;
     }
 
-    final var previouslyScheduled =
+    final var replacedExecution =
         AtomicUtil.update(
             nextExecution,
             currentlyScheduled -> {
@@ -88,9 +88,8 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
             },
             newlyScheduled -> newlyScheduled.task().cancel());
 
-    if (previouslyScheduled != null) {
-      // cancel the execution that we just replaced
-      previouslyScheduled.task().cancel();
+    if (replacedExecution != null) {
+      replacedExecution.task().cancel();
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -21,6 +21,15 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
+/**
+ * The Due Date Checker is a special purpose checker (for due date related tasks) that doesn't
+ * execute periodically but can be scheduled to run at a specific due date, i.e. it can idle for
+ * extended periods of time and only runs when needed.
+ *
+ * <p>This class is thread safe and can be used concurrently. However, it cannot entirely prevent
+ * that multiple executions are scheduled. See the comment in {@link #execute(TaskResultBuilder)}
+ * for details.
+ */
 public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private final boolean scheduleAsync;
   private final long timerResolution;
@@ -40,6 +49,11 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
    */
   private final AtomicReference<NextExecution> nextExecution = new AtomicReference<>(null);
 
+  /**
+   * @param timerResolution The resolution in ms for the timer
+   * @param scheduleAsync Whether to schedule the execution happens asynchronously or not
+   * @param visitor Function that runs the task and returns the next due date or -1 if there is none
+   */
   public DueDateChecker(
       final long timerResolution,
       final boolean scheduleAsync,
@@ -69,6 +83,26 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     return taskResultBuilder.build();
   }
 
+  /**
+   * Schedules the next execution of the checker and stores it in {@link #nextExecution}.
+   *
+   * <p>When called it guarantees that there is an execution scheduled at or before the provided due
+   * date within the {@link #timerResolution}.
+   *
+   * <p>If there is no execution scheduled, it always schedules a new one. If there is already an
+   * execution scheduled for a later time (within the timer resolution), that execution is cancelled
+   * and replaced by the new one. In all other cases, no new execution is scheduled.
+   *
+   * <p>It is guaranteed that the next execution is scheduled at least {@link #timerResolution} ms
+   * into the future. For example when the due date is in the past, now or in the very near future.
+   * This is to prevent the checker from being immediately rescheduled and thus not giving any other
+   * tasks a chance to run.
+   *
+   * <p>This method is thread safe and can be called concurrently. On concurrent scheduling, this
+   * execution is cancelled and rescheduled.
+   *
+   * @param dueDate The due date for the next execution
+   */
   public void schedule(final long dueDate) {
     if (!shouldRescheduleChecker) {
       return;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -61,13 +61,14 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   }
 
   private void scheduleInitialExecution() {
+    if (!shouldRescheduleChecker) {
+      return;
+    }
     if (nextExecution != null) {
       return;
     }
-    if (shouldRescheduleChecker) {
-      final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
-      nextExecution = new NextExecution(-1, task);
-    }
+    final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
+    nextExecution = new NextExecution(-1, task);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -19,8 +19,12 @@ import java.time.Duration;
 import java.util.function.Function;
 
 public final class DueDateChecker implements StreamProcessorLifecycleAware {
-  private ScheduleDelayed scheduleService;
   private final boolean scheduleAsync;
+  private final long timerResolution;
+  private final Function<TaskResultBuilder, Long> visitor;
+  private final TriggerEntitiesTask triggerEntitiesTask = new TriggerEntitiesTask();
+
+  private ScheduleDelayed scheduleService;
 
   /**
    * Indicates whether the checker should reschedule itself. Controlled by the stream processor's
@@ -34,11 +38,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
    */
   private NextExecution nextExecution = null;
 
-  private final long timerResolution;
-
-  private final Function<TaskResultBuilder, Long> visitor;
-  private final TriggerEntitiesTask triggerEntitiesTask;
-
   public DueDateChecker(
       final long timerResolution,
       final boolean scheduleAsync,
@@ -46,7 +45,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     this.timerResolution = timerResolution;
     this.scheduleAsync = scheduleAsync;
     this.visitor = visitor;
-    triggerEntitiesTask = new TriggerEntitiesTask();
   }
 
   public void schedule(final long dueDate) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -49,12 +49,14 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     // - Otherwise, we don't need to cancel the runnable. It will be rescheduled when it is
     // executed.
 
-    if (shouldRescheduleChecker) {
-      if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
-        final var delay = calculateDelayForNextRun(dueDate);
-        final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
-        nextExecution = new NextExecution(dueDate, task);
-      }
+    if (!shouldRescheduleChecker) {
+      return;
+    }
+
+    if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
+      final var delay = calculateDelayForNextRun(dueDate);
+      final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
+      nextExecution = new NextExecution(dueDate, task);
     }
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -154,6 +154,8 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
 
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
+      nextExecution = null;
+
       if (shouldRescheduleChecker) {
         final long nextDueDate = visitor.apply(taskResultBuilder);
 
@@ -163,12 +165,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
           final Duration delay = calculateDelayForNextRun(nextDueDate);
           final var task = scheduleService.runDelayed(delay, this);
           nextExecution = new NextExecution(nextDueDate, task);
-        } else {
-          nextExecution = null;
         }
-      } else {
-        nextExecution = null;
       }
+
       return taskResultBuilder.build();
     }
   }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -22,8 +22,16 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private ScheduleDelayed scheduleService;
   private final boolean scheduleAsync;
 
+  /**
+   * Indicates whether the checker should reschedule itself. Controlled by the stream processor's
+   * lifecycle events, e.g. {@link #onPaused()} and {@link #onResumed()}.
+   */
   private boolean shouldRescheduleChecker;
 
+  /**
+   * Keeps track of the next execution of the checker. It is set to null when the checker has no
+   * need to reschedule itself anymore.
+   */
   private NextExecution nextExecution = null;
 
   private final long timerResolution;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -87,19 +87,6 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
   }
 
-  private void scheduleInitialExecution() {
-    if (!shouldRescheduleChecker) {
-      return;
-    }
-
-    // ensure that the checker is scheduled only once. No execution is expected, but we want to
-    // cover all edge cases.
-    cancelNextExecution();
-
-    final var task = scheduleService.runDelayed(Duration.ZERO, this::execute);
-    nextExecution = new NextExecution(-1, task);
-  }
-
   /**
    * Calculates the delay for the next run so that it occurs at (or close to) due date. If due date
    * is in the future, the delay will be precise. If due date is in the past, now or in the very
@@ -124,7 +111,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
 
     shouldRescheduleChecker = true;
-    scheduleInitialExecution();
+    schedule(-1);
   }
 
   @Override
@@ -148,7 +135,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onResumed() {
     shouldRescheduleChecker = true;
-    scheduleInitialExecution();
+    schedule(-1);
   }
 
   /**

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -49,14 +49,11 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     nextExecution = null;
 
-    if (shouldRescheduleChecker) {
-      final long nextDueDate = visitor.apply(taskResultBuilder);
+    final long nextDueDate = visitor.apply(taskResultBuilder);
 
-      // reschedule the runnable if there are timers left
-
-      if (nextDueDate > 0) {
-        schedule(nextDueDate);
-      }
+    // reschedule the runnable if there are timers left
+    if (nextDueDate > 0) {
+      schedule(nextDueDate);
     }
 
     return taskResultBuilder.build();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -117,19 +117,16 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onClose() {
     shouldRescheduleChecker = false;
-    cancelNextExecution();
   }
 
   @Override
   public void onFailed() {
     shouldRescheduleChecker = false;
-    cancelNextExecution();
   }
 
   @Override
   public void onPaused() {
     shouldRescheduleChecker = false;
-    cancelNextExecution();
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -52,10 +52,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     final Duration delay = calculateDelayForNextRun(dueDate);
 
     if (shouldRescheduleChecker) {
-      if (nextExecution == null) {
-        final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
-        nextExecution = new NextExecution(dueDate, task);
-      } else if (nextExecution.nextDueDate() - dueDate > timerResolution) {
+      if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
         final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
         nextExecution = new NextExecution(dueDate, task);
       }

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -58,6 +58,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     // already scheduled. While we try to avoid this, we can't prevent it entirely anyway because
     // cancellation of scheduled executions is best-effort and does not reliably prevent execution.
     nextExecution.set(null);
+
     final long nextDueDate = visitor.apply(taskResultBuilder);
 
     // reschedule the runnable if there are timers left
@@ -73,7 +74,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
       return;
     }
     final var replacedExecution =
-        AtomicUtil.update(
+        AtomicUtil.replace(
             nextExecution,
             currentlyScheduled -> {
               if (currentlyScheduled == null

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.scheduled;
 
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.engine.api.SimpleProcessingScheduleService.ScheduledTask;
 import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.api.Task;
 import io.camunda.zeebe.engine.api.TaskResult;
@@ -24,7 +25,8 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private boolean checkerRunning;
   private boolean shouldRescheduleChecker;
 
-  private long nextDueDate = -1L;
+  private NextExecution nextExecution = null;
+
   private final long timerResolution;
   private final Function<TaskResultBuilder, Long> nextDueDateSupplier;
   private final TriggerEntitiesTask triggerEntitiesTask;
@@ -52,20 +54,24 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
 
     if (shouldRescheduleChecker) {
       if (!checkerRunning) {
-        scheduleService.runDelayed(delay, triggerEntitiesTask);
-        nextDueDate = dueDate;
+        final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
+        nextExecution = new NextExecution(dueDate, task);
         checkerRunning = true;
-      } else if (nextDueDate - dueDate > timerResolution) {
-        scheduleService.runDelayed(delay, triggerEntitiesTask);
-        nextDueDate = dueDate;
+      } else if (nextExecution.nextDueDate() - dueDate > timerResolution) {
+        final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
+        nextExecution = new NextExecution(dueDate, task);
+        checkerRunning = true;
       }
     }
   }
 
   private void scheduleTriggerEntitiesTask() {
     if (shouldRescheduleChecker) {
-      scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
+      final var task = scheduleService.runDelayed(Duration.ZERO, triggerEntitiesTask);
+      nextExecution = new NextExecution(-1, task);
+      checkerRunning = true;
     } else {
+      nextExecution = null;
       checkerRunning = false;
     }
   }
@@ -101,7 +107,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   @Override
   public void onPaused() {
     shouldRescheduleChecker = false;
-    nextDueDate = -1;
+    nextExecution = null;
   }
 
   @Override
@@ -112,6 +118,15 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     }
   }
 
+  /**
+   * Keeps track of the next execution of the checker.
+   *
+   * @param nextDueDate The due date of the next timer to be checked or -1 on the first execution,
+   *     i.e. we don't know the next due date yet.
+   * @param task The scheduled task for the next execution, can be used for canceling the task.
+   */
+  private record NextExecution(long nextDueDate, ScheduledTask task) {}
+
   /** Abstracts over async and sync scheduling methods of {@link ProcessingScheduleService}. */
   @FunctionalInterface
   interface ScheduleDelayed {
@@ -119,7 +134,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
      * Implemented by either {@link ProcessingScheduleService#runDelayed(Duration, Task)} or {@link
      * ProcessingScheduleService#runDelayedAsync(Duration, Task)}
      */
-    void runDelayed(final Duration delay, final Task task);
+    ScheduledTask runDelayed(final Duration delay, final Task task);
   }
 
   private final class TriggerEntitiesTask implements Task {
@@ -127,18 +142,21 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
       if (shouldRescheduleChecker) {
-        nextDueDate = nextDueDateSupplier.apply(taskResultBuilder);
+        final long nextDueDate = nextDueDateSupplier.apply(taskResultBuilder);
 
         // reschedule the runnable if there are timers left
 
         if (nextDueDate > 0) {
           final Duration delay = calculateDelayForNextRun(nextDueDate);
-          scheduleService.runDelayed(delay, this);
+          final var task = scheduleService.runDelayed(delay, this);
+          nextExecution = new NextExecution(nextDueDate, task);
           checkerRunning = true;
         } else {
+          nextExecution = null;
           checkerRunning = false;
         }
       } else {
+        nextExecution = null;
         checkerRunning = false;
       }
       return taskResultBuilder.build();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -35,16 +35,17 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   private NextExecution nextExecution = null;
 
   private final long timerResolution;
-  private final Function<TaskResultBuilder, Long> nextDueDateSupplier;
+
+  private final Function<TaskResultBuilder, Long> visitor;
   private final TriggerEntitiesTask triggerEntitiesTask;
 
   public DueDateChecker(
       final long timerResolution,
       final boolean scheduleAsync,
-      final Function<TaskResultBuilder, Long> nextDueDateFunction) {
+      final Function<TaskResultBuilder, Long> visitor) {
     this.timerResolution = timerResolution;
     this.scheduleAsync = scheduleAsync;
-    nextDueDateSupplier = nextDueDateFunction;
+    this.visitor = visitor;
     triggerEntitiesTask = new TriggerEntitiesTask();
   }
 
@@ -143,7 +144,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     @Override
     public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
       if (shouldRescheduleChecker) {
-        final long nextDueDate = nextDueDateSupplier.apply(taskResultBuilder);
+        final long nextDueDate = visitor.apply(taskResultBuilder);
 
         // reschedule the runnable if there are timers left
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -49,10 +49,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     // - Otherwise, we don't need to cancel the runnable. It will be rescheduled when it is
     // executed.
 
-    final Duration delay = calculateDelayForNextRun(dueDate);
-
     if (shouldRescheduleChecker) {
       if (nextExecution == null || nextExecution.nextDueDate() - dueDate > timerResolution) {
+        final var delay = calculateDelayForNextRun(dueDate);
         final var task = scheduleService.runDelayed(delay, triggerEntitiesTask);
         nextExecution = new NextExecution(dueDate, task);
       }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ExtendedProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ExtendedProcessingScheduleServiceImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.SimpleProcessingScheduleService;
 import io.camunda.zeebe.engine.api.Task;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
 import java.time.Duration;
 
 public class ExtendedProcessingScheduleServiceImpl implements ProcessingScheduleService {
@@ -38,12 +39,15 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public void runDelayedAsync(final Duration delay, final Task task) {
+  public ScheduledTask runDelayedAsync(final Duration delay, final Task task) {
+    final var futureScheduledTask = concurrencyControl.<ScheduledTask>createFuture();
     concurrencyControl.run(
         () -> {
           // we must run in different actor in order to schedule task
-          asyncActorService.runDelayed(delay, task);
+          final var scheduledTask = asyncActorService.runDelayed(delay, task);
+          futureScheduledTask.complete(scheduledTask);
         });
+    return new AsyncScheduledTask(futureScheduledTask);
   }
 
   @Override
@@ -59,5 +63,35 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   @Override
   public void runAtFixedRate(final Duration delay, final Task task) {
     processorActorService.runAtFixedRate(delay, task);
+  }
+
+  /**
+   * Allows control over a task that is asynchronously scheduled. It uses a future that holds the
+   * task once it's scheduled.
+   */
+  private final class AsyncScheduledTask implements ScheduledTask {
+
+    private final ActorFuture<ScheduledTask> futureScheduledTask;
+
+    public AsyncScheduledTask(final ActorFuture<ScheduledTask> futureScheduledTask) {
+      this.futureScheduledTask = futureScheduledTask;
+    }
+
+    /**
+     * Cancels the task after it's scheduled. Depending on the delay, the task may execute before
+     * cancellation takes effect.
+     */
+    @Override
+    public void cancel() {
+      concurrencyControl.run(
+          () ->
+              concurrencyControl.runOnCompletion(
+                  futureScheduledTask,
+                  (scheduledTask, throwable) -> {
+                    if (scheduledTask != null) {
+                      scheduledTask.cancel();
+                    }
+                  }));
+    }
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ExtendedProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ExtendedProcessingScheduleServiceImpl.java
@@ -47,13 +47,13 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public void runDelayed(final Duration delay, final Runnable task) {
-    processorActorService.runDelayed(delay, task);
+  public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
+    return processorActorService.runDelayed(delay, task);
   }
 
   @Override
-  public void runDelayed(final Duration delay, final Task task) {
-    processorActorService.runDelayed(delay, task);
+  public ScheduledTask runDelayed(final Duration delay, final Task task) {
+    return processorActorService.runDelayed(delay, task);
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 public class ProcessingScheduleServiceImpl
     implements SimpleProcessingScheduleService, AutoCloseable {
 
+  private static final ScheduledTask NOOP_SCHEDULED_TASK = () -> {};
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
   private final Supplier<StreamProcessor.Phase> streamProcessorPhaseSupplier;
   private final BooleanSupplier abortCondition;
@@ -51,17 +52,18 @@ public class ProcessingScheduleServiceImpl
   }
 
   @Override
-  public void runDelayed(final Duration delay, final Runnable followUpTask) {
+  public ScheduledTask runDelayed(final Duration delay, final Runnable followUpTask) {
     if (actorControl == null) {
       LOG.debug("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
-      return;
+      return NOOP_SCHEDULED_TASK;
     }
-    actorControl.runDelayed(delay, followUpTask);
+    final var scheduledTimer = actorControl.runDelayed(delay, followUpTask);
+    return scheduledTimer::cancel;
   }
 
   @Override
-  public void runDelayed(final Duration delay, final Task task) {
-    runDelayed(delay, toRunnable(task));
+  public ScheduledTask runDelayed(final Duration delay, final Task task) {
+    return runDelayed(delay, toRunnable(task));
   }
 
   @Override

--- a/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
+++ b/engine/src/main/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceImpl.java
@@ -52,7 +52,11 @@ public class ProcessingScheduleServiceImpl
 
   @Override
   public void runDelayed(final Duration delay, final Runnable followUpTask) {
-    useActorControl(() -> actorControl.runDelayed(delay, followUpTask));
+    if (actorControl == null) {
+      LOG.debug("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
+      return;
+    }
+    actorControl.runDelayed(delay, followUpTask);
   }
 
   @Override
@@ -72,14 +76,6 @@ public class ProcessingScheduleServiceImpl
                 runAtFixedRate(delay, task);
               }
             }));
-  }
-
-  private void useActorControl(final Runnable task) {
-    if (actorControl == null) {
-      LOG.debug("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
-      return;
-    }
-    task.run();
   }
 
   public ActorFuture<Void> open(final ActorControl control) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -30,13 +30,14 @@ public class DueDateCheckerTest {
   @Test
   public void shouldNotScheduleTwoTasks() {
     // given
-    final var dueDateChecker = new DueDateChecker(100, false, (builder) -> 0L);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -52,7 +53,8 @@ public class DueDateCheckerTest {
   @Test
   public void shouldScheduleForAnEarlierTasks() {
     // given
-    final var dueDateChecker = new DueDateChecker(100, false, (builder) -> 0L);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -61,7 +63,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -81,7 +83,8 @@ public class DueDateCheckerTest {
     final Function<TaskResultBuilder, Long> visitor =
         (builder) -> ActorClock.currentTimeMillis() + 1000L;
 
-    final var dueDateChecker = new DueDateChecker(100, false, visitor);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, visitor);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -90,7 +93,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
@@ -106,7 +109,8 @@ public class DueDateCheckerTest {
     final Function<TaskResultBuilder, Long> visitor =
         (builder) -> ActorClock.currentTimeMillis() + 1000L;
 
-    final var dueDateChecker = new DueDateChecker(100, false, visitor);
+    final var timerResolution = 100;
+    final var dueDateChecker = new DueDateChecker(timerResolution, false, visitor);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -115,7 +119,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     dueDateChecker.execute(mock(TaskResultBuilder.class));

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Zeebe Community License 1.1. You may not use this file
  * except in compliance with the Zeebe Community License 1.1.
  */
-package io.camunda.zeebe.engine.processing.timer;
+package io.camunda.zeebe.engine.processing.scheduled;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,7 +17,6 @@ import static org.mockito.Mockito.when;
 import io.camunda.zeebe.engine.api.ProcessingScheduleService;
 import io.camunda.zeebe.engine.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.engine.api.Task;
-import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
@@ -386,6 +386,25 @@ class ProcessingScheduleServiceTest {
     assertThat(commandCache.contains(ACTIVATE_ELEMENT, 1)).isFalse();
   }
 
+  @Test
+  void shouldNotExecuteCancelledDelayedTask() {
+    // given
+    final var mockedTask = spy(new DummyTask());
+
+    final var scheduledTask = scheduleService.runDelayed(Duration.ofMinutes(1), mockedTask);
+    actorScheduler.workUntilDone(); // Ensure task is scheduled
+
+    scheduledTask.cancel();
+    actorScheduler.workUntilDone(); // Ensure task is cancelled
+
+    // when
+    actorScheduler.updateClock(Duration.ofMinutes(2));
+    actorScheduler.workUntilDone(); // Would execute task if not cancelled
+
+    // then
+    verify(mockedTask, never()).execute(any());
+  }
+
   /**
    * This decorator is an actor and implements {@link ProcessingScheduleService} and delegates to
    * {@link ProcessingScheduleServiceImpl}, on each call it will submit an extra job to the related

--- a/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/streamprocessor/ProcessingScheduleServiceTest.java
@@ -405,13 +405,35 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
-    public void runDelayed(final Duration delay, final Runnable task) {
-      actor.submit(() -> processingScheduleService.runDelayed(delay, task));
+    public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
+      final var futureScheduledTask =
+          actor.call(() -> processingScheduleService.runDelayed(delay, task));
+      return () ->
+          actor.run(
+              () ->
+                  actor.runOnCompletion(
+                      futureScheduledTask,
+                      (scheduledTask, throwable) -> {
+                        if (scheduledTask != null) {
+                          scheduledTask.cancel();
+                        }
+                      }));
     }
 
     @Override
-    public void runDelayed(final Duration delay, final Task task) {
-      actor.submit(() -> processingScheduleService.runDelayed(delay, task));
+    public ScheduledTask runDelayed(final Duration delay, final Task task) {
+      final var futureScheduledTask =
+          actor.call(() -> processingScheduleService.runDelayed(delay, task));
+      return () ->
+          actor.run(
+              () ->
+                  actor.runOnCompletion(
+                      futureScheduledTask,
+                      (scheduledTask, throwable) -> {
+                        if (scheduledTask != null) {
+                          scheduledTask.cancel();
+                        }
+                      }));
     }
 
     @Override

--- a/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/TimerTriggerSchedulingTest.java
+++ b/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/TimerTriggerSchedulingTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.processing;
+
+import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.it.util.GrpcClientRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.assertj.core.api.Assertions;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.RuleChain;
+
+public class TimerTriggerSchedulingTest {
+
+  private static final EmbeddedBrokerRule BROKER_RULE = new EmbeddedBrokerRule();
+  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+
+  @ClassRule
+  public static final RuleChain RULE_CHAIN = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  /**
+   * Regression test against issue <a href="https://github.com/camunda/zeebe/issues/17128">17128</a>
+   *
+   * <p>Given a process with a timer event that triggers some time in the future, and a process that
+   * schedules a timer event every second, we should not produce many Timer TRIGGER commands for any
+   * of these timers.
+   *
+   * <p>This was a problem previously because every time the DueDateChecker ran, it would reschedule
+   * another execution for the next timer (the one further in the future). This would cause the
+   * DueDateChecker to run many times in a row for this same timer, and not benefit from the command
+   * cache because executions are scheduled beforehand and executed before the cache is persisted.
+   */
+  @Test
+  public void shouldTriggerTimerOnlyOnce() {
+    // given
+    final long processDefinitionKey =
+        CLIENT_RULE.deployProcess(
+            Bpmn.createExecutableProcess("PROCESS")
+                .startEvent()
+                .intermediateCatchEvent("timer", t -> t.timerWithDurationExpression("duration"))
+                .endEvent()
+                .done());
+    final long processInstanceKey =
+        CLIENT_RULE.createProcessInstance(
+            processDefinitionKey,
+            """
+            {
+              "duration": "PT1H"
+            }
+            """);
+
+    // when
+    for (int i = 0; i < 10; i++) {
+      final long shortProcessInstanceKey =
+          CLIENT_RULE.createProcessInstance(
+              processDefinitionKey,
+              """
+              {
+                "duration": "PT1S"
+              }
+              """);
+      RecordingExporter.timerRecords(TimerIntent.CREATED)
+          .withProcessInstanceKey(shortProcessInstanceKey)
+          .await();
+      BROKER_RULE.getClock().addTime(Duration.ofSeconds(2));
+      RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+          .withProcessInstanceKey(shortProcessInstanceKey)
+          .await();
+    }
+
+    BROKER_RULE.getClock().addTime(Duration.ofHours(2));
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.timerRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(t -> t.getIntent() == TimerIntent.TRIGGERED)
+                .filter(t -> t.getIntent() == TimerIntent.TRIGGER)
+                .onlyCommands())
+        .describedAs("We only expect a single TRIGGER command")
+        .hasSize(1);
+  }
+}

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/ScheduledTimer.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/ScheduledTimer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.scheduler;
 
+@FunctionalInterface
 public interface ScheduledTimer {
   void cancel();
 }

--- a/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
@@ -32,7 +32,7 @@ public final class AtomicUtil {
    *     {@code empty} the atomic reference is not updated
    * @param rollback The rollback function used to revert any side effect produced by the update
    *     function
-   * @return The previous value of the atomic reference
+   * @return The previous value of the atomic reference, or null if the value was left unchanged
    * @param <T> The type of the atomic reference
    */
   public static <T> T update(
@@ -49,7 +49,7 @@ public final class AtomicUtil {
       currentVal = ref.get();
       final var result = update.apply(currentVal);
       if (result.isEmpty()) {
-        return currentVal;
+        return null;
       }
       newVal = result.get();
     } while (!ref.compareAndSet(currentVal, newVal));

--- a/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
+++ b/util/src/main/java/io/camunda/zeebe/util/AtomicUtil.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.util;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/** Utility class for common tasks with {@link AtomicReference} instances. */
+public final class AtomicUtil {
+
+  private AtomicUtil() {}
+
+  /**
+   * Locklessly updates an atomic reference using the provided update function and rollbacks if the
+   * reference changed during the update, e.g. by another thread.
+   *
+   * <p>If the update function returns an empty optional, the atomic reference is not updated.
+   *
+   * <p>If the atomic reference has been updated by another thread in the meantime, the rollback
+   * function is called with the value provided by the update function, and the update function is
+   * called again.
+   *
+   * @param ref The atomic reference to update
+   * @param update The update function used to provide a new value to the atomic reference; if
+   *     {@code empty} the atomic reference is not updated
+   * @param rollback The rollback function used to revert any side effect produced by the update
+   *     function
+   * @return The previous value of the atomic reference
+   * @param <T> The type of the atomic reference
+   */
+  public static <T> T update(
+      final AtomicReference<T> ref,
+      final Function<T, Optional<T>> update,
+      final Consumer<T> rollback) {
+    T currentVal;
+    T newVal = null;
+    do {
+      if (newVal != null) {
+        // another thread appears to have replaced the value in the meantime
+        rollback.accept(newVal);
+      }
+      currentVal = ref.get();
+      final var result = update.apply(currentVal);
+      if (result.isEmpty()) {
+        return currentVal;
+      }
+      newVal = result.get();
+    } while (!ref.compareAndSet(currentVal, newVal));
+    return currentVal;
+  }
+}


### PR DESCRIPTION
# Description
Backport of #17136 to `stable/8.1`.

relates to https://github.com/camunda/zeebe/issues/17128
relates to https://github.com/camunda/zeebe/issues/10541
relates to https://github.com/camunda/zeebe/issues/16884
relates to https://github.com/camunda/zeebe/issues/8991

original author: @korthout

There were a few conflicts that I had to resolve by hand, mostly related to imports. A description is added to the specific commits.