### PR TITLE
fix: return inner IndexSettings object that holds all settings

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ReindexIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ReindexIT.java
@@ -64,7 +64,7 @@ public class ReindexIT extends OperateAbstractIT {
     schemaManager.deleteIndicesFor(idxName("index-*"));
   }
 
-  private String idxName(String name) {
+  private String idxName(final String name) {
     return indexPrefix + "-" + name;
   }
 
@@ -164,8 +164,8 @@ public class ReindexIT extends OperateAbstractIT {
         schemaManager.getIndexSettingsFor(
             idxName("index-1.2.3_"), NUMBERS_OF_REPLICA, REFRESH_INTERVAL);
     assertThat(reindexSettings)
-        .containsEntry(NUMBERS_OF_REPLICA, DatabaseInfo.isOpensearch() ? null : NO_REPLICA)
-        .containsEntry(REFRESH_INTERVAL, DatabaseInfo.isOpensearch() ? null : NO_REFRESH);
+        .containsEntry(NUMBERS_OF_REPLICA, NO_REPLICA)
+        .containsEntry(REFRESH_INTERVAL, NO_REFRESH);
     // Migrator uses this
     assertThat(schemaManager.getOrDefaultNumbersOfReplica(idxName("index-1.2.3_"), "5"))
         .isEqualTo("5");
@@ -173,7 +173,7 @@ public class ReindexIT extends OperateAbstractIT {
         .isEqualTo("2");
   }
 
-  private void createIndex(final String indexName, List<Map<String, String>> documents)
+  private void createIndex(final String indexName, final List<Map<String, String>> documents)
       throws Exception {
     if (DatabaseInfo.isElasticsearch()) {
       final Map<String, ?> mapping =
@@ -184,7 +184,7 @@ public class ReindexIT extends OperateAbstractIT {
     if (documents.isEmpty() && DatabaseInfo.isOpensearch()) {
       searchRepository.createOrUpdateDocument(indexName, UUID.randomUUID().toString(), Map.of());
     }
-    for (var document : documents) {
+    for (final var document : documents) {
       searchRepository.createOrUpdateDocument(indexName, UUID.randomUUID().toString(), document);
     }
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
@@ -211,10 +211,11 @@ public class OpenSearchIndexOperations extends OpenSearchRetryOperation {
     return executeWithRetries(
         "GetIndexSettings " + indexName,
         () -> {
-          final Map<String, String> settings = new HashMap<>();
           final GetIndicesSettingsResponse response =
               openSearchClient.indices().getSettings(s -> s.index(List.of(indexName)));
-          return response.result().get(indexName).settings();
+          final IndexSettings settings = response.result().get(indexName).settings();
+          // Opensearch bug where all index settings are in the inner index object
+          return (settings.index() == null ? settings : settings.index());
         });
   }
 


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe/issues/17272

Original PR: https://github.com/camunda/zeebe/pull/17278

## Related issues

closes #17272 
