### PR TITLE
deps: renovate: bundle playwright deps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -109,6 +109,10 @@
     {
       "matchFileNames": ["operate.Dockerfile"],
       "enabled": false
+    },
+    {
+      "matchPackagePatterns": ["@playwright/test", "mcr.microsoft.com/playwright"],
+      "groupName": "playwright"
     }
   ],
   "dockerfile": {


### PR DESCRIPTION
## Description

Bundle dependencies in renovate config, because playwright node dependency and playwright docker image need to be updated together to avoid test failures, see: https://github.com/camunda/zeebe/pull/17016, https://github.com/camunda/zeebe/pull/17249


