### PR TITLE
deps: add log4j-slf4j2-impl dependency to operate distribution

### DIFF
--- a/distro/pom.xml
+++ b/distro/pom.xml
@@ -22,6 +22,10 @@
       <classifier>exec</classifier>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+    </dependency>
   </dependencies>
 
   <build>


### PR DESCRIPTION
## Description

Same as https://github.com/camunda/zeebe/pull/17382

operate distro has `log4j-slf4j2-impl` dependency as test
```
io.camunda:camunda-operate:pom:8.6.0-SNAPSHOT
\- org.apache.logging.log4j:log4j-slf4j2-impl:jar:2.21.1:test
```


## Related issues

closes #
