### PR TITLE
perf: Backoff Mechanism to Handle ElasticSearch Unavailability [Backport stable/operate-8.5]

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/util/BackoffIdleStrategy.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/BackoffIdleStrategy.java
@@ -34,10 +34,10 @@ public class BackoffIdleStrategy {
     this.baseIdleTime = baseIdleTime;
     this.idleIncreaseFactor = idleIncreaseFactor;
     this.maxIdleTime = maxIdleTime;
-    this.maxIdles = ((int) log(idleIncreaseFactor, maxIdleTime / baseIdleTime)) + 1;
+    maxIdles = calculateMaxIdles();
   }
 
-  private double log(double base, double value) {
+  private double log(final double base, final double value) {
     return Math.log10(value) / Math.log10(base);
   }
 
@@ -73,5 +73,12 @@ public class BackoffIdleStrategy {
     }
 
     return idleTime;
+  }
+
+  private int calculateMaxIdles() {
+    if (baseIdleTime <= 0) {
+      return 1;
+    }
+    return ((int) log(idleIncreaseFactor, maxIdleTime / baseIdleTime)) + 1;
   }
 }


### PR DESCRIPTION
## Description
perf: Introduced Backoff Mechanism to Handle ElasticSearch Unavailability

Introduced backoff mechanism for elasticsearch and opensearch requests in the importer to fix log pollution when elasticsearch becomes unavailable.

## Related issues

closes # https://github.com/camunda/operate/issues/6428
original PR: https://github.com/camunda/zeebe/pull/17134