### PR TITLE
[Backport stable/8.5] fix: delete existing ISM policy when retention is disabled

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.AddPolicyRequest;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexAction;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexResponse;
 import io.camunda.zeebe.exporter.opensearch.dto.BulkIndexResponse.Error;
+import io.camunda.zeebe.exporter.opensearch.dto.DeleteStateManagementPolicyResponse;
 import io.camunda.zeebe.exporter.opensearch.dto.GetIndexStateManagementPolicyResponse;
 import io.camunda.zeebe.exporter.opensearch.dto.IndexPolicyResponse;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest;
@@ -235,6 +236,19 @@ public class OpensearchClient implements AutoCloseable {
     return putIndexStateManagementPolicy(queryParameters);
   }
 
+  public boolean deleteIndexStateManagementPolicy() {
+    try {
+      final var request =
+          new Request(
+              "DELETE", "_plugins/_ism/policies/" + configuration.retention.getPolicyName());
+
+      final var response = sendRequest(request, DeleteStateManagementPolicyResponse.class);
+      return response.result().equals(DeleteStateManagementPolicyResponse.DELETED);
+    } catch (final IOException e) {
+      throw new OpensearchExporterException("Failed to delete index state management policy", e);
+    }
+  }
+
   private boolean putIndexStateManagementPolicy(final Map<String, String> queryParameters) {
     try {
       final var request =
@@ -272,7 +286,7 @@ public class OpensearchClient implements AutoCloseable {
       final var response = sendRequest(request, IndexPolicyResponse.class);
       return !response.failures();
     } catch (final IOException e) {
-      throw new OpensearchExporterException("Failed to add policy to indices", e);
+      throw new OpensearchExporterException("Failed to remove policy from indices", e);
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -192,6 +192,8 @@ public class OpensearchExporter implements Exporter {
   private void createIndexTemplates() {
     if (configuration.retention.isEnabled()) {
       createIndexStateManagementPolicy();
+    } else {
+      deleteIndexStateManagementPolicy();
     }
 
     final IndexConfiguration index = configuration.index;
@@ -320,6 +322,17 @@ public class OpensearchExporter implements Exporter {
       if (!client.updateIndexStateManagementPolicy(policy.seqNo(), policy.primaryTerm())) {
         log.warn("Failed to acknowledge the update of the Index State Management Policy");
       }
+    }
+  }
+
+  private void deleteIndexStateManagementPolicy() {
+    final var policyOptional = client.getIndexStateManagementPolicy();
+    if (policyOptional.isEmpty()) {
+      return;
+    }
+
+    if (!client.deleteIndexStateManagementPolicy()) {
+      log.warn("Failed to acknowledge the deletion of the Index State Management Policy");
     }
   }
 

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/DeleteStateManagementPolicyResponse.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/DeleteStateManagementPolicyResponse.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.exporter.opensearch.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record DeleteStateManagementPolicyResponse(String result) {
+  public static final String DELETED = "deleted";
+}


### PR DESCRIPTION
# Description
Backport of #17386 to `stable/8.5`.

relates to #17279
original author: @mustafadagher