### PR TITLE
fix: avoid race between scheduling and execution of due date checker

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -134,7 +134,9 @@ public class ActorClockEndpoint {
           "Expected to pin the clock to the given time, but it is immutable", 403);
     }
 
-    clock.get().pinTime(Instant.ofEpochMilli(epochMilli));
+    final var mutableClock = clock.get();
+    mutableClock.pinTime(Instant.ofEpochMilli(epochMilli));
+    mutableClock.update();
     return getCurrentClock();
   }
 
@@ -151,7 +153,9 @@ public class ActorClockEndpoint {
     }
 
     final var offset = Duration.of(offsetMilli, ChronoUnit.MILLIS);
-    clock.get().addTime(offset);
+    final var mutableClock = clock.get();
+    mutableClock.addTime(offset);
+    mutableClock.update();
     return getCurrentClock();
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
@@ -49,5 +49,7 @@ public interface ActorClockService {
 
     /** Resets the clock to use the system time */
     void resetTime();
+
+    void update();
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
@@ -50,4 +50,9 @@ public final class ControlledActorClockService implements ActorClockService, Mut
   public void resetTime() {
     clock.reset();
   }
+
+  @Override
+  public void update() {
+    clock.update();
+  }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
@@ -24,8 +24,9 @@ final class ControlledActorClockEndpointTest {
   private final InstanceOfAssertFactory<Response, ObjectAssert<Response>> responseType =
       new InstanceOfAssertFactory<>(Response.class, Assertions::assertThat);
 
+  private final ControlledActorClock actorClock = new ControlledActorClock();
   private final ActorClockEndpoint endpoint =
-      new ActorClockEndpoint(new ControlledActorClockService(new ControlledActorClock()));
+      new ActorClockEndpoint(new ControlledActorClockService(actorClock));
 
   @BeforeEach
   public void resetClock() {
@@ -90,6 +91,7 @@ final class ControlledActorClockEndpointTest {
 
     // when
     Thread.sleep(100);
+    actorClock.update();
     final var secondResponse = endpoint.getCurrentClock();
     assertThat(secondResponse.getBody()).isNotNull();
     final var secondMillis = secondResponse.getBody().epochMilli();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -37,7 +37,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -63,7 +63,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -93,7 +93,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
@@ -119,7 +119,7 @@ public class DueDateCheckerTest {
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     dueDateChecker.execute(mock(TaskResultBuilder.class));

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 public final class ControlledActorClock implements ActorClock {
   private volatile long currentTime;
   private volatile long currentOffset;
+  private volatile long updatedTime;
 
   public ControlledActorClock() {
     reset();
@@ -34,6 +35,7 @@ public final class ControlledActorClock implements ActorClock {
   public void reset() {
     currentTime = -1;
     currentOffset = 0;
+    updatedTime = System.currentTimeMillis();
   }
 
   public Instant getCurrentTime() {
@@ -54,16 +56,17 @@ public final class ControlledActorClock implements ActorClock {
 
   @Override
   public boolean update() {
+    if (usesPointInTime()) {
+      updatedTime = currentTime;
+    } else {
+      updatedTime = System.currentTimeMillis() + currentOffset;
+    }
     return true;
   }
 
   @Override
   public long getTimeMillis() {
-    if (usesPointInTime()) {
-      return currentTime;
-    } else {
-      return System.currentTimeMillis() + currentOffset;
-    }
+    return updatedTime;
   }
 
   @Override


### PR DESCRIPTION
Because we schedule execution before updating the `nextExecution` atomic, there was an edge case where the execution would also happen before.

This was especially likely for the initial execution which was scheduled for `now`. In that case, we would start with `nextExecution=null`, the execution would again set it to `null` and then the scheduling would set it to the planned execution that already occurred. As a result, no new timers would be scheduled.

To resolve this, we don't use null as a sentinel value and instead use fresh instances of `None`. This allows scheduling to observe that the execution already occurred because the CAS will see a new instance of `None` instead of the "same" null value.

This has the drawback that there is a liveness issue when execution occurs before scheduling is done. To reduce the likeliness, we again schedule the initial run with a 100ms delay, making it unlikely that scheduling has to try several times which would lead to redundant executions.

This required a change to the `AtomicUtil.replace` method to ensure that it calls the replacer function again if another thread updated the reference, while the previous replacer call returned empty.

These changes highlighted test flakiness (see #17258), which we restored by mirroring the default actor clock in the controlled actor clock (only update time in between actor jobs).

closes #17227
closes #17254
closes #17255
closes #17258 