### PR TITLE
Fix can activate a job without retries bug

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTaskElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTaskElementsTest.java
@@ -318,6 +318,12 @@ public class ExecutionListenerTaskElementsTest {
         .hasErrorMessage("No more retries left.");
 
     // resolve incident & complete start EL jobs
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(START_EL_TYPE + "_1")
+        .withRetries(1)
+        .updateRetries();
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
     ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_1").complete();
     ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_2").complete();
@@ -336,6 +342,7 @@ public class ExecutionListenerTaskElementsTest {
             JobIntent.CREATED,
             JobIntent.FAILED,
             IncidentIntent.CREATED,
+            JobIntent.RETRIES_UPDATED,
             IncidentIntent.RESOLVED,
             JobIntent.COMPLETED,
             JobIntent.CREATED,
@@ -390,6 +397,12 @@ public class ExecutionListenerTaskElementsTest {
         .hasErrorMessage("No more retries left.");
 
     // resolve incident & complete end EL jobs
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(END_EL_TYPE + "_1")
+        .withRetries(1)
+        .updateRetries();
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
     ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_1").complete();
     ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_2").complete();
@@ -405,6 +418,7 @@ public class ExecutionListenerTaskElementsTest {
             JobIntent.CREATED,
             JobIntent.FAILED,
             IncidentIntent.CREATED,
+            JobIntent.RETRIES_UPDATED,
             IncidentIntent.RESOLVED,
             JobIntent.COMPLETED,
             JobIntent.CREATED,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTest.java
@@ -159,6 +159,12 @@ public class ExecutionListenerTest {
         .hasErrorMessage("No more retries left.");
 
     // and: resolve first incident
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(SERVICE_TASK_TYPE)
+        .withRetries(1)
+        .updateRetries();
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
     // complete service task job (NO need to re-complete start EL job(s))
     ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
@@ -752,7 +758,7 @@ public class ExecutionListenerTest {
   // process related tests: end
 
   // test util methods
-  private static long createProcessInstance(BpmnModelInstance modelInstance) {
+  private static long createProcessInstance(final BpmnModelInstance modelInstance) {
     ENGINE.deployment().withXmlResource(modelInstance).deploy();
     return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
   }
@@ -786,7 +792,7 @@ public class ExecutionListenerTest {
   }
 
   static void assertExecutionListenerJobsCompletedForElement(
-      final long processInstanceKey, String elementId, final String... elJobTypes) {
+      final long processInstanceKey, final String elementId, final String... elJobTypes) {
     assertThat(
             RecordingExporter.jobRecords()
                 .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CompensationIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CompensationIncidentTest.java
@@ -119,6 +119,12 @@ public class CompensationIncidentTest {
     ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).fail();
 
     // then
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(COMPENSATION_HANDLER_JOB_TYPE)
+        .withRetries(1)
+        .updateRetries();
     ENGINE.incident().ofInstance(processInstanceKey).resolve();
     ENGINE.job().ofInstance(processInstanceKey).withType(COMPENSATION_HANDLER_JOB_TYPE).complete();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -239,6 +239,7 @@ public class ActivatableJobsPushTest {
         RecordingExporter.incidentRecords(CREATED).getFirst();
 
     // when an incident is resolved
+    ENGINE.job().withKey(jobKey).withType(jobType).withRetries(1).updateRetries();
     ENGINE.incident().ofInstance(incident.getValue().getProcessInstanceKey()).resolve();
 
     // then
@@ -266,7 +267,9 @@ public class ActivatableJobsPushTest {
   }
 
   private void assertEventOrder(
-      String description, final Set<ValueType> targetValueTypes, final Intent... expectedIntents) {
+      final String description,
+      final Set<ValueType> targetValueTypes,
+      final Intent... expectedIntents) {
     assertThat(
             records()
                 .onlyEvents()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIncidentTest.java
@@ -100,6 +100,7 @@ public class MigrateIncidentTest {
         .hasTenantId(incident.getValue().getTenantId());
 
     // after resolving the incident, job can be completed and the process should continue
+    ENGINE.job().ofInstance(processInstanceKey).withType("jobTypeA").withRetries(1).updateRetries();
     final Record<IncidentRecordValue> incidentRecord =
         ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 


### PR DESCRIPTION
## Description
A fix for [this bug](https://github.com/camunda/zeebe/issues/16484).

It was possible before to resolve job incident when the job had 0 retries. According to Camunda 8 [documentation](https://docs.camunda.io/docs/8.3/components/concepts/incidents/#resolving-a-job-related-incident) it is not the expected behaviour and remaining retries of the job should be increased first.

Adding a check and relevant tests.

## Related issues

closes #16484 #15437
