### PR TITLE
[Backport stable/8.2] ci: cancel outdated ci runs

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -13,6 +13,10 @@ on:
   workflow_dispatch: { }
   workflow_call: { }
 
+concurrency:
+  cancel-in-progress: true
+  group: "${{ github.workflow }}-${{ github.ref }}"
+
 defaults:
   run:
     # use bash shell by default to ensure pipefail behavior is the default


### PR DESCRIPTION
# Description
Backport of #17315 to `stable/8.2`.

relates to 
original author: @oleschoenburg