### PR TITLE
Refactor release workflow (reduce build time)

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -103,10 +103,10 @@ jobs:
           echo "${RELEASE_VERSION}" > data/VERSION
 
           git commit -am "build(project): update go embedded version data"
-      - name: Build Go Client & Zeebe
+      - name: Build Go Client
         uses: ./.github/actions/build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild
+          java: false
       - uses: s4u/maven-settings-action@v3.0.0
         with:
           servers: |

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -145,7 +145,7 @@ jobs:
           # 
           # -Darguments
           #   Additional arguments to pass to the Maven executions, separated by spaces.
-          #   Per default it is not required, but it the release plugin is configured in the camunda release plugin (and this property is used)
+          #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
           #   This is the reason why we have to set it at least as empty string.
           ./mvnw release:prepare -B \
             -Dresume=false \

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -143,7 +143,7 @@ jobs:
           #
           # -DpreparationGoals 
           #   Goals to run as part of the preparation step, after transformation but before committing. Space delimited.
-          #   Default is 'clean verify'; We want to skip all the checks and packaging (as it will be done again later again) so we set it to empty
+          #   Default is 'clean verify'; We want to skip all the checks and packaging (as it will be done again later) so we set it to empty
           # 
           # -Darguments
           #   Additional arguments to pass to the Maven executions, separated by spaces.

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -177,7 +177,7 @@ jobs:
 
           # -P-integration-tests,-autoFormat
           #   In order to disable QA/IT and the auto formatting during the release.
-          #   It is not necessary to release integration tests, and we don't want to run unnecessary the auto formatting.
+          #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
           ./mvnw release:perform -B \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.dryRun }} \

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -129,8 +129,6 @@ jobs:
             }]
       - name: Maven Prepare Release
         id: maven-prepare-release
-        env:
-          SKIP_REPO_DEPLOY: ${{ inputs.dryRun }}
         run: |
           # Preparing the maven release
           # https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -146,8 +146,8 @@ jobs:
             -DremoteTagging=${PUSH_CHANGES} \
             -DlocalCheckout=${{ inputs.dryRun }} \
             -DcompletionGoals="spotless:apply" \
-            -P-autoFormat \
-            -Darguments='-T0.5C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -P-integration-tests,-autoFormat \
+            -Darguments='-T0.5C -P-integration-tests,-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -38,7 +38,7 @@ jobs:
     name: Maven & Go Release
     runs-on: gcp-core-16-release
     outputs:
-      releaseTagRevision: ${{ steps.maven-release.outputs.tagRevision }}
+      releaseTagRevision: ${{ steps.maven-perform-release.outputs.tagRevision }}
       releaseBranch: ${{ env.RELEASE_BRANCH }}
     env:
       DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
@@ -127,25 +127,60 @@ jobs:
                 "mirrorOf": "camunda-nexus",
                 "url": "https://repository.nexus.camunda.cloud/content/groups/internal/"
             }]
-      - name: Maven Release
-        id: maven-release
+      - name: Maven Prepare Release
+        id: maven-prepare-release
         env:
           SKIP_REPO_DEPLOY: ${{ inputs.dryRun }}
         run: |
-          # This var is used to include the previously built go artifacts into the final maven release build.
-          # As the maven build of the tag happens in a sub-directory to which maven checks out the release tag to build it.
-          # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
-          export ZBCTL_ROOT_DIR=${PWD}
-          ./mvnw release:prepare release:perform -B \
-            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
+          # Preparing the maven release
+          # https://maven.apache.org/maven-release/maven-release-plugin/prepare-mojo.html
+          # https://maven.apache.org/maven-release/maven-release-plugin/usage/prepare-release.html
+          #
+          # -DcompletionGoals
+          #   Goals to run on completion of the preparation step, after transformation back to the next development
+          #   version but before committing. Space delimited.
+          #   We apply spotless to make sure that pom format is correct before committing.
+          #
+          # -DpreparationGoals 
+          #   Goals to run as part of the preparation step, after transformation but before committing. Space delimited.
+          #   Default is 'clean verify'; We want to skip all the checks and packaging (as it will be done again later again) so we set it to empty
+          # 
+          # -Darguments
+          #   Additional arguments to pass to the Maven executions, separated by spaces.
+          #   Per default it is not required, but it the release plugin is configured in the camunda release plugin (and this property is used)
+          #   This is the reason why we have to set it at least as empty string.
+          ./mvnw release:prepare -B \
             -Dresume=false \
             -Dtag=${RELEASE_VERSION} \
             -DreleaseVersion=${RELEASE_VERSION} \
             -DdevelopmentVersion=${DEVELOPMENT_VERSION} \
             -DpushChanges=${PUSH_CHANGES} \
             -DremoteTagging=${PUSH_CHANGES} \
-            -DlocalCheckout=${{ inputs.dryRun }} \
             -DcompletionGoals="spotless:apply" \
+            -P-autoFormat \
+            -DpreparationGoals="" \
+            -Darguments=''
+
+      - name: Maven Perform Release
+        id: maven-perform-release
+        env:
+          SKIP_REPO_DEPLOY: ${{ inputs.dryRun }}
+        run: |
+          # Perform a maven release
+          # https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html
+          # https://maven.apache.org/maven-release/maven-release-plugin/usage/perform-release.html
+
+          # The following env var is used to include the previously built go artifacts into the final maven release build.
+          # As the maven build of the tag happens in a sub-directory to which maven checks out the release tag to build it.
+          # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
+          export ZBCTL_ROOT_DIR=${PWD}
+
+          # -P-integration-tests,-autoFormat
+          #   In order to disable QA/IT and the auto formatting during the release.
+          #   It is not necessary to release integration tests, and we don't want to run unnecessary the auto formatting.
+          ./mvnw release:perform -B \
+            -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
+            -DlocalCheckout=${{ inputs.dryRun }} \
             -P-integration-tests,-autoFormat \
             -Darguments='-T0.5C -P-integration-tests,-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -14,7 +14,6 @@
 
   <name>Operate Parent</name>
 
-
   <modules>
     <module>client</module>
     <module>common</module>
@@ -48,7 +47,6 @@
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/*5IT.java</excludeITNames>
   </properties>
-
 
   <build>
     <pluginManagement>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -14,6 +14,22 @@
 
   <name>Operate Parent</name>
 
+
+  <modules>
+    <module>client</module>
+    <module>common</module>
+    <module>schema</module>
+    <module>data-generator</module>
+    <module>importer-common</module>
+    <module>importer-8_5</module>
+    <module>importer-8_6</module>
+    <module>importer</module>
+    <module>archiver</module>
+    <module>webapp</module>
+    <module>mvc-auth-commons</module>
+    <module>../distro</module>
+  </modules>
+
   <properties>
 
     <!-- release parent settings -->
@@ -32,6 +48,7 @@
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/*5IT.java</excludeITNames>
   </properties>
+
 
   <build>
     <pluginManagement>
@@ -242,45 +259,18 @@
       </build>
     </profile>
 
+    <!-- 
+      Integration tests are run per default, but having it in a profile allows us to exclude it easily.
+      That is useful for example for creating releases.
+       -->
     <profile>
-      <id>all</id>
+      <id>integration-tests</id>
       <activation>
         <activeByDefault>true</activeByDefault>
       </activation>
       <modules>
-        <module>client</module>
-        <module>common</module>
-        <module>schema</module>
-        <module>data-generator</module>
-        <module>importer-common</module>
-        <module>importer-8_5</module>
-        <module>importer-8_6</module>
-        <module>importer</module>
-        <module>archiver</module>
-        <module>webapp</module>
         <module>qa</module>
-        <module>mvc-auth-commons</module>
-        <module>../distro</module>
-      </modules>
-    </profile>
-
-    <profile>
-      <id>release</id>
-      <modules>
-        <module>client</module>
-        <module>common</module>
-        <module>schema</module>
-        <module>data-generator</module>
-        <module>importer-common</module>
-        <module>importer-8_5</module>
-        <module>importer-8_6</module>
-        <module>importer</module>
-        <module>archiver</module>
-        <module>webapp</module>
-        <module>mvc-auth-commons</module>
-        <module>../distro</module>
       </modules>
     </profile>
   </profiles>
-
 </project>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -14,22 +14,6 @@
 
   <name>Operate Parent</name>
 
-  <modules>
-    <module>client</module>
-    <module>common</module>
-    <module>schema</module>
-    <module>data-generator</module>
-    <module>importer-common</module>
-    <module>importer-8_5</module>
-    <module>importer-8_6</module>
-    <module>importer</module>
-    <module>archiver</module>
-    <module>webapp</module>
-    <module>qa</module>
-    <module>mvc-auth-commons</module>
-    <module>../distro</module>
-  </modules>
-
   <properties>
 
     <!-- release parent settings -->
@@ -256,6 +240,46 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+
+    <profile>
+      <id>all</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>client</module>
+        <module>common</module>
+        <module>schema</module>
+        <module>data-generator</module>
+        <module>importer-common</module>
+        <module>importer-8_5</module>
+        <module>importer-8_6</module>
+        <module>importer</module>
+        <module>archiver</module>
+        <module>webapp</module>
+        <module>qa</module>
+        <module>mvc-auth-commons</module>
+        <module>../distro</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>release</id>
+      <modules>
+        <module>client</module>
+        <module>common</module>
+        <module>schema</module>
+        <module>data-generator</module>
+        <module>importer-common</module>
+        <module>importer-8_5</module>
+        <module>importer-8_6</module>
+        <module>importer</module>
+        <module>archiver</module>
+        <module>webapp</module>
+        <module>mvc-auth-commons</module>
+        <module>../distro</module>
+      </modules>
     </profile>
   </profiles>
 

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -258,7 +258,7 @@
     </profile>
 
     <!-- 
-      Integration tests are run per default, but having it in a profile allows us to exclude it easily.
+      The QA module is enabled per default, but having it in a profile allows us to exclude it easily.
       That is useful for example for creating releases.
        -->
     <profile>

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -49,7 +49,6 @@
     <module>dmn</module>
     <module>snapshot</module>
     <module>journal</module>
-    <module>qa</module>
     <module>benchmarks/project</module>
     <module>scheduler</module>
     <module>backup</module>
@@ -61,4 +60,20 @@
     <module>restore</module>
     <module>topology</module>
   </modules>
+
+  <profiles>
+    <!-- 
+      Integration tests are run per default, but having it in a profile allows us to exclude it easily.
+      That is useful for example for creating releases.
+      -->
+    <profile>
+      <id>integration-tests</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>qa</module>
+      </modules>
+    </profile>
+  </profiles>
 </project>

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -63,7 +63,7 @@
 
   <profiles>
     <!-- 
-      Integration tests are run per default, but having it in a profile allows us to exclude it easily.
+      The QA module is enabled by default, but having it in a profile allows us to exclude it easily.
       That is useful for example for creating releases.
       -->
     <profile>


### PR DESCRIPTION
## Description

This PR refactors the release workflow. 

It should increase the:
 
  * maintainability
  * performance (reduces the maven job time from ~15-17 minutes to 9 minutes).

### Details 

**Before:**

![2024-04-18_07-21_1](https://github.com/camunda/zeebe/assets/2758593/7ab58e48-bc2c-4355-8e97-033d59033b94)

**After**

![2024-04-18_07-21](https://github.com/camunda/zeebe/assets/2758593/4792363e-5ed6-4eef-9e4e-d124aadecc0c)


#### Split of jobs

With this PR we split the maven release prepare and perform steps into separate jobs, to separate the concerns. The split allows to make more clear what each step does, and
what each parameter is used for.

For example are we able to reduce the parameters to a minimum, and
skip re-building in the preparing step (as the artifacts are not used in a later stage). This reduces the build time of this step from 5 minutes to 30 seconds (factor 10).

For interesting parts and parameters we add some documentation to better understand the what and why.

I followed mostly [the documentation of the release plugin](https://maven.apache.org/maven-release/maven-release-plugin/index.html) to understand what each parameter and goal does. (I had a lot of learnings)

#### Integration tests

Introducing an integration test profile allows us to exclude the respective modules during the release (we need them in the preparation step as we have to change their versions as well). Makes it possible to not build and release unnecessary modules/classes.

#### Go client build

Previously we built the go client and the dist together. The resulting dist was never used, as the go client is packed in the release perform step again. From now on we skip building the Zeebe dist with the go client, this saves us around 1 minute.

## Related issues

related https://github.com/camunda/zeebe/pull/17474

Requesting from @megglos review as he created also previously the github release workflow (migrated from jenkins). Happy for your input.

Most recent run https://github.com/camunda/zeebe/actions/runs/8732895298/job/23960606631 (maven took ~13 min)
Previous run https://github.com/camunda/zeebe/actions/runs/8728270279/job/23947651262 (maven took ~9 min)

Looks like depends a lot of downloading the whole internet (maven thing) ;) 
