### PR TITLE
deps: remove Renovate config duplication and add descriptions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -30,49 +30,23 @@
   },
   "packageRules": [
     {
+      "description": "Only patch updates for our maintenance branches to avoid breaking changes.",
       "matchBaseBranches": [
         "/^stable\\/8\\..*/",
         "stable/operate-8.5"
       ],
-      "matchUpdateTypes": [
-        "minor",
-        "major"
-      ],
+      "matchUpdateTypes": ["minor", "major"],
       "enabled": false
     },
     {
-      "matchPackagePrefixes": ["org.opensearch.client"],
-      "matchUpdateTypes": [
-        "minor",
-        "major"
-      ],
+      "matchPackagePrefixes": ["org.opensearch.client", "org.elasticsearch", "co.elastic"],
+      "matchUpdateTypes": ["minor", "major"],
       "enabled": false
     },
     {
-      "matchPackagePrefixes": ["org.elasticsearch"],
-      "matchUpdateTypes": [
-        "minor",
-        "major"
-      ],
-      "enabled": false
-    },
-    {
-      "matchPackagePrefixes": ["co.elastic"],
-      "matchUpdateTypes": [
-        "minor",
-        "major"
-      ],
-      "enabled": false
-    },
-    {
-      "matchManagers": [
-        "dockerfile"
-      ],
-      "matchUpdateTypes": [
-        "major",
-        "minor",
-        "patch"
-      ],
+      "description": "Digest updates cover all use cases since they are used as base, so we disable other types.",
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major", "minor", "patch"],
       "enabled": false
     },
     {
@@ -80,14 +54,13 @@
       "allowedVersions": "!/0.8.9/"
     },
     {
-      "matchManagers": [
-        "maven"
-      ],
       "description" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
+      "matchManagers": ["maven"],
       "matchPackagePatterns": [".*"],
       "allowedVersions": "!/-SNAPSHOT$/"
     },
     {
+      "description": "This additional prefix is used to skip Operate backend tests.",
       "matchManagers": ["npm", "nvm"],
       "additionalBranchPrefix": "fe-"
     },
@@ -111,10 +84,12 @@
       "groupSlug": "all-minor-patch"
     },
     {
+      "description": "Each digest update breaks release process verification, remove when https://github.com/camunda/zeebe/issues/17181 is done.",
       "matchFileNames": ["operate.Dockerfile"],
       "enabled": false
     },
     {
+      "description": "Both dependencies need to be updated at once for green CI.",
       "matchPackagePatterns": ["@playwright/test", "mcr.microsoft.com/playwright"],
       "groupName": "playwright"
     }


### PR DESCRIPTION
## Description

This PR remove unnecessary duplicated package rules from the Renovate config (this should be functionally identical to the previous config).

I also add `description`s to all package rules where I knew the motivation behind.