### PR TITLE
Revert "ci: do not run codeql always"

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -348,7 +348,6 @@ jobs:
   codeql:
     name: CodeQL
     runs-on: [ self-hosted, linux, amd64, "16" ]
-    if:  github.event_name != 'merge_group' && github.actor != 'renovate[bot]' # we don't need to run codeql for renovate PR's and not in merge queues
     permissions:
       security-events: write
     steps:
@@ -514,7 +513,7 @@ jobs:
       - go-apidiff
       - docker-checks
     steps:
-      - run: exit ${{ (contains(needs.*.result, 'failure') && 1) || 0 }}
+      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ test-summary ]


### PR DESCRIPTION
Reverts camunda/zeebe#17183

It was reported that due to the removing of the skip check, failed CI can be merged currently.

See https://camunda.slack.com/archives/C05DH1F5TAR/p1712159620095719
See https://github.com/camunda/zeebe/pull/17183#issuecomment-2034984742