### PR TITLE
[Backport release-8.5.0] Clean Backoff column family from wrong jobs

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -24,14 +24,13 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.EnsureUtil;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.LongHashSet;
 import org.slf4j.Logger;
 
 public final class DbJobState implements JobState, MutableJobState {
@@ -280,17 +279,33 @@ public final class DbJobState implements JobState, MutableJobState {
 
   @Override
   public void restoreBackoff() {
-    final var failedKeys = getFailedJobKeys();
-
-    removeJobsWithoutRetries();
-
-    failedKeys.removeAll(getBackoffJobKeys());
-    failedKeys.forEach(
-        key -> {
-          jobKey.wrapLong(key);
+    final var jobsWithBackoff = new LongHashSet();
+    backoffColumnFamily.forEach(
+        (key, value) -> {
           final var jobRecord = jobsColumnFamily.get(jobKey);
-          if (isValidForRestore(jobRecord)) {
-            addJobBackoff(key, jobRecord.getRecord().getRecurringTime());
+          if (jobRecord == null
+              || jobRecord.getRecord().getRetries() <= 0
+              || jobRecord.getRecord().getRetryBackoff() <= 0) {
+            backoffColumnFamily.deleteExisting(key);
+          } else {
+            jobsWithBackoff.add(jobKey.getValue());
+          }
+        });
+
+    statesJobColumnFamily.forEach(
+        value -> {
+          if (!State.FAILED.equals(value.getState())) {
+            return;
+          }
+          if (jobsWithBackoff.contains(jobKey.getValue())) {
+            return;
+          }
+          final var jobRecord = jobsColumnFamily.get(jobKey);
+          final var backoff = jobRecord.getRecord().getRecurringTime();
+          final var retries = jobRecord.getRecord().getRetries();
+          if (backoff > 0 && retries > 0) {
+            backoffKey.wrapLong(backoff);
+            backoffColumnFamily.insert(backoffJobKey, DbNil.INSTANCE);
           }
         });
   }
@@ -540,48 +555,5 @@ public final class DbJobState implements JobState, MutableJobState {
 
   private List<String> getAuthorizedTenantIds(final Map<String, Object> authorizations) {
     return (List<String>) authorizations.get(Authorization.AUTHORIZED_TENANTS);
-  }
-
-  private Set<Long> getFailedJobKeys() {
-    final Set<Long> failedJobKeys = new HashSet<>();
-    statesJobColumnFamily.forEach(
-        (key, value) -> {
-          if ((State.FAILED).equals(value.getState())) {
-            failedJobKeys.add(key.inner().getValue());
-          }
-        });
-    return failedJobKeys;
-  }
-
-  private Set<Long> getBackoffJobKeys() {
-    final Set<Long> backoffJobKeys = new HashSet<>();
-    backoffColumnFamily.forEach(
-        (key, value) -> backoffJobKeys.add(key.second().inner().getValue()));
-    return backoffJobKeys;
-  }
-
-  private boolean isValidForRestore(final JobRecordValue jobRecord) {
-    if (jobRecord == null) {
-      return false;
-    }
-    final var job = jobRecord.getRecord();
-    return job.getRecurringTime() > -1 && job.getRetries() > 0;
-  }
-
-  /**
-   * Removing jobs that are mistakenly inserted into the backoff column family due to <a
-   * href="https://github.com/camunda/zeebe/issues/15954">this issue</a>
-   */
-  private void removeJobsWithoutRetries() {
-    final var backoffJobKeys = getBackoffJobKeys();
-
-    backoffJobKeys.forEach(
-        key -> {
-          jobKey.wrapLong(key);
-          final var jobRecord = jobsColumnFamily.get(jobKey);
-          if (jobRecord != null && jobRecord.getRecord().getRetries() <= 0) {
-            removeJobBackoff(key, jobRecord.getRecord().getRecurringTime());
-          }
-        });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -282,6 +282,8 @@ public final class DbJobState implements JobState, MutableJobState {
   public void restoreBackoff() {
     final var failedKeys = getFailedJobKeys();
 
+    removeWrongJobs();
+
     failedKeys.removeAll(getBackoffJobKey());
     failedKeys.forEach(
         key -> {
@@ -564,5 +566,24 @@ public final class DbJobState implements JobState, MutableJobState {
     }
     final var job = jobRecord.getRecord();
     return job.getRecurringTime() > -1 && job.getRetries() > 0;
+  }
+
+  /**
+   * Removing jobs that are mistakenly inserted into the backoff column family due to <a
+   * href="https://github.com/camunda/zeebe/issues/15954">this issue</a>
+   */
+  private void removeWrongJobs() {
+    final var failedKeys = getFailedJobKeys();
+    final var backoffJobs = getBackoffJobKey();
+
+    backoffJobs.retainAll(failedKeys);
+    backoffJobs.forEach(
+        key -> {
+          jobKey.wrapLong(key);
+          final var jobRecord = jobsColumnFamily.get(jobKey);
+          if (jobRecord != null && jobRecord.getRecord().getRetries() <= 0) {
+            removeJobBackoff(key, jobRecord.getRecord().getRecurringTime());
+          }
+        });
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
@@ -63,7 +63,7 @@ public class JobBackoffCleanupMigrationTest {
 
   // regression test of https://github.com/camunda/zeebe/issues/14329
   @Test
-  public void shoulCleanOrphanBackoffEntries() {
+  public void shouldCleanOrphanBackoffEntries() {
     // given
     final MutableJobState jobState = processingState.getJobState();
     final JobRecord record = createJobRecord(1000);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
@@ -160,6 +160,31 @@ public class JobBackoffRestoreMigrationTest {
     assertThat(backoffColumnFamily.count()).isEqualTo(1);
   }
 
+  @Test
+  public void shouldRemoveFailedJobFromBackoffColumn() {
+    // given
+    final MutableJobState jobState = processingState.getJobState();
+    final JobRecord record = createJobRecord(1000);
+    jobState.create(jobKey.getValue(), record);
+    jobState.fail(jobKey.getValue(), record);
+    backoffKey.wrapLong(record.getRecurringTime());
+    jobState.updateJobRetries(jobKey.getValue(), 0);
+
+    jobKey.wrapLong(2);
+    final JobRecord backoffRecord = createJobRecord(2000);
+    jobState.create(jobKey.getValue(), backoffRecord);
+    jobState.fail(jobKey.getValue(), backoffRecord);
+    backoffKey.wrapLong(backoffRecord.getRecurringTime());
+
+    // when
+    assertThat(jobBackoffRestoreMigration.needsToRun(processingState)).isTrue();
+    jobBackoffRestoreMigration.runMigration(processingState);
+
+    // then
+    assertThat(backoffColumnFamily.isEmpty()).isFalse();
+    assertThat(backoffColumnFamily.count()).isEqualTo(1);
+  }
+
   private static JobRecord createJobRecord(final long retryBackoff) {
     return new JobRecord()
         .setType("test")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
@@ -183,6 +183,8 @@ public class JobBackoffRestoreMigrationTest {
     // then
     assertThat(backoffColumnFamily.isEmpty()).isFalse();
     assertThat(backoffColumnFamily.count()).isEqualTo(1);
+    backoffKey.wrapLong(record.getRecurringTime());
+    assertThat(backoffColumnFamily.exists(backoffJobKey)).isFalse();
   }
 
   private static JobRecord createJobRecord(final long retryBackoff) {


### PR DESCRIPTION
# Description
Backport of #16508 to `release-8.5.0`.

relates to camunda/zeebe#14329 #15954
original author: @nicpuppa