### PR TITLE
ci: cancel outdated ci runs

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -21,6 +21,10 @@ on:
   workflow_dispatch: { }
   workflow_call: { }
 
+concurrency:
+  cancel-in-progress: true
+  group: "${{ github.workflow }}-${{ github.ref }}"
+
 defaults:
   run:
     # use bash shell by default to ensure pipefail behavior is the default


### PR DESCRIPTION
To free up some resources, we can automatically cancel CI runs if they become outdated by a new push.