### PR TITLE
[Backport stable/8.5] test: ensure PKCS1 support with REST

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
@@ -67,7 +67,7 @@ final class Pkcs1SupportTest {
 
       // then
       SslAssert.assertThat(
-              new·InetSocketAddress(zeebe.getExternalHost(),·zeebe.getMappedPort(8080)))
+              new InetSocketAddress(zeebe.getExternalHost(), zeebe.getMappedPort(8080)))
           .isSecuredBy(certificate);
       SslAssert.assertThat(
               new InetSocketAddress(

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
@@ -49,6 +49,10 @@ final class Pkcs1SupportTest {
                 containerCertPath)
             .withCopyFileToContainer(
                 MountableFile.forHostPath(pkcs1Key.toPath(), 511), containerKeyPath)
+            .withAdditionalExposedPort(8080)
+            .withEnv("SERVER_SSL_ENABLED", "true")
+            .withEnv("SERVER_SSL_CERTIFICATE", containerCertPath)
+            .withEnv("SERVER_SSL_CERTIFICATEPRIVATEKEY", containerKeyPath)
             .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_ENABLED", "true")
             .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_CERTIFICATECHAINPATH", containerCertPath)
             .withEnv("ZEEBE_BROKER_NETWORK_SECURITY_PRIVATEKEYPATH", containerKeyPath)
@@ -62,6 +66,10 @@ final class Pkcs1SupportTest {
       zeebe.start();
 
       // then
+      SslAssert.assertThat(
+              new InetSocketAddress(
+                  zeebe.getExternalHost(), zeebe.getMappedPort(8080)))
+          .isSecuredBy(certificate);
       SslAssert.assertThat(
               new InetSocketAddress(
                   zeebe.getExternalHost(), zeebe.getMappedPort(ZeebePort.INTERNAL.getPort())))

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/security/Pkcs1SupportTest.java
@@ -67,8 +67,7 @@ final class Pkcs1SupportTest {
 
       // then
       SslAssert.assertThat(
-              new InetSocketAddress(
-                  zeebe.getExternalHost(), zeebe.getMappedPort(8080)))
+              new·InetSocketAddress(zeebe.getExternalHost(),·zeebe.getMappedPort(8080)))
           .isSecuredBy(certificate);
       SslAssert.assertThat(
               new InetSocketAddress(


### PR DESCRIPTION
# Description
Backport of #17216 to `stable/8.5`.

relates to 
original author: @npepinpe