### PR TITLE
fix: fix broken job lifetime metric

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -162,7 +162,7 @@ public class MetricsExporter implements Exporter {
     if (currentIntent == JobBatchIntent.ACTIVATED) {
       final var value = (JobBatchRecordValue) record.getValue();
       for (final long jobKey : value.getJobKeys()) {
-        final var creationTime = jobCache.remove(jobKey);
+        final var creationTime = jobCache.get(jobKey);
         executionLatencyMetrics.observeJobActivationTime(
             partitionId, creationTime, record.getTimestamp());
       }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
@@ -42,7 +42,7 @@ final class TtlKeyCache {
    */
   TtlKeyCache(final int maxCapacity, final long nullValue) {
     this.maxCapacity = maxCapacity;
-    this.keyToTimestamp = new Long2LongHashMap(nullValue);
+    keyToTimestamp = new Long2LongHashMap(nullValue);
   }
 
   void store(final long key, final long timestamp) {
@@ -52,6 +52,20 @@ final class TtlKeyCache {
 
     keyToTimestamp.put(key, timestamp);
     timestampToKeys.computeIfAbsent(timestamp, ignored -> new LongArrayList()).add(key);
+  }
+
+  long get(final long key) {
+    final var timestamp = keyToTimestamp.get(key);
+    final var keys = timestampToKeys.get(timestamp);
+
+    if (keys != null) {
+      keys.remove(key);
+      if (keys.isEmpty()) {
+        timestampToKeys.remove(timestamp);
+      }
+    }
+
+    return timestamp;
   }
 
   long remove(final long key) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCache.java
@@ -55,17 +55,7 @@ final class TtlKeyCache {
   }
 
   long get(final long key) {
-    final var timestamp = keyToTimestamp.get(key);
-    final var keys = timestampToKeys.get(timestamp);
-
-    if (keys != null) {
-      keys.remove(key);
-      if (keys.isEmpty()) {
-        timestampToKeys.remove(timestamp);
-      }
-    }
-
-    return timestamp;
+    return keyToTimestamp.get(key);
   }
 
   long remove(final long key) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
@@ -140,5 +140,7 @@ final class TtlKeyCacheTest {
 
     // then
     assertThat(timestamp).isEqualTo(10L);
+    assertThat(cache.get(1L)).isEqualTo(10L); // assert it's still there
+    assertThat(cache.size()).isOne();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/TtlKeyCacheTest.java
@@ -128,4 +128,17 @@ final class TtlKeyCacheTest {
     // then
     assertThat(timestamp).isEqualTo(3L);
   }
+
+  @Test
+  void shouldGetTimestampByKey() {
+    // given
+    final var cache = new TtlKeyCache();
+    cache.store(1L, 10L);
+
+    // when
+    final var timestamp = cache.get(1L);
+
+    // then
+    assertThat(timestamp).isEqualTo(10L);
+  }
 }


### PR DESCRIPTION
## Description

The previous refactor broke the job lifetime metric, as an activation record would remove the cached key/timestamp, leading to all job lifetime being the default max value (60s).
