### PR TITLE
test: intercept request for deterministic test

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
@@ -60,7 +60,7 @@ public class RaftSnapshotReplicationFailureHandlingTest {
     // Time out request after sending a request. This simulates the behaviour that the receiver has
     // processed the request, but the request timeout out at the sender.
     leaderProtocol.interceptResponse(
-        InstallResponse.class, new TimingOutInterceptor(numberOfChunks - 1));
+        InstallResponse.class, new TimingOutResponseInterceptor(numberOfChunks - 1));
 
     // when
     reconnectFollowerAndAwaitSnapshot();
@@ -133,11 +133,12 @@ public class RaftSnapshotReplicationFailureHandlingTest {
     raftRule.appendEntry();
   }
 
-  private static class TimingOutInterceptor implements ResponseInterceptor<InstallResponse> {
+  private static class TimingOutResponseInterceptor
+      implements ResponseInterceptor<InstallResponse> {
     private int count = 0;
     private final int timeoutAtRequest;
 
-    public TimingOutInterceptor(final int timeoutAtRequest) {
+    public TimingOutResponseInterceptor(final int timeoutAtRequest) {
       this.timeoutAtRequest = timeoutAtRequest;
     }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationFailureHandlingTest.java
@@ -27,7 +27,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.awaitility.Awaitility;
+import java.util.function.Consumer;
+import java.util.function.Function;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,7 +47,8 @@ public class RaftSnapshotReplicationFailureHandlingTest {
     leaderProtocol = (TestRaftServerProtocol) leader.getContext().getProtocol();
     totalInstallRequest = new AtomicInteger(0);
     leaderProtocol.interceptRequest(
-        InstallRequest.class, (request) -> totalInstallRequest.incrementAndGet());
+        InstallRequest.class,
+        (Consumer<InstallRequest>) (request) -> totalInstallRequest.incrementAndGet());
   }
 
   @Test
@@ -55,6 +57,8 @@ public class RaftSnapshotReplicationFailureHandlingTest {
     final int numberOfChunks = 10;
     disconnectFollowerAndTakeSnapshot(numberOfChunks);
 
+    // Time out request after sending a request. This simulates the behaviour that the receiver has
+    // processed the request, but the request timeout out at the sender.
     leaderProtocol.interceptResponse(
         InstallResponse.class, new TimingOutInterceptor(numberOfChunks - 1));
 
@@ -95,27 +99,17 @@ public class RaftSnapshotReplicationFailureHandlingTest {
     final int numberOfChunks = 1;
     disconnectFollowerAndTakeSnapshot(numberOfChunks);
 
-    final TimingOutInterceptor responseInterceptor = new TimingOutInterceptor(1);
-    leaderProtocol.interceptResponse(InstallResponse.class, responseInterceptor);
+    // Time out request before sending it to the follower. This is required for deterministic test.
+    final var requestInterceptor = new TimingOutRequestInterceptor(1);
+    leaderProtocol.interceptRequest(InstallRequest.class, requestInterceptor);
 
     // when
     reconnectFollowerAndAwaitSnapshot();
 
     // then
-    // We have to wait because, the snapshot is persisted when receiving the first chunk. The
-    // interceptor is only called after the first chunks is processed. Hence, the await snapshot is
-    // completed before the leader resend the request. To ensure that the leader resent the request,
-    // we wait until the totalInstallRequest includes the retry.
-    Awaitility.await("Snapshot chunk-0 is resend")
-        .untilAsserted(
-            () ->
-                assertThat(responseInterceptor.getCount())
-                    .describedAs("Should resent snapshot chunk")
-                    // Before follower reconnects, sometimes leader sends an InstallRequest which
-                    // ends up in connect exception. So comparing number of requests results in
-                    // flaky test. Instead, compare there were two responses. First one is timeout
-                    // and second is success.
-                    .isEqualTo(2));
+    assertThat(requestInterceptor.getCount())
+        .describedAs("Should resent snapshot chunk")
+        .isEqualTo(2);
   }
 
   private void reconnectFollowerAndAwaitSnapshot() throws InterruptedException {
@@ -159,6 +153,30 @@ public class RaftSnapshotReplicationFailureHandlingTest {
 
     int getCount() {
       return count;
+    }
+  }
+
+  private static class TimingOutRequestInterceptor
+      implements Function<InstallRequest, CompletableFuture<Void>> {
+    private int count = 0;
+    private final int timeoutAtRequest;
+
+    public TimingOutRequestInterceptor(final int timeoutAtRequest) {
+      this.timeoutAtRequest = timeoutAtRequest;
+    }
+
+    int getCount() {
+      return count;
+    }
+
+    @Override
+    public CompletableFuture<Void> apply(final InstallRequest installRequest) {
+      count++;
+      if (count == timeoutAtRequest) {
+        return CompletableFuture.failedFuture(new TimeoutException());
+      } else {
+        return CompletableFuture.completedFuture(null);
+      }
     }
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -65,6 +65,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import net.jodah.concurrentunit.ConcurrentTestCase;
@@ -457,7 +458,8 @@ public class RaftTest extends ConcurrentTestCase {
 
     // when
     final TestRaftServerProtocol followerServer = serverProtocols.get(followerId);
-    followerServer.interceptRequest(PollRequest.class, r -> pollCount.increment());
+    followerServer.interceptRequest(
+        PollRequest.class, (Consumer<PollRequest>) r -> pollCount.increment());
     protocolFactory.partition(followerId);
 
     // then
@@ -479,7 +481,8 @@ public class RaftTest extends ConcurrentTestCase {
 
     // when
     final TestRaftServerProtocol followerServer = serverProtocols.get(followerId);
-    followerServer.interceptRequest(PollRequest.class, r -> pollCount.increment());
+    followerServer.interceptRequest(
+        PollRequest.class, (Consumer<PollRequest>) r -> pollCount.increment());
     protocolFactory.partition(followerId);
     Awaitility.await().timeout(Duration.ofSeconds(5)).untilAdder(pollCount, greaterThan(2L));
     pollCount.reset();

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftProtocolFactory.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftProtocolFactory.java
@@ -44,6 +44,15 @@ public class TestRaftProtocolFactory {
     servers.keySet().forEach(other -> partition(target, other));
   }
 
+  /**
+   * One way network partition
+   *
+   * @param target
+   */
+  public void blockMessagesTo(final MemberId target) {
+    servers.keySet().forEach(other -> servers.get(other).disconnect(target));
+  }
+
   /** Disconnect two members */
   private void partition(final MemberId first, final MemberId second) {
     servers.get(first).disconnect(second);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -44,7 +45,10 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   private Function<VoteRequest, CompletableFuture<VoteResponse>> voteHandler;
   private Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> appendHandler;
   private final Set<MemberId> partitions = Sets.newCopyOnWriteArraySet();
-  private final Map<Class<?>, Consumer<?>> interceptors = new ConcurrentHashMap<>();
+  private final Map<
+          Class<?>,
+          BiFunction<?, TestRaftServerProtocol, CompletableFuture<TestRaftServerProtocol>>>
+      interceptors = new ConcurrentHashMap<>();
   private final Map<MemberId, TestRaftServerProtocol> servers;
   private final Map<Class<?>, ResponseInterceptor<?>> responseInterceptors =
       new ConcurrentHashMap<>();
@@ -73,8 +77,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public CompletableFuture<ConfigureResponse> configure(
       final MemberId memberId, final ConfigureRequest request) {
-    intercept(request, ConfigureRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, ConfigureRequest.class))
         .thenCompose(listener -> listener.configure(request))
         .thenCompose(response -> transformResponse(response, ConfigureResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -83,8 +87,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public CompletableFuture<ReconfigureResponse> reconfigure(
       final MemberId memberId, final ReconfigureRequest request) {
-    intercept(request, ReconfigureRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, ReconfigureRequest.class))
         .thenCompose(listener -> listener.reconfigure(request))
         .thenCompose(response -> transformResponse(response, ReconfigureResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -93,8 +97,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public CompletableFuture<ForceConfigureResponse> forceConfigure(
       final MemberId memberId, final ForceConfigureRequest request) {
-    intercept(request, ForceConfigureRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, ForceConfigureRequest.class))
         .thenCompose(listener -> listener.forceConfigure(request))
         .thenCompose(response -> transformResponse(response, ForceConfigureResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -102,8 +106,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
 
   @Override
   public CompletableFuture<JoinResponse> join(final MemberId memberId, final JoinRequest request) {
-    intercept(request, JoinRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, JoinRequest.class))
         .thenCompose(listener -> listener.join(request))
         .thenCompose(response -> transformResponse(response, JoinResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -112,8 +116,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public CompletableFuture<LeaveResponse> leave(
       final MemberId memberId, final LeaveRequest request) {
-    intercept(request, LeaveRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, LeaveRequest.class))
         .thenCompose(listener -> listener.leave(request))
         .thenCompose(response -> transformResponse(response, LeaveResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -122,8 +126,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public CompletableFuture<InstallResponse> install(
       final MemberId memberId, final InstallRequest request) {
-    intercept(request, InstallRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, InstallRequest.class))
         .thenCompose(listener -> listener.install(request))
         .thenCompose(response -> transformResponse(response, InstallResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -132,8 +136,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public CompletableFuture<TransferResponse> transfer(
       final MemberId memberId, final TransferRequest request) {
-    intercept(request, TransferRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, TransferRequest.class))
         .thenCompose(listener -> listener.transfer(request))
         .thenCompose(response -> transformResponse(response, TransferResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -141,8 +145,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
 
   @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
-    intercept(request, PollRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, PollRequest.class))
         .thenCompose(listener -> listener.poll(request))
         .thenCompose(response -> transformResponse(response, PollResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -150,8 +154,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
 
   @Override
   public CompletableFuture<VoteResponse> vote(final MemberId memberId, final VoteRequest request) {
-    intercept(request, VoteRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, VoteRequest.class))
         .thenCompose(listener -> listener.vote(request))
         .thenCompose(response -> transformResponse(response, VoteResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -166,8 +170,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final VersionedAppendRequest request) {
-    intercept(request, VersionedAppendRequest.class);
     return getServer(memberId)
+        .thenCompose(listener -> intercept(listener, request, VersionedAppendRequest.class))
         .thenCompose(listener -> listener.append(request))
         .thenCompose(response -> transformResponse(response, AppendResponse.class))
         .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
@@ -316,8 +320,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
 
   CompletableFuture<PollResponse> poll(final PollRequest request) {
     if (pollHandler != null) {
-      intercept(request, PollRequest.class);
-      return pollHandler.apply(request);
+      return intercept(null, request, PollRequest.class)
+          .thenCompose(ignore -> pollHandler.apply(request));
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }
@@ -333,8 +337,8 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
 
   CompletableFuture<InstallResponse> install(final InstallRequest request) {
     if (installHandler != null) {
-      intercept(request, InstallRequest.class);
-      return installHandler.apply(request);
+      return intercept(null, request, InstallRequest.class)
+          .thenCompose(ignore -> installHandler.apply(request));
     } else {
       return CompletableFuture.failedFuture(new ConnectException());
     }
@@ -380,8 +384,29 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
     }
   }
 
+  /** interceptor is called before sending the request to the receiver */
   public <T> void interceptRequest(final Class<T> requestType, final Consumer<T> interceptor) {
-    interceptors.put(requestType, interceptor);
+    interceptors.put(
+        requestType,
+        (request, listener) -> {
+          interceptor.accept((T) request);
+          return CompletableFuture.completedFuture(listener);
+        });
+  }
+
+  /**
+   * interceptor is called before sending the request to the receiver. If the interceptor returns a
+   * failed future, the request is not processed by the receiver. Otherwise, request will be
+   * forwarded to the receiver.
+   */
+  public <T> void interceptRequest(
+      final Class<T> requestType, final Function<T, CompletableFuture<Void>> interceptor) {
+    interceptors.put(
+        requestType,
+        (request, listener) ->
+            interceptor
+                .apply((T) request)
+                .thenCompose(ignore -> CompletableFuture.completedFuture(listener)));
   }
 
   public <T extends RaftResponse> void interceptResponse(
@@ -400,11 +425,15 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
   }
 
   @SuppressWarnings("unchecked")
-  private <T> void intercept(final T request, final Class<T> requestType) {
-    final var interceptor = (Consumer<T>) interceptors.get(requestType);
+  private <T> CompletableFuture<TestRaftServerProtocol> intercept(
+      final TestRaftServerProtocol listener, final T request, final Class<T> requestType) {
+    final var interceptor =
+        (BiFunction<T, TestRaftServerProtocol, CompletableFuture<TestRaftServerProtocol>>)
+            interceptors.get(requestType);
     if (interceptor != null) {
-      interceptor.accept(request);
+      return interceptor.apply(request, listener);
     }
+    return CompletableFuture.completedFuture(listener);
   }
 
   @FunctionalInterface


### PR DESCRIPTION
## Description

The test was flaky because, while the follower is disconnected the leader attempts to send Append/Install request several times to the follower. These requests fail because follower is not reachable. When the first InstallRequest after the follower is reconnected is forced to timeout, the max failure count has reached. As a result, the leader do not re-send the InstallRequest, instead send an empty heartbeat. When follower receives the heartbeat, it responds with the latest snapshot info since it has already committed the snapshot. So leader will not send the snapshot again. Since we cannot restrict when an install request is send or when a heartbeat is send the test is flaky.

To make the test test deterministic following changes are made:
- Instead of intercepting the response, we now intercept the request and return a timeout exception.
- As a result, the first InstallRequest is never received by the follower.
- Leader resend the InstallRequest because the follower has never received the snapshot.

## Related issues

closes #17029 