### PR TITLE
deps: enable Renovate automerge for ALL deps of Operate+Zeebe

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -26,7 +26,9 @@
     "enabled": true
   },
   "lockFileMaintenance": {
-    "enabled": true
+    "enabled": true,
+    "automerge": true,
+    "addLabels": ["automerge"]
   },
   "packageRules": [
     {
@@ -92,6 +94,12 @@
       "description": "Both dependencies need to be updated at once for green CI.",
       "matchPackagePatterns": ["@playwright/test", "mcr.microsoft.com/playwright"],
       "groupName": "playwright"
+    },
+    {
+      "description": "Automerge all updates with green CI.",
+      "matchPackagePatterns": ["*"],
+      "automerge": true,
+      "addLabels": ["automerge"]
     }
   ],
   "dockerfile": {

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -656,7 +656,7 @@ jobs:
           FLAKY_UNIT_TESTS: ${{needs.test-summary.outputs.flakyUnitTests}}
           FLAKY_INTEGRATION_TESTS: ${{needs.test-summary.outputs.flakyIntegrationTests}}
   auto-merge:
-    # This workflow will auto merge a PR authored by backport-action or renovate[bot].
+    # This workflow will auto merge a PR authored by backport-action.
     # It runs only on open PRs ready for review.
     #
     # It will merge the PR only if it is authored by backport-action and all CI checks are successful
@@ -670,7 +670,7 @@ jobs:
     if: |
       github.repository == 'camunda/zeebe' &&
       github.event_name == 'pull_request' &&
-      (github.actor == 'backport-action' || github.actor == 'renovate[bot]' || github.actor == 'camundait')
+      (github.actor == 'backport-action' || github.actor == 'camundait')
     permissions:
       checks: read
       pull-requests: write


### PR DESCRIPTION
## Description

[Operate team wants](https://camunda.slack.com/archives/C06HTSPD5AP/p1711091253406079?thread_ts=1711040114.746319&cid=C06HTSPD5AP) to get Renovate PRs automerged now that there is minimal Operate CI also in merge queue. Zeebe team already has a custom mechanism for this (that also covers backports) using GHA CI from a time before Renovate supported that natively.

It makes sense to use native [Renovate automerge](https://docs.renovatebot.com/key-concepts/automerge/) functionality for the whole monorepo to avoid conflicts and special logic to distinguish which dependency belongs to which team.

This PR enables Renovate automerge for all dependencies (when required GH status checks are passed and CI is green, using GH merge queue) and removes Zeebe's special automerge mechanism for Renovate (but retains that for backports). [As discussed](https://camunda.slack.com/archives/C06HTSPD5AP/p1712667751585399?thread_ts=1711040114.746319&cid=C06HTSPD5AP) Renovate automerge should use the same criteria as Zeebe automerge.

## Related issues

closes #17170
