### PR TITLE
Fix flaky test reporting

### DIFF
--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -51,7 +51,7 @@ runs:
         # To cover cases where we use parameterized tests like
         # [WARNING]  io.camunda.zeebe.engine.state.BanInstanceTest.shouldBanInstance[PROCESS_MESSAGE_SUBSCRIPTION DELETE should ban instance true]
         # We grep the WARNING line and set the first argument to an empty string
-        flakyTests=$(grep "\[WARNING\] io.camunda" ${irOutputFile} | awk '{$1=""; print $0}')
+        flakyTests=$(grep -E "\[WARNING\] [a-z]+\." ${irOutputFile} | awk '{$1=""; print $0}')
 
         # To support multi-line string in output we have to work with EOF delimiter
         # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string

--- a/.github/actions/analyze-test-runs/action.yml
+++ b/.github/actions/analyze-test-runs/action.yml
@@ -33,6 +33,7 @@ runs:
     env:
       BUILD_OUTPUT_FILE_PATH: ${{ inputs.buildOutputFilePath }}
     run: |
+      set -eoux
       if [ ! -s "$BUILD_OUTPUT_FILE_PATH" ]; then
         echo "::error::Build output file does not exist or is empty!"
         exit 1


### PR DESCRIPTION
## Description

We recently introduce some flaky test reporting, that adds more details to our slack CI messages. Unfortuantelty this fails for some test cases, see related [slack thread](https://camunda.slack.com/archives/C013MEVQ4M9/p1712050070233109). 

The problem was that we expected that our tests are always at the `io.camunda` package, but this is not true for tests part of `atomix` for example.

To fix this, this PR adjusted the pattern to be more generic. Instead of matching the `io.camunda` we match any letters followed by a dot, so we know it is likely the test name (as this line also started with the [WARNING]).


Example flaky report from maven:

```
[WARNING] Flakes: 
[WARNING] io.atomix.raft.RaftSnapshotReplicationFailureHandlingTest.shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut
[ERROR]   Run 1: RaftSnapshotReplicationFailureHandlingTest.shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut:56 failing
[ERROR]   Run 2: RaftSnapshotReplicationFailureHandlingTest.shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut:56 failing
[INFO]   Run 3: PASS
```




### Verification

I tested this locally via making the `RaftSnapshotReplicationFailureHandlingTest` more flaky:

```diff
@@ -51,6 +52,10 @@ public class RaftSnapshotReplicationFailureHandlingTest {
 
   @Test
   public void shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut() throws Throwable {
+    if (System.currentTimeMillis() % 3 == 0) {
+      fail("failing");
+    }
+
     // given
     final int numberOfChunks = 10;
     disconnectFollowerAndTakeSnapshot(numberOfChunks);
```


Then running:

```
./mvnw clean verify -Dtest=RaftSnapshotReplicationFailureHandlingTest  -DskipITs -DskipChecks -Dsurefire.rerunFailingTestsCount=3 -Pextract-flaky-tests -Dsurefire.failIfNoSpecifiedTests=false  | tee flaky-output.txt
```

The `flaky-output.txt` contains the complete maven output (as in CI) for which we can execute the commands from the analyze action.

With that I was able to trace that `flakyTests=$(grep "\[WARNING\] io.camunda" ${irOutputFile} | awk '{$1=""; print $0}')` failed.

After fixing this command I was able to extract: `io.atomix.raft.RaftSnapshotReplicationFailureHandlingTest.shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut`


from:

```
[WARNING] Flakes: 
[WARNING] io.atomix.raft.RaftSnapshotReplicationFailureHandlingTest.shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut
[ERROR]   Run 1: RaftSnapshotReplicationFailureHandlingTest.shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut:56 failing
[ERROR]   Run 2: RaftSnapshotReplicationFailureHandlingTest.shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut:56 failing
[INFO]   Run 3: PASS
```

