### PR TITLE
ci: prevent hanging Operate builds with timeout

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -35,6 +35,7 @@ jobs:
   build:
     name: Build
     runs-on: ${{ (github.event_name == 'pull_request' && (startsWith(inputs.branch, 'fe-') || (startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')))) && 'ubuntu-latest' || 'gcp-core-16-default' }}
+    timeout-minutes: 20
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch


### PR DESCRIPTION
## Description

The build usually takes around 10 minutes or less., To limit CI costs and keep the merge queue going we should stop hanging builds (e.g. in frontend): https://github.com/camunda/zeebe/actions/workflows/operate-merge-ci.yaml

To allow for some headroom with slow networks, lets put a timeout at 20 minutes.