### PR TITLE
chore: add missing slf4j implementation dependency for operate

### DIFF
--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -248,6 +248,10 @@
       <artifactId>log4j-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>


### PR DESCRIPTION
## Description
![image](https://github.com/camunda/zeebe/assets/146710021/9bd09d78-6f28-40a0-8679-ffc794fe8ce6)

This dependency is normally brought with `org.springframework.boot:spring-boot-starter-log4j2` but the parent pom declares `org.apache.logging.log4j:log4j-slf4j2-impl` as a test dependency https://github.com/camunda/zeebe/blob/2c13cf11d6cbacc95a3c334d450ea423a75417b5/parent/pom.xml#L1797-L1801
## Related issues

closes #
