### PR TITLE
[Backport release-8.5.0] fix: opensearch exporter - update ISM policy for existing indices when retention config changes on rerun

### DIFF
--- a/zeebe/exporters/opensearch-exporter/pom.xml
+++ b/zeebe/exporters/opensearch-exporter/pom.xml
@@ -174,6 +174,12 @@
       <artifactId>agrona</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/AddPolicyRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/AddPolicyRequest.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record AddPolicyRequest(@JsonProperty("policy_id") String policyId) {}

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/IndexPolicyResponse.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/IndexPolicyResponse.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record IndexPolicyResponse(
+    @JsonProperty("updated_indices") int updatedIndices,
+    boolean failures,
+    @JsonProperty("failed_indices") List<FailedIndex> failedIndices) {
+  record FailedIndex(
+      @JsonProperty("index_name") String name,
+      @JsonProperty("index_uuid") String uuid,
+      String reason) {}
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -8,25 +8,33 @@
 package io.camunda.zeebe.exporter.opensearch;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 import io.camunda.zeebe.exporter.opensearch.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
+import io.camunda.zeebe.exporter.opensearch.TestClient.IndexISMPolicyDto;
 import io.camunda.zeebe.exporter.opensearch.TestClient.IndexTemplatesDto.IndexTemplateWrapper;
 import io.camunda.zeebe.exporter.test.ExporterTestConfiguration;
 import io.camunda.zeebe.exporter.test.ExporterTestContext;
 import io.camunda.zeebe.exporter.test.ExporterTestController;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Optional;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestInstance.Lifecycle;
@@ -48,7 +56,8 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 @TestInstance(Lifecycle.PER_CLASS)
 final class OpensearchExporterIT {
   @Container
-  private static final OpensearchContainer CONTAINER = TestSupport.createDefaultContainer();
+  private static final OpensearchContainer<?> CONTAINER =
+      TestSupport.createDefaultContainer().withEnv("action.destructive_requires_name", "false");
 
   private final OpensearchExporterConfiguration config = new OpensearchExporterConfiguration();
   private final ProtocolFactory factory = new ProtocolFactory();
@@ -57,6 +66,7 @@ final class OpensearchExporterIT {
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);
 
   private TestClient testClient;
+  private ExporterTestContext exporterTestContext;
 
   @BeforeAll
   public void beforeAll() {
@@ -72,15 +82,21 @@ final class OpensearchExporterIT {
 
     testClient = new TestClient(config, indexRouter);
 
-    exporter.configure(
+    exporterTestContext =
         new ExporterTestContext()
-            .setConfiguration(new ExporterTestConfiguration<>("opensearch", config)));
+            .setConfiguration(new ExporterTestConfiguration<>("opensearch", config));
+    exporter.configure(exporterTestContext);
     exporter.open(controller);
   }
 
   @AfterAll
   void afterAll() {
     CloseHelper.quietCloseAll(testClient);
+  }
+
+  @BeforeEach
+  void cleanup() {
+    testClient.deleteIndices();
   }
 
   @ParameterizedTest(name = "{0}")
@@ -90,7 +106,7 @@ final class OpensearchExporterIT {
     final var record = factory.generateRecord(valueType);
 
     // when
-    exporter.export(record);
+    export(record);
 
     // then
     final var response = testClient.getExportedDocumentFor(record);
@@ -120,7 +136,7 @@ final class OpensearchExporterIT {
         factory.generateRecord(ValueType.JOB, builder -> builder.withValue(value));
 
     // when
-    exporter.export(record);
+    export(record);
 
     // then
     final var response = testClient.getExportedDocumentFor(record);
@@ -146,7 +162,7 @@ final class OpensearchExporterIT {
         factory.generateRecord(ValueType.JOB_BATCH, builder -> builder.withValue(value));
 
     // when
-    exporter.export(record);
+    export(record);
 
     // then
     final var response = testClient.getExportedDocumentFor(record);
@@ -166,7 +182,7 @@ final class OpensearchExporterIT {
     final var expectedIndexTemplateName = indexRouter.indexPrefixForValueType(valueType);
 
     // when - export a single record to enforce installing all index templatesWrapper
-    exporter.export(record);
+    export(record);
 
     // then
     final var template = testClient.getIndexTemplate(valueType);
@@ -184,7 +200,7 @@ final class OpensearchExporterIT {
     final var record = factory.generateRecord();
 
     // when - export a single record to enforce installing all index templatesWrapper
-    exporter.export(record);
+    export(record);
 
     // then
     final var template = testClient.getComponentTemplate();
@@ -202,7 +218,7 @@ final class OpensearchExporterIT {
     final var record = factory.generateRecord();
 
     // when - export a single record to enforce creating the policy
-    exporter.export(record);
+    export(record);
 
     // then
     final var policy = testClient.getIndexStateManagementPolicy().policy();
@@ -248,12 +264,174 @@ final class OpensearchExporterIT {
     final var record = factory.generateRecord();
 
     // when - export a single record to enforce creating the policy
-    exporter.export(record);
+    export(record);
 
     // then
     final var updatedPolicy = testClient.getIndexStateManagementPolicy().policy();
     final String updatedMinimumAge =
         updatedPolicy.states().getFirst().transitions().getFirst().conditions().minIndexAge();
     assertThat(updatedMinimumAge).isEqualTo(config.retention.getMinimumAge());
+  }
+
+  private boolean export(final Record<?> record) {
+    exporter.export(record);
+    return true;
+  }
+
+  /**
+   * policy change is an asynchronous background process in opensearch, that's why I use awaits
+   * before asserts to reduce flakey results
+   */
+  @Nested
+  final class IndexSettingsTest {
+    @Test
+    void shouldAddIndexLifecycleSettingsToExistingIndicesOnRerunWhenRetentionIsEnabled() {
+      // given
+      configureExporter(false);
+      final var record1 = factory.generateRecord(ValueType.JOB);
+
+      // when
+      export(record1);
+
+      // then
+      final var index1 = indexRouter.indexFor(record1);
+      await()
+          .untilAsserted(
+              () -> {
+                final var index1Policy = testClient.explainIndex(index1);
+                assertHasNoISMPolicy(index1Policy);
+              });
+
+      /* Tests when retention is later enabled all indices should have lifecycle policy */
+      // given
+      configureExporter(true);
+      final var record2 = factory.generateRecord(ValueType.JOB);
+
+      // when
+      export(record2);
+
+      // then
+      final var index2 = indexRouter.indexFor(record2);
+      await()
+          .untilAsserted(
+              () -> {
+                final var index2Policy = testClient.explainIndex(index2);
+                assertHasISMPolicy(index2Policy);
+              });
+      await()
+          .untilAsserted(
+              () -> {
+                final var index1PolicyNew = testClient.explainIndex(index1);
+                assertHasISMPolicy(index1PolicyNew);
+              });
+    }
+
+    @Test
+    void shouldRemoveIndexLifecycleSettingsFromExistingIndicesOnRerunWhenRetentionIsDisabled() {
+      // given
+      configureExporter(true);
+      final var record1 = factory.generateRecord(ValueType.JOB);
+
+      // when
+      export(record1);
+
+      // then
+      final var index1 = indexRouter.indexFor(record1);
+      await()
+          .untilAsserted(
+              () -> {
+                final var indexPolicy1 = testClient.explainIndex(index1);
+                assertHasISMPolicy(indexPolicy1);
+              });
+
+      /* Tests when retention is later disabled all indices should not have a lifecycle policy */
+      // given
+      configureExporter(false);
+      final var record2 = factory.generateRecord(ValueType.JOB);
+
+      // when
+      export(record2);
+
+      // then
+      final var index2 = indexRouter.indexFor(record2);
+
+      await()
+          .atMost(Duration.ofSeconds(30))
+          .untilAsserted(
+              () -> {
+                final var response2 = testClient.explainIndex(index2);
+                assertHasNoISMPolicy(response2);
+              });
+      await()
+          .untilAsserted(
+              () -> {
+                final var index1PolicyNew = testClient.explainIndex(index1);
+                assertHasNoISMPolicy(index1PolicyNew);
+              });
+    }
+
+    /**
+     * Default timeout for elasticsearch `PUT /<target>/_settings` is 30 seconds.
+     *
+     * <p>500 records each has a shard and a replica means 1000 shards, which is the maximum open
+     * shards in a one node cluster
+     */
+    @Test
+    void shouldNotTimeoutWhenUpdatingLifecyclePolicyForExistingIndices() {
+      // given
+      configureExporter(false);
+      final var records = new ArrayList<Record<RecordValue>>();
+      // using 498 here as we will export one more record after (1 main shard, 1 replica)
+      final int limit = 498;
+      for (int i = 0; i < limit; i++) {
+        final var record = factory.generateRecord(ValueType.JOB);
+        records.add(record);
+        export(record);
+      }
+
+      // when
+      configureExporter(true);
+      final var record2 = factory.generateRecord(ValueType.JOB);
+
+      await("New record is exported, and existing indices are updated")
+          .atMost(Duration.ofSeconds(30))
+          .until(() -> export(record2));
+
+      // then
+      final var index2 = indexRouter.indexFor(record2);
+      await()
+          .untilAsserted(
+              () -> {
+                final var index2Policy = testClient.explainIndex(index2);
+                assertHasISMPolicy(index2Policy);
+              });
+
+      for (final var record : records) {
+        final var index = indexRouter.indexFor(record);
+        final var response = testClient.explainIndex(index);
+
+        assertHasISMPolicy(response);
+      }
+    }
+
+    private void configureExporter(final boolean retentionEnabled) {
+      config.retention.setEnabled(retentionEnabled);
+      exporter.configure(exporterTestContext);
+    }
+
+    private void assertHasISMPolicy(final Optional<IndexISMPolicyDto> indexSettings) {
+      assertThat(indexSettings)
+          .as("should have found the index")
+          .isPresent()
+          .get()
+          .extracting(IndexISMPolicyDto::policyId)
+          .as("should have lifecycle config")
+          .isNotNull()
+          .isEqualTo(config.retention.getPolicyName());
+    }
+
+    private static void assertHasNoISMPolicy(final Optional<IndexISMPolicyDto> policy) {
+      assertThat(policy).as("ISM policy should not be configured").isEmpty();
+    }
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -279,7 +279,7 @@ final class OpensearchExporterIT {
   }
 
   /**
-   * policy change is an asynchronous background process in opensearch, that's why I use awaits
+   * policy change is an asynchronous background process in opensearch, that's why we use awaits
    * before asserts to reduce flakey results
    */
   @Nested
@@ -370,12 +370,6 @@ final class OpensearchExporterIT {
               });
     }
 
-    /**
-     * Default timeout for elasticsearch `PUT /<target>/_settings` is 30 seconds.
-     *
-     * <p>500 records each has a shard and a replica means 1000 shards, which is the maximum open
-     * shards in a one node cluster
-     */
     @Test
     void shouldNotTimeoutWhenUpdatingLifecyclePolicyForExistingIndices() {
       // given

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -13,6 +13,7 @@ import static io.camunda.zeebe.exporter.opensearch.OpensearchClient.ISM_INITIAL_
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.zeebe.exporter.opensearch.TestClient.ComponentTemplatesDto.ComponentTemplateWrapper;
 import io.camunda.zeebe.exporter.opensearch.TestClient.IndexTemplatesDto.IndexTemplateWrapper;
@@ -33,6 +34,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.agrona.CloseHelper;
 import org.opensearch.client.Request;
@@ -165,6 +167,36 @@ final class TestClient implements CloseableSilently {
     return new PutIndexStateManagementPolicyRequest(policy);
   }
 
+  public Optional<IndexISMPolicyDto> explainIndex(final String index) {
+    try {
+      final var request = new Request("GET", "_plugins/_ism/explain/" + index);
+      final var response = restClient.performRequest(request);
+      final TypeReference<Map<String, Object>> mapTypeReference = new TypeReference<>() {};
+      final Map<String, Object> output =
+          MAPPER.readValue(response.getEntity().getContent(), mapTypeReference);
+      final var policy =
+          output.values().stream()
+              .filter(Map.class::isInstance)
+              .map(v -> (Map<String, String>) v)
+              .findFirst();
+
+      return policy
+          .map(p -> p.get("index.opendistro.index_state_management.policy_id"))
+          .map(IndexISMPolicyDto::new);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  void deleteIndices() {
+    try {
+      final var request = new Request("DELETE", config.index.prefix + "*");
+      restClient.performRequest(request);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
   record IndexTemplatesDto(@JsonProperty("index_templates") List<IndexTemplateWrapper> wrappers) {
     record IndexTemplateWrapper(String name, @JsonProperty("index_template") Template template) {}
   }
@@ -174,6 +206,8 @@ final class TestClient implements CloseableSilently {
     record ComponentTemplateWrapper(
         String name, @JsonProperty("component_template") Template template) {}
   }
+
+  record IndexISMPolicyDto(String policyId) {}
 
   @JsonInclude(Include.NON_EMPTY)
   private record PutUserRequest(


### PR DESCRIPTION
# Description
Backport of #17187 to `release-8.5.0`.

relates to #17186
original author: @mustafadagher