### PR TITLE
Align deployment rejection message for DMN resources

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -80,8 +80,9 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
               });
 
     } else {
-      final var failure = new Failure(parsedDrg.getFailureMessage());
-      return Either.left(failure);
+      final var failure =
+          String.format("'%s': %s", resource.getResourceName(), parsedDrg.getFailureMessage());
+      return Either.left(new Failure(failure));
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/DmnDeploymentTest.java
@@ -118,7 +118,8 @@ public final class DmnDeploymentTest {
         .hasRejectionType(RejectionType.INVALID_ARGUMENT);
 
     assertThat(deploymentEvent.getRejectionReason())
-        .contains("FEEL unary-tests: failed to parse expression");
+        .contains(
+            "'/dmn/decision-table-with-invalid-expression.dmn': FEEL unary-tests: failed to parse expression");
   }
 
   @Test


### PR DESCRIPTION
## Description

Included the resource name in the rejection message of DMN validation error. Also, updated the related test to verify the expected behaviour.

## Related issues

closes #8806 