### PR TITLE
feat:  Expose Soft Pause Endpoint 

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 @WebEndpoint(id = "exporting")
 public final class ExportingEndpoint {
   static final String PAUSE = "pause";
+  static final String SOFT_PAUSE = "softPause";
   static final String RESUME = "resume";
   final ExportingControlApi exportingService;
 
@@ -35,6 +36,7 @@ public final class ExportingEndpoint {
       final var result =
           switch (operationKey) {
             case PAUSE -> exportingService.pauseExporting();
+            case SOFT_PAUSE -> exportingService.softPauseExporting();
             case RESUME -> exportingService.resumeExporting();
             default -> throw new UnsupportedOperationException();
           };

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
@@ -20,7 +20,8 @@ import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 
 final class ExportingEndpointTest {
   @ParameterizedTest
-  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
+  @ValueSource(
+      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
   void pauseAndResumeFailsIfCallFailsDirectly(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -29,6 +30,7 @@ final class ExportingEndpointTest {
     // when
     when(service.pauseExporting()).thenThrow(new RuntimeException());
     when(service.resumeExporting()).thenThrow(new RuntimeException());
+    when(service.softPauseExporting()).thenThrow(new RuntimeException());
 
     // then
     assertThat(endpoint.post(operation))
@@ -37,7 +39,8 @@ final class ExportingEndpointTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
+  @ValueSource(
+      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
   void pauseAndResumeFailIfCallReturnsFailedFuture(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -48,6 +51,8 @@ final class ExportingEndpointTest {
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
     when(service.resumeExporting())
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
+    when(service.softPauseExporting())
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
 
     // then
     assertThat(endpoint.post(operation))
@@ -56,7 +61,8 @@ final class ExportingEndpointTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
+  @ValueSource(
+      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
   void pauseAndResumeCanSucceed(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -65,6 +71,7 @@ final class ExportingEndpointTest {
     // when
     when(service.pauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
     when(service.resumeExporting()).thenReturn(CompletableFuture.completedFuture(null));
+    when(service.softPauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
 
     // then
     assertThat(endpoint.post(operation))

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
@@ -20,8 +20,7 @@ import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 
 final class ExportingEndpointTest {
   @ParameterizedTest
-  @ValueSource(
-      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
+  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
   void pauseAndResumeFailsIfCallFailsDirectly(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -33,14 +32,13 @@ final class ExportingEndpointTest {
     when(service.softPauseExporting()).thenThrow(new RuntimeException());
 
     // then
-    assertThat(endpoint.post(operation))
+    assertThat(endpoint.post(operation, false))
         .returns(
             WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR, from(WebEndpointResponse::getStatus));
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
+  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
   void pauseAndResumeFailIfCallReturnsFailedFuture(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -55,14 +53,13 @@ final class ExportingEndpointTest {
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
 
     // then
-    assertThat(endpoint.post(operation))
+    assertThat(endpoint.post(operation, false))
         .returns(
             WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR, from(WebEndpointResponse::getStatus));
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
+  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
   void pauseAndResumeCanSucceed(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -74,7 +71,7 @@ final class ExportingEndpointTest {
     when(service.softPauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
 
     // then
-    assertThat(endpoint.post(operation))
+    assertThat(endpoint.post(operation, false))
         .returns(WebEndpointResponse.STATUS_NO_CONTENT, from(WebEndpointResponse::getStatus));
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminService.java
@@ -20,6 +20,9 @@ public interface BrokerAdminService {
   /** Request a partition to pause exporting */
   void pauseExporting();
 
+  /** Request a partition to soft pause exporting */
+  void softPauseExporting();
+
   /** Request a partition to resume exporting */
   void resumeExporting();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
@@ -31,6 +31,7 @@ public class BrokerAdminServiceEndpoint {
     operations.put("takeSnapshot", this::takeSnapshot);
     operations.put("prepareUpgrade", this::prepareUpgrade);
     operations.put("pauseExporting", this::pauseExporting);
+    operations.put("softPauseExporting", this::softPauseExporting);
     operations.put("resumeExporting", this::resumeExporting);
   }
 
@@ -57,6 +58,11 @@ public class BrokerAdminServiceEndpoint {
 
   private Map<Integer, PartitionStatus> pauseExporting() {
     springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::pauseExporting);
+    return partitionStatus();
+  }
+
+  private Map<Integer, PartitionStatus> softPauseExporting() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::softPauseExporting);
     return partitionStatus();
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -60,6 +60,11 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
   }
 
   @Override
+  public void softPauseExporting() {
+    actor.call(this::softPauseExportingOnAllPartitions);
+  }
+
+  @Override
   public void resumeExporting() {
     actor.call(this::resumeExportingOnAllPartitions);
   }
@@ -225,6 +230,14 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
     return partitionManager.getZeebePartitions().stream()
         .map(ZeebePartition::getAdminAccess)
         .map(PartitionAdminAccess::takeSnapshot)
+        .collect(new ActorFutureCollector<>(actor));
+  }
+
+  private ActorFuture<List<Void>> softPauseExportingOnAllPartitions() {
+    LOG.info("Soft Pausing exporting on all partitions.");
+    return partitionManager.getZeebePartitions().stream()
+        .map(ZeebePartition::getAdminAccess)
+        .map(PartitionAdminAccess::softPauseExporting)
         .collect(new ActorFutureCollector<>(actor));
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -262,11 +262,6 @@ public class PartitionStartupAndTransitionContextImpl
   }
 
   @Override
-  public boolean shouldExport() {
-    return !partitionProcessingState.isExportingPaused();
-  }
-
-  @Override
   public ExporterPhase getExporterPhase() {
     return partitionProcessingState.getExporterPhase();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -94,8 +94,6 @@ public interface PartitionTransitionContext extends PartitionContext {
 
   void setPartitionCommandSender(InterPartitionCommandSenderService sender);
 
-  boolean shouldExport();
-
   ExporterPhase getExporterPhase();
 
   Collection<ExporterDescriptor> getExportedDescriptors();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -79,10 +79,6 @@ public class PartitionProcessingState {
     return exporterPhase;
   }
 
-  public boolean isExportingSoftPaused() {
-    return exporterPhase.equals(ExporterPhase.SOFT_PAUSED);
-  }
-
   @SuppressWarnings({"squid:S899"})
   /** Returns true if exporting is paused. This method overrides the effects of soft pause. */
   public boolean pauseExporting() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -111,10 +111,16 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
           if (error == null) {
             context.setExporterDirector(director);
             // Pause/Resume here in case the state was changed after the director was created
-            if (!context.shouldExport()) {
-              director.pauseExporting();
-            } else {
-              director.resumeExporting();
+            switch (context.getExporterPhase()) {
+              case PAUSED:
+                director.pauseExporting();
+                break;
+              case SOFT_PAUSED:
+                director.softPauseExporting();
+                break;
+              default:
+                director.resumeExporting();
+                break;
             }
           }
         });

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/adminapi/AdminApiRequestHandler.java
@@ -58,6 +58,7 @@ public class AdminApiRequestHandler
           CompletableActorFuture.completed(
               stepDownIfNotPrimary(responseWriter, partitionId, errorWriter));
       case PAUSE_EXPORTING -> pauseExporting(responseWriter, partitionId, errorWriter);
+      case SOFT_PAUSE_EXPORTING -> softPauseExporting(responseWriter, partitionId, errorWriter);
       case RESUME_EXPORTING -> resumeExporting(responseWriter, partitionId, errorWriter);
       case BAN_INSTANCE -> banInstance(requestReader, responseWriter, partitionId, errorWriter);
       default -> unknownRequest(errorWriter, requestReader.getMessageDecoder().type());
@@ -123,6 +124,39 @@ public class AdminApiRequestHandler
                     Either.left(
                         errorWriter.internalError(
                             "Partition %s failed to pause exporting", partitionId)));
+              }
+            });
+
+    return result;
+  }
+
+  private ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> softPauseExporting(
+      final ApiResponseWriter responseWriter,
+      final int partitionId,
+      final ErrorResponseWriter errorWriter) {
+    final var partitionAdminAccess = adminAccess.forPartition(partitionId);
+    if (partitionAdminAccess.isEmpty()) {
+      return CompletableActorFuture.completed(
+          Either.left(
+              errorWriter.internalError(
+                  "Partition %s failed to soft pause exporting. Could not find the partition.",
+                  partitionId)));
+    }
+
+    final ActorFuture<Either<ErrorResponseWriter, ApiResponseWriter>> result = actor.createFuture();
+    partitionAdminAccess
+        .orElseThrow()
+        .softPauseExporting()
+        .onComplete(
+            (r, t) -> {
+              if (t == null) {
+                result.complete(Either.right(responseWriter));
+              } else {
+                LOG.error("Failed to soft pause exporting on partition {}", partitionId, t);
+                result.complete(
+                    Either.left(
+                        errorWriter.internalError(
+                            "Partition %s failed to soft pause exporting", partitionId)));
               }
             });
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -191,11 +191,6 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   public void setPartitionCommandSender(final InterPartitionCommandSenderService sender) {}
 
   @Override
-  public boolean shouldExport() {
-    return true;
-  }
-
-  @Override
   public ExporterPhase getExporterPhase() {
     return ExporterPhase.EXPORTING;
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -37,6 +37,10 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
     request.setType(AdminRequestType.PAUSE_EXPORTING);
   }
 
+  public void softPauseExporting() {
+    request.setType(AdminRequestType.SOFT_PAUSE_EXPORTING);
+  }
+
   public void resumeExporting() {
     request.setType(AdminRequestType.RESUME_EXPORTING);
   }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlApi.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlApi.java
@@ -12,5 +12,7 @@ import java.util.concurrent.CompletableFuture;
 public interface ExportingControlApi {
   CompletableFuture<Void> pauseExporting();
 
+  CompletableFuture<Void> softPauseExporting();
+
   CompletableFuture<Void> resumeExporting();
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -36,6 +36,13 @@ public class ExportingControlService implements ExportingControlApi {
   }
 
   @Override
+  public CompletableFuture<Void> softPauseExporting() {
+    LOG.info("Soft Pausing exporting on all partitions.");
+    final var topology = brokerClient.getTopologyManager().getTopology();
+    return broadcastOnTopology(topology, BrokerAdminRequest::softPauseExporting);
+  }
+
+  @Override
   public CompletableFuture<Void> resumeExporting() {
     LOG.info("Resuming exporting on all partitions.");
     final var topology = brokerClient.getTopologyManager().getTopology();

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -10,9 +10,9 @@
     <enum name="AdminRequestType" encodingType="uint8">
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
       <validValue name="PAUSE_EXPORTING">1</validValue>
-      <validValue name="SOFT_PAUSE_EXPORTING">2</validValue>
-      <validValue name="RESUME_EXPORTING">3</validValue>
-      <validValue name="BAN_INSTANCE">4</validValue>
+      <validValue name="RESUME_EXPORTING">2</validValue>
+      <validValue name="BAN_INSTANCE">3</validValue>
+      <validValue name="SOFT_PAUSE_EXPORTING">4</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">

--- a/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/zeebe/protocol/src/main/resources/cluster-management-protocol.xml
@@ -10,8 +10,9 @@
     <enum name="AdminRequestType" encodingType="uint8">
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
       <validValue name="PAUSE_EXPORTING">1</validValue>
-      <validValue name="RESUME_EXPORTING">2</validValue>
-      <validValue name="BAN_INSTANCE">3</validValue>
+      <validValue name="SOFT_PAUSE_EXPORTING">2</validValue>
+      <validValue name="RESUME_EXPORTING">3</validValue>
+      <validValue name="BAN_INSTANCE">4</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.management;
 import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -22,6 +23,8 @@ import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -184,6 +187,16 @@ final class ExportingEndpointIT {
     }
   }
 
+  private void allPartitionsSoftPausedExporting() {
+    for (final var broker : CLUSTER.brokers().values()) {
+      assertThat(PartitionsActuator.of(broker).query().values())
+          .allMatch(
+              status ->
+                  status.exporterPhase() == null || status.exporterPhase().equals("SOFT_PAUSED"),
+              "All exporters should be soft paused");
+    }
+  }
+
   private void allPartitionsExporting() {
     for (final var broker : CLUSTER.brokers().values()) {
       assertThat(PartitionsActuator.of(broker).query().values())
@@ -192,5 +205,182 @@ final class ExportingEndpointIT {
                   status.exporterPhase() == null || status.exporterPhase().equals("EXPORTING"),
               "All exporters should be running");
     }
+  }
+
+  @Test
+  void shouldSoftPauseExporting() {
+
+    final Map<Integer, Long> exportedPositionPerPartition = new HashMap<>();
+    final Map<Integer, Long> secondExportedPositionPerPartition = new HashMap<>();
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("7")
+        .messageId("7")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                exportedPositionPerPartition.put(partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    // when
+    getActuator().softPause();
+
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("8")
+        .messageId("8")
+        .send()
+        .join();
+
+    final var recordsAfterSoftPause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                secondExportedPositionPerPartition.put(
+                    partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    assertThat(recordsAfterSoftPause).isGreaterThan(recordsBeforePause);
+    assertThat(exportedPositionPerPartition.equals(secondExportedPositionPerPartition)).isTrue();
+  }
+
+  @Test
+  void shouldResumeAfterSoftPauseExporting() {
+
+    final Map<Integer, Long> exportedPositionPerPartition = new HashMap<>();
+    final Map<Integer, Long> secondExportedPositionPerPartition = new HashMap<>();
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("9")
+        .messageId("9")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                exportedPositionPerPartition.put(partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    // when
+    getActuator().softPause();
+
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("10")
+        .messageId("10")
+        .send()
+        .join();
+
+    final var recordsAfterSoftPause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    getActuator().resume();
+    try {
+      Thread.sleep(1000);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                secondExportedPositionPerPartition.put(
+                    partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    assertThat(recordsAfterSoftPause).isGreaterThan(recordsBeforePause);
+    // at least one partition should have a higher exported position
+    assertTrue(
+        exportedPositionPerPartition.entrySet().stream()
+            .anyMatch(
+                exportedPosition ->
+                    secondExportedPositionPerPartition.get(exportedPosition.getKey())
+                        > exportedPosition.getValue()));
+  }
+
+  @Test
+  void shouldStaySoftPausedAfterRestart() {
+    // given
+    getActuator().resume();
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("11")
+        .messageId("11")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // when
+    getActuator().softPause();
+    CLUSTER.shutdown();
+    CLUSTER.start();
+
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("12")
+        .messageId("12")
+        .send()
+        .join();
+
+    final var recordsAfterRestart =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // then
+    assertThat(recordsAfterRestart).isGreaterThan(recordsBeforePause);
+    Awaitility.await().untilAsserted(this::allPartitionsSoftPausedExporting);
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
@@ -47,6 +47,13 @@ public interface ExportingActuator {
   /**
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
+  @RequestLine("POST /softPause")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void softPause();
+
+  /**
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
   @RequestLine("POST /resume")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void resume();

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
@@ -47,7 +47,7 @@ public interface ExportingActuator {
   /**
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
-  @RequestLine("POST /softPause")
+  @RequestLine("POST /pause?soft=true")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void softPause();
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -87,6 +87,10 @@ public interface PartitionsActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> pauseExporting();
 
+  @RequestLine("POST /softPauseExporting")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Map<Integer, PartitionStatus> softPauseExporting();
+
   @RequestLine("POST /resumeExporting")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> resumeExporting();


### PR DESCRIPTION
## Description

This pull request exposes the soft pause functionality both at the broker level as at the gateway level.

The new endpoint added for the softpause functionality reuses the pause by just adding the parameter "soft" set as true. endpoint `/actuator/exporting/pause?soft=true` .



## Related issues

closes https://github.com/camunda/zeebe/issues/16874 
closes https://github.com/camunda/zeebe/issues/17256
