### PR TITLE
ci: never time out during release jobs

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -37,7 +37,6 @@ jobs:
   release:
     name: Maven & Go Release
     runs-on: gcp-core-16-release
-    timeout-minutes: 60
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}


### PR DESCRIPTION
Releasing can take a *very* long time because maven central is slow. Since its all manual and retry is painful, I think it's fine to just not set a timeout.