### PR TITLE
ci: rely on automatic setup of CodeQL

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -345,46 +345,6 @@ jobs:
       - name: Run Go tests
         working-directory: clients/go
         run: go test -mod=vendor -v ./...
-  codeql:
-    name: CodeQL
-    runs-on: [ self-hosted, linux, amd64, "16" ]
-    permissions:
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-zeebe
-        with:
-          go: false
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: java
-          queries: +security-and-quality
-      - uses: ./.github/actions/build-zeebe
-        with:
-          maven-extra-args: -T1C
-      - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
-        with:
-          upload: False
-          output: sarif-results
-      - name: Remove results for generated code
-        uses: advanced-security/filter-sarif@main
-        with:
-          patterns: |
-            +**/*.java
-            -**/generated-sources/**/*.java
-            -**/generated-test-sources/**/*.java
-          input: sarif-results/java.sarif
-          output: sarif-results/java.sarif
-      - name: Upload CodeQL Results
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: sarif-results/java.sarif
   go-lint:
     name: Go linting
     runs-on: ubuntu-latest
@@ -507,7 +467,6 @@ jobs:
       - property-tests
       - performance-tests
       - go-client
-      - codeql
       - java-checks
       - go-lint
       - go-apidiff


### PR DESCRIPTION
Rather than setup and run CodeQL ourselves, we can rely on the [automatic setup of CodeQL](https://docs.github.com/en/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning). This simplifies our CI and we benefit from a better integration with GitHub.
