### PR TITLE
Add C8 API guideline proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-proposal.md
@@ -1,0 +1,23 @@
+---
+
+name: API proposal
+about: General proposal for the API strategy
+title: ''
+labels: ['component/c8-api', 'kind/proposal']
+assignees: ''
+projects: ['camunda/111']
+
+---
+
+## Description
+
+_A clear and concise description of what this proposal is about and what problem it solves._
+
+## Proposal
+
+_A detailed description of your proposed changes or additions to the API guidelines._
+_Can also be a link to a document, slides, whiteboard, or anything that is ideally directly commentable._
+
+## Decisions
+
+_Will be filled in by the project DRIs after a peer review phase._


### PR DESCRIPTION
## Description

Adds an issue template for proposals for the C8 API guidelines. This ensures consistent proposals that are added to the right project directly.

## Related issues

related to #17302 

## Definition of Done

Code changes:
* [x] The changes are backwards compatibility with previous versions
* [ ] If it fixes a bug then PRs are created to [backport](https://github.com/camunda/zeebe/compare/stable/0.24...main?expand=1&template=backport_template.md&title=[Backport%200.24]) the fix to the last two minor versions. You can trigger a backport by assigning labels (e.g. `backport stable/1.3`) to the PR, in case that fails you need to create backports manually.

Testing:
* [ ] There are unit/integration tests that verify all acceptance criterias of the issue
* [ ] New tests are written to ensure backwards compatibility with further versions
* [x] The behavior is tested manually
* [ ] The change has been verified by a QA run
* [ ] The impact of the changes is verified by a benchmark

Documentation:
* [ ] The documentation is updated (e.g. BPMN reference, configuration, examples, get-started guides, etc.)
* [ ] If the PR changes how BPMN processes are validated (e.g. support new BPMN element) then the Camunda modeling team should be informed to adjust the BPMN linting.

Other teams:
If the change impacts another team an issue has been created for this team, explaining what they need to do to support this change.
- [ ] [Tasklist](https://github.com/camunda/tasklist/issues)
- [ ] [Web Modeler](https://github.com/camunda/web-modeler/issues)
- [ ] [Desktop Modeler](https://github.com/camunda/camunda-modeler/issues)
- [ ] [Optimize](https://github.com/camunda/camunda-optimize/issues)

Please refer to our [review guidelines](https://github.com/camunda/zeebe/wiki/Pull-Requests-and-Code-Reviews#code-review-guidelines).