### PR TITLE
[Backport stable/8.1] Clean Backoff column family from wrong jobs

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -248,6 +248,8 @@ public final class DbJobState implements JobState, MutableJobState {
   public void restoreBackoff() {
     final var failedKeys = getFailedJobKeys();
 
+    removeWrongJobs();
+
     failedKeys.removeAll(getBackoffJobKeys());
     failedKeys.forEach(
         key -> {
@@ -512,5 +514,24 @@ public final class DbJobState implements JobState, MutableJobState {
     }
     final var job = jobRecord.getRecord();
     return job.getRecurringTime() > -1 && job.getRetries() > 0;
+  }
+
+  /**
+   * Removing jobs that are mistakenly inserted into the backoff column family due to <a
+   * href="https://github.com/camunda/zeebe/issues/15954">this issue</a>
+   */
+  private void removeWrongJobs() {
+    final var failedKeys = getFailedJobKeys();
+    final var backoffJobs = getBackoffJobKey();
+
+    backoffJobs.retainAll(failedKeys);
+    backoffJobs.forEach(
+        key -> {
+          jobKey.wrapLong(key);
+          final var jobRecord = jobsColumnFamily.get(jobKey);
+          if (jobRecord != null && jobRecord.getRecord().getRetries() <= 0) {
+            removeJobBackoff(key, jobRecord.getRecord().getRecurringTime());
+          }
+        });
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -23,13 +23,12 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.util.EnsureUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
-import java.util.HashSet;
-import java.util.Set;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
+import org.agrona.collections.LongHashSet;
 import org.slf4j.Logger;
 
 public final class DbJobState implements JobState, MutableJobState {
@@ -246,17 +245,33 @@ public final class DbJobState implements JobState, MutableJobState {
 
   @Override
   public void restoreBackoff() {
-    final var failedKeys = getFailedJobKeys();
-
-    removeJobsWithoutRetries();
-
-    failedKeys.removeAll(getBackoffJobKeys());
-    failedKeys.forEach(
-        key -> {
-          jobKey.wrapLong(key);
+    final var jobsWithBackoff = new LongHashSet();
+    backoffColumnFamily.forEach(
+        (key, value) -> {
           final var jobRecord = jobsColumnFamily.get(jobKey);
-          if (isValidForRestore(jobRecord)) {
-            addJobBackoff(key, jobRecord.getRecord().getRecurringTime());
+          if (jobRecord == null
+              || jobRecord.getRecord().getRetries() <= 0
+              || jobRecord.getRecord().getRetryBackoff() <= 0) {
+            backoffColumnFamily.deleteExisting(key);
+          } else {
+            jobsWithBackoff.add(jobKey.getValue());
+          }
+        });
+
+    statesJobColumnFamily.forEach(
+        value -> {
+          if (!State.FAILED.equals(value.getState())) {
+            return;
+          }
+          if (jobsWithBackoff.contains(jobKey.getValue())) {
+            return;
+          }
+          final var jobRecord = jobsColumnFamily.get(jobKey);
+          final var backoff = jobRecord.getRecord().getRecurringTime();
+          final var retries = jobRecord.getRecord().getRetries();
+          if (backoff > 0 && retries > 0) {
+            backoffKey.wrapLong(backoff);
+            backoffColumnFamily.insert(backoffJobKey, DbNil.INSTANCE);
           }
         });
   }
@@ -488,48 +503,5 @@ public final class DbJobState implements JobState, MutableJobState {
       backoffKey.wrapLong(backoff);
       backoffColumnFamily.deleteIfExists(backoffJobKey);
     }
-  }
-
-  private Set<Long> getFailedJobKeys() {
-    final Set<Long> failedJobKeys = new HashSet<>();
-    statesJobColumnFamily.forEach(
-        (key, value) -> {
-          if ((State.FAILED).equals(value.getState())) {
-            failedJobKeys.add(key.inner().getValue());
-          }
-        });
-    return failedJobKeys;
-  }
-
-  private Set<Long> getBackoffJobKeys() {
-    final Set<Long> backoffJobKeys = new HashSet<>();
-    backoffColumnFamily.forEach(
-        (key, value) -> backoffJobKeys.add(key.second().inner().getValue()));
-    return backoffJobKeys;
-  }
-
-  private boolean isValidForRestore(final JobRecordValue jobRecord) {
-    if (jobRecord == null) {
-      return false;
-    }
-    final var job = jobRecord.getRecord();
-    return job.getRecurringTime() > -1 && job.getRetries() > 0;
-  }
-
-  /**
-   * Removing jobs that are mistakenly inserted into the backoff column family due to <a
-   * href="https://github.com/camunda/zeebe/issues/15954">this issue</a>
-   */
-  private void removeJobsWithoutRetries() {
-    final var backoffJobKeys = getBackoffJobKeys();
-
-    backoffJobKeys.forEach(
-        key -> {
-          jobKey.wrapLong(key);
-          final var jobRecord = jobsColumnFamily.get(jobKey);
-          if (jobRecord != null && jobRecord.getRecord().getRetries() <= 0) {
-            removeJobBackoff(key, jobRecord.getRecord().getRecurringTime());
-          }
-        });
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -248,7 +248,7 @@ public final class DbJobState implements JobState, MutableJobState {
   public void restoreBackoff() {
     final var failedKeys = getFailedJobKeys();
 
-    removeWrongJobs();
+    removeJobsWithoutRetries();
 
     failedKeys.removeAll(getBackoffJobKeys());
     failedKeys.forEach(
@@ -520,12 +520,10 @@ public final class DbJobState implements JobState, MutableJobState {
    * Removing jobs that are mistakenly inserted into the backoff column family due to <a
    * href="https://github.com/camunda/zeebe/issues/15954">this issue</a>
    */
-  private void removeWrongJobs() {
-    final var failedKeys = getFailedJobKeys();
-    final var backoffJobs = getBackoffJobKey();
+  private void removeJobsWithoutRetries() {
+    final var backoffJobKeys = getBackoffJobKeys();
 
-    backoffJobs.retainAll(failedKeys);
-    backoffJobs.forEach(
+    backoffJobKeys.forEach(
         key -> {
           jobKey.wrapLong(key);
           final var jobRecord = jobsColumnFamily.get(jobKey);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffCleanupMigrationTest.java
@@ -63,7 +63,7 @@ public class JobBackoffCleanupMigrationTest {
 
   // regression test of https://github.com/camunda/zeebe/issues/14329
   @Test
-  public void shoulCleanOrphanBackoffEntries() {
+  public void shouldCleanOrphanBackoffEntries() {
     // given
     final MutableJobState jobState = processingState.getJobState();
     final JobRecord record = createJobRecord(1000);

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
@@ -159,6 +159,31 @@ public class JobBackoffRestoreMigrationTest {
     assertThat(countBackoffRecords()).isEqualTo(1);
   }
 
+  @Test
+  public void shouldRemoveFailedJobFromBackoffColumn() {
+    // given
+    final MutableJobState jobState = processingState.getJobState();
+    final JobRecord record = createJobRecord(1000);
+    jobState.create(jobKey.getValue(), record);
+    jobState.fail(jobKey.getValue(), record);
+    backoffKey.wrapLong(record.getRecurringTime());
+    jobState.updateJobRetries(jobKey.getValue(), 0);
+
+    jobKey.wrapLong(2);
+    final JobRecord backoffRecord = createJobRecord(2000);
+    jobState.create(jobKey.getValue(), backoffRecord);
+    jobState.fail(jobKey.getValue(), backoffRecord);
+    backoffKey.wrapLong(backoffRecord.getRecurringTime());
+
+    // when
+    assertThat(jobBackoffRestoreMigration.needsToRun(processingState)).isTrue();
+    jobBackoffRestoreMigration.runMigration(processingState);
+
+    // then
+    assertThat(backoffColumnFamily.isEmpty()).isFalse();
+    assertThat(backoffColumnFamily.count()).isEqualTo(1);
+  }
+
   private static JobRecord createJobRecord(final long retryBackoff) {
     return new JobRecord()
         .setType("test")

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
@@ -182,6 +182,8 @@ public class JobBackoffRestoreMigrationTest {
     // then
     assertThat(backoffColumnFamily.isEmpty()).isFalse();
     assertThat(backoffColumnFamily.count()).isEqualTo(1);
+    backoffKey.wrapLong(record.getRecurringTime());
+    assertThat(backoffColumnFamily.exists(backoffJobKey)).isFalse();
   }
 
   private static JobRecord createJobRecord(final long retryBackoff) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/state/migration/JobBackoffRestoreMigrationTest.java
@@ -181,7 +181,6 @@ public class JobBackoffRestoreMigrationTest {
 
     // then
     assertThat(backoffColumnFamily.isEmpty()).isFalse();
-    assertThat(backoffColumnFamily.count()).isEqualTo(1);
     backoffKey.wrapLong(record.getRecurringTime());
     assertThat(backoffColumnFamily.exists(backoffJobKey)).isFalse();
   }


### PR DESCRIPTION
Backport of https://github.com/camunda/zeebe/pull/16508 to stable/8.1.

relates to https://github.com/camunda/zeebe/issues/14329 https://github.com/camunda/zeebe/issues/15954