### PR TITLE
refactor: remove unused spring-client-common

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -768,12 +768,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-client-common</artifactId>
-        <version>${version.spring-boot}</version>
-      </dependency>
-
-      <dependency>
         <groupId>io.camunda</groupId>
         <artifactId>zeebe-broker</artifactId>
         <version>${project.version}</version>


### PR DESCRIPTION
## Description

This was identified by Renovate failing to find the dependency in Maven Central -> turns out it is not from Spring project but from Camunda instead. If it was actually used, we'd have noticed failing builds -> so it is unused.
