### PR TITLE
deps: switch rest gateway from spring-webflux to spring-web

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -206,10 +206,15 @@
       </exclusions>
     </dependency>
 
-    <!-- needed for the Spring actuators which enable health checks and liveness probes-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>
@@ -239,12 +244,17 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-webflux</artifactId>
+      <artifactId>spring-webmvc</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>io.projectreactor</groupId>
-      <artifactId>reactor-core</artifactId>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
 
     <dependency>
@@ -316,11 +326,6 @@
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.reactivestreams</groupId>
-      <artifactId>reactive-streams</artifactId>
     </dependency>
 
     <!-- /end -->
@@ -507,10 +512,11 @@
             <dependency>io.camunda:zeebe-elasticsearch-exporter</dependency>
             <dependency>io.camunda:zeebe-opensearch-exporter</dependency>
 
-            <!-- Needed for Spring Actuators, which provide health checks and liveness/readiness probed -->
-            <dependency>org.springframework.boot:spring-boot-starter-webflux</dependency>
+            <!-- Needed for Spring Actuators, and REST API -->
+            <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
             <dependency>org.openapitools:jackson-databind-nullable</dependency>
             <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
+            <dependency>jakarta.servlet:jakarta.servlet-api</dependency>
 
             <!-- Needed for configuring the Identity SDK by providing an IdentityConfiguration bean -->
             <dependency>io.camunda:identity-spring-boot-autoconfigure</dependency>

--- a/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerHealthRoutes.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/health/BrokerHealthRoutes.java
@@ -16,12 +16,11 @@ import org.springframework.boot.actuate.autoconfigure.web.server.ManagementServe
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.reactive.function.server.RouterFunction;
-import org.springframework.web.reactive.function.server.RouterFunctions;
-import org.springframework.web.reactive.function.server.ServerResponse;
+import org.springframework.web.servlet.function.RouterFunction;
+import org.springframework.web.servlet.function.RouterFunctions;
+import org.springframework.web.servlet.function.ServerResponse;
 import org.springframework.web.util.DefaultUriBuilderFactory;
 import org.springframework.web.util.UriBuilderFactory;
-import reactor.core.publisher.Mono;
 
 @Profile("broker")
 @ConditionalOnManagementContext
@@ -57,7 +56,7 @@ public class BrokerHealthRoutes {
         .build();
   }
 
-  private Mono<ServerResponse> movedPermanently(final String... paths) {
+  private ServerResponse movedPermanently(final String... paths) {
     final var builder = uriBuilderFactory.builder();
     for (final var path : paths) {
       builder.path(path);

--- a/dist/src/main/java/io/camunda/zeebe/shared/MainSupport.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/MainSupport.java
@@ -41,7 +41,7 @@ public final class MainSupport {
    * module, with sane defaults.
    */
   public static SpringApplicationBuilder createDefaultApplicationBuilder() {
-    return new SpringApplicationBuilder().web(WebApplicationType.REACTIVE).logStartupInfo(true);
+    return new SpringApplicationBuilder().web(WebApplicationType.SERVLET).logStartupInfo(true);
   }
 
   /**

--- a/dist/src/main/java/io/camunda/zeebe/shared/security/IdentityAuthenticationManager.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/security/IdentityAuthenticationManager.java
@@ -15,15 +15,14 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
-import org.springframework.security.authentication.ReactiveAuthenticationManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
-import reactor.core.publisher.Mono;
 
 @Component
-public final class IdentityAuthenticationManager implements ReactiveAuthenticationManager {
+public final class IdentityAuthenticationManager implements AuthenticationManager {
 
   private final Identity identity;
   private final MultiTenancyCfg multiTenancy;
@@ -36,9 +35,9 @@ public final class IdentityAuthenticationManager implements ReactiveAuthenticati
   }
 
   @Override
-  public Mono<Authentication> authenticate(final Authentication authentication) {
+  public Authentication authenticate(final Authentication authentication) {
     if (!(authentication instanceof final PreAuthToken preAuthToken)) {
-      return Mono.just(authentication);
+      return authentication;
     }
 
     final List<String> tenants;
@@ -53,7 +52,7 @@ public final class IdentityAuthenticationManager implements ReactiveAuthenticati
 
     tenants = getTenants(tokenValue);
 
-    return Mono.just(new IdentityAuthentication(token, tenants));
+    return new IdentityAuthentication(token, tenants);
   }
 
   private List<String> getTenants(final String token) {

--- a/dist/src/main/resources/application.properties
+++ b/dist/src/main/resources/application.properties
@@ -8,7 +8,7 @@ logging.register-shutdown-hook=true
 server.address=0.0.0.0
 server.port=8080
 # Enable a richer error model for the REST server
-spring.webflux.problemdetails.enabled=true
+spring.mvc.problemdetails.enabled=true
 # Embedded HTTP server configuration for monitoring
 # Defaults are picked from the previous Zeebe specific defaults for backwards compatibility
 management.server.port=9600
@@ -16,10 +16,9 @@ management.server.address=0.0.0.0
 # Explicitly disable SSL on the management server to prevent any REST API server
 # SSL configuration from being implicitly applied to it
 management.server.ssl.enabled=false
-# WebFlux/Reactor configuration
+# Web/Servlet configuration
 # Disable the default resource mappings (e.g. service static assets)
 spring.web.resources.add-mappings=false
-spring.reactor.netty.shutdown-quiet-period=1s
 # General management configuration; disable all endpoints by default but exposes all enabled ones
 # via web. Endpoints should be enabled individually based on the target application
 management.endpoints.enabled-by-default=false
@@ -43,10 +42,8 @@ management.sanitize.keywords=user,pass,secret,accessKey,accountKey,connectionStr
 # Disable specific autoconfiguration classes which are triggered automatically (e.g. creating an
 # Elastic client which spawns 16 threads)
 spring.autoconfigure.exclude=\
-  org.springframework.boot.autoconfigure.security.reactive.ReactiveSecurityAutoConfiguration, \
-  org.springframework.boot.actuate.autoconfigure.security.reactive.ReactiveManagementWebSecurityAutoConfiguration, \
+  org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration, \
+  org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration, \
   org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration, \
-  org.springframework.boot.autoconfigure.web.reactive.function.client.ClientHttpConnectorAutoConfiguration, \
-  org.springframework.boot.autoconfigure.web.reactive.function.client.WebClientAutoConfiguration, \
   org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
 spring.thymeleaf.check-template-location=false

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -77,6 +77,11 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
+      <artifactId>spring-webmvc</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
       <artifactId>spring-beans</artifactId>
     </dependency>
 
@@ -121,6 +126,12 @@
       <artifactId>jackson-annotations</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
     <!-- test dependencies -->
     <dependency>
       <groupId>org.springframework</groupId>
@@ -136,7 +147,7 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-webflux</artifactId>
+      <artifactId>spring-boot-starter-web</artifactId>
       <scope>test</scope>
     </dependency>
 
@@ -257,7 +268,7 @@
           <!-- dependencies only packaged but not explicitly used -->
           <usedDependencies>
             <!-- Needed to run tests -->
-            <dependency>org.springframework.boot:spring-boot-starter-webflux</dependency>
+            <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
             <!-- Used for OpenAPI generation -->
             <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
           </usedDependencies>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/GlobalControllerExceptionHandler.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/GlobalControllerExceptionHandler.java
@@ -7,39 +7,67 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ServerWebExchange;
-import org.springframework.web.server.ServerWebInputException;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 @ControllerAdvice(annotations = RestController.class)
-public class GlobalControllerExceptionHandler {
+public class GlobalControllerExceptionHandler extends ResponseEntityExceptionHandler {
 
-  @ExceptionHandler(ServerWebInputException.class)
-  public ResponseEntity<ProblemDetail> handleServerWebInputExceptions(
-      final ServerWebInputException ex, final ServerWebExchange context) {
-    final ProblemDetail problemDetail = ProblemDetail.forStatus(ex.getStatusCode());
-    problemDetail.setTitle(ex.getReason());
-    if (ex.getCause() != null) {
-      problemDetail.setDetail(ex.getCause().getMessage());
+  private static final String REQUEST_BODY_MISSING_EXCEPTION_MESSAGE =
+      "Required request body is missing";
+
+  @Override
+  protected ProblemDetail createProblemDetail(
+      final Exception ex,
+      final HttpStatusCode status,
+      final String defaultDetail,
+      final String detailMessageCode,
+      final Object[] detailMessageArguments,
+      final WebRequest request) {
+
+    final String detail;
+
+    if (isRequestBodyMissing(ex)) {
+      // Replace detail "Failed to read request"
+      // with "Required request body is missing"
+      // for proper exception tracing
+      detail = REQUEST_BODY_MISSING_EXCEPTION_MESSAGE;
     } else {
-      problemDetail.setDetail(ex.getMessage());
+      detail = defaultDetail;
     }
-    problemDetail.setInstance(URI.create(context.getRequest().getPath().toString()));
-    return ResponseEntity.of(problemDetail).build();
+
+    return super.createProblemDetail(
+        ex, status, detail, detailMessageCode, detailMessageArguments, request);
+  }
+
+  private boolean isRequestBodyMissing(final Exception ex) {
+    if (ex instanceof HttpMessageNotReadableException exception) {
+      final var exceptionMessage = exception.getMessage();
+      if (exceptionMessage != null
+          && exceptionMessage.startsWith(REQUEST_BODY_MISSING_EXCEPTION_MESSAGE)) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   @ExceptionHandler(Exception.class)
   public ResponseEntity<ProblemDetail> handleAllExceptions(
-      final Exception ex, final ServerWebExchange context) {
+      final Exception ex, final HttpServletRequest request) {
     final ProblemDetail problemDetail =
         ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, ex.getMessage());
-    problemDetail.setInstance(URI.create(context.getRequest().getPath().toString()));
+    problemDetail.setInstance(URI.create(request.getRequestURI()));
     return ResponseEntity.of(problemDetail).build();
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/UserTaskController.java
@@ -24,7 +24,6 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.server.ServerWebExchange;
 
 @ZeebeRestController
 public class UserTaskController {
@@ -41,11 +40,10 @@ public class UserTaskController {
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> completeUserTask(
-      final ServerWebExchange context,
       @PathVariable final long userTaskKey,
       @RequestBody(required = false) final UserTaskCompletionRequest completionRequest) {
 
-    return RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey, context)
+    return RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey)
         .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
   }
 
@@ -54,19 +52,18 @@ public class UserTaskController {
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> assignUserTask(
-      final ServerWebExchange context,
       @PathVariable final long userTaskKey,
       @RequestBody final UserTaskAssignmentRequest assignmentRequest) {
 
-    return RequestMapper.toUserTaskAssignmentRequest(assignmentRequest, userTaskKey, context)
+    return RequestMapper.toUserTaskAssignmentRequest(assignmentRequest, userTaskKey)
         .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
   }
 
   @DeleteMapping(path = "/user-tasks/{userTaskKey}/assignee")
   public CompletableFuture<ResponseEntity<Object>> unassignUserTask(
-      final ServerWebExchange context, @PathVariable final long userTaskKey) {
+      @PathVariable final long userTaskKey) {
 
-    return RequestMapper.toUserTaskUnassignmentRequest(userTaskKey, context)
+    return RequestMapper.toUserTaskUnassignmentRequest(userTaskKey)
         .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
   }
 
@@ -75,11 +72,10 @@ public class UserTaskController {
       produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
       consumes = MediaType.APPLICATION_JSON_VALUE)
   public CompletableFuture<ResponseEntity<Object>> updateUserTask(
-      final ServerWebExchange context,
       @PathVariable final long userTaskKey,
       @RequestBody(required = false) final UserTaskUpdateRequest updateRequest) {
 
-    return RequestMapper.toUserTaskUpdateRequest(updateRequest, userTaskKey, context)
+    return RequestMapper.toUserTaskUpdateRequest(updateRequest, userTaskKey)
         .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
   }
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/UserTaskControllerTest.java
@@ -1003,4 +1003,30 @@ public class UserTaskControllerTest {
 
     Assertions.assertThat(argumentCaptor.getValue().getIntent()).isEqualTo(UserTaskIntent.ASSIGN);
   }
+
+  @Test
+  public void shouldReturnProblemDetailWithRequestBodyMissing() {
+    // given
+    final var expectedBody =
+        ProblemDetail.forStatusAndDetail(
+            HttpStatus.BAD_REQUEST, "Required request body is missing");
+    expectedBody.setTitle("Bad Request");
+    expectedBody.setInstance(URI.create("/" + USER_TASKS_BASE_URL + "/1/assignment"));
+
+    // when / then
+    webClient
+        .post()
+        .uri(USER_TASKS_BASE_URL + "/1/assignment")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody(ProblemDetail.class)
+        .isEqualTo(expectedBody);
+
+    Mockito.verifyNoInteractions(brokerClient);
+  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/startup/RestAPIContextPathIT.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 public final class RestAPIContextPathIT {
   @TestZeebe
   private final TestStandaloneBroker zeebe =
-      new TestStandaloneBroker().withProperty("spring.webflux.base-path", "/zeebe");
+      new TestStandaloneBroker().withProperty("server.servlet.context-path", "/zeebe");
 
   @Test
   void shouldConnectWithContextPath() {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestGateway.java
@@ -59,7 +59,7 @@ public interface TestGateway<T extends TestGateway<T>> extends TestApplication<T
    * @return the REST gateway address
    */
   default URI restAddress() {
-    final var basePath = property("spring.webflux.base-path", String.class, "");
+    final var basePath = property("server.servlet.context-path", String.class, "");
     final var sslEnabled = property("server.ssl.enabled", Boolean.class, false);
     return uri(sslEnabled ? "https" : "http", TestZeebePort.REST, basePath);
   }


### PR DESCRIPTION
## Description

Migrates the `gateway-rest` and the `distro` from the Reactive (Spring Webflux) to the Servlet (Spring Web MVC) stack. This step is necessary as a pre-condition to implement Single Application #17579; that way, we avoid having different stacks with the application.

## Related issues

related to #17579
