### PR TITLE
Fix OpenAPI generation on Windows

### DIFF
--- a/clients/go/internal/utils/jobStreamActuator.go
+++ b/clients/go/internal/utils/jobStreamActuator.go
@@ -30,7 +30,7 @@ type RemoteJobStream struct {
 
 type RemoteJobStreamMetadata struct {
 	Worker         string   `json:"worker"`
-	Timeout        string   `json:"timeout"`
+	Timeout        int64    `json:"timeout"`
 	FetchVariables []string `json:"fetchVariables"`
 }
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -258,6 +258,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.swagger.core.v3</groupId>
       <artifactId>swagger-annotations</artifactId>
     </dependency>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -267,12 +267,6 @@
       <artifactId>swagger-annotations</artifactId>
     </dependency>
 
-    <!--
-      the following are only used in tests, but we cannot scope them as tests as they're transitive
-      dependencies required at runtime by other modules; if we scope them as tests here, they will
-      be omitted from the resulting artifact, causing ClassNotFoundException errors at runtime
-      -->
-
     <dependency>
       <groupId>com.fasterxml.jackson.datatype</groupId>
       <artifactId>jackson-datatype-jsr310</artifactId>

--- a/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
@@ -7,9 +7,7 @@
  */
 package io.camunda.zeebe.shared;
 
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -21,8 +19,7 @@ public final class JacksonConfig {
   @Primary
   public Jackson2ObjectMapperBuilder restObjectMapper() {
     return new Jackson2ObjectMapperBuilder()
-        .serializationInclusion(Include.NON_EMPTY)
         // required for consistent parsing between the client and the REST API
-        .modules(new JavaTimeModule(), new Jdk8Module());
+        .modules(new Jdk8Module());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.shared;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration(proxyBeanMethods = false)
+public final class JacksonConfig {
+  @Bean
+  @Primary
+  public Jackson2ObjectMapperBuilder restObjectMapper() {
+    return new Jackson2ObjectMapperBuilder()
+        .serializationInclusion(Include.NON_NULL)
+        // required for consistent parsing between the client and the REST API
+        .modules(new JavaTimeModule(), new Jdk8Module());
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
@@ -21,7 +21,7 @@ public final class JacksonConfig {
   @Primary
   public Jackson2ObjectMapperBuilder restObjectMapper() {
     return new Jackson2ObjectMapperBuilder()
-        .serializationInclusion(Include.NON_NULL)
+        .serializationInclusion(Include.NON_EMPTY)
         // required for consistent parsing between the client and the REST API
         .modules(new JavaTimeModule(), new Jdk8Module());
   }

--- a/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/JacksonConfig.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.shared;
 
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -20,6 +21,6 @@ public final class JacksonConfig {
   public Jackson2ObjectMapperBuilder restObjectMapper() {
     return new Jackson2ObjectMapperBuilder()
         // required for consistent parsing between the client and the REST API
-        .modules(new Jdk8Module());
+        .modules(new JavaTimeModule(), new Jdk8Module());
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.shared.management;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Feature;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
@@ -147,7 +149,15 @@ public final class JobStreamEndpoint {
       implements JobStream {}
 
   /** View model for the {@link JobActivationProperties} of a job stream. */
-  public record Metadata(String worker, Duration timeout, Collection<String> fetchVariables) {}
+  public record Metadata(
+      String worker,
+      @JsonFormat(
+              without = {
+                Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS,
+                Feature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS
+              })
+          Duration timeout,
+      Collection<String> fetchVariables) {}
 
   /** View model for a remote job stream ID */
   public record RemoteStreamId(UUID id, String receiver) {}

--- a/zeebe/clients/java/pom.xml
+++ b/zeebe/clients/java/pom.xml
@@ -75,6 +75,17 @@
     </dependency>
 
     <dependency>
+      <groupId>org.openapitools</groupId>
+      <artifactId>jackson-databind-nullable</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-stub</artifactId>
     </dependency>

--- a/zeebe/clients/java/pom.xml
+++ b/zeebe/clients/java/pom.xml
@@ -298,7 +298,7 @@
               <!-- validate the spec on every generation -->
               <skipValidateSpec>false</skipValidateSpec>
               <configOptions>
-                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
+                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)</additionalModelTypeAnnotations>
                 <documentationProvider>none</documentationProvider>
                 <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
                 <library>apache-httpclient</library>

--- a/zeebe/clients/java/pom.xml
+++ b/zeebe/clients/java/pom.xml
@@ -40,6 +40,16 @@
     </dependency>
 
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -72,11 +82,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.openapitools</groupId>
-      <artifactId>jackson-databind-nullable</artifactId>
     </dependency>
 
     <dependency>
@@ -221,6 +226,7 @@
       <artifactId>guava</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
@@ -231,6 +237,7 @@
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
     </dependency>
+
     <dependency>
       <groupId>net.jcip</groupId>
       <artifactId>jcip-annotations</artifactId>
@@ -281,11 +288,12 @@
               <generatorName>java</generatorName>
               <inputSpec>${openapi.dir}/rest-api.yaml</inputSpec>
               <modelPackage>io.camunda.zeebe.client.protocol.rest</modelPackage>
+              <typeMappings>OffsetDateTime=String</typeMappings>
               <generateApis>false</generateApis>
               <generateApiTests>false</generateApiTests>
               <generateSupportingFiles>false</generateSupportingFiles>
               <generateModels>true</generateModels>
-              <generateModelDocumentation>true</generateModelDocumentation>
+              <generateModelDocumentation>false</generateModelDocumentation>
               <generateModelTests>false</generateModelTests>
               <!-- validate the spec on every generation -->
               <skipValidateSpec>false</skipValidateSpec>
@@ -294,6 +302,8 @@
                 <documentationProvider>none</documentationProvider>
                 <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
                 <library>apache-httpclient</library>
+                <java8>true</java8>
+                <openApiNullable>false</openApiNullable>
                 <serializationLibrary>jackson</serializationLibrary>
                 <useReflectionEqualsHashCode>false</useReflectionEqualsHashCode>
               </configOptions>

--- a/zeebe/clients/java/pom.xml
+++ b/zeebe/clients/java/pom.xml
@@ -264,6 +264,7 @@
           </ignoredNonTestScopedDependencies>
           <ignoredDependencies>
             <ignoredDependency>io.netty:netty-tcnative-boringssl-static</ignoredDependency>
+            <ignoredDependency>javax.annotation:javax.annotation-api</ignoredDependency>
           </ignoredDependencies>
         </configuration>
       </plugin>

--- a/zeebe/clients/java/pom.xml
+++ b/zeebe/clients/java/pom.xml
@@ -45,11 +45,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.datatype</groupId>
-      <artifactId>jackson-datatype-jsr310</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
@@ -299,7 +294,7 @@
               <!-- validate the spec on every generation -->
               <skipValidateSpec>false</skipValidateSpec>
               <configOptions>
-                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)</additionalModelTypeAnnotations>
+                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
                 <documentationProvider>none</documentationProvider>
                 <enumUnknownDefaultCase>true</enumUnknownDefaultCase>
                 <library>apache-httpclient</library>

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -22,14 +22,15 @@ import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
-import io.camunda.zeebe.client.protocol.rest.Changeset;
 import io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequest;
+import io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequestChangeset;
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandStep1 {
 
@@ -74,77 +75,73 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
   @Override
   public UpdateUserTaskCommandStep1 dueDate(final String dueDate) {
     ArgumentUtil.ensureNotNull("dueDate", dueDate);
-    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_DUE_DATE, dueDate);
+    getChangesetEnsureInitialized().dueDate(OffsetDateTime.parse(dueDate));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearDueDate() {
-    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_DUE_DATE, "");
+    getChangesetEnsureInitialized().setDueDate_JsonNullable(JsonNullable.undefined());
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 followUpDate(final String followUpDate) {
     ArgumentUtil.ensureNotNull("followUpDate", followUpDate);
-    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_FOLLOW_UP_DATE, followUpDate);
+    getChangesetEnsureInitialized().followUpDate(OffsetDateTime.parse(followUpDate));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearFollowUpDate() {
-    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_FOLLOW_UP_DATE, "");
+    getChangesetEnsureInitialized().setFollowUpDate_JsonNullable(JsonNullable.undefined());
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateGroups(final List<String> candidateGroups) {
     ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
-    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, candidateGroups);
+    getChangesetEnsureInitialized().candidateGroups(candidateGroups);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateGroups(final String... candidateGroups) {
     ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
-    getChangesetEnsureInitialized()
-        .put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, Arrays.asList(candidateGroups));
+    getChangesetEnsureInitialized().candidateGroups(Arrays.asList(candidateGroups));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateGroups() {
-    getChangesetEnsureInitialized()
-        .put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, Collections.emptyList());
+    getChangesetEnsureInitialized().setCandidateGroups_JsonNullable(JsonNullable.undefined());
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateUsers(final List<String> candidateUsers) {
     ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
-    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, candidateUsers);
+    getChangesetEnsureInitialized().candidateUsers(candidateUsers);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateUsers(final String... candidateUsers) {
     ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
-    getChangesetEnsureInitialized()
-        .put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, Arrays.asList(candidateUsers));
+    getChangesetEnsureInitialized().candidateUsers(Arrays.asList(candidateUsers));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateUsers() {
-    getChangesetEnsureInitialized()
-        .put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, Collections.emptyList());
+    getChangesetEnsureInitialized().setCandidateUsers_JsonNullable(JsonNullable.undefined());
     return this;
   }
 
-  private Changeset getChangesetEnsureInitialized() {
-    Changeset changeset = request.getChangeset();
+  private UserTaskUpdateRequestChangeset getChangesetEnsureInitialized() {
+    UserTaskUpdateRequestChangeset changeset = request.getChangeset();
     if (changeset == null) {
-      changeset = new Changeset();
+      changeset = new UserTaskUpdateRequestChangeset();
       request.setChangeset(changeset);
     }
     return changeset;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -25,12 +25,11 @@ import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequest;
 import io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequestChangeset;
 import java.time.Duration;
-import java.time.OffsetDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.hc.client5.http.config.RequestConfig;
-import org.openapitools.jackson.nullable.JsonNullable;
 
 public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandStep1 {
 
@@ -75,26 +74,26 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
   @Override
   public UpdateUserTaskCommandStep1 dueDate(final String dueDate) {
     ArgumentUtil.ensureNotNull("dueDate", dueDate);
-    getChangesetEnsureInitialized().dueDate(OffsetDateTime.parse(dueDate));
+    getChangesetEnsureInitialized().dueDate(dueDate);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearDueDate() {
-    getChangesetEnsureInitialized().setDueDate_JsonNullable(JsonNullable.undefined());
+    getChangesetEnsureInitialized().setDueDate("");
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 followUpDate(final String followUpDate) {
     ArgumentUtil.ensureNotNull("followUpDate", followUpDate);
-    getChangesetEnsureInitialized().followUpDate(OffsetDateTime.parse(followUpDate));
+    getChangesetEnsureInitialized().followUpDate(followUpDate);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearFollowUpDate() {
-    getChangesetEnsureInitialized().setFollowUpDate_JsonNullable(JsonNullable.undefined());
+    getChangesetEnsureInitialized().followUpDate("");
     return this;
   }
 
@@ -114,7 +113,7 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateGroups() {
-    getChangesetEnsureInitialized().setCandidateGroups_JsonNullable(JsonNullable.undefined());
+    getChangesetEnsureInitialized().setCandidateGroups(Collections.emptyList());
     return this;
   }
 
@@ -134,7 +133,7 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateUsers() {
-    getChangesetEnsureInitialized().setCandidateUsers_JsonNullable(JsonNullable.undefined());
+    getChangesetEnsureInitialized().candidateUsers(Collections.emptyList());
     return this;
   }
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -59,11 +59,13 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 public class HttpClientFactory {
 
   private static final String REST_API_PATH = "/v1";
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final ObjectMapper JSON_MAPPER =
+      new ObjectMapper().registerModule(new JsonNullableModule());
 
   private final ZeebeClientConfiguration config;
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -17,7 +17,6 @@ package io.camunda.zeebe.client.impl.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.impl.NoopCredentialsProvider;
@@ -66,7 +65,7 @@ public class HttpClientFactory {
 
   private static final String REST_API_PATH = "/v1";
   private static final ObjectMapper JSON_MAPPER =
-      new ObjectMapper().registerModules(new JavaTimeModule(), new Jdk8Module());
+      new ObjectMapper().registerModules(new Jdk8Module());
 
   private final ZeebeClientConfiguration config;
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -16,6 +16,8 @@
 package io.camunda.zeebe.client.impl.http;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.camunda.zeebe.client.CredentialsProvider;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.impl.NoopCredentialsProvider;
@@ -59,13 +61,12 @@ import org.apache.hc.core5.net.URIBuilder;
 import org.apache.hc.core5.ssl.SSLContexts;
 import org.apache.hc.core5.util.TimeValue;
 import org.apache.hc.core5.util.Timeout;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 
 public class HttpClientFactory {
 
   private static final String REST_API_PATH = "/v1";
   private static final ObjectMapper JSON_MAPPER =
-      new ObjectMapper().registerModule(new JsonNullableModule());
+      new ObjectMapper().registerModules(new JavaTimeModule(), new Jdk8Module());
 
   private final ZeebeClientConfiguration config;
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/TopologyImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/TopologyImpl.java
@@ -18,7 +18,9 @@ package io.camunda.zeebe.client.impl.response;
 import io.camunda.zeebe.client.api.response.BrokerInfo;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public final class TopologyImpl implements Topology {
@@ -42,11 +44,16 @@ public final class TopologyImpl implements Topology {
 
   public TopologyImpl(final io.camunda.zeebe.client.protocol.rest.TopologyResponse httpResponse) {
     brokers =
-        httpResponse.getBrokers().stream().map(BrokerInfoImpl::new).collect(Collectors.toList());
-    clusterSize = httpResponse.getClusterSize();
-    partitionsCount = httpResponse.getPartitionsCount();
-    replicationFactor = httpResponse.getReplicationFactor();
-    gatewayVersion = httpResponse.getGatewayVersion();
+        Optional.ofNullable(httpResponse.getBrokers()).orElse(Collections.emptyList()).stream()
+            .map(BrokerInfoImpl::new)
+            .collect(Collectors.toList());
+    clusterSize = httpResponse.getClusterSize() == null ? 0 : httpResponse.getClusterSize();
+    partitionsCount =
+        httpResponse.getPartitionsCount() == null ? 0 : httpResponse.getPartitionsCount();
+    replicationFactor =
+        httpResponse.getReplicationFactor() == null ? 0 : httpResponse.getReplicationFactor();
+    gatewayVersion =
+        httpResponse.getGatewayVersion() == null ? "" : httpResponse.getGatewayVersion();
   }
 
   @Override

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -23,6 +23,8 @@ import static org.mockito.Mockito.spy;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -78,7 +80,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 @WireMockTest
 public final class OAuthCredentialsProviderTest {
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final ObjectMapper JSON_MAPPER =
+      new ObjectMapper().registerModules(new JavaTimeModule(), new Jdk8Module());
   private static final Key<String> AUTH_KEY =
       Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
   private static final ZonedDateTime EXPIRY =

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.spy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -81,7 +80,7 @@ import org.junit.jupiter.api.io.TempDir;
 @WireMockTest
 public final class OAuthCredentialsProviderTest {
   private static final ObjectMapper JSON_MAPPER =
-      new ObjectMapper().registerModules(new JavaTimeModule(), new Jdk8Module());
+      new ObjectMapper().registerModules(new Jdk8Module());
   private static final Key<String> AUTH_KEY =
       Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
   private static final ZonedDateTime EXPIRY =
@@ -326,7 +325,7 @@ public final class OAuthCredentialsProviderTest {
                             () -> {
                               try {
                                 provider.applyCredentials(applier);
-                              } catch (IOException e) {
+                              } catch (final IOException e) {
                                 throw new UncheckedIOException(e);
                               }
                             }))

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -44,7 +43,7 @@ import org.junit.jupiter.api.Test;
 @WireMockTest
 public final class TopologyRequestRestTest {
   private static final ObjectMapper JSON_MAPPER =
-      new ObjectMapper().registerModules(new JavaTimeModule(), new Jdk8Module());
+      new ObjectMapper().registerModules(new Jdk8Module());
 
   private ZeebeClient client;
 

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
@@ -38,10 +38,12 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.openapitools.jackson.nullable.JsonNullableModule;
 
 @WireMockTest
 public final class TopologyRequestRestTest {
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+  private static final ObjectMapper JSON_MAPPER =
+      new ObjectMapper().registerModule(new JsonNullableModule());
 
   private ZeebeClient client;
 

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
@@ -19,6 +19,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -38,12 +40,11 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.openapitools.jackson.nullable.JsonNullableModule;
 
 @WireMockTest
 public final class TopologyRequestRestTest {
   private static final ObjectMapper JSON_MAPPER =
-      new ObjectMapper().registerModule(new JsonNullableModule());
+      new ObjectMapper().registerModules(new JavaTimeModule(), new Jdk8Module());
 
   private ZeebeClient client;
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1,4 +1,4 @@
-openapi: "3.1.0"
+openapi: "3.0.3"
 info:
   title: Zeebe REST API
   version: "0.1"
@@ -63,12 +63,18 @@ paths:
           description: >
             The user task with the given key is in the wrong state currently.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         '400':
           description: >
             The user task with the given key cannot be completed.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
   /user-tasks/{userTaskKey}/assignment:
     post:
       tags:
@@ -98,12 +104,18 @@ paths:
           description: >
             The user task with the given key is in the wrong state currently.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         '400':
           description: >
             The assignment of the user task with the given key cannot be completed.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
   /user-tasks/{userTaskKey}:
     patch:
       tags:
@@ -133,12 +145,18 @@ paths:
           description: >
             The user task with the given key is in the wrong state currently.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         '400':
           description: >
             The user task with the given key cannot be updated.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
   /user-tasks/{userTaskKey}/assignee:
     delete:
       tags:
@@ -162,12 +180,18 @@ paths:
           description: >
             The user task with the given key is in the wrong state currently.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
         '400':
           description: >
             The user task with the given key cannot be unassigned.
             More details are provided in the response body.
-          $ref: "#/components/responses/ProblemResponse"
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
 
 components:
   responses:
@@ -263,10 +287,10 @@ components:
       type: object
       properties:
         variables:
+          additionalProperties: true
           description: The variables to complete the user task with.
           type: object
           nullable: true
-          $ref: "#/components/schemas/Variables"
         action:
           description: >
             A custom action value that will be accessible from user task events resulting
@@ -298,6 +322,8 @@ components:
       type: object
       properties:
         changeset:
+          allOf:
+            - $ref: "#/components/schemas/Changeset"
           description: |
             JSON object with changed task attribute values.
 
@@ -316,7 +342,6 @@ components:
             This ensures correct event emission for assignee changes.
           type: object
           nullable: true
-          $ref: "#/components/schemas/Changeset"
         action:
           description: >
             A custom action value that will be accessible from user task events resulting

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -240,7 +240,7 @@
               <!-- validate the spec on every generation -->
               <skipValidateSpec>false</skipValidateSpec>
               <configOptions>
-                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
+                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)</additionalModelTypeAnnotations>
                 <serializationLibrary>jackson</serializationLibrary>
                 <library>spring-boot</library>
                 <jdk8>true</jdk8>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -258,6 +258,8 @@
           <usedDependencies>
             <!-- Needed to run tests -->
             <dependency>org.springframework.boot:spring-boot-starter-webflux</dependency>
+            <!-- Used for OpenAPI generation -->
+            <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -87,11 +87,6 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-autoconfigure</artifactId>
     </dependency>
 
@@ -112,8 +107,8 @@
     </dependency>
 
     <dependency>
-      <groupId>org.openapitools</groupId>
-      <artifactId>jackson-databind-nullable</artifactId>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
     </dependency>
 
     <dependency>
@@ -136,6 +131,12 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-webflux</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-webflux</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -242,6 +243,8 @@
                 <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
                 <serializationLibrary>jackson</serializationLibrary>
                 <library>spring-boot</library>
+                <jdk8>true</jdk8>
+                <openApiNullable>false</openApiNullable>
               </configOptions>
             </configuration>
           </execution>
@@ -253,9 +256,8 @@
         <configuration>
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
-            <!-- Needed for the OpenAPI model generation -->
+            <!-- Needed to run tests -->
             <dependency>org.springframework.boot:spring-boot-starter-webflux</dependency>
-            <dependency>org.openapitools:jackson-databind-nullable</dependency>
           </usedDependencies>
         </configuration>
       </plugin>

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -235,12 +235,12 @@
               <generateApis>false</generateApis>
               <generateSupportingFiles>false</generateSupportingFiles>
               <generateModels>true</generateModels>
-              <generateModelDocumentation>true</generateModelDocumentation>
+              <generateModelDocumentation>false</generateModelDocumentation>
               <generateModelTests>false</generateModelTests>
               <!-- validate the spec on every generation -->
               <skipValidateSpec>false</skipValidateSpec>
               <configOptions>
-                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY)</additionalModelTypeAnnotations>
+                <additionalModelTypeAnnotations>@com.fasterxml.jackson.annotation.JsonInclude(com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL)</additionalModelTypeAnnotations>
                 <serializationLibrary>jackson</serializationLibrary>
                 <library>spring-boot</library>
                 <jdk8>true</jdk8>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -11,10 +11,10 @@ import static io.camunda.zeebe.protocol.record.RejectionType.INVALID_ARGUMENT;
 
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
 import io.camunda.zeebe.auth.impl.Authorization;
-import io.camunda.zeebe.gateway.protocol.rest.Changeset;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequestChangeset;
 import io.camunda.zeebe.gateway.rest.impl.broker.request.BrokerUserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.rest.impl.broker.request.BrokerUserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.rest.impl.broker.request.BrokerUserTaskUpdateRequest;
@@ -38,16 +38,13 @@ import org.springframework.web.server.ServerWebExchange;
 
 public class RequestMapper {
 
-  // TODO: create proper multi-tenancy handling, e.g. via HTTP filter
-  public static final String TENANT_CTX_KEY = "io.camunda.zeebe.broker.rest.tenantIds";
-
   private static final String ERROR_MESSAGE_EMPTY_ASSIGNEE = "No assignee provided";
   private static final String ERROR_MESSAGE_DATE_PARSING =
       "The provided %s '%s' cannot be parsed as a date according to RFC 3339, section 5.6.";
   private static final String ERROR_MESSAGE_EMPTY_UPDATE_CHANGESET =
       """
-      No update data provided. Provide at least an \"action\" or a non-null value \
-      for a supported attribute in the \"changeset\".""";
+      No update data provided. Provide at least an "action" or a non-null value \
+      for a supported attribute in the "changeset".""";
 
   public static Either<ProblemDetail, BrokerUserTaskCompletionRequest> toUserTaskCompletionRequest(
       final UserTaskCompletionRequest completionRequest,
@@ -147,7 +144,7 @@ public class RequestMapper {
       violations.add(ERROR_MESSAGE_EMPTY_UPDATE_CHANGESET);
     }
     if (updateRequest != null && !isEmpty(updateRequest.getChangeset())) {
-      final Changeset changeset = updateRequest.getChangeset();
+      final UserTaskUpdateRequestChangeset changeset = updateRequest.getChangeset();
       validateDate(changeset.getDueDate(), "due date", violations);
       validateDate(changeset.getFollowUpDate(), "follow-up date", violations);
     }
@@ -170,7 +167,7 @@ public class RequestMapper {
     }
   }
 
-  private static boolean isEmpty(final Changeset changeset) {
+  private static boolean isEmpty(final UserTaskUpdateRequestChangeset changeset) {
     return changeset == null
         || (changeset.getFollowUpDate() == null
             && changeset.getDueDate() == null
@@ -195,7 +192,7 @@ public class RequestMapper {
     if (updateRequest == null || updateRequest.getChangeset() == null) {
       return record;
     }
-    final Changeset changeset = updateRequest.getChangeset();
+    final UserTaskUpdateRequestChangeset changeset = updateRequest.getChangeset();
     if (changeset.getCandidateGroups() != null) {
       record.setCandidateGroupsList(changeset.getCandidateGroups()).setCandidateGroupsChanged();
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TopologyController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/TopologyController.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.gateway.protocol.rest.Partition.HealthEnum;
 import io.camunda.zeebe.gateway.protocol.rest.Partition.RoleEnum;
 import io.camunda.zeebe.gateway.protocol.rest.TopologyResponse;
 import io.camunda.zeebe.util.VersionUtil;
-import java.util.ArrayList;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -39,14 +38,14 @@ public final class TopologyController {
 
     final String gatewayVersion = VersionUtil.getVersion();
     if (gatewayVersion != null && !gatewayVersion.isBlank()) {
-      response.setGatewayVersion(gatewayVersion);
+      response.gatewayVersion(gatewayVersion);
     }
 
-    final ArrayList<BrokerInfo> brokers = new ArrayList<>();
     if (topology != null) {
-      response.setClusterSize(topology.getClusterSize());
-      response.setPartitionsCount(topology.getPartitionsCount());
-      response.setReplicationFactor(topology.getReplicationFactor());
+      response
+          .clusterSize(topology.getClusterSize())
+          .partitionsCount(topology.getPartitionsCount())
+          .replicationFactor(topology.getReplicationFactor());
 
       topology
           .getBrokers()
@@ -56,10 +55,9 @@ public final class TopologyController {
                 addBrokerInfo(brokerInfo, brokerId, topology);
                 addPartitionInfoToBrokerInfo(brokerInfo, brokerId, topology);
 
-                brokers.add(brokerInfo);
+                response.addBrokersItem(brokerInfo);
               });
     }
-    response.setBrokers(brokers);
 
     return response;
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/TopologyControllerTest.java
@@ -81,7 +81,7 @@ public class TopologyControllerTest {
   void shouldReturnEmptyTopology() {
     // given
     final var version = VersionUtil.getVersion();
-    final var expectedResponse = new TopologyResponse().brokers(List.of()).gatewayVersion(version);
+    final var expectedResponse = new TopologyResponse().gatewayVersion(version);
     Mockito.when(brokerClient.getTopologyManager().getTopology()).thenReturn(null);
 
     // when / then

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
@@ -13,10 +13,10 @@ import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
 import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
-import io.camunda.zeebe.gateway.protocol.rest.Changeset;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequestChangeset;
 import io.camunda.zeebe.gateway.rest.TopologyControllerTest.TestTopologyApplication;
 import io.camunda.zeebe.gateway.rest.impl.broker.request.BrokerUserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.rest.impl.broker.request.BrokerUserTaskCompletionRequest;
@@ -212,7 +212,7 @@ public class UserTaskControllerTest {
     final var request =
         new UserTaskUpdateRequest()
             .changeset(
-                new Changeset()
+                new UserTaskUpdateRequestChangeset()
                     .addCandidateGroupsItem("foo")
                     .addCandidateUsersItem("bar")
                     .dueDate(TEST_TIME)
@@ -252,7 +252,10 @@ public class UserTaskControllerTest {
     // given
     final var request =
         new UserTaskUpdateRequest()
-            .changeset(new Changeset().addCandidateGroupsItem("foo").followUpDate(TEST_TIME));
+            .changeset(
+                new UserTaskUpdateRequestChangeset()
+                    .addCandidateGroupsItem("foo")
+                    .followUpDate(TEST_TIME));
 
     // when / then
     webClient
@@ -315,7 +318,8 @@ public class UserTaskControllerTest {
     // given
     final var request =
         new UserTaskUpdateRequest()
-            .changeset(new Changeset().candidateGroups(List.of()).followUpDate(""));
+            .changeset(
+                new UserTaskUpdateRequestChangeset().candidateGroups(List.of()).followUpDate(""));
 
     // when / then
     webClient
@@ -378,7 +382,7 @@ public class UserTaskControllerTest {
         new UserTaskUpdateRequest()
             .action("customAction")
             .changeset(
-                new Changeset()
+                new UserTaskUpdateRequestChangeset()
                     .addCandidateGroupsItem("foo")
                     .addCandidateUsersItem("bar")
                     .dueDate(TEST_TIME)
@@ -444,7 +448,8 @@ public class UserTaskControllerTest {
   @Test
   public void shouldYieldBadRequestWhenUpdateTaskWithoutMalformedDueDate() {
     // given
-    final var request = new UserTaskUpdateRequest().changeset(new Changeset().dueDate("foo"));
+    final var request =
+        new UserTaskUpdateRequest().changeset(new UserTaskUpdateRequestChangeset().dueDate("foo"));
 
     final var expectedBody =
         ProblemDetail.forStatusAndDetail(
@@ -474,7 +479,9 @@ public class UserTaskControllerTest {
   @Test
   public void shouldYieldBadRequestWhenUpdateTaskWithMalformedFollowUpDate() {
     // given
-    final var request = new UserTaskUpdateRequest().changeset(new Changeset().followUpDate("foo"));
+    final var request =
+        new UserTaskUpdateRequest()
+            .changeset(new UserTaskUpdateRequestChangeset().followUpDate("foo"));
 
     final var expectedBody =
         ProblemDetail.forStatusAndDetail(
@@ -505,7 +512,8 @@ public class UserTaskControllerTest {
   public void shouldYieldBadRequestWhenUpdateTaskWithoutMalformedFollowUpAndDueDate() {
     // given
     final var request =
-        new UserTaskUpdateRequest().changeset(new Changeset().dueDate("bar").followUpDate("foo"));
+        new UserTaskUpdateRequest()
+            .changeset(new UserTaskUpdateRequestChangeset().dueDate("bar").followUpDate("foo"));
 
     final var expectedBody =
         ProblemDetail.forStatusAndDetail(
@@ -536,9 +544,7 @@ public class UserTaskControllerTest {
   @Test
   public void shouldYieldBadRequestWhenUpdateTaskWithUntrackedChanges() {
     // given
-    final var request =
-        new UserTaskUpdateRequest()
-            .changeset(new Changeset().putAdditionalProperty("elementInstanceKey", 123456L));
+    final var request = new UserTaskUpdateRequest().changeset(new UserTaskUpdateRequestChangeset());
 
     final var expectedBody =
         ProblemDetail.forStatusAndDetail(


### PR DESCRIPTION
## Description

This PR fixes the OpenAPI generator issues on Windows by downgrading the spec from 3.1.0 to 3.0.3. This also aligns it with the rest of C8, as everyone is on 3.0.x.

Doing so re-introduced the `JsonNullable` dependency, which then needs to be added to the build, and its serialization module also added to any `ObjectMapper` that will be used for serialization (both client and server).

Since OpenAPI < 3.1.0 does not allow adding _any_ properties next to a `$ref`, in order to keep the description I had to be a bit creative.

The `UserTaskUpdateRequest` changeset property now "inherits" from the changeset property. This is not true inheritance for the generated model, but more composition. So it has the same properties, its own description, etc., but does not directly inherit from the `Changeset` class. This means it loses the inheritance to `HashMap`. Unfortunately, adding `additionalProperty` to it failed - while it would now inherit from `HashMap`, it failed to import the class in the generated code. Since additional properties are effectively ignored for this, however, I figured it was fine as is.

I also added the Java 8 modules for Jackson on both the server and client already. I would recommend making use of them for consistent parsing between both.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #16759 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
