### PR TITLE
fix: get reason phrase from catalog instead response

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiResponseConsumer.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/ApiResponseConsumer.java
@@ -43,7 +43,7 @@ final class ApiResponseConsumer<T>
   @Override
   protected ApiResponse<T> buildResult(
       final HttpResponse response, final ApiEntity<T> entity, final ContentType contentType) {
-    return new ApiResponse<>(response.getCode(), response.getReasonPhrase(), entity);
+    return new ApiResponse<>(response.getCode(), entity);
   }
 
   @Override
@@ -53,8 +53,8 @@ final class ApiResponseConsumer<T>
 
     private final ApiEntity<T> entity;
 
-    ApiResponse(final int code, final String reasonPhrase, final ApiEntity<T> entity) {
-      super(code, reasonPhrase);
+    ApiResponse(final int code, final ApiEntity<T> entity) {
+      super(code);
       this.entity = entity;
     }
 


### PR DESCRIPTION
## Description

In the context of #17062, the Single Jar will contain Tomcat on the classpath. When starting Zeebe, it will start Tomcat, but Tomcat does not send the reason phrase with the response. So, instead of relying on the server response, the reason phrase is retrieved from the Apache HTTP Client Reason Phrase Catalog.

## Related issues

related #17062 
