### PR TITLE
style: apply formatting to 8.5 poms

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -8,7 +8,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>3.9.1</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath></relativePath>
   </parent>
 
   <groupId>io.camunda</groupId>
@@ -164,7 +164,7 @@
           <configuration>
             <pom>
               <!-- https://github.com/diffplug/spotless/blob/main/plugin-maven/README.md#sortpom -->
-              <sortPom />
+              <sortPom></sortPom>
             </pom>
           </configuration>
         </plugin>

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -430,7 +430,7 @@
               <goal>assemble</goal>
             </goals>
             <phase>package</phase>
-            <configuration />
+            <configuration></configuration>
           </execution>
         </executions>
       </plugin>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1557,7 +1557,7 @@
                 <goal>check</goal>
               </goals>
               <phase>validate</phase>
-              <configuration />
+              <configuration></configuration>
             </execution>
           </executions>
         </plugin>
@@ -1587,7 +1587,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter" />
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
             <skip>${skipUTs}</skip>
           </configuration>
           <dependencies>
@@ -1627,7 +1627,7 @@
               <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
               <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
             </statelessTestsetReporter>
-            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter" />
+            <consoleOutputReporter implementation="io.camunda.zeebe.ZeebeConsoleOutputReporter"></consoleOutputReporter>
             <skip>${skipITs}</skip>
           </configuration>
           <dependencies>
@@ -1757,7 +1757,7 @@
                     </goals>
                   </pluginExecutionFilter>
                   <action>
-                    <ignore />
+                    <ignore></ignore>
                   </action>
                 </pluginExecution>
               </pluginExecutions>
@@ -1855,7 +1855,7 @@
               </goals>
               <configuration>
                 <rules>
-                  <banDuplicatePomDependencyVersions />
+                  <banDuplicatePomDependencyVersions></banDuplicatePomDependencyVersions>
                 </rules>
               </configuration>
             </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
               <exclude>**/target/**/*.md</exclude>
               <exclude>clients/go/vendor/**/*.md</exclude>
             </excludes>
-            <flexmark />
+            <flexmark></flexmark>
           </markdown>
         </configuration>
       </plugin>

--- a/zeebe/gateway-protocol-impl/pom.xml
+++ b/zeebe/gateway-protocol-impl/pom.xml
@@ -131,7 +131,7 @@
                 <phase>generate-sources</phase>
                 <configuration>
                   <target>
-                    <copy failonerror="true" file="${project.build.directory}/generated-sources/protobuf/go/gateway.pb.go" tofile="${maven.multiModuleProjectDirectory}/clients/go/pkg/pb/gateway.pb.go" />
+                    <copy failonerror="true" file="${project.build.directory}/generated-sources/protobuf/go/gateway.pb.go" tofile="${maven.multiModuleProjectDirectory}/clients/go/pkg/pb/gateway.pb.go"></copy>
                   </target>
                 </configuration>
               </execution>


### PR DESCRIPTION
Formatting was broken, probably because the poms were changed when preparing for the next development iteration.