### PR TITLE
ci: skip Docker push in operate-merge-ci

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -119,6 +119,7 @@ jobs:
         with:
           tags: ${{ steps.meta.outputs.tags }}
           push: ${{ inputs.pushDocker }}
+          platforms: ${{ inputs.pushDocker && 'linux/arm64,linux/amd64' || 'linux/amd64' }}
 
       #########################################################################
       # Docker login for snapshot deployment

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -21,6 +21,7 @@ on:
         type: string
       pushDocker:
         description: "whether the built docker images are pushed to camunda registry"
+        type: boolean
         default: true
 
 defaults:

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -19,6 +19,9 @@ on:
         description: "The branch name to be used for the workflow"
         required: true
         type: string
+      pushDocker:
+        description: "whether the built docker images are pushed to camunda registry"
+        default: true
 
 defaults:
   run:
@@ -114,7 +117,7 @@ jobs:
         uses: ./.github/actions/build-operate-docker
         with:
           tags: ${{ steps.meta.outputs.tags }}
-          push: true
+          push: ${{ inputs.pushDocker }}
 
       #########################################################################
       # Docker login for snapshot deployment

--- a/.github/workflows/operate-merge-ci.yaml
+++ b/.github/workflows/operate-merge-ci.yaml
@@ -2,7 +2,7 @@ name: Operate merge queue CI
 
 on:
   merge_group: { }
-  pull_request: { }    
+  pull_request: { }
   workflow_dispatch: { }
 
 
@@ -13,6 +13,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
+      pushDocker: false
 
   operate-ci-test-summary:
     # Used by the merge queue to check all jobs.


### PR DESCRIPTION
## Description
It is not needed to push the docker image that is built with operate-merge-ci

## Related issues

closes #
