### PR TITLE
revert: Remove Hotjar

### DIFF
--- a/tasklist/client/package.json
+++ b/tasklist/client/package.json
@@ -9,7 +9,6 @@
     "@camunda/camunda-composite-components": "0.6.2",
     "@carbon/elements": "11.43.0",
     "@carbon/react": "1.55.0",
-    "@hotjar/browser": "1.0.9",
     "@monaco-editor/react": "4.6.0",
     "@tanstack/react-query": "4.36.1",
     "classnames": "^2.5.1",

--- a/tasklist/client/src/modules/tracking/index.tsx
+++ b/tasklist/client/src/modules/tracking/index.tsx
@@ -19,7 +19,6 @@ import {Mixpanel} from 'mixpanel-browser';
 import {getStage} from 'modules/utils/getStage';
 import {CurrentUser} from 'modules/types';
 import {TaskFilters} from 'modules/hooks/useTaskFilters';
-import Hotjar from '@hotjar/browser';
 
 const EVENT_PREFIX = 'tasklist:';
 type Events =
@@ -190,12 +189,6 @@ class Tracking {
     return Boolean(window.Osano?.cm?.analytics);
   };
 
-  #loadHotjar = () => {
-    Hotjar.init(4937911, 6);
-
-    return Promise.resolve();
-  };
-
   #loadMixpanel = (): Promise<void> => {
     return import('mixpanel-browser').then(({default: mixpanel}) => {
       mixpanel.init(
@@ -257,11 +250,7 @@ class Tracking {
     }
 
     return this.#loadOsano().then(() =>
-      Promise.all([
-        this.#loadMixpanel(),
-        this.#loadAppCues(),
-        this.#loadHotjar(),
-      ]).then(() => {
+      Promise.all([this.#loadMixpanel(), this.#loadAppCues()]).then(() => {
         window.Osano?.cm?.addEventListener(
           'osano-cm-consent-saved',
           ({ANALYTICS}) => {

--- a/tasklist/client/yarn.lock
+++ b/tasklist/client/yarn.lock
@@ -705,11 +705,6 @@
     protobufjs "^7.2.4"
     yargs "^17.7.2"
 
-"@hotjar/browser@1.0.9":
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/@hotjar/browser/-/browser-1.0.9.tgz#769b4ded3fa7b9557b785c107f0cd76d3f83789a"
-  integrity sha512-n9akDMod8BLGpYEQCrHwlYWWd63c1HlhUSXNIDfClZtKYXbUjIUOFlNZNNcUxgHTCsi4l2i+SWKsGsO0t93S8w==
-
 "@humanwhocodes/config-array@^0.11.14":
   version "0.11.14"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"


### PR DESCRIPTION
## Description
We won't be using Hotjar on Tasklist, so I'm removing the deps

Reverts: https://github.com/camunda/tasklist/pull/4859 , https://github.com/camunda/tasklist/pull/4862
