### PR TITLE
docs: minor modifications to REST OpenAPI spec for docs.camunda.io experience

### DIFF
--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -381,3 +381,8 @@ components:
           type: string
           format: uri
           description: A URI identifying the origin of the problem.
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -26,14 +26,14 @@ servers:
 paths:
   /topology:
     get:
-      summary: Get cluster topology.
+      summary: Get cluster topology
       description: Obtains the current topology of the cluster the gateway is part of.
       responses:
         '200':
           $ref: "#/components/responses/TopologyResponse"
   /user-tasks/{userTaskKey}/completion:
     post:
-      summary: Complete a user task.
+      summary: Complete a user task
       description: Completes a user task with the given key.
       parameters:
         - name: userTaskKey
@@ -67,7 +67,7 @@ paths:
           $ref: "#/components/responses/ProblemResponse"
   /user-tasks/{userTaskKey}/assignment:
     post:
-      summary: Assigns a user task.
+      summary: Assign a user task
       description: Assigns a user task with the given key to the given assignee.
       parameters:
         - name: userTaskKey
@@ -100,7 +100,7 @@ paths:
           $ref: "#/components/responses/ProblemResponse"
   /user-tasks/{userTaskKey}:
     patch:
-      summary: Update a user task.
+      summary: Update a user task
       description: Update a user task with the given key.
       parameters:
         - name: userTaskKey
@@ -133,7 +133,7 @@ paths:
           $ref: "#/components/responses/ProblemResponse"
   /user-tasks/{userTaskKey}/assignee:
     delete:
-      summary: Remove the assignee of a task.
+      summary: Unassign a user task
       description: Removes the assignee of a task with the given key.
       parameters:
         - name: userTaskKey

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -26,6 +26,8 @@ servers:
 paths:
   /topology:
     get:
+      tags:
+        - Cluster
       summary: Get cluster topology
       description: Obtains the current topology of the cluster the gateway is part of.
       responses:
@@ -33,6 +35,8 @@ paths:
           $ref: "#/components/responses/TopologyResponse"
   /user-tasks/{userTaskKey}/completion:
     post:
+      tags:
+        - User task
       summary: Complete a user task
       description: Completes a user task with the given key.
       parameters:
@@ -67,6 +71,8 @@ paths:
           $ref: "#/components/responses/ProblemResponse"
   /user-tasks/{userTaskKey}/assignment:
     post:
+      tags:
+        - User task
       summary: Assign a user task
       description: Assigns a user task with the given key to the given assignee.
       parameters:
@@ -100,6 +106,8 @@ paths:
           $ref: "#/components/responses/ProblemResponse"
   /user-tasks/{userTaskKey}:
     patch:
+      tags:
+        - User task
       summary: Update a user task
       description: Update a user task with the given key.
       parameters:
@@ -133,6 +141,8 @@ paths:
           $ref: "#/components/responses/ProblemResponse"
   /user-tasks/{userTaskKey}/assignee:
     delete:
+      tags:
+        - User task
       summary: Unassign a user task
       description: Removes the assignee of a task with the given key.
       parameters:


### PR DESCRIPTION
## Description

A few minor modifications to the REST OpenAPI spec, to align with the changes I made in https://github.com/camunda/camunda-docs/pull/3529. These changes were made to improve the docs.camunda.io browsing experience. See [here](https://stage.docs.camunda.io/docs/next/apis-tools/zeebe-api-rest/specifications/zeebe-rest-api/) to see the changes applied on the docs side.

1. Modifies endpoint names to (a) remove periods, and (b) shorten the language. This align this API's left-nav with other APIs in docs.camunda.io.
2. Adds tags to each endpoint. This allows the docs.camunda.io navigation to be grouped by resource.
3. Adds a `bearerAuth` security scheme. This instructs the docs.camunda.io documentation to specify that authentication is required.

If any of these changes feel inappropriate to make here at the source, let me know, and I can update the PR with only the changes you wish to include.

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [x] I've reviewed my own code
* [x] I've written a clear changelist description
* [x] I've narrowly scoped my changes
* [x] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [x] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
