### PR TITLE
Cleanup contributing links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,19 +333,6 @@ unacceptable behavior as soon as possible.
 [issues]: https://github.com/zeebe-io/zeebe/issues
 [forum]: https://forum.zeebe.io/
 [sample]: https://github.com/zeebe-io/zeebe-test-template-java
-[status]: https://github.com/zeebe-io/zeebe/labels?q=Type
-[planned]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Enhancement
-[ready]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Maintenance
-[in progress]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Bug
-[needs review]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Docs
-[type]: https://github.com/zeebe-io/zeebe/labels?q=Type
-[enhancement]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Enhancement
-[maintenance]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Maintenance
-[bug]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Bug
-[docs]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Docs
-[question]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Question
-[scope]: https://github.com/zeebe-io/zeebe/labels?q=Scope
-[broker]: https://github.com/zeebe-io/zeebe/labels/Scope%3A%20broker
 [clients/java]: https://github.com/zeebe-io/zeebe/labels/Scope%3A%20clients%2Fjava
 [clients/go]: https://github.com/zeebe-io/zeebe/labels/Scope%3A%20clients%2Fgo
 [changelog generation]: https://github.com/zeebe-io/zeebe-changelog

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ If you report a bug, please help speed up problem diagnosis by
 providing as much information as possible. Ideally, that would include a small
 [sample project][sample] that reproduces the problem.
 
-If you have a general usage question please ask on the [forum](http://forum.camunda.io/).
+If you have a general usage question please ask on the [forum].
 
 ## GitHub Issue Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ If you report a bug, please help speed up problem diagnosis by
 providing as much information as possible. Ideally, that would include a small
 [sample project][sample] that reproduces the problem.
 
-If you have a general usage question please ask on the [forum](http://forum.camunda.io/) or [Slack](https://www.camunda.com/slack) channel.
+If you have a general usage question please ask on the [forum](http://forum.camunda.io/).
 
 ## GitHub Issue Guidelines
 
@@ -332,7 +332,6 @@ unacceptable behavior as soon as possible.
 
 [issues]: https://github.com/zeebe-io/zeebe/issues
 [forum]: https://forum.zeebe.io/
-[slack]: https://www.camunda.com/slack
 [sample]: https://github.com/zeebe-io/zeebe-test-template-java
 [status]: https://github.com/zeebe-io/zeebe/labels?q=Type
 [planned]: https://github.com/zeebe-io/zeebe/labels/Type%3A%20Enhancement

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -333,7 +333,7 @@ unacceptable behavior as soon as possible.
 [issues]: https://github.com/camunda/zeebe/issues
 [forum]: https://forum.camunda.io/
 [sample]: https://github.com/zeebe-io/zeebe-test-template-java
-[clients/java]: https://github.com/zeebe-io/zeebe/labels/Scope%3A%20clients%2Fjava
-[clients/go]: https://github.com/zeebe-io/zeebe/labels/Scope%3A%20clients%2Fgo
+[clients/java]: https://github.com/camunda/zeebe/labels/scope%2Fclients-java
+[clients/go]: https://github.com/camunda/zeebe/labels/scope%2Fclients-go
 [changelog generation]: https://github.com/zeebe-io/zeebe-changelog
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,8 +330,8 @@ This project adheres to the [Camunda Code of Conduct](https://camunda.com/events
 By participating, you are expected to uphold this code. Please [report](https://camunda.com/events/code-conduct/reporting-violations/)
 unacceptable behavior as soon as possible.
 
-[issues]: https://github.com/zeebe-io/zeebe/issues
-[forum]: https://forum.zeebe.io/
+[issues]: https://github.com/camunda/zeebe/issues
+[forum]: https://forum.camunda.io/
 [sample]: https://github.com/zeebe-io/zeebe-test-template-java
 [clients/java]: https://github.com/zeebe-io/zeebe/labels/Scope%3A%20clients%2Fjava
 [clients/go]: https://github.com/zeebe-io/zeebe/labels/Scope%3A%20clients%2Fgo


### PR DESCRIPTION
## Description

I noticed that the Contributing guide still referred to our slack, which is no longer in use. While changing this, I noticed several references were no longer in use or referenced deprecated URLs.

## Related issues

Rather than open an issue, I thought it was best just to correct it.
