### PR TITLE
test: increase await assertion timeout in OpensearchExporterIT IndexSettingsTest to overcome flaky test runs

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterIT.java
@@ -280,7 +280,7 @@ final class OpensearchExporterIT {
 
   /**
    * policy change is an asynchronous background process in opensearch, that's why we use awaits
-   * before asserts to reduce flakey results
+   * before asserts to reduce flaky results
    */
   @Nested
   final class IndexSettingsTest {
@@ -296,6 +296,7 @@ final class OpensearchExporterIT {
       // then
       final var index1 = indexRouter.indexFor(record1);
       await()
+          .atMost(Duration.ofSeconds(30))
           .untilAsserted(
               () -> {
                 final var index1Policy = testClient.explainIndex(index1);
@@ -313,12 +314,14 @@ final class OpensearchExporterIT {
       // then
       final var index2 = indexRouter.indexFor(record2);
       await()
+          .atMost(Duration.ofSeconds(30))
           .untilAsserted(
               () -> {
                 final var index2Policy = testClient.explainIndex(index2);
                 assertHasISMPolicy(index2Policy);
               });
       await()
+          .atMost(Duration.ofSeconds(30))
           .untilAsserted(
               () -> {
                 final var index1PolicyNew = testClient.explainIndex(index1);
@@ -338,6 +341,7 @@ final class OpensearchExporterIT {
       // then
       final var index1 = indexRouter.indexFor(record1);
       await()
+          .atMost(Duration.ofSeconds(30))
           .untilAsserted(
               () -> {
                 final var indexPolicy1 = testClient.explainIndex(index1);
@@ -363,6 +367,7 @@ final class OpensearchExporterIT {
                 assertHasNoISMPolicy(response2);
               });
       await()
+          .atMost(Duration.ofSeconds(30))
           .untilAsserted(
               () -> {
                 final var index1PolicyNew = testClient.explainIndex(index1);
@@ -394,6 +399,7 @@ final class OpensearchExporterIT {
       // then
       final var index2 = indexRouter.indexFor(record2);
       await()
+          .atMost(Duration.ofSeconds(30))
           .untilAsserted(
               () -> {
                 final var index2Policy = testClient.explainIndex(index2);

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -190,7 +190,7 @@ final class TestClient implements CloseableSilently {
 
   void deleteIndices() {
     try {
-      final var request = new Request("DELETE", config.index.prefix + "*");
+      final var request = new Request("DELETE", config.index.prefix + "*?expand_wildcards=all");
       restClient.performRequest(request);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);


### PR DESCRIPTION

## Description
Increase await assertion timeout to overcome flaky test runs

Policy change is an asynchronous background process in opensearch, that's why we use awaits before asserts to reduce flaky results

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #17279

<!-- Cut-off marker
_All lines under and including the cut-off marker will be removed from the merge commit message_

## Definition of Ready

Please check the items that apply, before requesting a review.

You can find more details about these items in our wiki page about [Pull Requests and Code Reviews](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews).

* [ ] I've reviewed my own code
* [ ] I've written a clear changelist description
* [ ] I've narrowly scoped my changes
* [ ] I've separated structural from behavioural changes
-->

## Definition of Done

<!-- Please check the items that apply, before merging or (if possible) before requesting a review. -->

_Not all items need to be done depending on the issue and the pull request._

Code changes:
* [ ] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [ ] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).
