### PR TITLE
ci: enable renovate on stable/operate-8.5

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,8 @@
   "commitMessagePrefix": "deps:",
   "baseBranches": [
     "main",
-    "/^stable\\/8\\..*/"
+    "/^stable\\/8\\..*/",
+    "stable/operate-8.5"
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 30,
@@ -29,7 +30,10 @@
   },
   "packageRules": [
     {
-      "matchBaseBranches": ["/^stable\\/8\\..*/"],
+      "matchBaseBranches": [
+        "/^stable\\/8\\..*/",
+        "stable/operate-8.5"
+      ],
       "matchUpdateTypes": [
         "minor",
         "major"


### PR DESCRIPTION
## Description

Operate uses `stable/operate-8.5` for 8.5 patch releases.
I hardcoded the branch name value as we don't expect similar branches in the future (8.6 or later)
## Related issues

closes #
