### PR TITLE
fix: allowed for empty POST request bodies

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionControllerIT.java
@@ -90,8 +90,14 @@ public class DecisionDefinitionControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(DecisionDefinitionController.URI + SEARCH, "{}");
+    verify(decisionDefinitionDao).search(new Query<>());
+  }
+
+  @Test
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(DecisionDefinitionController.URI + SEARCH, "");
     verify(decisionDefinitionDao).search(new Query<>());
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceControllerIT.java
@@ -90,8 +90,14 @@ public class DecisionInstanceControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(DecisionInstanceController.URI + SEARCH, "{}");
+    verify(decisionInstanceDao).search(new Query<>());
+  }
+
+  @Test
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(DecisionInstanceController.URI + SEARCH, "");
     verify(decisionInstanceDao).search(new Query<>());
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsControllerIT.java
@@ -116,8 +116,14 @@ public class DecisionRequirementsControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(DecisionRequirementsController.URI + SEARCH, "{}");
+    verify(decisionRequirementsDao).search(new Query<>());
+  }
+
+  @Test
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(DecisionRequirementsController.URI + SEARCH, "");
     verify(decisionRequirementsDao).search(new Query<>());
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceControllerIT.java
@@ -63,8 +63,14 @@ public class FlowNodeInstanceControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(URI + SEARCH, "{}");
+    verify(flowNodeInstanceDao).search(new Query<>());
+  }
+
+  @Test
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(URI + SEARCH, "");
     verify(flowNodeInstanceDao).search(new Query<>());
   }
 
@@ -94,7 +100,7 @@ public class FlowNodeInstanceControllerIT {
                 .setSort(Sort.listOf(FlowNodeInstance.START_DATE, Order.DESC)));
   }
 
-  private String getSortFor(String field, Query.Sort.Order order) {
+  private String getSortFor(final String field, final Query.Sort.Order order) {
     return "{ \"field\":\"" + field + "\", \"order\": \"" + order.name() + "\" }";
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/IncidentControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/IncidentControllerIT.java
@@ -64,8 +64,14 @@ public class IncidentControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(URI + SEARCH, "{}");
+    verify(incidentDao).search(new Query<>());
+  }
+
+  @Test
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(URI + SEARCH, "");
     verify(incidentDao).search(new Query<>());
   }
 
@@ -93,7 +99,7 @@ public class IncidentControllerIT {
                 .setSort(Sort.listOf(Incident.CREATION_TIME, Order.DESC)));
   }
 
-  private String getSortFor(String field, Query.Sort.Order order) {
+  private String getSortFor(final String field, final Query.Sort.Order order) {
     return "{ \"field\":\"" + field + "\", \"order\": \"" + order.name() + "\" }";
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionControllerIT.java
@@ -67,8 +67,14 @@ public class ProcessDefinitionControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(URI + SEARCH, "{}");
+    verify(processDefinitionDao).search(new Query<>());
+  }
+
+  @Test
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(URI + SEARCH, "");
     verify(processDefinitionDao).search(new Query<>());
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceControllerIT.java
@@ -77,8 +77,13 @@ public class ProcessInstanceControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(URI + SEARCH, "{}");
+    verify(processInstanceDao).search(new Query<>());
+  }
+
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(URI + SEARCH, "");
     verify(processInstanceDao).search(new Query<>());
   }
 
@@ -97,7 +102,7 @@ public class ProcessInstanceControllerIT {
         .search(new Query<ProcessInstance>().setSize(7).setSort(Sort.listOf(VERSION, Order.DESC)));
   }
 
-  private String getSortFor(String field, Query.Sort.Order order) {
+  private String getSortFor(final String field, final Query.Sort.Order order) {
     return "{ \"field\":\"" + field + "\", \"order\": \"" + order.name() + "\" }";
   }
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/VariableControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/api/v1/rest/VariableControllerIT.java
@@ -63,8 +63,14 @@ public class VariableControllerIT {
   }
 
   @Test
-  public void shouldAcceptEmptyQuery() throws Exception {
+  public void shouldAcceptEmptyJSONQuery() throws Exception {
     assertPostToWithSucceed(URI + SEARCH, "{}");
+    verify(variableDao).search(new Query<>());
+  }
+
+  @Test
+  public void shouldAcceptEmptyQuery() throws Exception {
+    assertPostToWithSucceed(URI + SEARCH, "");
     verify(variableDao).search(new Query<>());
   }
 
@@ -89,7 +95,7 @@ public class VariableControllerIT {
         .search(new Query<Variable>().setSize(7).setSort(Sort.listOf(Variable.NAME, Order.DESC)));
   }
 
-  private String getSortFor(String field, Query.Sort.Order order) {
+  private String getSortFor(final String field, final Query.Sort.Order order) {
     return "{ \"field\":\"" + field + "\", \"order\": \"" + order.name() + "\" }";
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionDefinitionController.java
@@ -144,7 +144,9 @@ public class DecisionDefinitionController extends ErrorController
                     description = "Filter by version and sort by decisionId"),
               }))
   @Override
-  public Results<DecisionDefinition> search(@RequestBody final Query<DecisionDefinition> query) {
+  public Results<DecisionDefinition> search(
+      @RequestBody(required = false) Query<DecisionDefinition> query) {
+    query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, DecisionDefinition.class, SEARCH_SORT_VALIDATOR);
     return decisionDefinitionDao.search(query);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionInstanceController.java
@@ -86,7 +86,7 @@ public class DecisionInstanceController extends ErrorController {
       produces = {MediaType.APPLICATION_JSON_VALUE})
   public DecisionInstance byId(
       @Parameter(description = "Id of decision instance", required = true) @PathVariable
-          String id) {
+          final String id) {
     return decisionInstanceDao.byId(id);
   }
 
@@ -168,7 +168,9 @@ public class DecisionInstanceController extends ErrorController {
       value = SEARCH,
       consumes = {MediaType.APPLICATION_JSON_VALUE},
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public Results<DecisionInstance> search(@RequestBody final Query<DecisionInstance> query) {
+  public Results<DecisionInstance> search(
+      @RequestBody(required = false) Query<DecisionInstance> query) {
+    query = (query == null) ? new Query<>() : query;
     return decisionInstanceDao.search(query);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/DecisionRequirementsController.java
@@ -165,7 +165,8 @@ public class DecisionRequirementsController extends ErrorController
               }))
   @Override
   public Results<DecisionRequirements> search(
-      @RequestBody final Query<DecisionRequirements> query) {
+      @RequestBody(required = false) Query<DecisionRequirements> query) {
+    query = (query == null) ? new Query<>() : query;
     return decisionRequirementsDao.search(query);
   }
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/FlowNodeInstanceController.java
@@ -142,8 +142,10 @@ public class FlowNodeInstanceController extends ErrorController
                             + ", sorted ascending by 'startDate' and paged from previous 'sortValues' value."),
               }))
   @Override
-  public Results<FlowNodeInstance> search(@RequestBody final Query<FlowNodeInstance> query) {
+  public Results<FlowNodeInstance> search(
+      @RequestBody(required = false) Query<FlowNodeInstance> query) {
     logger.debug("search for query {}", query);
+    query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, FlowNodeInstance.class);
     return flowNodeInstanceDao.search(query);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/IncidentController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/IncidentController.java
@@ -154,8 +154,9 @@ public class IncidentController extends ErrorController implements SearchControl
                             + "sorted descending by 'creationTime' and paged from previous 'sortValues' value."),
               }))
   @Override
-  public Results<Incident> search(@RequestBody final Query<Incident> query) {
+  public Results<Incident> search(@RequestBody(required = false) Query<Incident> query) {
     logger.debug("search for query {}", query);
+    query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, Incident.class, MESSAGE_SORT_VALIDATOR);
     return incidentDao.search(query);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessDefinitionController.java
@@ -133,8 +133,10 @@ public class ProcessDefinitionController extends ErrorController
                     description = "Filter by version and sort by bpmnProcessId"),
               }))
   @Override
-  public Results<ProcessDefinition> search(@RequestBody final Query<ProcessDefinition> query) {
+  public Results<ProcessDefinition> search(
+      @RequestBody(required = false) Query<ProcessDefinition> query) {
     logger.debug("search for query {}", query);
+    query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, ProcessDefinition.class);
     return processDefinitionDao.search(query);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/ProcessInstanceController.java
@@ -136,8 +136,10 @@ public class ProcessInstanceController extends ErrorController
                         "Returns max 50 process instances, filtered by processVersion of 2 sorted ascending by bpmnProcessId"),
               }))
   @Override
-  public Results<ProcessInstance> search(@RequestBody final Query<ProcessInstance> query) {
+  public Results<ProcessInstance> search(
+      @RequestBody(required = false) Query<ProcessInstance> query) {
     logger.debug("search for query {}", query);
+    query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, ProcessInstance.class);
     return processInstanceDao.search(query);
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/VariableController.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/rest/VariableController.java
@@ -123,8 +123,9 @@ public class VariableController extends ErrorController implements SearchControl
                         "Returns next variables for 'processInstanceKey' ascending by 'name'. (Copy value of 'sortValues' field of previous results) "),
               }))
   @Override
-  public Results<Variable> search(@RequestBody final Query<Variable> query) {
+  public Results<Variable> search(@RequestBody(required = false) Query<Variable> query) {
     logger.debug("search for query {}", query);
+    query = (query == null) ? new Query<>() : query;
     queryValidator.validate(query, Variable.class);
     return variableDao.search(query);
   }


### PR DESCRIPTION
## Description
Made request bodies optional for POST requests to avoid unspecific error messages.

## Related issues

closes [#camunda/operate/2694](https://github.com/camunda/operate/issues/2694)
