### PR TITLE
docs: developer guidance on rolling updates for Zeebe

### DIFF
--- a/zeebe/docs/rolling_updates.md
+++ b/zeebe/docs/rolling_updates.md
@@ -34,6 +34,17 @@ The third option is the one we chose when implementing dynamic scaling, where ne
 The new version avoids the need to communicate with an old version because it can assume the state of the old version and make decisions without communicating.
 See `RollingUpdateAwareInitializerV83ToV84` for implementation details.
 
+### Protocol
+
+The [Zeebe protocol](../protocol/src/main/resources/protocol.xml) defines both the network protocol between gateways and brokers as well as the on-disk serialization of records.
+The protocol is defined as [SBE](https://www.fixtrading.org/standards/sbe-online/), a binary encoding with limited support for backwards compatibility.
+We must be careful when extending or modifying the protocol to ensure that we do not break compatibility.
+Because SBE is a binary encoding with relatively little overhead, accidentally breaking compatibility can result in silent data corruption when data is read the wrong way.
+See https://github.com/camunda/zeebe/issues/14957 for an example of such an issue.
+
+There is guidance on message versioning that explains some of the rules we have to follow to ensure compatibility: https://github.com/real-logic/simple-binary-encoding/wiki/Message-Versioning
+Additionally, we have automated tests that prevent changes until we [mark them as acceptable](../protocol/revapi.json).
+
 ### Processing
 
 Processing is ideally compatible between old and new versions.

--- a/zeebe/docs/rolling_updates.md
+++ b/zeebe/docs/rolling_updates.md
@@ -4,7 +4,7 @@ Starting with 8.5.0, Zeebe officially supports rolling updates.
 
 ## Breaking Changes
 
-To support rolling updates, we have to ensure that all patch version of the previous or current minor are compatible with the development version.
+To support rolling updates, we have to ensure that all patch versions of the previous or current minor are compatible with the development version.
 
 ### Network
 
@@ -13,7 +13,7 @@ Most importantly, they need to be able to form a raft replication group, and upd
 The command API should also remain compatible between old and new versions but exceptions can be made.
 Breaking command API compatibility drastically increases the impact of rolling updates because it may block all processing until the rolling update is finished.
 
-Compatibility can be achieved through differently, depending on the use case.
+Compatibility can be achieved differently, depending on the use case.
 For example:
 1. New version supports both old and new protocol and can automatically choose which to use.
 2. New version supports a new protocol but doesn't use it by default.
@@ -26,11 +26,11 @@ See `AbstractMessageDecoder` and its implementations for an (old) example.
 Details are documented in our [messaging](./messaging.md#protocol-format) docs.
 
 The second option should be avoided if possible because it requires more effort.
-When switching to a new protocol requires a configuration change, this has a higher impact than the rolling update itself.
+Switching to a new protocol requires a configuration change, this has a higher impact than the rolling update itself.
 Additionally, the old protocol has to be deprecated and can only be removed later.
 When removing a deprecated protocol, there is the risk that unaware users encounter problems during the rolling update.
 
-The third option is the one we chose when implementing dynamic scaling where new versions would communicate via a new gossip protocol that old versions did not support.
+The third option is the one we chose when implementing dynamic scaling, where new versions would communicate via a new gossip protocol that old versions did not support.
 The new version avoids the need to communicate with an old version because it can assume the state of the old version and make decisions without communicating.
 See `RollingUpdateAwareInitializerV83ToV84` for implementation details.
 

--- a/zeebe/docs/rolling_updates.md
+++ b/zeebe/docs/rolling_updates.md
@@ -1,5 +1,76 @@
 # Rolling Updates
 
+Starting with 8.5.0, Zeebe officially supports rolling updates.
+
+## Breaking Changes
+
+To support rolling updates, we have to ensure that all patch version of the previous or current minor are compatible with the development version.
+
+### Network
+
+Old and new versions need to be able to communicate with each other.
+Most importantly, they need to be able to form a raft replication group, and update cluster membership via SWIM.
+The command API should also remain compatible between old and new versions but exceptions can be made.
+Breaking command API compatibility drastically increases the impact of rolling updates because it may block all processing until the rolling update is finished.
+
+Compatibility can be achieved through differently, depending on the use case.
+For example:
+1. New version supports both old and new protocol and can automatically choose which to use.
+2. New version supports a new protocol but doesn't use it by default.
+3. New version detects an old version and has explicit update logic.
+
+The first option is the classic solution to evolve network protocols.
+To make this possible, we recommend to always version protocols, for example by prefixing all messages with a single integer version.
+This makes it possible for old versions to detect newer protocol versions and for new versions to support both protocol versions at the same time.
+See `AbstractMessageDecoder` and its implementations for an (old) example.
+Details are documented in our [messaging](./messaging.md#protocol-format) docs.
+
+The second option should be avoided if possible because it requires more effort.
+When switching to a new protocol requires a configuration change, this has a higher impact than the rolling update itself.
+Additionally, the old protocol has to be deprecated and can only be removed later.
+When removing a deprecated protocol, there is the risk that unaware users encounter problems during the rolling update.
+
+The third option is the one we chose when implementing dynamic scaling where new versions would communicate via a new gossip protocol that old versions did not support.
+The new version avoids the need to communicate with an old version because it can assume the state of the old version and make decisions without communicating.
+See `RollingUpdateAwareInitializerV83ToV84` for implementation details.
+
+### Processing
+
+Processing is ideally compatible between old and new versions.
+This is not always possible, for example because the new version supports a new feature or has changed the behavior of an existing feature.
+In that case we must fail early and stay on the safe side by stopping processing.
+
+There are two mechanisms that ensure processing correctness:
+1. Processing and replay is stopped when encountering commands or events that are unknown.
+2. Events have a version that is incremented whenever the behavior changes.
+
+The event versioning is not automatically enforced and requires awareness of the developers.
+
+## Data migrations
+
+Data migrations are applied every time a new version opens a snapshot taken by an old version.
+In the past we used data migrations liberally to implement new features and to fix broken data that was caused by bugs.
+
+As we learned after the implementation of multi-tenancy, data migrations incur a high cost.
+Especially for critical use cases that have accumulated a lot of runtime state, rewriting large parts of the state is prohibitive.
+On the one hand, these migrations take a long time.
+This increases the risk of rolling updates because it delays recovery and increases the risk that manual intervention is needed.
+For example, a rolling update as implemented by Kubernetes will not complete if data migrations take so long that the updated brokers don't become ready in time.
+On the other hand, the migrations require additional resources that may not be accounted for.
+This can show up in CPU but most importantly in memory and disk resources.
+See for example https://github.com/camunda/zeebe/issues/14975.
+
+When implementing a new feature, we actively try to avoid data migrations because their impact is difficult to assess for all use cases.
+Instead, we try to find alternative ways to implement new features:
+
+1. Staying backwards compatible and writing data to a new column family while reading it from both old and new.
+2. Staying backwards compatible by mixing old and new data in the same column family.
+3. Incrementally moving data from old to new column family on first access.
+4. Using secondary column families that contain only the data needed for the new feature.
+
+Avoiding full migrations of entire column families has a cost when implementing new features.
+We accept this cost because it is difficult to assess the potential impact on different use cases and setups.
+
 ## Testing
 
 ### Continuous Integration


### PR DESCRIPTION
## Description

This adds developer documentation for us developers regarding rolling updates.

It is not only a useful resource to have but also establishes a policy against data migrations if they can be avoided.

## Related issues

relates to #15879 
