### PR TITLE
deps: add renovate config for playwright docker image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -67,6 +67,10 @@
       "additionalBranchPrefix": "fe-"
     },
     {
+      "matchPackageNames": ["mcr.microsoft.com/playwright"],
+      "additionalBranchPrefix": "fe-"
+    },
+    {
       "matchPackagePrefixes": ["@types/"],
       "groupName": "definitelyTyped"
     },
@@ -87,7 +91,7 @@
     },
     {
       "description": "Both dependencies need to be updated at once for green CI.",
-      "matchPackagePatterns": ["@playwright/test", "mcr.microsoft.com/playwright"],
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
       "groupName": "playwright"
     },
     {


### PR DESCRIPTION
## Description

Add renovate config to add `fe-` prefix for playwright docker image. This is needed, otherwise renovate will open two separate PRs (example: https://github.com/camunda/zeebe/pull/17462 , https://github.com/camunda/zeebe/pull/17466).

:x: Before:
`mcr.microsoft.com/playwright` -> branch name: `playwright`
`@playwright/test` -> branch name: `fe-playwright`

:white_check_mark:  After:
`mcr.microsoft.com/playwright` /  `@playwright/test` -> branch name: `fe-playwright`

## Related issues

closes #
