### PR TITLE
Trigger merge ci on PR

### DIFF
--- a/.github/workflows/operate-merge-ci.yaml
+++ b/.github/workflows/operate-merge-ci.yaml
@@ -2,6 +2,7 @@ name: Operate merge queue CI
 
 on:
   merge_group: { }
+  pull_request: { }    
   workflow_dispatch: { }
 
 


### PR DESCRIPTION
## Description
We can't auto merge when merge CI hasn't run before, we need to be triggered on PRs as well to make this working

See https://camunda.slack.com/archives/C05DH1F5TAR/p1712299408624469?thread_ts=1712250281.508679&cid=C05DH1F5TAR
<!-- Please explain the changes you made here. -->
