### PR TITLE
feat: Implement process-level Execution Listener support

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -29,10 +29,14 @@ import java.util.function.Consumer;
 /**
  * @author Sebastian Menski
  */
-public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
+public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder>
+    implements ZeebeExecutionListenersBuilder<ProcessBuilder> {
+
+  private final ZeebeExecutionListenersBuilder<ProcessBuilder> zeebeExecutionListenersBuilder;
 
   public ProcessBuilder(final BpmnModelInstance modelInstance, final Process process) {
     super(modelInstance, process, ProcessBuilder.class);
+    this.zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
   }
 
   public StartEventBuilder startEvent() {
@@ -117,5 +121,31 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder> {
       }
     }
     return lowestheight;
+  }
+
+  @Override
+  public ProcessBuilder zeebeStartExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
+  }
+
+  @Override
+  public ProcessBuilder zeebeStartExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type);
+  }
+
+  @Override
+  public ProcessBuilder zeebeEndExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type, retries);
+  }
+
+  @Override
+  public ProcessBuilder zeebeEndExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type);
+  }
+
+  @Override
+  public ProcessBuilder zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
+    return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -34,6 +34,7 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
   private static final Set<String> ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS =
       new HashSet<>(
           Arrays.asList(
+              BpmnModelConstants.BPMN_ELEMENT_PROCESS,
               BpmnModelConstants.BPMN_ELEMENT_TASK,
               BpmnModelConstants.BPMN_ELEMENT_SEND_TASK,
               BpmnModelConstants.BPMN_ELEMENT_SERVICE_TASK,

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -134,7 +134,7 @@ public class ZeebeExecutionListenersValidationTest {
         expect(
             ZeebeExecutionListeners.class,
             "Execution listeners are not supported for the 'startEvent' element. "
-                + "Currently, only [scriptTask, task, serviceTask, businessRuleTask, manualTask, "
+                + "Currently, only [process, scriptTask, task, serviceTask, businessRuleTask, manualTask, "
                 + "sendTask, receiveTask, userTask] elements can have execution listeners."));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/BpmnStreamProcessor.java
@@ -227,7 +227,7 @@ public final class BpmnStreamProcessor implements TypedRecordProcessor<ProcessIn
 
     if (!(element instanceof final ExecutableFlowNode node)) {
       // other elements, like sequence flows, do not have execution listeners
-      // assume that the element is activated already
+      // assume that the element is processed already
       return BpmnElementProcessor.SUCCESS;
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/ProcessProcessor.java
@@ -56,7 +56,7 @@ public final class ProcessProcessor
   }
 
   @Override
-  public Either<Failure, ?> onActivate(
+  public Either<Failure, ?> finalizeActivation(
       final ExecutableFlowElementContainer element, final BpmnElementContext context) {
     final var activatedContext =
         stateTransitionBehavior.transitionToActivated(context, element.getEventType());
@@ -70,6 +70,12 @@ public final class ProcessProcessor
 
     eventSubscriptionBehavior.unsubscribeFromEvents(context);
     compensationSubscriptionBehaviour.deleteSubscriptionsOfProcessInstance(context);
+    return SUCCESS;
+  }
+
+  @Override
+  public Either<Failure, ?> finalizeCompletion(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
 
     // we need to send the result before we transition to completed, since the
     // event applier will delete the element instance

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventSubProcessInterruptionMarker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventSubProcessInterruptionMarker.java
@@ -43,6 +43,7 @@ public class EventSubProcessInterruptionMarker {
         processState.getFlowElement(
             processDefinitionKey, tenantId, elementId, ExecutableFlowElement.class);
     if (!isRootStartEvent(flowScopeElementInstanceKey)
+        && flowElement.getFlowScope() != null
         && flowElement.getFlowScope().getElementType() == BpmnElementType.EVENT_SUB_PROCESS
         && flowElement instanceof ExecutableStartEvent
         && ((ExecutableStartEvent) flowElement).isInterrupting()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCompletedApplier.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.protocol.record.value.JobKind;
 
 class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
@@ -38,9 +37,6 @@ class JobCompletedApplier implements TypedEventApplier<JobIntent, JobRecord> {
       final ElementInstance scopeInstance = elementInstanceState.getInstance(scopeKey);
 
       if (scopeInstance != null && scopeInstance.isActive()) {
-        if (value.getJobKind() == JobKind.EXECUTION_LISTENER) {
-          elementInstance.incrementExecutionListenerIndex();
-        }
         elementInstance.setJobKey(-1);
         elementInstanceState.updateInstance(elementInstance);
       }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobCreatedApplier.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableJobState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 
 final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord> {
 
@@ -34,6 +35,9 @@ final class JobCreatedApplier implements TypedEventApplier<JobIntent, JobRecord>
       final ElementInstance elementInstance = elementInstanceState.getInstance(elementInstanceKey);
 
       if (elementInstance != null) {
+        if (value.getJobKind() == JobKind.EXECUTION_LISTENER) {
+          elementInstance.incrementExecutionListenerIndex();
+        }
         elementInstance.setJobKey(key);
         elementInstanceState.updateInstance(elementInstance);
       }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTest.java
@@ -8,12 +8,17 @@
 package io.camunda.zeebe.engine.processing.bpmn.activity;
 
 import static io.camunda.zeebe.test.util.record.RecordingExporter.jobRecords;
+import static io.camunda.zeebe.test.util.record.RecordingExporter.records;
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -23,11 +28,11 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
-import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.VariableRecordValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,16 +42,16 @@ public class ExecutionListenerTest {
 
   private static final String PROCESS_ID = "process";
   private static final String SERVICE_TASK_TYPE = "test_service_task";
-  private static final String START_EL_TYPE = "start_execution_listener";
-  private static final String END_EL_TYPE = "end_execution_listener";
+  private static final String START_EL_TYPE = "start_execution_listener_job";
+  private static final String END_EL_TYPE = "end_execution_listener_job";
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
+  // task related tests: start
   @Test
-  public void
-      shouldCreateIncidentWhenCorrelationKeyNotProvidedBeforeProcessingTaskWithMessageBoundaryEvent() {
+  public void shouldCreateIncidentForMissingCorrelationKeyOnMessageBoundaryWithServiceTask() {
     // given
     final BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess(PROCESS_ID)
@@ -87,15 +92,29 @@ public class ExecutionListenerTest {
     // resolve incident
     ENGINE.incident().ofInstance(processInstanceKey).withKey(firstIncident.getKey()).resolve();
 
-    // complete EL[start] job again
+    // complete start EL job again
     completeRecreatedJobWithType(processInstanceKey, START_EL_TYPE);
 
-    // Job for service task should be created
-    verifyJobCreationThenComplete(processInstanceKey, 2, SERVICE_TASK_TYPE, JobKind.BPMN_ELEMENT);
+    // complete service task & end EL jobs
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
 
-    // job for EL[end] should be created
-    assertJobState(
-        processInstanceKey, 3, END_EL_TYPE, JobIntent.CREATED, JobKind.EXECUTION_LISTENER);
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test
@@ -117,27 +136,55 @@ public class ExecutionListenerTest {
 
     // when: complete EL[start] job
     ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
-    // fail service task job
-    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).withRetries(0).fail();
+    // fail service task job with no retries
+    final long failedJobKey =
+        ENGINE
+            .job()
+            .ofInstance(processInstanceKey)
+            .withType(SERVICE_TASK_TYPE)
+            .withRetries(0)
+            .fail()
+            .getKey();
 
-    final Record<IncidentRecordValue> firstIncident =
+    // then: incident created
+    final Record<IncidentRecordValue> incident =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
             .getFirst();
 
-    // and: resolve first incident
-    ENGINE.incident().ofInstance(processInstanceKey).withKey(firstIncident.getKey()).resolve();
-    // complete service task job (NO need to re-complete EL[start] job(s))
-    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasJobKey(failedJobKey)
+        .hasErrorType(ErrorType.JOB_NO_RETRIES)
+        .hasErrorMessage("No more retries left.");
 
-    // then: EL[end] created
-    assertJobState(
-        processInstanceKey, 2, END_EL_TYPE, JobIntent.CREATED, JobKind.EXECUTION_LISTENER);
+    // and: resolve first incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    // complete service task job (NO need to re-complete start EL job(s))
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+    // complete end EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   @Test
-  public void
-      shouldReCreateFirstElJobAfterResolvingIncidentCreatedDuringResolvingServiceJobExpressions() {
+  public void shouldRecreateELJobAfterResolvingServiceJobExpressionIncident() {
     // given
     final BpmnModelInstance modelInstance =
         Bpmn.createExecutableProcess("process")
@@ -152,7 +199,7 @@ public class ExecutionListenerTest {
     ENGINE.deployment().withXmlResource(modelInstance).deploy();
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
-    // when: complete EL[start] job
+    // when: complete start EL job
     ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
 
     // an incident is created due to the unresolved job type expression in the service task
@@ -166,17 +213,27 @@ public class ExecutionListenerTest {
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """
-               Expected result of the expression 'service_task_job_name_var + "_type"' to be \
-               'STRING', but was 'NULL'. The evaluation reported the following warnings:
-               [NO_VARIABLE_FOUND] No variable found with name 'service_task_job_name_var'
-               [INVALID_TYPE] Can't add '"_type"' to 'null'""");
+             Expected result of the expression 'service_task_job_name_var + "_type"' to be \
+             'STRING', but was 'NULL'. The evaluation reported the following warnings:
+             [NO_VARIABLE_FOUND] No variable found with name 'service_task_job_name_var'
+             [INVALID_TYPE] Can't add '"_type"' to 'null'""");
 
     // and: resolve incident
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
 
-    // then: the first EL[start] job is re-created
-    assertJobState(
-        processInstanceKey, 1, START_EL_TYPE, JobIntent.CREATED, JobKind.EXECUTION_LISTENER);
+    // then: the first start EL job is recreated
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .onlyEvents()
+                .limit(3))
+        .extracting(Record::getIntent, r -> r.getValue().getType())
+        .containsSequence(
+            tuple(JobIntent.CREATED, START_EL_TYPE),
+            tuple(JobIntent.COMPLETED, START_EL_TYPE),
+            // recreated start EL job
+            tuple(JobIntent.CREATED, START_EL_TYPE));
   }
 
   @Test
@@ -249,7 +306,7 @@ public class ExecutionListenerTest {
         Bpmn.createExecutableProcess(PROCESS_ID)
             .startEvent()
             .serviceTask(
-                "A",
+                "task",
                 t ->
                     t.zeebeJobType(SERVICE_TASK_TYPE)
                         .zeebeStartExecutionListener(START_EL_TYPE)
@@ -283,6 +340,423 @@ public class ExecutionListenerTest {
             "Expected to throw an error event with the code 'err', but it was not caught. No error events are available in the scope.");
   }
 
+  // task related tests: end
+
+  // process related tests: start
+  @Test
+  public void shouldCompleteProcessWithMultipleExecutionListeners() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeStartExecutionListener(START_EL_TYPE + "_1")
+                .zeebeStartExecutionListener(START_EL_TYPE + "_2")
+                .zeebeEndExecutionListener(END_EL_TYPE + "_1")
+                .zeebeEndExecutionListener(END_EL_TYPE + "_2")
+                .startEvent()
+                .endEvent()
+                .done());
+
+    // when: complete the start execution listener jobs
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_2").complete();
+
+    // complete the end execution listener jobs
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_2").complete();
+
+    // then: EL jobs completed in expected order
+    assertExecutionListenerJobsCompletedForElement(
+        processInstanceKey,
+        PROCESS_ID,
+        START_EL_TYPE + "_1",
+        START_EL_TYPE + "_2",
+        END_EL_TYPE + "_1",
+        END_EL_TYPE + "_2");
+
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldRetryProcessStartExecutionListenerAfterFailure() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeStartExecutionListener(START_EL_TYPE)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .startEvent()
+                .endEvent()
+                .done());
+
+    // when: fail start EL with retries
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).withRetries(1).fail();
+    // complete failed start EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+    // complete end EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: assert the start EL job was completed after the failure
+    assertThat(records().betweenProcessInstance(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(ValueType.JOB, JobIntent.CREATED),
+            tuple(ValueType.JOB, JobIntent.FAILED),
+            tuple(ValueType.JOB, JobIntent.COMPLETE),
+            tuple(ValueType.JOB, JobIntent.COMPLETED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_ACTIVATED));
+
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldRetryProcessEndExecutionListenerAfterFailure() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeStartExecutionListener(START_EL_TYPE)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .startEvent()
+                .endEvent()
+                .done());
+
+    // complete start EL
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+
+    // when: fail end EL with retries
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).withRetries(1).fail();
+    // complete failed end EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: assert the end EL job was completed after the failure
+    assertThat(records().betweenProcessInstance(processInstanceKey))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsSubsequence(
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(ValueType.JOB, JobIntent.CREATED),
+            tuple(ValueType.JOB, JobIntent.FAILED),
+            tuple(ValueType.JOB, JobIntent.COMPLETE),
+            tuple(ValueType.JOB, JobIntent.COMPLETED),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(ValueType.PROCESS_INSTANCE, ProcessInstanceIntent.ELEMENT_COMPLETED));
+
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldRecreateProcessStartExecutionListenerJobsAndProceedAfterIncidentResolution() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeExecutionListener(el -> el.start().type(START_EL_TYPE + "_1"))
+                .zeebeExecutionListener(el -> el.start().typeExpression("start_el_2_name_var"))
+                .zeebeExecutionListener(el -> el.end().type(END_EL_TYPE))
+                .startEvent()
+                .manualTask()
+                .endEvent()
+                .done());
+
+    // when: compete first EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_1").complete();
+
+    // then: incident for the second EL should be raised due to missing `start_el_2_name_var` var
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+                Expected result of the expression 'start_el_2_name_var' to be 'STRING', but was 'NULL'. \
+                The evaluation reported the following warnings:
+                [NO_VARIABLE_FOUND] No variable found with name 'start_el_2_name_var'""");
+
+    // fix issue with missing `start_el_2_name_var` variable, required by 2nd start EL
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("start_el_2_name_var", START_EL_TYPE + "_evaluated_2"))
+        .update();
+    // and: resolve incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+    // then: complete 1st re-created start EL job
+    completeRecreatedJobWithType(processInstanceKey, START_EL_TYPE + "_1");
+    // complete 2nd start EL
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_evaluated_2").complete();
+
+    // complete end EL
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: assert that the first start EL job was re-created
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .limit(6)
+                .onlyEvents())
+        .extracting(r -> r.getValue().getType(), Record::getIntent)
+        .containsSequence(
+            tuple(START_EL_TYPE + "_1", JobIntent.CREATED),
+            tuple(START_EL_TYPE + "_1", JobIntent.COMPLETED),
+            // 1st start EL job recreated
+            tuple(START_EL_TYPE + "_1", JobIntent.CREATED),
+            tuple(START_EL_TYPE + "_1", JobIntent.COMPLETED),
+            // last start EL job processing
+            tuple(START_EL_TYPE + "_evaluated_2", JobIntent.CREATED),
+            tuple(START_EL_TYPE + "_evaluated_2", JobIntent.COMPLETED));
+
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldRecreateProcessEndExecutionListenerJobsAndProceedAfterIncidentResolution() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeExecutionListener(el -> el.start().type(START_EL_TYPE))
+                .zeebeExecutionListener(el -> el.end().type(END_EL_TYPE + "_1"))
+                .zeebeExecutionListener(el -> el.end().typeExpression("end_el_2_name_var"))
+                .startEvent()
+                .manualTask()
+                .endEvent()
+                .done());
+
+    // compete start EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+
+    // when: complete 1st end EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_1").complete();
+
+    // then: incident for the second EL should be raised due to missing `end_el_2_name_var` var
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incident.getValue())
+        .hasProcessInstanceKey(processInstanceKey)
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            """
+                Expected result of the expression 'end_el_2_name_var' to be 'STRING', but was 'NULL'. \
+                The evaluation reported the following warnings:
+                [NO_VARIABLE_FOUND] No variable found with name 'end_el_2_name_var'""");
+
+    // fix issue with missing `end_el_3_name_var` variable, required by 2nd EL[start]
+    ENGINE
+        .variables()
+        .ofScope(processInstanceKey)
+        .withDocument(Map.of("end_el_2_name_var", END_EL_TYPE + "_evaluated_2"))
+        .update();
+    // resolve incident
+    ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    // then: complete 1st re-created end EL job
+    completeRecreatedJobWithType(processInstanceKey, END_EL_TYPE + "_1");
+    // complete last end EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_evaluated_2").complete();
+
+    // then: assert that the 1st & 2nd end EL job were re-created
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .limit(8)
+                .onlyEvents())
+        .extracting(r -> r.getValue().getType(), Record::getIntent)
+        .containsSequence(
+            // start EL job processing
+            tuple(START_EL_TYPE, JobIntent.CREATED),
+            tuple(START_EL_TYPE, JobIntent.COMPLETED),
+            // end EL jobs processing
+            tuple(END_EL_TYPE + "_1", JobIntent.CREATED),
+            tuple(END_EL_TYPE + "_1", JobIntent.COMPLETED),
+            // re-created 1st end EL job
+            tuple(END_EL_TYPE + "_1", JobIntent.CREATED),
+            tuple(END_EL_TYPE + "_1", JobIntent.COMPLETED),
+            // last end EL job processing after incident resolution
+            tuple(END_EL_TYPE + "_evaluated_2", JobIntent.CREATED),
+            tuple(END_EL_TYPE + "_evaluated_2", JobIntent.COMPLETED));
+
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldAllowServiceTaskToAccessVariableFromProcessStartListener() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeStartExecutionListener(START_EL_TYPE)
+                .startEvent()
+                .serviceTask("task", b -> b.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent()
+                .done());
+
+    // when: complete start EL job with `bar` variable
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(START_EL_TYPE)
+        .withVariable("bar", 1)
+        .complete();
+
+    // then: assert the variable was created after start EL completion
+    assertThat(records().withValueTypes(ValueType.JOB, ValueType.VARIABLE).onlyEvents().limit(3))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsExactly(
+            tuple(ValueType.JOB, JobIntent.CREATED),
+            tuple(ValueType.JOB, JobIntent.COMPLETED),
+            tuple(ValueType.VARIABLE, VariableIntent.CREATED));
+
+    // `bar` variable accessible in service task job
+    final Optional<JobRecordValue> jobActivated =
+        ENGINE.jobs().withType(SERVICE_TASK_TYPE).activate().getValue().getJobs().stream()
+            .filter(job -> job.getProcessInstanceKey() == processInstanceKey)
+            .findFirst();
+
+    assertThat(jobActivated)
+        .hasValueSatisfying(job -> assertThat(job.getVariables()).contains(entry("bar", 1)));
+  }
+
+  @Test
+  public void shouldEvaluateExpressionsForProcessExecutionListeners() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeExecutionListener(el -> el.start().type(START_EL_TYPE + "_1"))
+                .zeebeExecutionListener(
+                    el ->
+                        el.start().typeExpression("listenerNameVar").retriesExpression("elRetries"))
+                .zeebeExecutionListener(
+                    el -> el.end().type(END_EL_TYPE).retriesExpression("elRetries + 5"))
+                .startEvent()
+                .endEvent()
+                .done());
+
+    // complete 1st start EL with variables that will be used in expressions by the 2nd stat EL
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(START_EL_TYPE + "_1")
+        .withVariables(Map.of("elRetries", 6, "listenerNameVar", START_EL_TYPE + "evaluated_2"))
+        .complete();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "evaluated_2").complete();
+
+    // complete end EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: assert the EL job completed with expected evaluated `type` and `retries` props
+    assertThat(
+            jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .onlyEvents()
+                .limit(3))
+        .extracting(r -> r.getValue().getType(), r -> r.getValue().getRetries())
+        .containsExactly(
+            tuple(START_EL_TYPE + "_1", 3),
+            tuple(START_EL_TYPE + "evaluated_2", 6),
+            tuple(END_EL_TYPE, 11));
+  }
+
+  // process related tests: end
+
+  // test util methods
+  private static long createProcessInstance(BpmnModelInstance modelInstance) {
+    ENGINE.deployment().withXmlResource(modelInstance).deploy();
+    return ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+  }
+
   private static void completeRecreatedJobWithType(
       final long processInstanceKey, final String jobType) {
     final long jobKey =
@@ -295,7 +769,7 @@ public class ExecutionListenerTest {
     ENGINE.job().ofInstance(processInstanceKey).withKey(jobKey).complete();
   }
 
-  private void assertVariable(
+  private static void assertVariable(
       final long processInstanceKey,
       final VariableIntent intent,
       final String varName,
@@ -311,47 +785,16 @@ public class ExecutionListenerTest {
         .hasValue(expectedVarValue);
   }
 
-  private void assertJobState(
-      final long processInstanceKey,
-      final long jobIndex,
-      final String expectedJobType,
-      final JobIntent expectedJobIntent,
-      final JobKind expectedJobKind) {
-    final Record<ProcessInstanceRecordValue> activatingJob =
-        RecordingExporter.processInstanceRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .withIntent(ProcessInstanceIntent.ELEMENT_ACTIVATING)
-            .withElementType(BpmnElementType.SERVICE_TASK)
-            .getFirst();
-
-    final Record<JobRecordValue> jobRecord =
-        jobRecords(expectedJobIntent)
-            .withProcessInstanceKey(processInstanceKey)
-            .skip(jobIndex)
-            .getFirst();
-
-    Assertions.assertThat(jobRecord.getValue())
-        .hasElementInstanceKey(activatingJob.getKey())
-        .hasElementId(activatingJob.getValue().getElementId())
-        .hasProcessDefinitionKey(activatingJob.getValue().getProcessDefinitionKey())
-        .hasBpmnProcessId(activatingJob.getValue().getBpmnProcessId())
-        .hasProcessDefinitionVersion(activatingJob.getValue().getVersion())
-        .hasJobKind(expectedJobKind)
-        .hasType(expectedJobType);
-  }
-
-  private void verifyJobCreationThenComplete(
-      final long processInstanceKey,
-      final long jobIndex,
-      final String jobType,
-      final JobKind jobKind) {
-    // given: assert job created
-    assertJobState(processInstanceKey, jobIndex, jobType, JobIntent.CREATED, jobKind);
-
-    // when: complete job
-    ENGINE.job().ofInstance(processInstanceKey).withType(jobType).complete();
-
-    // then: assert job completed
-    assertJobState(processInstanceKey, jobIndex, jobType, JobIntent.COMPLETED, jobKind);
+  static void assertExecutionListenerJobsCompletedForElement(
+      final long processInstanceKey, String elementId, final String... elJobTypes) {
+    assertThat(
+            RecordingExporter.jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .withElementId(elementId)
+                .limit(elJobTypes.length))
+        .extracting(r -> r.getValue().getType())
+        .containsExactly(elJobTypes);
   }
 }


### PR DESCRIPTION
## Description
This pull request introduces Execution Listener support at the process level within the Zeebe workflow engine. The aim is to enhance monitoring and management capabilities across entire process lifecycles, enabling better control over workflow execution.

**Key Changes:**
- Provided support for Execution Listeners that are triggered during the process activation and completion phases.
- Updated the Zeebe Java builder APIs and `ProcessTransformer.java` to allow users to define process-level Execution Listeners.

## Related issues
closes #16212 
