### PR TITLE
Fix Zeebe release (avoid oom)

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -147,7 +147,7 @@ jobs:
             -DlocalCheckout=${{ inputs.dryRun }} \
             -DcompletionGoals="spotless:apply" \
             -P-autoFormat \
-            -Darguments='-T1C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -Darguments='-T0.5C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory


### PR DESCRIPTION
## Description

Changing the concurrency (reducing it from thread per core to half thread per core) reduces the memory pressure on GPG and allows the release dry run to succeed.

Success run: https://github.com/camunda/zeebe/actions/runs/8690933557

Found related issue in another project: 
Related issue https://github.com/sbt/sbt-pgp/issues/168 

After merging this we should try to enable the dry run again.

## Related issues

related https://github.com/camunda/zeebe/issues/17435
