### PR TITLE
ci: create dummy Test summary job

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -1,0 +1,31 @@
+name: Common CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/operate-*'
+      - '.github/workflows/zeebe-*'
+      - 'Dockerfile'
+      - 'bom/*'
+      - 'build-tools/**'
+      - 'clients/**'
+      - 'dist/**'
+      - 'distro/**'
+      - 'operate.Dockerfile'
+      - 'operate/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'spring-boot-starter-camunda-sdk/**'
+      - 'zeebe/**'
+
+jobs:
+  test-summary:
+    # Dummy job used for pull requests that do not trigger zeebe-ci or operate-ci
+    # This name is hard-coded in the branch rules; remember to update that if this name changes
+    name: Test summary
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0


### PR DESCRIPTION
## Description
Branch protections require a passing "Test summary" Job to allow pull request merge to main or stable branches
"Test summary" job is not triggered when Zeebe CI or Operate CI is not triggered
So, as workaround, I am creating this dummy workflow that it is triggered on all paths not triggering Zeebe and/or Operate CIs
closes #
