### PR TITLE
ci: do not run codeql always

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -514,7 +514,7 @@ jobs:
       - go-apidiff
       - docker-checks
     steps:
-      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+      - run: exit ${{ (contains(needs.*.result, 'failure') && 1) || 0 }}
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ test-summary ]

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -348,6 +348,7 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: [ self-hosted, linux, amd64, "16" ]
+    if:  github.event_name != 'merge_group' && github.actor != 'renovate[bot]' # we don't need to run codeql for renovate PR's and not in merge queues
     permissions:
       security-events: write
     steps:


### PR DESCRIPTION
## Description

it has shown that CodeQL seems to be quite instable especially in merge queues, as it was causing most of our merges to fail.

Exluding it from the merge queue and renovate PR's as it is not necessary in such cases.
<!-- Please explain the changes you made here. -->

See related thread https://camunda.slack.com/archives/C05DH1F5TAR/p1711638977681099