### PR TITLE
deps: ignore internal Tasklist modules

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -70,6 +70,8 @@
         "io.camunda:operate-parent",
         "io.camunda:operate-qa",
         "io.camunda:operate-qa-migration-tests-parent",
+        "io.camunda:tasklist-qa",
+        "io.camunda:tasklist-qa-migration-tests-parent",
         "net.jcip:jcip-annotations"
       ],
       "enabled": false


### PR DESCRIPTION
## Description

Same as https://github.com/camunda/zeebe/pull/17473 but for newly merged Tasklist