### PR TITLE
fix: API error message for invalid size parameters [Backport stable/operate-8.5]

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
@@ -59,7 +59,8 @@ public class QueryValidator<T> {
   protected void validatePaging(final Query<T> query) {
     final int size = query.getSize();
     if (size <= 0 || size > MAX_QUERY_SIZE) {
-      throw new ClientException("size should be greater than zero and less than " + MAX_QUERY_SIZE);
+      throw new ClientException(
+          "size should be greater than zero and equal or less than " + MAX_QUERY_SIZE);
     }
     final Object[] searchAfter = query.getSearchAfter();
     if (searchAfter != null && searchAfter.length == 0) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/entities/QueryValidator.java
@@ -30,12 +30,15 @@ public class QueryValidator<T> {
   public static final int MAX_QUERY_SIZE = 1000;
   private List<String> fields;
 
-  public void validate(final Query<T> query, Class<T> queriedClass) throws ValidationException {
+  public void validate(final Query<T> query, final Class<T> queriedClass)
+      throws ValidationException {
     validate(query, queriedClass, null);
   }
 
   public void validate(
-      final Query<T> query, Class<T> queriedClass, CustomQueryValidator<T> customValidator) {
+      final Query<T> query,
+      final Class<T> queriedClass,
+      final CustomQueryValidator<T> customValidator) {
     retrieveFieldsFor(queriedClass);
     validateSorting(query.getSort(), fields);
     validatePaging(query);
@@ -71,7 +74,7 @@ public class QueryValidator<T> {
     }
   }
 
-  protected void validateSorting(final List<Sort> sortSpecs, List<String> fields) {
+  protected void validateSorting(final List<Sort> sortSpecs, final List<String> fields) {
     if (sortSpecs == null || sortSpecs.isEmpty()) {
       return;
     }


### PR DESCRIPTION
## Description
Changed error message in the QueryValidator to better communicate the actually allowed/valid values for "size".

## Related issues

closes # https://github.com/camunda/operate/issues/2584
original PR: https://github.com/camunda/zeebe/pull/17222