### PR TITLE
[Backport stable/8.1] fix: avoid race between scheduling and execution of due date checker

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockEndpoint.java
@@ -134,7 +134,9 @@ public class ActorClockEndpoint {
           "Expected to pin the clock to the given time, but it is immutable", 403);
     }
 
-    clock.get().pinTime(Instant.ofEpochMilli(epochMilli));
+    final var mutableClock = clock.get();
+    mutableClock.pinTime(Instant.ofEpochMilli(epochMilli));
+    mutableClock.update();
     return getCurrentClock();
   }
 
@@ -151,7 +153,9 @@ public class ActorClockEndpoint {
     }
 
     final var offset = Duration.of(offsetMilli, ChronoUnit.MILLIS);
-    clock.get().addTime(offset);
+    final var mutableClock = clock.get();
+    mutableClock.addTime(offset);
+    mutableClock.update();
     return getCurrentClock();
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ActorClockService.java
@@ -49,5 +49,7 @@ public interface ActorClockService {
 
     /** Resets the clock to use the system time */
     void resetTime();
+
+    void update();
   }
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ControlledActorClockService.java
@@ -50,4 +50,9 @@ public final class ControlledActorClockService implements ActorClockService, Mut
   public void resetTime() {
     clock.reset();
   }
+
+  @Override
+  public void update() {
+    clock.update();
+  }
 }

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ControlledActorClockEndpointTest.java
@@ -24,8 +24,9 @@ final class ControlledActorClockEndpointTest {
   private final InstanceOfAssertFactory<Response, ObjectAssert<Response>> responseType =
       new InstanceOfAssertFactory<>(Response.class, Assertions::assertThat);
 
+  private final ControlledActorClock actorClock = new ControlledActorClock();
   private final ActorClockEndpoint endpoint =
-      new ActorClockEndpoint(new ControlledActorClockService(new ControlledActorClock()));
+      new ActorClockEndpoint(new ControlledActorClockService(actorClock));
 
   @BeforeEach
   public void resetClock() {
@@ -90,6 +91,7 @@ final class ControlledActorClockEndpointTest {
 
     // when
     Thread.sleep(100);
+    actorClock.update();
     final var secondResponse = endpoint.getCurrentClock();
     assertThat(secondResponse.getBody()).isNotNull();
     final var secondMillis = secondResponse.getBody().epochMilli();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -14,6 +14,8 @@ import io.camunda.zeebe.engine.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.engine.api.Task;
 import io.camunda.zeebe.engine.api.TaskResult;
 import io.camunda.zeebe.engine.api.TaskResultBuilder;
+import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker.NextExecution.None;
+import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker.NextExecution.Scheduled;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.AtomicUtil;
 import java.time.Duration;
@@ -47,7 +49,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
    * Keeps track of the next execution of the checker. Value can be null if there is no scheduled
    * execution known.
    */
-  private final AtomicReference<NextExecution> nextExecution = new AtomicReference<>(null);
+  private final AtomicReference<NextExecution> nextExecution = new AtomicReference<>(new None());
 
   /**
    * @param timerResolution The resolution in ms for the timer
@@ -64,14 +66,14 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   }
 
   TaskResult execute(final TaskResultBuilder taskResultBuilder) {
-    // There is a benign edge case where we are not supposed to set nextExecution to null here.
+    // There is a benign edge case where we are not supposed to set nextExecution to None here.
     // If this execution was supposed to be cancelled because an earlier execution was scheduled
-    // instead, nextExecution would hold that earlier execution. We still overwrite it with null and
+    // instead, nextExecution would hold that earlier execution. We still overwrite it with None and
     // thus forget that we planned an execution. The next time something is scheduled, we will
-    // observe the null value and thus decide to schedule something new without cancelling what's
+    // observe the None value and thus decide to schedule something new without cancelling what's
     // already scheduled. While we try to avoid this, we can't prevent it entirely anyway because
     // cancellation of scheduled executions is best-effort and does not reliably prevent execution.
-    nextExecution.set(null);
+    nextExecution.set(new None());
 
     final long nextDueDate = visitor.apply(taskResultBuilder);
 
@@ -110,21 +112,21 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
     final var replacedExecution =
         AtomicUtil.replace(
             nextExecution,
-            currentlyScheduled -> {
+            currentlyPlanned -> {
               final var now = ActorClock.currentTimeMillis();
-              final var scheduleFor = now + Math.max(dueDate - now, timerResolution);
-              if (currentlyScheduled == null
-                  || currentlyScheduled.scheduledFor() - scheduleFor > timerResolution) {
+              final long scheduleFor = now + Math.max(dueDate - now, timerResolution);
+              if (!(currentlyPlanned instanceof final Scheduled currentlyScheduled)
+                  || (currentlyScheduled.scheduledFor() - scheduleFor > timerResolution)) {
                 final var delay = Duration.ofMillis(scheduleFor - now);
                 final var task = scheduleService.runDelayed(delay, this::execute);
-                return Optional.of(new NextExecution(scheduleFor, task));
+                return Optional.of(new Scheduled(scheduleFor, task));
               }
               return Optional.empty();
             },
-            newlyScheduled -> newlyScheduled.task().cancel());
+            NextExecution::cancel);
 
     if (replacedExecution != null) {
-      replacedExecution.task().cancel();
+      replacedExecution.cancel();
     }
   }
 
@@ -163,14 +165,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   }
 
   /**
-   * Keeps track of the next execution of the checker.
-   *
-   * @param scheduledFor The deadline in ms for when this execution is scheduled.
-   * @param task The scheduled task for the next execution, can be used for canceling the task.
+   * Abstracts over async and sync scheduling methods of {@link
+   * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService}.
    */
-  private record NextExecution(long scheduledFor, ScheduledTask task) {}
-
-  /** Abstracts over async and sync scheduling methods of {@link ProcessingScheduleService}. */
   @FunctionalInterface
   interface ScheduleDelayed {
     /**
@@ -178,5 +175,30 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
      * ProcessingScheduleService#runDelayedAsync(Duration, Task)}
      */
     ScheduledTask runDelayed(final Duration delay, final Task task);
+  }
+
+  interface NextExecution {
+    void cancel();
+
+    /** Sentinel value to signal that nothing is scheduled. */
+    record None() implements NextExecution {
+
+      @Override
+      public void cancel() {}
+    }
+
+    /**
+     * Keeps track of the next execution of the checker.
+     *
+     * @param scheduledFor The deadline in ms for when this execution is scheduled.
+     * @param task The scheduled task for the next execution, can be used for canceling the task.
+     */
+    record Scheduled(long scheduledFor, ScheduledTask task) implements NextExecution {
+
+      @Override
+      public void cancel() {
+        task.cancel();
+      }
+    }
   }
 }

--- a/expression-language/src/test/java/io/camunda/zeebe/el/FeelExpressionTest.java
+++ b/expression-language/src/test/java/io/camunda/zeebe/el/FeelExpressionTest.java
@@ -167,6 +167,7 @@ public class FeelExpressionTest {
     final var localDateTime = LocalDateTime.parse("2020-09-21T07:20:00");
     final var now = localDateTime.atZone(ZoneId.systemDefault());
     clock.setCurrentTime(now.toInstant());
+    clock.update();
 
     final var evaluationResult = evaluateExpression("now()", EMPTY_CONTEXT);
 
@@ -179,6 +180,7 @@ public class FeelExpressionTest {
     final var localDateTime = LocalDateTime.parse("2020-09-21T07:20:00");
     final var now = localDateTime.atZone(ZoneId.systemDefault());
     clock.setCurrentTime(now.toInstant());
+    clock.update();
 
     final var evaluationResult = evaluateExpression("string(today())", EMPTY_CONTEXT);
 

--- a/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
+++ b/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ControlledActorClock.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 public final class ControlledActorClock implements ActorClock {
   private volatile long currentTime;
   private volatile long currentOffset;
+  private volatile long updatedTime;
 
   public ControlledActorClock() {
     reset();
@@ -34,6 +35,7 @@ public final class ControlledActorClock implements ActorClock {
   public void reset() {
     currentTime = -1;
     currentOffset = 0;
+    updatedTime = System.currentTimeMillis();
   }
 
   public Instant getCurrentTime() {
@@ -54,16 +56,17 @@ public final class ControlledActorClock implements ActorClock {
 
   @Override
   public boolean update() {
+    if (usesPointInTime()) {
+      updatedTime = currentTime;
+    } else {
+      updatedTime = System.currentTimeMillis() + currentOffset;
+    }
     return true;
   }
 
   @Override
   public long getTimeMillis() {
-    if (usesPointInTime()) {
-      return currentTime;
-    } else {
-      return System.currentTimeMillis() + currentOffset;
-    }
+    return updatedTime;
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #17251 to `stable/8.1`.

relates to #17227 #17254 #17255 #17258
original author: @oleschoenburg