### PR TITLE
feat(zbctl): allows scope to be supplied via command line parameter

### DIFF
--- a/clients/go/cmd/zbctl/internal/commands/root.go
+++ b/clients/go/cmd/zbctl/internal/commands/root.go
@@ -33,6 +33,7 @@ const defaultTimeout = 10 * time.Second
 var client zbc.Client
 
 var addressFlag string
+var scopeFlag string
 var hostFlag string
 var portFlag string
 var caCertPathFlag string
@@ -78,6 +79,7 @@ func Execute() {
 }
 
 func init() {
+	rootCmd.PersistentFlags().StringVar(&scopeFlag, "scope", "", fmt.Sprintf("Optionally specify the client token scope used when fetching credentials. If omitted, will read from the environment variable '%s'", zbc.OAuthTokenScopeEnvVar))
 	rootCmd.PersistentFlags().StringVar(&hostFlag, "host", "", fmt.Sprintf("Specify the host part of the gateway address. If omitted, will read from the environment variable '%s' (default '%s')", zbc.GatewayHostEnvVar, zbc.DefaultAddressHost))
 	rootCmd.PersistentFlags().StringVar(&portFlag, "port", "", fmt.Sprintf("Specify the port part of the gateway address. If omitted, will read from the environment variable '%s' (default '%s')", zbc.GatewayPortEnvVar, zbc.DefaultAddressPort))
 	rootCmd.PersistentFlags().StringVar(&addressFlag, "address", "", "Specify a contact point address. If omitted, will read from the environment variable '"+zbc.GatewayAddressEnvVar+"' (default '"+fmt.Sprintf("%s:%s", zbc.DefaultAddressHost, zbc.DefaultAddressPort)+"')")
@@ -154,6 +156,10 @@ func setSecurityParamsAsEnv() (err error) {
 	}
 	if clientIDFlag != "" {
 		setEnv(zbc.OAuthClientIdEnvVar, clientIDFlag)
+	}
+
+	if scopeFlag != "" {
+		setEnv(zbc.OAuthTokenScopeEnvVar, scopeFlag)
 	}
 	if clientSecretFlag != "" {
 		setEnv(zbc.OAuthClientSecretEnvVar, clientSecretFlag)

--- a/clients/go/cmd/zbctl/testdata/help.golden
+++ b/clients/go/cmd/zbctl/testdata/help.golden
@@ -44,5 +44,6 @@ Flags:
       --insecure                  Specify if zbctl should use an unsecured connection. If omitted, will read from the environment variable 'ZEEBE_INSECURE_CONNECTION'
       --port string               Specify the port part of the gateway address. If omitted, will read from the environment variable 'ZEEBE_PORT' (default '26500')
       --requestTimeout duration   Specify the default timeout for all requests. Example values: 300ms, 50s or 1m (default 10s)
+      --scope string              Optionally specify the client token scope used when fetching credentials. If omitted, will read from the environment variable 'ZEEBE_TOKEN_SCOPE'
 
 Use "zbctl [command] --help" for more information about a command.


### PR DESCRIPTION
example usage:

```
./zbctl --address zeebe-gateway.dev.jlscode.com:443 \
    --clientId zeebe \
    --clientSecret EasySecret \
    --authzUrl 'https://dev.jlscode.com/auth/realms/camunda-platform/protocol/openid-connect/token' \
    --audience zeebe-api --scope camunda-identity status
```

## Description

This allows users to set the scope for zbctl. For some reason, this scope attribute appears mandatory in 8.5 when installed with identity. I'm not sure why. 

## Related issues

closes #
