### PR TITLE
ci: GHA path filters work better on pull_reuqest triggers

### DIFF
--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -1,6 +1,15 @@
 name: Operate a11y tests
 on:
   push:
+    branches:
+      - 'main'
+      - 'stable/**'
+    paths-ignore:
+      - '.github/workflows/zeebe-*'
+      - 'dist/**'
+      - 'zeebe/**'
+      - 'spring-boot-starter-camunda-sdk/**'
+  pull_request:
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
+      - 'release/**'
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-backend-linting.yml
+++ b/.github/workflows/operate-backend-linting.yml
@@ -2,7 +2,9 @@ name: Operate Backend
 on:
   push:
     branches:
-      - main
+      - 'main'
+      - 'stable/**'
+      - 'release/**'
     paths-ignore:
       - ".github/workflows/zeebe-*"
       - "operate/client/**"

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
+      - 'release/**'
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -2,6 +2,15 @@
 name: Operate Tests
 on:
   push:
+    branches:
+      - 'main'
+      - 'stable/**'
+    paths-ignore:
+      - '.github/workflows/zeebe-*'
+      - 'dist/**'
+      - 'zeebe/**'
+      - 'spring-boot-starter-camunda-sdk/**'
+  pull_request:
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
+      - 'release/**'
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -2,6 +2,15 @@
 name: Operate E2E Tests
 on:
   push:
+    branches:
+      - 'main'
+      - 'stable/**'
+    paths-ignore:
+      - '.github/workflows/zeebe-*'
+      - 'dist/**'
+      - 'zeebe/**'
+      - 'spring-boot-starter-camunda-sdk/**'
+  pull_request:
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
+      - 'release/**'
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -2,7 +2,9 @@ name: Operate Frontend
 on:
   push:
     branches:
-      - main
+      - 'main'
+      - 'stable/**'
+      - 'release/**'
     paths:
       - 'operate/client/**'
       - '!.github/workflows/zeebe-*'

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - 'main'
       - 'stable/**'
+      - 'release/**'
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -2,6 +2,15 @@
 name: Operate Visual regression tests
 on:
   push:
+    branches:
+      - 'main'
+      - 'stable/**'
+    paths-ignore:
+      - '.github/workflows/zeebe-*'
+      - 'dist/**'
+      - 'zeebe/**'
+      - 'spring-boot-starter-camunda-sdk/**'
+  pull_request:
     paths-ignore:
       - '.github/workflows/zeebe-*'
       - 'dist/**'


### PR DESCRIPTION
## Description

The idea here is to try to avoid more unnecessary (Operate) CI runs by switching from `on.push` GHA triggers to `on.pull_request` with `paths`/`path-ignore` filters.

The hypothesis behind that switch is that `on.push` Github is not always able to properly diff against `main` because it doesn't know yet what the merge base should be - for `on.pull_request` it can derive that from the PR.

We still use `on.push` triggers for stable branches and the default branch `main` since they will not be the source of a PR most of the time.

## Related issues

Closes #17149