### PR TITLE
[Backport stable/8.3] fix: update lifecycle policy for existing indices when retention config changes on elasticsearch exporter re-run.

### DIFF
--- a/exporters/elasticsearch-exporter/pom.xml
+++ b/exporters/elasticsearch-exporter/pom.xml
@@ -154,6 +154,12 @@
       <artifactId>agrona</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -17,6 +17,10 @@ import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.De
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Phases;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Policy;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyResponse;
+import io.camunda.zeebe.exporter.dto.PutIndexSettingsRequest;
+import io.camunda.zeebe.exporter.dto.PutIndexSettingsRequest.Index;
+import io.camunda.zeebe.exporter.dto.PutIndexSettingsRequest.Lifecycle;
+import io.camunda.zeebe.exporter.dto.PutIndexSettingsResponse;
 import io.camunda.zeebe.exporter.dto.PutIndexTemplateResponse;
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.Record;
@@ -219,6 +223,20 @@ class ElasticsearchClient implements AutoCloseable {
     } catch (final IOException e) {
       throw new ElasticsearchExporterException(
           "Failed to put index lifecycle management policy", e);
+    }
+  }
+
+  public boolean bulkPutIndexLifecycleSettings(final String policyName) {
+    try {
+      final var request =
+          new Request(
+              "PUT", "/" + configuration.index.prefix + "*/_settings?allow_no_indices=true");
+      final var requestEntity = new PutIndexSettingsRequest(new Index(new Lifecycle(policyName)));
+      request.setJsonEntity(MAPPER.writeValueAsString(requestEntity));
+      final var response = sendRequest(request, PutIndexSettingsResponse.class);
+      return response.acknowledged();
+    } catch (final IOException e) {
+      throw new ElasticsearchExporterException("Failed to update indices lifecycle settings", e);
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -63,6 +63,7 @@ public class ElasticsearchExporter implements Exporter {
     validate(configuration);
 
     context.setFilter(new ElasticsearchRecordFilter(configuration));
+    indexTemplatesCreated = false;
   }
 
   @Override
@@ -347,10 +348,6 @@ public class ElasticsearchExporter implements Exporter {
     if (!acknowledged) {
       log.warn("Failed to acknowledge the the update of retention policy for existing indices");
     }
-  }
-
-  void setIndexTemplatesCreated(final boolean indexTemplatesCreated) {
-    this.indexTemplatesCreated = indexTemplatesCreated;
   }
 
   private static class ElasticsearchRecordFilter implements Context.RecordFilter {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -105,6 +105,8 @@ public class ElasticsearchExporter implements Exporter {
   public void export(final Record<?> record) {
     if (!indexTemplatesCreated) {
       createIndexTemplates();
+
+      updateRetentionPolicyForExistingIndices();
     }
 
     final var recordSequence = recordCounters.getNextRecordSequence(record);
@@ -331,6 +333,19 @@ public class ElasticsearchExporter implements Exporter {
       log.warn(
           "Failed to acknowledge the creation or update of the index template for value type {}",
           valueType);
+    }
+  }
+
+  private void updateRetentionPolicyForExistingIndices() {
+    final boolean acknowledged;
+    if (configuration.retention.isEnabled()) {
+      acknowledged = client.bulkPutIndexLifecycleSettings(configuration.retention.getPolicyName());
+    } else {
+      acknowledged = client.bulkPutIndexLifecycleSettings(null);
+    }
+
+    if (!acknowledged) {
+      log.warn("Failed to acknowledge the the update of retention policy for existing indices");
     }
   }
 

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -349,6 +349,10 @@ public class ElasticsearchExporter implements Exporter {
     }
   }
 
+  void setIndexTemplatesCreated(final boolean indexTemplatesCreated) {
+    this.indexTemplatesCreated = indexTemplatesCreated;
+  }
+
   private static class ElasticsearchRecordFilter implements Context.RecordFilter {
 
     private final ElasticsearchExporterConfiguration configuration;

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexSettingsRequest.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexSettingsRequest.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.dto;
+
+public record PutIndexSettingsRequest(Index index) {
+  public record Index(Lifecycle lifecycle) {}
+
+  public record Lifecycle(String name) {}
+}

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexSettingsResponse.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexSettingsResponse.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PutIndexSettingsResponse(boolean acknowledged) {}

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
@@ -212,15 +213,7 @@ final class ElasticsearchExporterIT {
     final var index1 = indexRouter.indexFor(record1);
     var response1 = testClient.getIndexSettings(index1);
 
-    assertThat(response1)
-        .as("should have found the index")
-        .isPresent()
-        .get()
-        .extracting(IndexSettings::settings)
-        .extracting(Settings::index)
-        .extracting(Index::lifecycle)
-        .as("Lifecycle policy should not be configured")
-        .isNull();
+    assertIndexSettingsHasNoLifecyclePolicy(response1);
 
     /* Tests when retention is later enabled all indices should have lifecycle policy */
     // given
@@ -234,30 +227,10 @@ final class ElasticsearchExporterIT {
     // then
     final var index2 = indexRouter.indexFor(record2);
     final var response2 = testClient.getIndexSettings(index2);
-    assertThat(response2)
-        .as("should have found the index")
-        .isPresent()
-        .get()
-        .extracting(IndexSettings::settings)
-        .extracting(Settings::index)
-        .extracting(Index::lifecycle)
-        .as("should have lifecycle config")
-        .isNotNull()
-        .extracting(IndexSettings.Lifecycle::name)
-        .isEqualTo(config.retention.getPolicyName());
+    assertIndexSettingsHasLifecyclePolicy(response2);
 
     response1 = testClient.getIndexSettings(index1);
-    assertThat(response1)
-        .as("should have found the index")
-        .isPresent()
-        .get()
-        .extracting(IndexSettings::settings)
-        .extracting(Settings::index)
-        .extracting(Index::lifecycle)
-        .as("should have lifecycle config")
-        .isNotNull()
-        .extracting(IndexSettings.Lifecycle::name)
-        .isEqualTo(config.retention.getPolicyName());
+    assertIndexSettingsHasLifecyclePolicy(response1);
   }
 
   @Test
@@ -272,17 +245,7 @@ final class ElasticsearchExporterIT {
     // then
     final var index1 = indexRouter.indexFor(record1);
     var response1 = testClient.getIndexSettings(index1);
-    assertThat(response1)
-        .as("should have found the index")
-        .isPresent()
-        .get()
-        .extracting(IndexSettings::settings)
-        .extracting(Settings::index)
-        .extracting(Index::lifecycle)
-        .as("should have lifecycle config")
-        .isNotNull()
-        .extracting(IndexSettings.Lifecycle::name)
-        .isEqualTo(config.retention.getPolicyName());
+    assertIndexSettingsHasLifecyclePolicy(response1);
 
     /* Tests when retention is later disabled all indices should not have a lifecycle policy */
     // given
@@ -296,18 +259,28 @@ final class ElasticsearchExporterIT {
     // then
     final var index2 = indexRouter.indexFor(record2);
     final var response2 = testClient.getIndexSettings(index2);
-    assertThat(response2)
+    assertIndexSettingsHasNoLifecyclePolicy(response2);
+
+    response1 = testClient.getIndexSettings(index1);
+    assertIndexSettingsHasNoLifecyclePolicy(response1);
+  }
+
+  private void assertIndexSettingsHasLifecyclePolicy(final Optional<IndexSettings> indexSettings) {
+    assertThat(indexSettings)
         .as("should have found the index")
         .isPresent()
         .get()
         .extracting(IndexSettings::settings)
         .extracting(Settings::index)
         .extracting(Index::lifecycle)
-        .as("Lifecycle policy should not be configured")
-        .isNull();
+        .as("should have lifecycle config")
+        .isNotNull()
+        .extracting(IndexSettings.Lifecycle::name)
+        .isEqualTo(config.retention.getPolicyName());
+  }
 
-    response1 = testClient.getIndexSettings(index1);
-    assertThat(response1)
+  private static void assertIndexSettingsHasNoLifecyclePolicy(final Optional<IndexSettings> indexSettings) {
+    assertThat(indexSettings)
         .as("should have found the index")
         .isPresent()
         .get()

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -279,7 +279,8 @@ final class ElasticsearchExporterIT {
         .isEqualTo(config.retention.getPolicyName());
   }
 
-  private static void assertIndexSettingsHasNoLifecyclePolicy(final Optional<IndexSettings> indexSettings) {
+  private static void assertIndexSettingsHasNoLifecyclePolicy(
+      final Optional<IndexSettings> indexSettings) {
     assertThat(indexSettings)
         .as("should have found the index")
         .isPresent()

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchExporterIT.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.exporter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import co.elastic.clients.elasticsearch.core.GetResponse;
 import io.camunda.zeebe.exporter.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
@@ -26,6 +27,7 @@ import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
@@ -41,7 +43,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
 import org.junit.jupiter.api.TestMethodOrder;
-import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
@@ -210,9 +211,10 @@ final class ElasticsearchExporterIT {
         .isEqualTo(config.index.prefix);
   }
 
-  private void export(final Record<?> record) {
+  private boolean export(final Record<?> record) {
     exporter.export(record);
     exportedRecordsCounter++;
+    return true;
   }
 
   @Nested
@@ -291,7 +293,6 @@ final class ElasticsearchExporterIT {
      */
     @Test
     @Order(3)
-    @Timeout(30)
     void shouldNotTimeoutWhenUpdatingLifecyclePolicyForExistingIndices() {
       // given
       configureExporter(false);
@@ -320,7 +321,9 @@ final class ElasticsearchExporterIT {
       final var record2 = factory.generateRecord(ValueType.JOB);
 
       // when
-      export(record2);
+      await("New record is exported, and existing indices are updated")
+          .atMost(Duration.ofSeconds(30))
+          .until(() -> export(record2));
 
       // then
       final var index2 = indexRouter.indexFor(record2);

--- a/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
+++ b/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestClient.java
@@ -104,6 +104,15 @@ final class TestClient implements CloseableSilently {
     }
   }
 
+  void deleteIndices() {
+    try {
+      final var request = new Request("DELETE", config.index.prefix + "*");
+      restClient.performRequest(request);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
   ElasticsearchClient getEsClient() {
     return esClient;
   }


### PR DESCRIPTION
## Description

Backport of #17124 to `stable/8.3`.

Fixed conflict in pom.xml, otherwise only adding new files 

relates to #16720