### PR TITLE
Fix broken job stream aggregation across stream restarts

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.shared.management;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonFormat.Feature;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.protocol.impl.stream.job.JobActivationProperties;
 import io.camunda.zeebe.transport.stream.api.ClientStream;
@@ -128,7 +126,8 @@ public final class JobStreamEndpoint {
     return new Metadata(
         BufferUtil.bufferAsString(properties.worker()),
         Duration.ofMillis(properties.timeout()),
-        properties.fetchVariables().stream().map(BufferUtil::bufferAsString).toList());
+        properties.fetchVariables().stream().map(BufferUtil::bufferAsString).toList(),
+        properties.tenantIds());
   }
 
   /** View model for the combined list of all remote and client job streams. */
@@ -151,13 +150,9 @@ public final class JobStreamEndpoint {
   /** View model for the {@link JobActivationProperties} of a job stream. */
   public record Metadata(
       String worker,
-      @JsonFormat(
-              without = {
-                Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS,
-                Feature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS
-              })
-          Duration timeout,
-      Collection<String> fetchVariables) {}
+      Duration timeout,
+      Collection<String> fetchVariables,
+      Collection<String> tenantIds) {}
 
   /** View model for a remote job stream ID */
   public record RemoteStreamId(UUID id, String receiver) {}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -114,7 +114,7 @@ public final class ActivateJobsCommandImpl
 
   @Override
   public ZeebeFuture<ActivateJobsResponse> send() {
-
+    builder.clearTenantIds();
     if (customTenantIds.isEmpty()) {
       builder.addAllTenantIds(defaultTenantIds);
     } else {

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -82,7 +82,7 @@ public final class StreamJobsCommandImpl
 
   @Override
   public ZeebeFuture<StreamJobsResponse> send() {
-
+    builder.clearTenantIds();
     if (customTenantIds.isEmpty()) {
       builder.addAllTenantIds(defaultTenantIds);
     } else {
@@ -158,6 +158,7 @@ public final class StreamJobsCommandImpl
   public StreamJobsCommandStep3 tenantIds(final List<String> tenantIds) {
     customTenantIds.clear();
     customTenantIds.addAll(tenantIds);
+    System.out.println("Tenants: " + customTenantIds);
     return this;
   }
 

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -158,7 +158,6 @@ public final class StreamJobsCommandImpl
   public StreamJobsCommandStep3 tenantIds(final List<String> tenantIds) {
     customTenantIds.clear();
     customTenantIds.addAll(tenantIds);
-    System.out.println("Tenants: " + customTenantIds);
     return this;
   }
 


### PR DESCRIPTION
## Description

Adding tenants to the and job activation and streaming commands can end up accumulating the same tenant IDs over and over if the command builder is reuse to send new commands. This is because the commands keep adding the tenant IDs to the underlying gRPC request, without ever clearing them. So each successive `send()` call would end up accumulating IDs.

Say you use only the default tenant ID (`<default>`), then on the first send it would be `[<default>]`. On the second, `[<default>, <default>]`, and so on.

For job streaming, this would break the aggregation as the tenant IDs are part of the stream aggregation.

This highlights that the aggregation for job streaming is not ideal - for example, if one stream is tenants `foo, bar`, and the other `foo`, then technically any job of type `foo` can go to either of them. This is out of scope for now, but I will open another issue to improve the aggregation.

## Related issues

closes #17513 
