### PR TITLE
[Backport stable/8.1] ci: never time out during release jobs

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -37,7 +37,6 @@ jobs:
   release:
     name: Maven & Go Release
     runs-on: gcp-core-16-release
-    timeout-minutes: 60
     outputs:
       releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}


### PR DESCRIPTION
# Description
Backport of #17271 to `stable/8.1`.

relates to 
original author: @oleschoenburg