### PR TITLE
deps: enable Renovate lockfile updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,6 +20,13 @@
       "helm-camunda-io": "https://helm.camunda.io"
     }
   },
+  "vulnerabilityAlerts": {
+    "labels": ["area/security"],
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchBaseBranches": ["/^stable\\/8\\..*/"],


### PR DESCRIPTION
## Description

As discovered in https://github.com/camunda/zeebe/issues/17172#issuecomment-2036754792 Renovate is by default not proposing any lockfile updates thus transitive (frontend) dependencies will not receive any (security) update PRs.

This PR proposes to rectify this by enabling those updates (incoming weekly) and allowing Renovate to use GitHubs vulnerability database (already enabled on this repo) to prioritize security PRs.

After this PR is merged we can disable "Dependabot security updates" (PRs) on https://github.com/camunda/zeebe/settings/security_analysis

Docs:
* https://docs.renovatebot.com/configuration-options/#lockfilemaintenance
* https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts

## Related issues

Related to #17172