### PR TITLE
ci: Add Operate Build step to merge queue (#17226)

### DIFF
--- a/.github/workflows/operate-merge-ci.yaml
+++ b/.github/workflows/operate-merge-ci.yaml
@@ -1,0 +1,26 @@
+name: Operate merge queue CI
+
+on:
+  merge_group: { }
+  workflow_dispatch: { }
+
+
+jobs:
+  run-build:
+    name: run-build
+    uses: ./.github/workflows/operate-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
+
+  operate-ci-test-summary:
+    # Used by the merge queue to check all jobs.
+    # New test jobs must be added to the `needs` lists!
+    # This name is hard-coded in the branch rules; remember to update that if this name changes
+    name: Operate CI test summary
+    if: always()
+    runs-on: ubuntu-latest
+    needs:
+      - run-build
+    steps:
+      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}

--- a/.github/workflows/operate-merge-ci.yaml
+++ b/.github/workflows/operate-merge-ci.yaml
@@ -2,6 +2,7 @@ name: Operate merge queue CI
 
 on:
   merge_group: { }
+  pull_request: { }    
   workflow_dispatch: { }
 
 

--- a/operate/qa/pom.xml
+++ b/operate/qa/pom.xml
@@ -30,7 +30,7 @@
 
     <!-- properties for ImportSeveralVersionsTest and import-old-zeebe-tests module -->
     <version.zeebe.old>8.1.0</version.zeebe.old>
-    <version.zeebe.docker.current>SNAPSHOT</version.zeebe.docker.current>
+    <version.zeebe.docker.current>8.5.0</version.zeebe.docker.current>
     <version.identity.docker.current>8.5.0</version.identity.docker.current>
 
   </properties>


### PR DESCRIPTION
## Description

A while ago we decided to leave the Operate CI out of the merge queue, as it was seen as not reliable and fast enough. This contains some risks, when merging several PRs together. Recently we made several changes how dependency are handled (and enforced). After merging some refactoring in the POM's several other PRs which have been merged failed on main, see related [slack
thread](https://camunda.slack.com/archives/C9B5270DA/p1711376024115889?thread_ts=1711375403.007319&cid=C9B5270DA).

As we want to avoid such and want to build a stable product we want to slowly integrate Operate CI into our merge queue, for now only the build process to at least make sure that we can build the code basis still after merging a PR, see related issue #17118

> [!Important]
>
> Merge queues don't support any path filtering, this needs to be done
later manually.
> See related discussion
https://github.com/orgs/community/discussions/45899#discussioncomment-5643259

This PR adds a new workflow, that is triggered by the merge queue or manually. It specifies a new `operate-ci-test-summary` which we need to specify in our merge queue configuration.

Furthermore, the old test-summary in the Zeebe ci was renamed to make more clear what this test-summary references. We can discuss this whether this is really necessary.

<!-- Please explain the changes you made here. -->

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #17118

## Description

## Related issues

closes #
