### PR TITLE
fix: update index validation to ignore dynamic indices that have been altered by data inserts

### DIFF
--- a/operate/schema/pom.xml
+++ b/operate/schema/pom.xml
@@ -227,7 +227,10 @@
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
       </plugin>
-
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexMappingDifference.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexMappingDifference.java
@@ -21,6 +21,7 @@ import static io.camunda.operate.schema.IndexMapping.IndexMappingProperty.create
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,6 +33,8 @@ public class IndexMappingDifference {
   private Set<IndexMappingProperty> entriesOnlyOnRight;
   private Set<IndexMappingProperty> entriesInCommon;
   private Set<PropertyDifference> entriesDiffering;
+  private IndexMapping leftIndexMapping;
+  private IndexMapping rightIndexMapping;
 
   public boolean isEqual() {
     return equal;
@@ -82,10 +85,34 @@ public class IndexMappingDifference {
     return this;
   }
 
+  public IndexMapping getLeftIndexMapping() {
+    return leftIndexMapping;
+  }
+
+  public IndexMappingDifference setLeftIndexMapping(final IndexMapping leftIndexMapping) {
+    this.leftIndexMapping = leftIndexMapping;
+    return this;
+  }
+
+  public IndexMapping getRightIndexMapping() {
+    return rightIndexMapping;
+  }
+
+  public IndexMappingDifference setRightIndexMapping(final IndexMapping rightIndexMapping) {
+    this.rightIndexMapping = rightIndexMapping;
+    return this;
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(
-        equal, entriesOnlyOnLeft, entriesOnlyOnRight, entriesInCommon, entriesDiffering);
+        equal,
+        entriesOnlyOnLeft,
+        entriesOnlyOnRight,
+        entriesInCommon,
+        entriesDiffering,
+        leftIndexMapping,
+        rightIndexMapping);
   }
 
   @Override
@@ -101,7 +128,9 @@ public class IndexMappingDifference {
         && Objects.equals(entriesOnlyOnLeft, that.entriesOnlyOnLeft)
         && Objects.equals(entriesOnlyOnRight, that.entriesOnlyOnRight)
         && Objects.equals(entriesInCommon, that.entriesInCommon)
-        && Objects.equals(entriesDiffering, that.entriesDiffering);
+        && Objects.equals(entriesDiffering, that.entriesDiffering)
+        && Objects.equals(leftIndexMapping, that.leftIndexMapping)
+        && Objects.equals(rightIndexMapping, that.rightIndexMapping);
   }
 
   @Override
@@ -117,11 +146,32 @@ public class IndexMappingDifference {
         + entriesInCommon
         + ", entriesDiffering="
         + entriesDiffering
+        + ", leftIndexMapping="
+        + leftIndexMapping
+        + ", rightIndexMapping="
+        + rightIndexMapping
         + '}';
   }
 
+  // Compares the differences between two IndexMappingDifference objects independent
+  // of the index mappings. Used to validate that different indices have the "same"
+  // differences.
+  public boolean checkEqualityForDifferences(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final IndexMappingDifference that = (IndexMappingDifference) o;
+    return equal == that.equal
+        && Objects.equals(entriesOnlyOnLeft, that.entriesOnlyOnLeft)
+        && Objects.equals(entriesOnlyOnRight, that.entriesOnlyOnRight)
+        && Objects.equals(entriesInCommon, that.entriesInCommon)
+        && Objects.equals(entriesDiffering, that.entriesDiffering);
+  }
+
   public static class IndexMappingDifferenceBuilder {
-    private boolean ignoreDynamicDifferences;
     private IndexMapping left;
     private IndexMapping right;
 
@@ -139,53 +189,41 @@ public class IndexMappingDifference {
       return this;
     }
 
-    public IndexMappingDifferenceBuilder setIgnoreDynamicDifferences(
-        final boolean ignoreDynamicDifferences) {
-      this.ignoreDynamicDifferences = ignoreDynamicDifferences;
-      return this;
-    }
-
     public IndexMappingDifference build() {
-      final MapDifference<String, Object> difference = Maps.difference(left.toMap(), right.toMap());
-      final IndexMappingDifference diff =
-          new IndexMappingDifference()
-              .setEqual(difference.areEqual())
-              .setEntriesOnlyOnLeft(
-                  difference.entriesOnlyOnLeft().entrySet().stream()
-                      .map(p -> createIndexMappingProperty(p))
-                      .collect(Collectors.toSet()))
-              .setEntriesOnlyOnRight(
-                  difference.entriesOnlyOnRight().entrySet().stream()
-                      .map(p -> createIndexMappingProperty(p))
-                      .collect(Collectors.toSet()))
-              .setEntriesInCommon(
-                  difference.entriesInCommon().entrySet().stream()
-                      .map(p -> createIndexMappingProperty(p))
-                      .collect(Collectors.toSet()));
-
-      if (ignoreDynamicDifferences
-          && (Boolean.parseBoolean(left.getDynamic())
-              || Boolean.parseBoolean(right.getDynamic()))) {
-        diff.setEntriesDiffering(Set.of());
-      } else {
-        diff.setEntriesDiffering(
-            difference.entriesDiffering().entrySet().stream()
-                .map(
-                    entry ->
-                        new PropertyDifference()
-                            .setName(entry.getKey())
-                            .setLeftValue(
-                                new IndexMappingProperty()
-                                    .setName(entry.getKey())
-                                    .setTypeDefinition(entry.getValue().leftValue()))
-                            .setRightValue(
-                                new IndexMappingProperty()
-                                    .setName(entry.getKey())
-                                    .setTypeDefinition(entry.getValue().rightValue())))
-                .collect(Collectors.toSet()));
-      }
-
-      return diff;
+      final Map<String, Object> leftMap = left == null ? Map.of() : left.toMap();
+      final Map<String, Object> rightMap = right == null ? Map.of() : right.toMap();
+      final MapDifference<String, Object> difference = Maps.difference(leftMap, rightMap);
+      return new IndexMappingDifference()
+          .setEqual(difference.areEqual())
+          .setLeftIndexMapping(left)
+          .setRightIndexMapping(right)
+          .setEntriesOnlyOnLeft(
+              difference.entriesOnlyOnLeft().entrySet().stream()
+                  .map(p -> createIndexMappingProperty(p))
+                  .collect(Collectors.toSet()))
+          .setEntriesOnlyOnRight(
+              difference.entriesOnlyOnRight().entrySet().stream()
+                  .map(p -> createIndexMappingProperty(p))
+                  .collect(Collectors.toSet()))
+          .setEntriesInCommon(
+              difference.entriesInCommon().entrySet().stream()
+                  .map(p -> createIndexMappingProperty(p))
+                  .collect(Collectors.toSet()))
+          .setEntriesDiffering(
+              difference.entriesDiffering().entrySet().stream()
+                  .map(
+                      entry ->
+                          new PropertyDifference()
+                              .setName(entry.getKey())
+                              .setLeftValue(
+                                  new IndexMappingProperty()
+                                      .setName(entry.getKey())
+                                      .setTypeDefinition(entry.getValue().leftValue()))
+                              .setRightValue(
+                                  new IndexMappingProperty()
+                                      .setName(entry.getKey())
+                                      .setTypeDefinition(entry.getValue().rightValue())))
+                  .collect(Collectors.toSet()));
     }
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/IndexSchemaValidator.java
@@ -189,20 +189,24 @@ public class IndexSchemaValidator {
           String.format(
               "Index fields differ from expected. Index name: %s. Difference: %s.",
               indexDescriptor.getIndexName(), difference));
+
       if (!difference.getEntriesDiffering().isEmpty()) {
-        final String errorMsg =
-            String.format(
-                "Index name: %s. Not supported index changes are introduced. Data migration is required. Changes found: %s",
-                indexDescriptor.getIndexName(), difference.getEntriesDiffering());
-        LOGGER.error(errorMsg);
-        throw new OperateRuntimeException(errorMsg);
-      } else if (!difference.getEntriesOnlyOnRight().isEmpty()) {
+        // This call will throw an exception unless the index is dynamic, in which case
+        // field differences will be ignored. In the case of a dynamic index, we still want
+        // to collect any new fields, so we should continue to the next checks instead of making
+        // this part of the if/else block
+        validateFieldsDifferBetweenIndices(difference, indexDescriptor);
+      }
+
+      if (!difference.getEntriesOnlyOnRight().isEmpty()) {
         final String message =
             String.format(
                 "Index name: %s. Field deletion is requested, will be ignored. Fields: %s",
                 indexDescriptor.getIndexName(), difference.getEntriesOnlyOnRight());
         LOGGER.info(message);
+
       } else if (!difference.getEntriesOnlyOnLeft().isEmpty()) {
+        // Collect the new fields
         newFields.put(indexDescriptor, difference.getEntriesOnlyOnLeft());
       }
     } else {
@@ -219,20 +223,18 @@ public class IndexSchemaValidator {
     IndexMappingDifference difference = null;
     // compare every index in group
     for (final Map.Entry<String, IndexMapping> singleIndexMapping : indexMappingsGroup.entrySet()) {
-      // Defer to the builder to exclude fields that would normally be detected as "changed" if
-      // either the actual or expected is dynamic. This is done so that when data is inserted
-      // that adds subfields dynamically (such as when an object is inserted), it does not get
-      // picked up by validation and cause a false failure
       final IndexMappingDifference currentDifference =
           new IndexMappingDifference.IndexMappingDifferenceBuilder()
-              .setIgnoreDynamicDifferences(true)
               .setLeft(indexMappingMustBe)
               .setRight(singleIndexMapping.getValue())
               .build();
       if (!currentDifference.isEqual()) {
         if (difference == null) {
           difference = currentDifference;
-        } else if (!difference.equals(currentDifference)) {
+          // If there is a difference between the template and the existing runtime/data indices,
+          // all those indices should have the same difference. Compare based only on the
+          // differences (exclude the IndexMapping fields in the comparison)
+        } else if (!difference.checkEqualityForDifferences(currentDifference)) {
           throw new OperateRuntimeException(
               "Ambiguous schema update. First bring runtime and date indices to one schema. Difference 1: "
                   + difference
@@ -256,5 +258,38 @@ public class IndexSchemaValidator {
     return Maps.filterEntries(
         indexMappings,
         e -> e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
+  }
+
+  private boolean indexIsDynamic(final IndexMapping mapping) {
+    if (mapping == null) {
+      return false;
+    }
+    if (mapping.getDynamic() == null) {
+      return true;
+    }
+
+    return Boolean.parseBoolean(mapping.getDynamic());
+  }
+
+  private void validateFieldsDifferBetweenIndices(
+      final IndexMappingDifference difference, final IndexDescriptor indexDescriptor) {
+    if (indexIsDynamic(difference.getLeftIndexMapping())) {
+      LOGGER.debug(
+          String.format(
+              "Left index name: %s is dynamic, ignoring changes found: %s",
+              indexDescriptor.getIndexName(), difference.getEntriesDiffering()));
+    } else if (indexIsDynamic(difference.getRightIndexMapping())) {
+      LOGGER.debug(
+          String.format(
+              "Right index name: %s is dynamic, ignoring changes found: %s",
+              indexDescriptor.getIndexName(), difference.getEntriesDiffering()));
+    } else {
+      final String errorMsg =
+          String.format(
+              "Index name: %s. Not supported index changes are introduced. Data migration is required. Changes found: %s",
+              indexDescriptor.getIndexName(), difference.getEntriesDiffering());
+      LOGGER.error(errorMsg);
+      throw new OperateRuntimeException(errorMsg);
+    }
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -29,7 +29,6 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.IndexMapping;
 import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.SchemaManager;
-import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
 import io.camunda.operate.schema.indices.IndexDescriptor;
 import io.camunda.operate.schema.templates.TemplateDescriptor;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -306,19 +305,19 @@ public class OpensearchSchemaManager implements SchemaManager {
   @Override
   public IndexMapping getExpectedIndexFields(final IndexDescriptor indexDescriptor) {
     final InputStream description =
-        ElasticsearchSchemaManager.class.getResourceAsStream(
+        OpensearchSchemaManager.class.getResourceAsStream(
             indexDescriptor.getSchemaClasspathFilename());
     try {
       final String currentVersionSchema =
           StreamUtils.copyToString(description, StandardCharsets.UTF_8);
       final TypeReference<HashMap<String, Object>> type = new TypeReference<>() {};
-      final Map<String, Object> properties =
-          (Map<String, Object>)
-              ((Map<String, Object>)
-                      objectMapper.readValue(currentVersionSchema, type).get("mappings"))
-                  .get("properties");
+      final Map<String, Object> mappings =
+          (Map<String, Object>) objectMapper.readValue(currentVersionSchema, type).get("mappings");
+      final Map<String, Object> properties = (Map<String, Object>) mappings.get("properties");
+      final String dynamic = (String) mappings.get("dynamic");
       return new IndexMapping()
           .setIndexName(indexDescriptor.getIndexName())
+          .setDynamic(dynamic)
           .setProperties(
               properties.entrySet().stream()
                   .map(

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.operate.store.elasticsearch;
 
-import static io.camunda.operate.schema.IndexMappingDifference.createIndexMapping;
+import static io.camunda.operate.schema.IndexMapping.IndexMappingProperty.createIndexMappingProperty;
 import static io.camunda.operate.util.CollectionUtil.getOrDefaultForNullValue;
 import static io.camunda.operate.util.CollectionUtil.map;
 
@@ -115,7 +115,7 @@ public class RetryElasticsearchClient {
     return numberOfRetries;
   }
 
-  public RetryElasticsearchClient setNumberOfRetries(int numberOfRetries) {
+  public RetryElasticsearchClient setNumberOfRetries(final int numberOfRetries) {
     this.numberOfRetries = numberOfRetries;
     return this;
   }
@@ -130,7 +130,7 @@ public class RetryElasticsearchClient {
                   RequestOptions.DEFAULT);
       final ClusterHealthStatus status = response.getStatus();
       return !response.isTimedOut() && !status.equals(ClusterHealthStatus.RED);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error(
           String.format(
               "Couldn't connect to Elasticsearch due to %s. Return unhealthy state. ",
@@ -144,12 +144,12 @@ public class RetryElasticsearchClient {
     return delayIntervalInSeconds;
   }
 
-  public RetryElasticsearchClient setDelayIntervalInSeconds(int delayIntervalInSeconds) {
+  public RetryElasticsearchClient setDelayIntervalInSeconds(final int delayIntervalInSeconds) {
     this.delayIntervalInSeconds = delayIntervalInSeconds;
     return this;
   }
 
-  public RetryElasticsearchClient setRequestOptions(RequestOptions requestOptions) {
+  public RetryElasticsearchClient setRequestOptions(final RequestOptions requestOptions) {
     this.requestOptions = requestOptions;
     return this;
   }
@@ -159,10 +159,10 @@ public class RetryElasticsearchClient {
         "Refresh " + indexPattern,
         () -> {
           try {
-            for (var index : getFilteredIndices(indexPattern)) {
+            for (final var index : getFilteredIndices(indexPattern)) {
               esClient.indices().refresh(new RefreshRequest(index), requestOptions);
             }
-          } catch (IOException e) {
+          } catch (final IOException e) {
             throw new RuntimeException(e);
           }
           return true;
@@ -176,7 +176,7 @@ public class RetryElasticsearchClient {
         (r) -> r.getFailedShards() > 0);
   }
 
-  public long getNumberOfDocumentsFor(String... indexPatterns) {
+  public long getNumberOfDocumentsFor(final String... indexPatterns) {
     final var response =
         executeWithRetries(
             "Count number of documents in " + Arrays.asList(indexPatterns),
@@ -185,7 +185,7 @@ public class RetryElasticsearchClient {
     return response.getCount();
   }
 
-  public Set<String> getIndexNames(String namePattern) {
+  public Set<String> getIndexNames(final String namePattern) {
     return executeWithRetries(
         "Get indices for " + namePattern,
         () -> {
@@ -193,7 +193,7 @@ public class RetryElasticsearchClient {
             final GetIndexResponse response =
                 esClient.indices().get(new GetIndexRequest(namePattern), RequestOptions.DEFAULT);
             return Set.of(response.getIndices());
-          } catch (ElasticsearchException e) {
+          } catch (final ElasticsearchException e) {
             if (e.status().equals(RestStatus.NOT_FOUND)) {
               return Set.of();
             }
@@ -202,7 +202,7 @@ public class RetryElasticsearchClient {
         });
   }
 
-  public Map<String, IndexMapping> getIndexMappings(String namePattern) {
+  public Map<String, IndexMapping> getIndexMappings(final String namePattern) {
     return executeWithRetries(
         "Get indices mappings for " + namePattern,
         () -> {
@@ -214,25 +214,26 @@ public class RetryElasticsearchClient {
                     .getMapping(
                         new GetMappingsRequest().indices(namePattern), RequestOptions.DEFAULT)
                     .mappings();
-            for (Map.Entry<String, MappingMetadata> entry : mappings.entrySet()) {
+            for (final Map.Entry<String, MappingMetadata> entry : mappings.entrySet()) {
               final Map<String, Object> mappingMetadata =
-                  (Map<String, Object>)
-                      objectMapper
-                          .readValue(
-                              entry.getValue().source().string(),
-                              new TypeReference<HashMap<String, Object>>() {})
-                          .get("properties");
+                  objectMapper.readValue(
+                      entry.getValue().source().string(),
+                      new TypeReference<HashMap<String, Object>>() {});
+              final Map<String, Object> properties =
+                  (Map<String, Object>) mappingMetadata.get("properties");
+              final String dynamic = (String) mappingMetadata.get("dynamic");
               mappingsMap.put(
                   entry.getKey(),
                   new IndexMapping()
                       .setIndexName(entry.getKey())
+                      .setDynamic(dynamic)
                       .setProperties(
-                          mappingMetadata.entrySet().stream()
-                              .map(p -> createIndexMapping(p))
+                          properties.entrySet().stream()
+                              .map(p -> createIndexMappingProperty(p))
                               .collect(Collectors.toSet())));
             }
             return mappingsMap;
-          } catch (ElasticsearchException e) {
+          } catch (final ElasticsearchException e) {
             if (e.status().equals(RestStatus.NOT_FOUND)) {
               return Map.of();
             }
@@ -241,7 +242,7 @@ public class RetryElasticsearchClient {
         });
   }
 
-  public Set<String> getAliasesNames(String namePattern) {
+  public Set<String> getAliasesNames(final String namePattern) {
     return executeWithRetries(
         "Get aliases for " + namePattern,
         () -> {
@@ -252,12 +253,12 @@ public class RetryElasticsearchClient {
 
             final Set<String> returnAliases = new HashSet<>();
             final Map<String, Set<AliasMetadata>> mapAliases = response.getAliases();
-            for (Map.Entry<String, Set<AliasMetadata>> a : mapAliases.entrySet()) {
+            for (final Map.Entry<String, Set<AliasMetadata>> a : mapAliases.entrySet()) {
               returnAliases.addAll(
                   a.getValue().stream().map(m -> m.getAlias()).collect(Collectors.toSet()));
             }
             return returnAliases;
-          } catch (ElasticsearchException e) {
+          } catch (final ElasticsearchException e) {
             // NOT_FOUND response means that aliases are not found
             if (e.status().equals(RestStatus.NOT_FOUND)) {
               return Set.of();
@@ -267,7 +268,7 @@ public class RetryElasticsearchClient {
         });
   }
 
-  public boolean createIndex(CreateIndexRequest createIndexRequest) {
+  public boolean createIndex(final CreateIndexRequest createIndexRequest) {
     return executeWithRetries(
         "CreateIndex " + createIndexRequest.index(),
         () -> {
@@ -298,12 +299,12 @@ public class RetryElasticsearchClient {
         });
   }
 
-  private boolean aliasExists(Alias alias, String index) throws IOException {
+  private boolean aliasExists(final Alias alias, final String index) throws IOException {
     final GetAliasesRequest aliasExistsReq = new GetAliasesRequest(alias.name()).indices(index);
     return esClient.indices().existsAlias(aliasExistsReq, RequestOptions.DEFAULT);
   }
 
-  public boolean createOrUpdateDocument(String name, String id, Map source) {
+  public boolean createOrUpdateDocument(final String name, final String id, final Map source) {
     return executeWithRetries(
         "RetryElasticsearchClient#createOrUpdateDocument",
         () -> {
@@ -316,7 +317,7 @@ public class RetryElasticsearchClient {
         });
   }
 
-  public boolean createOrUpdateDocument(String name, String id, String source) {
+  public boolean createOrUpdateDocument(final String name, final String id, final String source) {
     return executeWithRetries(
         "RetryElasticsearchClient#createOrUpdateDocument",
         () -> {
@@ -329,7 +330,7 @@ public class RetryElasticsearchClient {
         });
   }
 
-  public boolean documentExists(String name, String id) {
+  public boolean documentExists(final String name, final String id) {
     return executeWithGivenRetries(
         10,
         String.format("Exists document from %s with id %s", name, id),
@@ -339,7 +340,7 @@ public class RetryElasticsearchClient {
         null);
   }
 
-  public Map<String, Object> getDocument(String name, String id) {
+  public Map<String, Object> getDocument(final String name, final String id) {
     return executeWithGivenRetries(
         10,
         String.format("Get document from %s with id %s", name, id),
@@ -355,7 +356,7 @@ public class RetryElasticsearchClient {
         null);
   }
 
-  public boolean deleteDocument(String name, String id) {
+  public boolean deleteDocument(final String name, final String id) {
     return executeWithRetries(
         "RetryElasticsearchClient#deleteDocument",
         () -> {
@@ -373,7 +374,7 @@ public class RetryElasticsearchClient {
             new ComposableIndexTemplateExistRequest(templatePattern), requestOptions);
   }
 
-  public boolean createComponentTemplate(PutComponentTemplateRequest request) {
+  public boolean createComponentTemplate(final PutComponentTemplateRequest request) {
     return executeWithRetries(
         "CreateComponentTemplate " + request.name(),
         () -> {
@@ -387,11 +388,12 @@ public class RetryElasticsearchClient {
         });
   }
 
-  public boolean createTemplate(PutComposableIndexTemplateRequest request) {
+  public boolean createTemplate(final PutComposableIndexTemplateRequest request) {
     return createTemplate(request, false);
   }
 
-  public boolean createTemplate(PutComposableIndexTemplateRequest request, boolean overwrite) {
+  public boolean createTemplate(
+      final PutComposableIndexTemplateRequest request, final boolean overwrite) {
     return executeWithRetries(
         "CreateTemplate " + request.name(),
         () -> {
@@ -440,14 +442,14 @@ public class RetryElasticsearchClient {
     return executeWithRetries(
         "DeleteIndices " + indexPattern,
         () -> {
-          for (var index : getFilteredIndices(indexPattern)) {
+          for (final var index : getFilteredIndices(indexPattern)) {
             esClient.indices().delete(new DeleteIndexRequest(index), RequestOptions.DEFAULT);
           }
           return true;
         });
   }
 
-  public Map<String, String> getIndexSettingsFor(String indexName, String... fields) {
+  public Map<String, String> getIndexSettingsFor(final String indexName, final String... fields) {
     return executeWithRetries(
         "GetIndexSettings " + indexName,
         () -> {
@@ -456,14 +458,14 @@ public class RetryElasticsearchClient {
               esClient
                   .indices()
                   .getSettings(new GetSettingsRequest().indices(indexName), requestOptions);
-          for (String field : fields) {
+          for (final String field : fields) {
             settings.put(field, response.getSetting(indexName, field));
           }
           return settings;
         });
   }
 
-  public String getOrDefaultRefreshInterval(String indexName, String defaultValue) {
+  public String getOrDefaultRefreshInterval(final String indexName, final String defaultValue) {
     final Map<String, String> settings = getIndexSettingsFor(indexName, REFRESH_INTERVAL);
     String refreshInterval = getOrDefaultForNullValue(settings, REFRESH_INTERVAL, defaultValue);
     if (refreshInterval.trim().equals(NO_REFRESH)) {
@@ -472,7 +474,7 @@ public class RetryElasticsearchClient {
     return refreshInterval;
   }
 
-  public String getOrDefaultNumbersOfReplica(String indexName, String defaultValue) {
+  public String getOrDefaultNumbersOfReplica(final String indexName, final String defaultValue) {
     final Map<String, String> settings = getIndexSettingsFor(indexName, NUMBERS_OF_REPLICA);
     String numbersOfReplica = getOrDefaultForNullValue(settings, NUMBERS_OF_REPLICA, defaultValue);
     if (numbersOfReplica.trim().equals(NO_REPLICA)) {
@@ -481,7 +483,7 @@ public class RetryElasticsearchClient {
     return numbersOfReplica;
   }
 
-  public boolean setIndexSettingsFor(Settings settings, String indexPattern) {
+  public boolean setIndexSettingsFor(final Settings settings, final String indexPattern) {
     return executeWithRetries(
         "SetIndexSettings " + indexPattern,
         () ->
@@ -492,7 +494,7 @@ public class RetryElasticsearchClient {
                 .isAcknowledged());
   }
 
-  public boolean addPipeline(String name, String definition) {
+  public boolean addPipeline(final String name, final String definition) {
     final BytesReference content = new BytesArray(definition.getBytes());
     return executeWithRetries(
         "AddPipeline " + name,
@@ -504,7 +506,7 @@ public class RetryElasticsearchClient {
                 .isAcknowledged());
   }
 
-  public boolean removePipeline(String name) {
+  public boolean removePipeline(final String name) {
     return executeWithRetries(
         "RemovePipeline " + name,
         () ->
@@ -518,7 +520,7 @@ public class RetryElasticsearchClient {
     reindex(reindexRequest, true);
   }
 
-  public void reindex(final ReindexRequest reindexRequest, boolean checkDocumentCount) {
+  public void reindex(final ReindexRequest reindexRequest, final boolean checkDocumentCount) {
     executeWithRetries(
         "Reindex "
             + Arrays.asList(reindexRequest.getSearchRequest().indices())
@@ -564,7 +566,7 @@ public class RetryElasticsearchClient {
         done -> !done);
   }
 
-  private boolean waitUntilTaskIsCompleted(String taskId) {
+  private boolean waitUntilTaskIsCompleted(final String taskId) {
     return waitUntilTaskIsCompleted(taskId, null);
   }
 
@@ -574,7 +576,7 @@ public class RetryElasticsearchClient {
   // - If the response has a status with uncompleted flag and a sum of changed documents
   // (created,updated and deleted documents) not equal to total documents
   //   we need to wait and poll again the task status
-  private boolean waitUntilTaskIsCompleted(final String taskId, Long srcCount) {
+  private boolean waitUntilTaskIsCompleted(final String taskId, final Long srcCount) {
     final String[] taskIdParts = taskId.split(":");
     final String nodeId = taskIdParts[0];
     final Long smallTaskId = Long.parseLong(taskIdParts[1]);
@@ -625,7 +627,7 @@ public class RetryElasticsearchClient {
   }
 
   public int doWithEachSearchResult(
-      SearchRequest searchRequest, Consumer<SearchHit> searchHitConsumer) {
+      final SearchRequest searchRequest, final Consumer<SearchHit> searchHitConsumer) {
     return executeWithRetries(
         "RetryElasticsearchClient#doWithEachSearchResult",
         () -> {
@@ -654,7 +656,9 @@ public class RetryElasticsearchClient {
   }
 
   public <T> List<T> searchWithScroll(
-      SearchRequest searchRequest, Class<T> resultClass, ObjectMapper objectMapper) {
+      final SearchRequest searchRequest,
+      final Class<T> resultClass,
+      final ObjectMapper objectMapper) {
     final long totalHits =
         executeWithRetries(
             "Count search results",
@@ -665,7 +669,8 @@ public class RetryElasticsearchClient {
         resultList -> resultList.size() != totalHits);
   }
 
-  private <T> List<T> scroll(SearchRequest searchRequest, Class<T> clazz, ObjectMapper objectMapper)
+  private <T> List<T> scroll(
+      final SearchRequest searchRequest, final Class<T> clazz, final ObjectMapper objectMapper)
       throws IOException {
     final List<T> results = new ArrayList<>();
     searchRequest.scroll(TimeValue.timeValueMillis(SCROLL_KEEP_ALIVE_MS));
@@ -691,10 +696,11 @@ public class RetryElasticsearchClient {
     return results;
   }
 
-  private <T> T searchHitToObject(SearchHit searchHit, Class<T> clazz, ObjectMapper objectMapper) {
+  private <T> T searchHitToObject(
+      final SearchHit searchHit, final Class<T> clazz, final ObjectMapper objectMapper) {
     try {
       return objectMapper.readValue(searchHit.getSourceAsString(), clazz);
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       throw new OperateRuntimeException(
           String.format(
               "Error while reading entity of type %s from Elasticsearch!", clazz.getName()),
@@ -705,22 +711,22 @@ public class RetryElasticsearchClient {
   // ------------------- Retry part ------------------
 
   private <T> T executeWithRetries(
-      String operationName, RetryOperation.RetryConsumer<T> retryConsumer) {
+      final String operationName, final RetryOperation.RetryConsumer<T> retryConsumer) {
     return executeWithRetries(operationName, retryConsumer, null);
   }
 
   private <T> T executeWithRetries(
-      String operationName,
-      RetryOperation.RetryConsumer<T> retryConsumer,
-      RetryOperation.RetryPredicate<T> retryPredicate) {
+      final String operationName,
+      final RetryOperation.RetryConsumer<T> retryConsumer,
+      final RetryOperation.RetryPredicate<T> retryPredicate) {
     return executeWithGivenRetries(numberOfRetries, operationName, retryConsumer, retryPredicate);
   }
 
   private <T> T executeWithGivenRetries(
-      int retries,
-      String operationName,
-      RetryOperation.RetryConsumer<T> retryConsumer,
-      RetryOperation.RetryPredicate<T> retryPredicate) {
+      final int retries,
+      final String operationName,
+      final RetryOperation.RetryConsumer<T> retryConsumer,
+      final RetryOperation.RetryPredicate<T> retryPredicate) {
     try {
       return RetryOperation.<T>newBuilder()
           .retryConsumer(retryConsumer)
@@ -732,7 +738,7 @@ public class RetryElasticsearchClient {
           .message(operationName)
           .build()
           .retry();
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new OperateRuntimeException(
           "Couldn't execute operation "
               + operationName

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
@@ -242,8 +242,15 @@ public class OpenSearchIndexOperations extends OpenSearchRetryOperation {
                       .setName(entry.getKey())
                       .setTypeDefinition(indexMappingAsMap));
             }
+            final String dynamic =
+                indexMapping.getValue().mappings().dynamic() == null
+                    ? null
+                    : indexMapping.getValue().mappings().dynamic().name();
             final IndexMapping mapping =
-                new IndexMapping().setIndexName(indexMapping.getKey()).setProperties(properties);
+                new IndexMapping()
+                    .setIndexName(indexMapping.getKey())
+                    .setDynamic(dynamic)
+                    .setProperties(properties);
             mappings.put(indexMapping.getKey(), mapping);
           }
           return mappings;

--- a/operate/schema/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
@@ -30,6 +30,7 @@ import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
 import io.camunda.operate.schema.indices.IndexDescriptor;
 import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
 import io.camunda.operate.schema.util.SchemaTestHelper;
+import io.camunda.operate.schema.util.TestDynamicIndex;
 import io.camunda.operate.schema.util.TestIndex;
 import io.camunda.operate.schema.util.TestTemplate;
 import io.camunda.operate.schema.util.elasticsearch.ElasticsearchSchemaTestHelper;
@@ -49,6 +50,7 @@ import org.springframework.test.context.ContextConfiguration;
       IndexSchemaValidator.class,
       TestIndex.class,
       TestTemplate.class,
+      TestDynamicIndex.class,
       ElasticsearchSchemaManager.class,
       ElasticsearchConnector.class,
       ElasticsearchTaskStore.class,
@@ -68,6 +70,7 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
   @Autowired public SchemaTestHelper schemaHelper;
 
   @Autowired public TestIndex testIndex;
+  @Autowired public TestDynamicIndex testDynamicIndex;
   @Autowired public TestTemplate testTemplate;
 
   @BeforeEach
@@ -78,6 +81,65 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
   @AfterEach
   public void dropSchema() {
     schemaHelper.dropSchema();
+  }
+
+  @Test
+  public void shouldValidateDynamicIndex() {}
+
+  @Test
+  public void shouldValidateDynamicIndexWithAddedProperty() {
+    // Create a dynamic index and insert data
+    schemaManager.createIndex(
+        testDynamicIndex,
+        "/schema/elasticsearch/create/index/operate-testdynamicindex-property-removed.json");
+    final Map<String, Object> subDocument =
+        Map.of(
+            "requestedUrl",
+            "test",
+            "SPRING_SECURITY_CONTEXT",
+            "test",
+            "SPRING_SECURITY_SAVED_REQUEST",
+            "test");
+    final Map<String, Object> document = Map.of("propA", "test", "propC", subDocument);
+    clientTestHelper.createDocument(testDynamicIndex.getFullQualifiedName(), "1", document);
+
+    final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
+        validator.validateIndexMappings();
+
+    // Only property B shows up in the diff, and no exception is thrown due to the data adding
+    // fields dynamically in propC
+    assertThat(indexDiff)
+        .containsExactly(
+            entry(
+                testDynamicIndex,
+                Set.of(
+                    new IndexMappingProperty()
+                        .setName("propB")
+                        .setTypeDefinition(Map.of("type", "text")))));
+  }
+
+  @Test
+  public void shouldValidateDynamicIndexWithDataAddingFields() {
+    // Create a dynamic index and insert data
+    schemaManager.createIndex(
+        testDynamicIndex, "/schema/elasticsearch/create/index/operate-testdynamicindex.json");
+    final Map<String, Object> subDocument =
+        Map.of(
+            "requestedUrl",
+            "test",
+            "SPRING_SECURITY_CONTEXT",
+            "test",
+            "SPRING_SECURITY_SAVED_REQUEST",
+            "test");
+    final Map<String, Object> document =
+        Map.of("propA", "test", "propB", "test", "propC", subDocument);
+    clientTestHelper.createDocument(testDynamicIndex.getFullQualifiedName(), "1", document);
+
+    final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
+        validator.validateIndexMappings();
+
+    // No diff should show and no exception thrown due to fields dynamically added from propC data
+    assertThat(indexDiff).isEmpty();
   }
 
   @Test

--- a/operate/schema/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/IndexSchemaValidatorIT.java
@@ -84,9 +84,6 @@ public class IndexSchemaValidatorIT extends AbstractSchemaIT {
   }
 
   @Test
-  public void shouldValidateDynamicIndex() {}
-
-  @Test
   public void shouldValidateDynamicIndexWithAddedProperty() {
     // Create a dynamic index and insert data
     schemaManager.createIndex(

--- a/operate/schema/src/test/java/io/camunda/operate/schema/SchemaManagerIT.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/SchemaManagerIT.java
@@ -110,6 +110,7 @@ public class SchemaManagerIT extends AbstractSchemaIT {
                 indexName,
                 new IndexMapping()
                     .setIndexName(indexName)
+                    .setDynamic("strict")
                     .setProperties(
                         Set.of(
                             new IndexMappingProperty()
@@ -161,6 +162,7 @@ public class SchemaManagerIT extends AbstractSchemaIT {
                 indexName,
                 new IndexMapping()
                     .setIndexName(indexName)
+                    .setDynamic("strict")
                     .setProperties(
                         Set.of(
                             new IndexMappingProperty()
@@ -184,7 +186,7 @@ public class SchemaManagerIT extends AbstractSchemaIT {
 
     // and a second templated index of it
     final String secondTemplatedIndexName = testTemplate.getFullQualifiedName() + "instantiated";
-    final Map<String, String> document = Map.of("propA", "test", "propB", "test");
+    final Map<String, Object> document = Map.of("propA", "test", "propB", "test");
     clientTestHelper.createDocument(secondTemplatedIndexName, "1", document);
 
     final Map<IndexDescriptor, Set<IndexMappingProperty>> indexDiff =
@@ -204,6 +206,7 @@ public class SchemaManagerIT extends AbstractSchemaIT {
                 secondTemplatedIndexName,
                 new IndexMapping()
                     .setIndexName(secondTemplatedIndexName)
+                    .setDynamic("strict")
                     .setProperties(
                         Set.of(
                             new IndexMappingProperty()
@@ -230,7 +233,7 @@ public class SchemaManagerIT extends AbstractSchemaIT {
 
     // and a second templated index of it
     final String secondTemplatedIndexName = testTemplate.getFullQualifiedName() + "instantiated";
-    final Map<String, String> document = Map.of("propA", "test", "propB", "test");
+    final Map<String, Object> document = Map.of("propA", "test", "propB", "test");
     clientTestHelper.createDocument(secondTemplatedIndexName, "1", document);
 
     // and one of the indices is read only

--- a/operate/schema/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -106,12 +106,14 @@ public class SchemaStartupIT extends AbstractSchemaIT {
     // the index should have been updated
     final String indexName = testIndex.getFullQualifiedName();
     final Map<String, IndexMapping> indexMappings = schemaManager.getIndexMappings(indexName);
+
     assertThat(indexMappings)
         .containsExactly(
             entry(
                 indexName,
                 new IndexMapping()
                     .setIndexName(indexName)
+                    .setDynamic("strict")
                     .setProperties(
                         Set.of(
                             new IndexMappingProperty()

--- a/operate/schema/src/test/java/io/camunda/operate/schema/util/SearchClientTestHelper.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/util/SearchClientTestHelper.java
@@ -22,5 +22,5 @@ public interface SearchClientTestHelper {
 
   void setClientRetries(int retries);
 
-  void createDocument(String indexName, String id, Map<String, String> document);
+  void createDocument(String indexName, String id, Map<String, Object> document);
 }

--- a/operate/schema/src/test/java/io/camunda/operate/schema/util/TestDynamicIndex.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/util/TestDynamicIndex.java
@@ -14,36 +14,13 @@
  * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
-package io.camunda.operate.schema.util.opensearch;
+package io.camunda.operate.schema.util;
 
-import static io.camunda.operate.store.opensearch.dsl.RequestDSL.indexRequestBuilder;
+import io.camunda.operate.schema.indices.AbstractIndexDescriptor;
 
-import io.camunda.operate.conditions.OpensearchCondition;
-import io.camunda.operate.schema.util.SearchClientTestHelper;
-import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
-import java.util.Map;
-import org.opensearch.client.opensearch._types.Refresh;
-import org.opensearch.client.opensearch.core.IndexRequest.Builder;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Conditional;
-
-@Conditional(OpensearchCondition.class)
-public class OpenSearchClientTestHelper implements SearchClientTestHelper {
-
-  @Autowired private RichOpenSearchClient openSearchClient;
-
+public class TestDynamicIndex extends AbstractIndexDescriptor {
   @Override
-  public void setClientRetries(final int retries) {
-    // currently not implemented, tests that expect this behavior are currently
-    // ignored for Opensearch
-  }
-
-  @Override
-  public void createDocument(
-      final String indexName, final String id, final Map<String, Object> document) {
-    final Builder<Object> requestBuilder =
-        indexRequestBuilder(indexName).id(id).document(document).refresh(Refresh.True);
-
-    openSearchClient.doc().index(requestBuilder);
+  public String getIndexName() {
+    return "testdynamicindex";
   }
 }

--- a/operate/schema/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchClientTestHelper.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchClientTestHelper.java
@@ -29,12 +29,13 @@ public class ElasticsearchClientTestHelper implements SearchClientTestHelper {
   @Autowired public RetryElasticsearchClient elasticsearchClient;
 
   @Override
-  public void setClientRetries(int retries) {
+  public void setClientRetries(final int retries) {
     elasticsearchClient.setNumberOfRetries(retries);
   }
 
   @Override
-  public void createDocument(String indexName, String id, Map<String, String> document) {
+  public void createDocument(
+      final String indexName, final String id, final Map<String, Object> document) {
     elasticsearchClient.createOrUpdateDocument(indexName, id, document);
   }
 }

--- a/operate/schema/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchSchemaTestHelper.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/util/elasticsearch/ElasticsearchSchemaTestHelper.java
@@ -16,7 +16,7 @@
  */
 package io.camunda.operate.schema.util.elasticsearch;
 
-import static io.camunda.operate.schema.IndexMappingDifference.createIndexMapping;
+import static io.camunda.operate.schema.IndexMapping.IndexMappingProperty.createIndexMappingProperty;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -98,7 +98,7 @@ public class ElasticsearchSchemaTestHelper implements SchemaTestHelper {
           .setIndexName(templateName)
           .setProperties(
               mappingMetadata.entrySet().stream()
-                  .map(p -> createIndexMapping(p))
+                  .map(p -> createIndexMappingProperty(p))
                   .collect(Collectors.toSet()));
     } catch (final ElasticsearchException e) {
       if (e.status().equals(RestStatus.NOT_FOUND)) {

--- a/operate/schema/src/test/resources/schema/elasticsearch/create/index/operate-testdynamicindex-property-removed.json
+++ b/operate/schema/src/test/resources/schema/elasticsearch/create/index/operate-testdynamicindex-property-removed.json
@@ -1,0 +1,13 @@
+{
+  "mappings": {
+    "dynamic": "true",
+    "properties": {
+      "propA": {
+        "type": "keyword"
+      },
+      "propC": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/operate/schema/src/test/resources/schema/elasticsearch/create/index/operate-testdynamicindex.json
+++ b/operate/schema/src/test/resources/schema/elasticsearch/create/index/operate-testdynamicindex.json
@@ -1,0 +1,16 @@
+{
+  "mappings": {
+    "dynamic": "true",
+    "properties": {
+      "propA": {
+        "type": "keyword"
+      },
+      "propB": {
+        "type": "text"
+      },
+      "propC": {
+        "type": "object"
+      }
+    }
+  }
+}

--- a/operate/schema/src/test/resources/schema/opensearch/create/index/operate-testdynamicindex.json
+++ b/operate/schema/src/test/resources/schema/opensearch/create/index/operate-testdynamicindex.json
@@ -1,0 +1,16 @@
+{
+  "mappings": {
+    "dynamic": "true",
+    "properties": {
+      "propA": {
+        "type": "keyword"
+      },
+      "propB": {
+        "type": "text"
+      },
+      "propC": {
+        "type": "object"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description


<!-- Please explain the changes you made here. -->

- IndexMapping creation is deferred to a builder. In the future this can be moved completely into a factory or other separate component for abstraction.
- Added "dynamic" field to IndexMapping required to determine if an index is dynamic or strict
- Added logic to not ignore "changed" fields (existing fields that have properties added or changed) when either the template or existing schema is dynamic. New fields will still be processed. The criteria for whether an index is dynamic is by looking at the "dynamic" field of the index mapping for a value of "true" or if the "dynamic" field is not present. Any other values for "dynamic" will be interpreted as false, this can be expanded on later as needed. See: https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html#dynamic-parameters for possible values
- Added integration tests to simulate error condition on startup when data was added to a dynamic index and created new subfields

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #17229 

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
