### PR TITLE
fix: API error message for invalid size parameters

### DIFF
--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -42,3 +42,13 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }}
+
+  test-summary:
+    # Used by the merge queue as a dummy instead of the Zeebe CI in case only Operate files got changed:
+    # https://github.com/orgs/community/discussions/26251
+    # This name is hard-coded in the branch rules; remember to update that if this name changes
+    name: Test summary
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
@@ -665,8 +665,18 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
       throw new OperateRuntimeException(
           "One and only one of 'doc' or 'script' must be provided for the update request");
     }
-    if (index == null && operateProperties.getImporter().isPostImporterIgnoreMissingData()) {
-      return;
+    if (index == null) {
+      final String reason =
+          String.format(
+              "Cannot create update request for document with id [%s]: index is null. This suggests possible data loss.",
+              id);
+      if (operateProperties.getImporter().isPostImporterIgnoreMissingData()) {
+        LOGGER.error(reason + " Ignoring document...");
+        return;
+      } else {
+        throw new OperateRuntimeException(
+            reason + " Note: PostImporter can be configured to ignore missing data.");
+      }
     }
     final UpdateRequest updateRequest =
         new UpdateRequest(index, id).retryOnConflict(UPDATE_RETRY_COUNT);

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/opensearch/OpensearchIncidentPostImportAction.java
@@ -653,8 +653,18 @@ public class OpensearchIncidentPostImportAction extends AbstractIncidentPostImpo
       throw new OperateRuntimeException(
           "One and only one of 'doc' or 'script' must be provided for the update request");
     }
-    if (index == null && operateProperties.getImporter().isPostImporterIgnoreMissingData()) {
-      return;
+    if (index == null) {
+      final String reason =
+          String.format(
+              "Cannot create update request for document with id [%s]: index is null. This suggests possible data loss.",
+              id);
+      if (operateProperties.getImporter().isPostImporterIgnoreMissingData()) {
+        LOGGER.error(reason + " Ignoring document...");
+        return;
+      } else {
+        throw new OperateRuntimeException(
+            reason + " Note: PostImporter can be configured to ignore missing data.");
+      }
     }
     requestMap.put(
         id,

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
@@ -59,7 +59,8 @@ public class QueryValidator<T> {
   protected void validatePaging(final Query<T> query) {
     final int size = query.getSize();
     if (size <= 0 || size > MAX_QUERY_SIZE) {
-      throw new ClientException("size should be greater than zero and less than " + MAX_QUERY_SIZE);
+      throw new ClientException(
+          "size should be greater than zero and equal or less than " + MAX_QUERY_SIZE);
     }
     final Object[] searchAfter = query.getSearchAfter();
     if (searchAfter != null && searchAfter.length == 0) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
@@ -30,12 +30,15 @@ public class QueryValidator<T> {
   public static final int MAX_QUERY_SIZE = 1000;
   private List<String> fields;
 
-  public void validate(final Query<T> query, Class<T> queriedClass) throws ValidationException {
+  public void validate(final Query<T> query, final Class<T> queriedClass)
+      throws ValidationException {
     validate(query, queriedClass, null);
   }
 
   public void validate(
-      final Query<T> query, Class<T> queriedClass, CustomQueryValidator<T> customValidator) {
+      final Query<T> query,
+      final Class<T> queriedClass,
+      final CustomQueryValidator<T> customValidator) {
     retrieveFieldsFor(queriedClass);
     validateSorting(query.getSort(), fields);
     validatePaging(query);
@@ -71,7 +74,7 @@ public class QueryValidator<T> {
     }
   }
 
-  protected void validateSorting(final List<Sort> sortSpecs, List<String> fields) {
+  protected void validateSorting(final List<Sort> sortSpecs, final List<String> fields) {
     if (sortSpecs == null || sortSpecs.isEmpty()) {
       return;
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -768,12 +768,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-client-common</artifactId>
-        <version>${version.spring-boot}</version>
-      </dependency>
-
-      <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-broker</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
Changed error message in the QueryValidator to better communicate the actually allowed/valid values for "size".

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes [camunda/operate/#2584](https://github.com/camunda/operate/issues/2584)

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [x] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark
