### PR TITLE
test: add e2e test for process instance batch modification

### DIFF
--- a/operate/client/e2e-playwright/pages/Processes/Processes.ts
+++ b/operate/client/e2e-playwright/pages/Processes/Processes.ts
@@ -57,6 +57,7 @@ export class Processes {
   readonly variableValueFilter: Locator;
   readonly deleteResourceButton: Locator;
   readonly migrateButton: Locator;
+  readonly moveButton: Locator;
   readonly processInstancesTable: Locator;
 
   constructor(page: Page) {
@@ -125,12 +126,16 @@ export class Processes {
       name: 'Delete Process Definition',
     });
 
-    this.migrateButton = page.getByRole('button', {
+    this.processInstancesTable = page.getByRole('region', {
+      name: /process instances panel/i,
+    });
+
+    this.migrateButton = this.processInstancesTable.getByRole('button', {
       name: 'Migrate',
     });
 
-    this.processInstancesTable = page.getByRole('region', {
-      name: /process instances panel/i,
+    this.moveButton = this.processInstancesTable.getByRole('button', {
+      name: 'Move',
     });
   }
 

--- a/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
+++ b/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE ("USE"), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * "Licensee" means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+
+import {setup} from './batchMoveModification.mocks';
+import {test} from '../test-fixtures';
+import {expect} from '@playwright/test';
+import {SETUP_WAITING_TIME} from './constants';
+import {config} from '../config';
+import {IS_BATCH_MOVE_MODIFICATION_ENABLED} from 'modules/feature-flags';
+
+let initialData: Awaited<ReturnType<typeof setup>>;
+
+const NUM_PROCESS_INSTANCES = 10;
+const NUM_SELECTED_PROCESS_INSTANCES = 4;
+
+test.beforeAll(async ({request}) => {
+  initialData = await setup();
+  const {processInstances} = initialData;
+
+  // wait until all instances are created
+  await Promise.all(
+    processInstances.map(
+      async (instance) =>
+        await expect
+          .poll(
+            async () => {
+              const response = await request.get(
+                `${config.endpoint}/v1/process-instances/${instance.processInstanceKey}`,
+              );
+              return response.status();
+            },
+            {timeout: SETUP_WAITING_TIME},
+          )
+          .toBe(200),
+    ),
+  );
+});
+
+(IS_BATCH_MOVE_MODIFICATION_ENABLED ? test.describe : test.describe.skip)(
+  'Process Instance Batch Modification',
+  () => {
+    test('Move Operation', async ({processesPage, commonPage, page}) => {
+      await processesPage.navigateToProcesses({
+        searchParams: {active: 'true'},
+      });
+
+      const processInstanceKeys = initialData.processInstances
+        .map((instance) => instance.processInstanceKey)
+        .join(',');
+
+      await processesPage.selectProcess('Order process');
+      await processesPage.selectVersion(initialData.version.toString());
+      await processesPage.selectFlowNode('Check payment');
+
+      // Filter by all process instances which have been created in setup
+      await processesPage.displayOptionalFilter('Process Instance Key(s)');
+      await processesPage.processInstanceKeysFilter.fill(processInstanceKeys);
+
+      await expect(
+        processesPage.processInstancesTable.getByText(
+          `${NUM_PROCESS_INSTANCES} results`,
+        ),
+      ).toBeVisible();
+
+      // Select 4 process instances for move modification
+      await processesPage.getNthProcessInstanceCheckbox(0).click();
+      await processesPage.getNthProcessInstanceCheckbox(1).click();
+      await processesPage.getNthProcessInstanceCheckbox(2).click();
+      await processesPage.getNthProcessInstanceCheckbox(3).click();
+
+      await expect(
+        page.getByText(`${NUM_SELECTED_PROCESS_INSTANCES} items selected`),
+      ).toBeVisible();
+
+      await processesPage.moveButton.click();
+
+      // Confirm move modification modal
+      await page.getByRole('button', {name: 'Continue'}).click();
+
+      // Select target flow node
+      await processesPage.diagram.clickFlowNode('Ship Articles');
+
+      await expect(
+        page.getByText(
+          `Modification scheduled: Move ${NUM_SELECTED_PROCESS_INSTANCES} instances from “Check payment” to “Ship Articles”. Press “Apply Modification” button to confirm.`,
+        ),
+      ).toBeVisible();
+
+      await page.getByRole('button', {name: /apply modification/i}).click();
+
+      // Expect that modal is open with "apply modifications" title
+      await expect(
+        page.getByRole('heading', {name: /apply modifications/i}),
+      ).toBeVisible();
+
+      // Confirm modal
+      await page.getByRole('button', {name: /^apply$/i}).click();
+
+      // Expect Operations Panel to be visible
+      await expect(commonPage.operationsList).toBeVisible();
+
+      const modificationOperationEntry = commonPage.operationsList
+        .getByRole('listitem')
+        .first();
+      await expect(modificationOperationEntry).toContainText('Modify');
+      await expect(
+        modificationOperationEntry.getByRole('progressbar'),
+      ).toBeVisible();
+
+      // Wait for migrate operation to finish
+      await expect(
+        modificationOperationEntry.getByRole('progressbar'),
+      ).not.toBeVisible();
+
+      await modificationOperationEntry
+        .getByRole('link', {
+          name: `${NUM_SELECTED_PROCESS_INSTANCES} Instances`,
+        })
+        .click();
+
+      await processesPage.selectProcess('Order process');
+      await processesPage.selectVersion(initialData.version.toString());
+
+      // Filter by all process instances which have been created in setup
+      await processesPage.displayOptionalFilter('Process Instance Key(s)');
+      await processesPage.processInstanceKeysFilter.fill(processInstanceKeys);
+
+      // Expect the correct number of instances related to the move modification
+      await expect(
+        processesPage.processInstancesTable.getByText(
+          `${NUM_SELECTED_PROCESS_INSTANCES} results`,
+        ),
+      ).toBeVisible();
+
+      // Expect that shipArticles flow node instances got canceled in all process instances
+      await expect(
+        processesPage.diagram.diagram.getByTestId(
+          'state-overlay-shipArticles-active',
+        ),
+      ).toHaveText(NUM_SELECTED_PROCESS_INSTANCES.toString());
+
+      // Expect that flow node instances have been created on checkPayment in all process instances
+      await expect(
+        processesPage.diagram.diagram.getByTestId(
+          'state-overlay-checkPayment-canceled',
+        ),
+      ).toHaveText(NUM_SELECTED_PROCESS_INSTANCES.toString());
+    });
+  },
+);

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.test.tsx
@@ -261,7 +261,7 @@ describe('DiagramPanel', () => {
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
     await waitFor(() => expect(handleFetchErrorSpy).toHaveBeenCalled());
-    expect(screen.queryByTestId('state-overlay')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/^state-overlay/)).not.toBeInTheDocument();
   });
 
   it('should render statistics', async () => {
@@ -280,7 +280,7 @@ describe('DiagramPanel', () => {
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
-    expect(await screen.findByTestId('state-overlay')).toBeInTheDocument();
+    expect(await screen.findByTestId(/^state-overlay/)).toBeInTheDocument();
   });
 
   it('should clear statistics before fetching new statistics', async () => {
@@ -299,7 +299,7 @@ describe('DiagramPanel', () => {
     });
 
     expect(await screen.findByTestId('diagram')).toBeInTheDocument();
-    expect(await screen.findByTestId('state-overlay')).toBeInTheDocument();
+    expect(await screen.findByTestId(/^state-overlay/)).toBeInTheDocument();
 
     mockFetchProcessInstancesStatistics().withServerError();
 
@@ -307,7 +307,7 @@ describe('DiagramPanel', () => {
       await processStatisticsStore.fetchProcessStatistics();
     });
 
-    expect(screen.queryByTestId('state-overlay')).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/^state-overlay/)).not.toBeInTheDocument();
   });
 
   it('should render batch modification notification', async () => {

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.tsx
@@ -237,6 +237,7 @@ const DiagramPanel: React.FC = observer(() => {
 
               return (
                 <StateOverlay
+                  testId={`state-overlay-${overlay.flowNodeId}-${payload.flowNodeState}`}
                   key={`${overlay.flowNodeId}-${payload.flowNodeState}`}
                   state={payload.flowNodeState}
                   count={payload.count}

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/index.tsx
@@ -40,7 +40,11 @@ const BatchModificationFooter: React.FC = observer(() => {
         </Button>
         <ModalStateManager
           renderLauncher={({setOpen}) => (
-            <Button size="sm" disabled={isButtonDisabled} onClick={setOpen}>
+            <Button
+              size="sm"
+              disabled={isButtonDisabled}
+              onClick={() => setOpen(true)}
+            >
               Apply Modification
             </Button>
           )}

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -101,8 +101,15 @@ const InstancesTable: React.FC = observer(() => {
       return;
     }
 
+    const processInstanceFilters = getProcessInstanceFilters(location.search);
+    const filteredIds = processInstanceFilters.ids?.split(/[\s,]+/);
+    const ids = ['EXCLUDE', 'ALL'].includes(selectionMode)
+      ? filteredIds ?? []
+      : selectedProcessInstanceIds;
+
     const requestFilterParameters = {
-      ids: selectedProcessInstanceIds,
+      ...processInstanceFilters,
+      ids,
       excludeIds: excludedProcessInstanceIds,
       finished: false,
       completed: false,
@@ -117,6 +124,7 @@ const InstancesTable: React.FC = observer(() => {
     excludedProcessInstanceIds,
     isBatchModificationEnabled,
     selectionMode,
+    location.search,
   ]);
 
   const getEmptyListMessage = () => {

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -16,10 +16,7 @@
  */
 
 import {RequestHandler, rest} from 'msw';
-import {
-  IS_BATCH_MOVE_MODIFICATION_ENABLED,
-  IS_OPERATIONS_PANEL_IMPROVEMENT_ENABLED,
-} from 'modules/feature-flags';
+import {IS_OPERATIONS_PANEL_IMPROVEMENT_ENABLED} from 'modules/feature-flags';
 
 const mocks = [
   {completedOperationsCount: 1, failedOperationsCount: 0, instancesCount: 1}, //delete instance
@@ -48,38 +45,6 @@ const batchOperationHandlers = IS_OPERATIONS_PANEL_IMPROVEMENT_ENABLED
     ]
   : [];
 
-const batchModificationHandlers = IS_BATCH_MOVE_MODIFICATION_ENABLED
-  ? [
-      rest.post(
-        '/api/process-instances/batch-operation',
-        async (req, res, ctx) => {
-          const request = await req.json();
-
-          if (request.operationType !== 'MODIFY_PROCESS_INSTANCE') {
-            return req.passthrough();
-          }
-
-          return res(
-            ctx.json({
-              id: '0b10e52c-a13c-424a-b83a-057ae99c64af',
-              name: null,
-              type: 'MOVE_TOKEN',
-              startDate: '2023-11-16T09:45:05.427+0100',
-              endDate: null,
-              username: 'demo',
-              instancesCount: 1,
-              operationsTotalCount: 1,
-              operationsFinishedCount: 0,
-            }),
-          );
-        },
-      ),
-    ]
-  : [];
-
-const handlers: RequestHandler[] = [
-  ...batchOperationHandlers,
-  ...batchModificationHandlers,
-];
+const handlers: RequestHandler[] = [...batchOperationHandlers];
 
 export {handlers};


### PR DESCRIPTION
## Description

- fix a but where the wrong number of process instances was displayed in case process instance ids were filtered in modification mode (https://github.com/camunda/zeebe/commit/8787def5d8944515a4892f3231a57f1fa594449a)
- fix an issue where setOpen has not been called with boolean (https://github.com/camunda/zeebe/commit/5256c113bc463c7dbe994dde8524313e3dacc086)
- remove batch modification API mock, since the backend API is now merged (https://github.com/camunda/zeebe/commit/67d94e078678d81a04414aa43f0b3a56e09cd194)
- add e2e test for process instance batch modification (https://github.com/camunda/zeebe/commit/4331d2cdda9e18d7cabd1521002cc21dd8b6099a)

## Related issues

closes https://github.com/camunda/operate/issues/6244
