### PR TITLE
feat(clients/go): jobWorker can set tenantIds to activate jobs

### DIFF
--- a/clients/go/pkg/commands/activate_jobs.go
+++ b/clients/go/pkg/commands/activate_jobs.go
@@ -16,17 +16,19 @@ package commands
 
 import (
 	"context"
-	"github.com/camunda/camunda/clients/go/v8/pkg/entities"
-	"github.com/camunda/camunda/clients/go/v8/pkg/pb"
 	"io"
 	"log"
 	"time"
+
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 )
 
 const (
 	DefaultJobTimeout     = 5 * time.Minute
 	DefaultJobTimeoutInMs = int64(DefaultJobTimeout / time.Millisecond)
 	DefaultJobWorkerName  = "default"
+	DefaultJobTenantId    = "<default>"
 )
 
 type DispatchActivateJobsCommand interface {

--- a/clients/go/pkg/commands/activate_jobs.go
+++ b/clients/go/pkg/commands/activate_jobs.go
@@ -28,7 +28,7 @@ const (
 	DefaultJobTimeout     = 5 * time.Minute
 	DefaultJobTimeoutInMs = int64(DefaultJobTimeout / time.Millisecond)
 	DefaultJobWorkerName  = "default"
-	DefaultJobTenantId    = "<default>"
+	DefaultJobTenantID    = "<default>"
 )
 
 type DispatchActivateJobsCommand interface {

--- a/clients/go/pkg/commands/activate_jobs.go
+++ b/clients/go/pkg/commands/activate_jobs.go
@@ -20,8 +20,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"github.com/camunda/camunda/clients/go/v8/pkg/entities"
+	"github.com/camunda/camunda/clients/go/v8/pkg/pb"
 )
 
 const (

--- a/clients/go/pkg/worker/jobWorker_builder.go
+++ b/clients/go/pkg/worker/jobWorker_builder.go
@@ -271,6 +271,7 @@ func NewJobWorkerBuilder(gatewayClient pb.GatewayClient, jobClient JobClient, re
 			Timeout:        commands.DefaultJobTimeoutInMs,
 			Worker:         commands.DefaultJobWorkerName,
 			RequestTimeout: DefaultRequestTimeout.Milliseconds(),
+			TenantIds:      []string{commands.DefaultJobTenantId},
 		},
 		requestTimeout:  DefaultRequestTimeout + RequestTimeoutOffset,
 		shouldRetry:     retryPred,

--- a/clients/go/pkg/worker/jobWorker_builder.go
+++ b/clients/go/pkg/worker/jobWorker_builder.go
@@ -86,6 +86,8 @@ type JobWorkerBuilderStep3 interface {
 	PollThreshold(float64) JobWorkerBuilderStep3
 	// FetchVariables Set list of variable names which should be fetched on job activation
 	FetchVariables(...string) JobWorkerBuilderStep3
+	// a list of IDs of tenants for which to activate jobs
+	TenantIds(...string) JobWorkerBuilderStep3
 	// Metrics Set implementation for metrics reporting
 	Metrics(metrics JobWorkerMetrics) JobWorkerBuilderStep3
 	// BackoffSupplier Set the backoffSupplier to back off polling on errors
@@ -158,6 +160,11 @@ func (builder *JobWorkerBuilder) PollThreshold(pollThreshold float64) JobWorkerB
 
 func (builder *JobWorkerBuilder) FetchVariables(fetchVariables ...string) JobWorkerBuilderStep3 {
 	builder.request.FetchVariable = fetchVariables
+	return builder
+}
+
+func (builder *JobWorkerBuilder) TenantIds(tenantIds ...string) JobWorkerBuilderStep3 {
+	builder.request.TenantIds = tenantIds
 	return builder
 }
 

--- a/clients/go/pkg/worker/jobWorker_builder.go
+++ b/clients/go/pkg/worker/jobWorker_builder.go
@@ -271,7 +271,7 @@ func NewJobWorkerBuilder(gatewayClient pb.GatewayClient, jobClient JobClient, re
 			Timeout:        commands.DefaultJobTimeoutInMs,
 			Worker:         commands.DefaultJobWorkerName,
 			RequestTimeout: DefaultRequestTimeout.Milliseconds(),
-			TenantIds:      []string{commands.DefaultJobTenantId},
+			TenantIds:      []string{commands.DefaultJobTenantID},
 		},
 		requestTimeout:  DefaultRequestTimeout + RequestTimeoutOffset,
 		shouldRetry:     retryPred,

--- a/clients/go/pkg/worker/jobWorker_builder_test.go
+++ b/clients/go/pkg/worker/jobWorker_builder_test.go
@@ -19,9 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/camunda/camunda/clients/go/v8/internal/mock_pb"
-	"github.com/camunda/camunda/clients/go/v8/pkg/entities"
-	"github.com/camunda/camunda/clients/go/v8/pkg/pb"
+	"github.com/camunda/zeebe/clients/go/v8/internal/mock_pb"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
+	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )
@@ -100,9 +101,14 @@ func TestJobWorkerBuilder_FetchVariables(t *testing.T) {
 func TestJobWorkerBuilder_TenantIds(t *testing.T) {
 	tenantIds := []string{"foo", "bar", "baz"}
 
-	builder := JobWorkerBuilder{request: &pb.ActivateJobsRequest{}}
+	builder := NewJobWorkerBuilder(nil, nil, nil).(*JobWorkerBuilder)
 	builder.TenantIds(tenantIds...)
 	assert.Equal(t, tenantIds, builder.request.TenantIds)
+}
+
+func TestJobWorkerBuilder_DefaultTenantIds(t *testing.T) {
+	builder := NewJobWorkerBuilder(nil, nil, nil).(*JobWorkerBuilder)
+	assert.Equal(t, []string{commands.DefaultJobTenantId}, builder.request.TenantIds)
 }
 
 func TestJobWorkerBuilder_Metrics(t *testing.T) {

--- a/clients/go/pkg/worker/jobWorker_builder_test.go
+++ b/clients/go/pkg/worker/jobWorker_builder_test.go
@@ -97,6 +97,14 @@ func TestJobWorkerBuilder_FetchVariables(t *testing.T) {
 	assert.Equal(t, fetchVariables, builder.request.FetchVariable)
 }
 
+func TestJobWorkerBuilder_TenantIds(t *testing.T) {
+	tenantIds := []string{"foo", "bar", "baz"}
+
+	builder := JobWorkerBuilder{request: &pb.ActivateJobsRequest{}}
+	builder.TenantIds(tenantIds...)
+	assert.Equal(t, tenantIds, builder.request.TenantIds)
+}
+
 func TestJobWorkerBuilder_Metrics(t *testing.T) {
 	builder := JobWorkerBuilder{}
 	workerMetrics := mock_pb.NewMockJobWorkerMetrics(gomock.NewController(t))

--- a/clients/go/pkg/worker/jobWorker_builder_test.go
+++ b/clients/go/pkg/worker/jobWorker_builder_test.go
@@ -108,7 +108,7 @@ func TestJobWorkerBuilder_TenantIds(t *testing.T) {
 
 func TestJobWorkerBuilder_DefaultTenantIds(t *testing.T) {
 	builder := NewJobWorkerBuilder(nil, nil, nil).(*JobWorkerBuilder)
-	assert.Equal(t, []string{commands.DefaultJobTenantId}, builder.request.TenantIds)
+	assert.Equal(t, []string{commands.DefaultJobTenantID}, builder.request.TenantIds)
 }
 
 func TestJobWorkerBuilder_Metrics(t *testing.T) {

--- a/clients/go/pkg/worker/jobWorker_builder_test.go
+++ b/clients/go/pkg/worker/jobWorker_builder_test.go
@@ -19,10 +19,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/camunda/zeebe/clients/go/v8/internal/mock_pb"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/commands"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/entities"
-	"github.com/camunda/zeebe/clients/go/v8/pkg/pb"
+	"github.com/camunda/camunda/clients/go/v8/internal/mock_pb"
+	"github.com/camunda/camunda/clients/go/v8/pkg/commands"
+	"github.com/camunda/camunda/clients/go/v8/pkg/entities"
+	"github.com/camunda/camunda/clients/go/v8/pkg/pb"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 )

--- a/clients/go/pkg/worker/jobWorker_test.go
+++ b/clients/go/pkg/worker/jobWorker_test.go
@@ -62,6 +62,7 @@ func TestJobWorkerActivateJobsDefault(t *testing.T) {
 		Timeout:           commands.DefaultJobTimeoutInMs,
 		Worker:            commands.DefaultJobWorkerName,
 		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		TenantIds:         []string{commands.DefaultJobTenantID},
 	}
 
 	response := &pb.ActivateJobsResponse{
@@ -108,6 +109,7 @@ func TestJobWorkerActivateJobsCustom(t *testing.T) {
 		Timeout:           int64(timeout / time.Millisecond),
 		Worker:            "fooWorker",
 		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		TenantIds:         []string{commands.DefaultJobTenantID},
 	}
 
 	response := &pb.ActivateJobsResponse{
@@ -154,6 +156,7 @@ func TestJobWorkerStreamDisabled(t *testing.T) {
 		Timeout:           int64(timeout / time.Millisecond),
 		Worker:            "fooWorker",
 		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		TenantIds:         []string{commands.DefaultJobTenantID},
 	}
 
 	response := &pb.ActivateJobsResponse{
@@ -193,9 +196,10 @@ func TestJobWorkerStreamEnabled(t *testing.T) {
 	activateJobsStream := mock_pb.NewMockGateway_ActivateJobsClient(ctrl)
 	timeout := 7 * time.Minute
 	request := &pb.StreamActivatedJobsRequest{
-		Type:    "foo",
-		Timeout: int64(timeout / time.Millisecond),
-		Worker:  "fooWorker",
+		Type:      "foo",
+		Timeout:   int64(timeout / time.Millisecond),
+		Worker:    "fooWorker",
+		TenantIds: []string{commands.DefaultJobTenantID},
 	}
 	activateJobsRequest := &pb.ActivateJobsRequest{
 		Type:              "foo",
@@ -203,6 +207,7 @@ func TestJobWorkerStreamEnabled(t *testing.T) {
 		Timeout:           int64(timeout / time.Millisecond),
 		Worker:            "fooWorker",
 		RequestTimeout:    int64(utils.DefaultTestTimeout / time.Millisecond),
+		TenantIds:         []string{commands.DefaultJobTenantID},
 	}
 
 	response := &pb.ActivatedJob{Key: 1}
@@ -248,9 +253,10 @@ func TestStreamingJobWorkerClose(t *testing.T) {
 	activateJobsStream := mock_pb.NewMockGateway_ActivateJobsClient(ctrl)
 	timeout := 7 * time.Minute
 	request := &pb.StreamActivatedJobsRequest{
-		Type:    "foo",
-		Timeout: int64(timeout / time.Millisecond),
-		Worker:  "default",
+		Type:      "foo",
+		Timeout:   int64(timeout / time.Millisecond),
+		Worker:    "default",
+		TenantIds: []string{commands.DefaultJobTenantID},
 	}
 	activateJobsRequest := &pb.ActivateJobsRequest{
 		Type:              "foo",
@@ -258,6 +264,7 @@ func TestStreamingJobWorkerClose(t *testing.T) {
 		Timeout:           int64(timeout / time.Millisecond),
 		Worker:            "default",
 		RequestTimeout:    10000,
+		TenantIds:         []string{commands.DefaultJobTenantID},
 	}
 
 	stream.EXPECT().Recv().Return(nil, io.EOF).AnyTimes()
@@ -303,6 +310,7 @@ func TestJobWorkerClose(t *testing.T) {
 		Timeout:           int64(timeout / time.Millisecond),
 		Worker:            "default",
 		RequestTimeout:    10000,
+		TenantIds:         []string{commands.DefaultJobTenantID},
 	}
 
 	stream.EXPECT().Recv().Return(nil, io.EOF).AnyTimes()


### PR DESCRIPTION
## Description
This is a small leftover of https://github.com/camunda/zeebe/pull/14946, we just need to add TenantIds method to allow JobWorkerBuilder set tenantIds, so jobWorker can activate specific tenant's jobs.

## Related issues
closes #17167