### PR TITLE
refactor: Type styles are set in SASS stylesheets

### DIFF
--- a/tasklist/client/src/Processes/History/index.tsx
+++ b/tasklist/client/src/Processes/History/index.tsx
@@ -16,7 +16,6 @@
  */
 
 import {useProcessInstances} from 'modules/queries/useProcessInstances';
-import {BodyCompact, BodyLong, Label} from 'modules/components/FontTokens';
 import capitalize from 'lodash/capitalize';
 import {formatDate} from 'modules/utils/formatDate';
 import {Skeleton} from './Skeleton';
@@ -30,21 +29,19 @@ const History: React.FC = () => {
 
   return (
     <div className={styles.container}>
-      <Label $color="secondary" className={styles.header}>
-        History
-      </Label>
+      <span className={styles.header}>History</span>
       <div className={styles.itemContainer}>
         {match({status})
           .with({status: 'loading'}, () => <Skeleton />)
           .with({status: 'error'}, () => (
             <Layer>
               <Stack gap={3} className={styles.message}>
-                <BodyCompact $variant="02">
+                <span className={styles.messageHeading}>
                   Oops! Something went wrong while fetching the history
-                </BodyCompact>
-                <BodyLong $color="secondary">
+                </span>
+                <span className={styles.messageBody}>
                   Please check your internet connection and try again.
-                </BodyLong>
+                </span>
               </Stack>
             </Layer>
           ))
@@ -57,32 +54,30 @@ const History: React.FC = () => {
               processInstances.length === 0 ? (
                 <Layer>
                   <Stack gap={3} className={styles.message}>
-                    <BodyCompact $variant="02">
+                    <span className={styles.messageHeading}>
                       No history entries found
-                    </BodyCompact>
-                    <BodyLong $color="secondary">
+                    </span>
+                    <span className={styles.messageBody}>
                       There is no history to display. Start a new process to see
                       it here.
-                    </BodyLong>
+                    </span>
                   </Stack>
                 </Layer>
               ) : (
                 processInstances.map(({id, process, creationDate, state}) => (
                   <Stack key={id} gap={3} className={styles.item}>
-                    <BodyCompact $showEllipsisOnOverflow>
+                    <span className={styles.itemName}>
                       {process.name ?? process.bpmnProcessId}
-                    </BodyCompact>
-                    <BodyCompact $color="secondary" $showEllipsisOnOverflow>
-                      {id}
-                    </BodyCompact>
-                    <Label $color="secondary">
+                    </span>
+                    <span className={styles.itemId}>{id}</span>
+                    <span className={styles.itemDetails}>
                       {formatDate(creationDate)} - {capitalize(state)}
                       <ProcessInstanceStateIcon
                         className={styles.icon}
                         state={state}
                         size={16}
                       />
-                    </Label>
+                    </span>
                   </Stack>
                 ))
               ),

--- a/tasklist/client/src/Processes/History/styles.module.scss
+++ b/tasklist/client/src/Processes/History/styles.module.scss
@@ -15,6 +15,7 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 @use '@carbon/layout';
+@use '@carbon/type';
 
 .container {
   width: 100%;
@@ -27,6 +28,11 @@
   width: 100%;
   padding: var(--cds-spacing-04) var(--cds-spacing-05);
   border-bottom: 1px solid var(--cds-border-subtle);
+
+  display: inline-flex;
+  align-items: center;
+  color: var(--cds-text-secondary);
+  @include type.type-style('label-01');
 }
 
 .item {
@@ -38,6 +44,31 @@
   &:last-child {
     border-bottom: none;
   }
+}
+
+.itemName {
+  color: var(--cds-text-primary);
+  @include type.type-style('body-short-01');
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.itemId {
+  color: var(--cds-text-secondary);
+  @include type.type-style('body-short-01');
+
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.itemDetails {
+  display: inline-flex;
+  align-items: center;
+  color: var(--cds-text-secondary);
+  @include type.type-style('label-01');
 }
 
 .skeletonText {
@@ -55,6 +86,16 @@
   border: 1px solid var(--cds-border-subtle);
   background-color: var(--cds-layer);
   margin: var(--cds-spacing-05);
+}
+
+.messageHeading {
+  color: var(--cds-text-primary);
+  @include type.type-style('body-short-02');
+}
+
+.messageBody {
+  color: var(--cds-text-primary);
+  @include type.type-style('body-long-01');
 }
 
 .icon {

--- a/tasklist/client/src/Tasks/AvailableTasks/Task/styled.tsx
+++ b/tasklist/client/src/Tasks/AvailableTasks/Task/styled.tsx
@@ -101,16 +101,6 @@ const Container: React.FC<
   </article>
 );
 
-const SkeletonContainer: React.FC<React.ComponentProps<'article'>> = ({
-  className = '',
-  children,
-  ...rest
-}) => (
-  <article {...rest} className={cn(className, styles.taskSkeleton)}>
-    {children}
-  </article>
-);
-
 const DateLabel: React.FC<React.ComponentProps<typeof Label>> = ({
   className = '',
   children,
@@ -142,7 +132,6 @@ export {
   TaskLink,
   Stack,
   Container,
-  SkeletonContainer,
   DateLabel,
   PopoverContent,
   InlineCalender,

--- a/tasklist/client/src/Tasks/Task/Details/index.tsx
+++ b/tasklist/client/src/Tasks/Task/Details/index.tsx
@@ -24,7 +24,6 @@ import {tracking} from 'modules/tracking';
 import {useState} from 'react';
 import {notificationsStore} from 'modules/stores/notifications';
 import {AsyncActionButton} from 'modules/components/AsyncActionButton';
-import {BodyCompact, Label} from 'modules/components/FontTokens';
 import {TaskDetailsRow} from 'modules/components/TaskDetailsLayout';
 import {
   ContainedList,
@@ -151,13 +150,13 @@ const Details: React.FC<Props> = ({
           title="Task details header"
         >
           <div className={styles.headerLeftContainer}>
-            <BodyCompact $variant="02">{name}</BodyCompact>
-            <Label $color="secondary">{processName}</Label>
+            <span className={styles.taskName}>{name}</span>
+            <span className={styles.processName}>{processName}</span>
           </div>
           <div className={styles.headerRightContainer}>
             {taskState === 'COMPLETED' ? (
-              <Label
-                $color="secondary"
+              <span
+                className={styles.taskStatus}
                 data-testid="completion-label"
                 title="Completed by"
               >
@@ -172,25 +171,28 @@ const Details: React.FC<Props> = ({
                     <>
                       {' '}
                       by
-                      <Label $color="secondary" data-testid="assignee">
+                      <span
+                        className={styles.taskAssignee}
+                        data-testid="assignee"
+                      >
                         <AssigneeTag
                           currentUser={user}
                           assignee={assignee}
                           isShortFormat={true}
                         />
-                      </Label>
+                      </span>
                     </>
                   ) : null}
                 </Stack>
-              </Label>
+              </span>
             ) : (
-              <Label $color="secondary" data-testid="assignee">
+              <span className={styles.taskAssignee} data-testid="assignee">
                 <AssigneeTag
                   currentUser={user}
                   assignee={assignee}
                   isShortFormat={false}
                 />
-              </Label>
+              </span>
             )}
             {taskState === 'CREATED' && (
               <Restricted scopes={['write']}>
@@ -236,22 +238,22 @@ const Details: React.FC<Props> = ({
           <>
             {taskTenant === undefined ? null : (
               <ContainedListItem>
-                <BodyCompact $color="secondary">Tenant</BodyCompact>
+                <span className={styles.itemHeading}>Tenant</span>
                 <br />
-                <BodyCompact>{taskTenant.name}</BodyCompact>
+                <span className={styles.itemBody}>{taskTenant.name}</span>
               </ContainedListItem>
             )}
           </>
           <ContainedListItem>
-            <BodyCompact $color="secondary">Creation date</BodyCompact>
+            <span className={styles.itemHeading}>Creation date</span>
             <br />
-            <BodyCompact>{formatDate(creationDate)}</BodyCompact>
+            <span className={styles.itemBody}>{formatDate(creationDate)}</span>
           </ContainedListItem>
           <ContainedListItem>
-            <BodyCompact $color="secondary">Candidates</BodyCompact>
+            <span className={styles.itemHeading}>Candidates</span>
             <br />
             {candidates.length === 0 ? (
-              <BodyCompact>No candidates</BodyCompact>
+              <span className={styles.itemBody}>No candidates</span>
             ) : null}
             {candidates.map((candidate) => (
               <Tag size="sm" type="gray" key={candidate}>
@@ -261,23 +263,27 @@ const Details: React.FC<Props> = ({
           </ContainedListItem>
           {completionDate ? (
             <ContainedListItem>
-              <BodyCompact $color="secondary">Completion date</BodyCompact>
+              <span className={styles.itemHeading}>Completion date</span>
               <br />
-              <BodyCompact>{formatDate(completionDate)}</BodyCompact>
+              <span className={styles.itemBody}>
+                {formatDate(completionDate)}
+              </span>
             </ContainedListItem>
           ) : null}
           <ContainedListItem>
-            <BodyCompact $color="secondary">Due date</BodyCompact>
+            <span className={styles.itemHeading}>Due date</span>
             <br />
-            <BodyCompact>
+            <span className={styles.itemBody}>
               {dueDate ? formatDate(dueDate) : 'No due date'}
-            </BodyCompact>
+            </span>
           </ContainedListItem>
           {followUpDate ? (
             <ContainedListItem>
-              <BodyCompact $color="secondary">Follow up date</BodyCompact>
+              <span className={styles.itemHeading}>Follow up date</span>
               <br />
-              <BodyCompact>{formatDate(followUpDate)}</BodyCompact>
+              <span className={styles.itemBody}>
+                {formatDate(followUpDate)}
+              </span>
             </ContainedListItem>
           ) : null}
         </ContainedList>

--- a/tasklist/client/src/Tasks/Task/Details/styles.module.scss
+++ b/tasklist/client/src/Tasks/Task/Details/styles.module.scss
@@ -15,6 +15,7 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 @use '@carbon/layout';
+@use '@carbon/type';
 
 .assignButtonContainer {
   flex-shrink: 0;
@@ -51,6 +52,32 @@
   margin-left: auto;
 }
 
+.taskName {
+  color: var(--cds-text-primary);
+  @include type.type-style('body-short-02');
+}
+
+.processName {
+  display: inline-flex;
+  align-items: center;
+  color: var(--cds-text-secondary);
+  @include type.type-style('label-01');
+}
+
+.taskStatus {
+  display: inline-flex;
+  align-items: center;
+  color: var(--cds-text-secondary);
+  @include type.type-style('label-01');
+}
+
+.taskAssignee {
+  display: inline-flex;
+  align-items: center;
+  color: var(--cds-text-secondary);
+  @include type.type-style('label-01');
+}
+
 .content {
   width: 100%;
   height: 100%;
@@ -65,6 +92,16 @@
   border-left: 1px solid var(--cds-border-subtle);
   display: flex;
   flex-direction: column;
+}
+
+.itemHeading {
+  color: var(--cds-text-secondary);
+  @include type.type-style('body-short-01');
+}
+
+.itemBody {
+  color: var(--cds-text-primary);
+  @include type.type-style('body-short-01');
 }
 
 .container {

--- a/tasklist/client/src/modules/components/FontTokens.tsx
+++ b/tasklist/client/src/modules/components/FontTokens.tsx
@@ -71,19 +71,4 @@ const HeadingCompact = styled.span<Props & BaseProps>`
   `}
 `;
 
-const Label = styled.span<Props & BaseProps>`
-  ${({
-    theme,
-    $color = 'primary',
-    $variant = '01',
-    $showEllipsisOnOverflow,
-  }) => css`
-    display: inline-flex;
-    align-items: center;
-    color: var(--cds-text-${$color});
-    ${$variant === '01' ? theme.label01 : theme.label02};
-    ${$showEllipsisOnOverflow ? textOverflowStyles : ''};
-  `}
-`;
-
-export {BodyCompact, HeadingCompact, Label, BodyLong};
+export {BodyCompact, HeadingCompact, BodyLong};

--- a/tasklist/client/src/modules/components/SkeletonText.module.scss
+++ b/tasklist/client/src/modules/components/SkeletonText.module.scss
@@ -15,35 +15,7 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {SkeletonText, Stack} from '@carbon/react';
-import styles from './styles.module.scss';
-import cn from 'classnames';
-
-const TaskSkeleton: React.FC = () => {
-  return (
-    <article className={styles.taskSkeleton}>
-      <Stack gap={3}>
-        <div className={cn(styles.flex, styles.flexColumn)}>
-          <span className={styles.name}>
-            <SkeletonText width="250px" />
-          </span>
-          <span className={styles.label}>
-            <SkeletonText width="200px" />
-          </span>
-        </div>
-        <div className={cn(styles.flex, styles.flexColumn)}>
-          <span className={styles.label}>
-            <SkeletonText width="50px" />
-          </span>
-        </div>
-        <div className={cn(styles.flex, styles.flexColumn)}>
-          <span className={styles.label}>
-            <SkeletonText width="100px" />
-          </span>
-        </div>
-      </Stack>
-    </article>
-  );
-};
-
-export {TaskSkeleton};
+.skeletonText {
+  height: 19px;
+  margin-bottom: 0;
+}


### PR DESCRIPTION
## Description
Clone of https://github.com/camunda/tasklist/pull/4888

We use styled components to apply font styles to elements. Move these to SASS stylesheets and use the macros to add in the correct font styles.

## Related issues

closes https://github.com/camunda/tasklist/issues/4676
