### PR TITLE
fix: make deprecated brokerContactPoint backward compatible

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ZeebeProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ZeebeProperties.java
@@ -18,6 +18,7 @@ package io.camunda.operate.property;
 
 public class ZeebeProperties {
 
+  private String brokerContactPoint;
   private String gatewayAddress = "localhost:26500";
   private boolean isSecure = false;
   private String certificatePath = null;
@@ -42,12 +43,12 @@ public class ZeebeProperties {
 
   @Deprecated
   public String getBrokerContactPoint() {
-    return gatewayAddress;
+    return brokerContactPoint;
   }
 
   @Deprecated
-  public void setBrokerContactPoint(String brokerContactPoint) {
-    this.gatewayAddress = brokerContactPoint;
+  public void setBrokerContactPoint(final String brokerContactPoint) {
+    this.brokerContactPoint = brokerContactPoint;
   }
 
   public String getGatewayAddress() {

--- a/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
@@ -37,13 +37,15 @@ public class ZeebeConnector {
 
   @Bean // will be closed automatically
   public ZeebeClient zeebeClient() {
-    return newZeebeClient(operateProperties.getZeebe());
+    final var properties = operateProperties.getZeebe();
+    return newZeebeClient(properties);
   }
 
   public ZeebeClient newZeebeClient(final ZeebeProperties zeebeProperties) {
+    final var gatewayAdress = getGatewayAddress(zeebeProperties);
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder()
-            .gatewayAddress(zeebeProperties.getGatewayAddress())
+            .gatewayAddress(gatewayAdress)
             .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE);
     if (zeebeProperties.isSecure()) {
       builder.caCertificatePath(zeebeProperties.getCertificatePath());
@@ -53,5 +55,20 @@ public class ZeebeConnector {
       LOGGER.info("Use plaintext connection to zeebe");
     }
     return builder.build();
+  }
+
+  private String getGatewayAddress(final ZeebeProperties properties) {
+    final String address;
+
+    final var deprecatedBrokerContactPoint = properties.getBrokerContactPoint();
+    final var gatewayAddress = properties.getGatewayAddress();
+
+    if (deprecatedBrokerContactPoint != null) {
+      address = deprecatedBrokerContactPoint;
+    } else {
+      address = gatewayAddress;
+    }
+
+    return address;
   }
 }


### PR DESCRIPTION
## Description

With #17062, the `application.yml` moved to `application.yaml` which configures a `gatewayAddress` (default `localhost:26500`). When users will update to 8.6.0, they might end up in a situation having their `application.yml` next to the `application.yaml` (coming with the distribution). In the `application.yml` they set the `brokerContactPoint` to `zeebe-service:26500`, so that the following happens:

1. Spring loads `application.yml`
2. `brokerContactPoint` is set to `zeebe-service:26500`, but internally, Operate sets the `gatewayAddress` property to `zeebe-service:26500`
3. Spring loads `application.yaml` (which is contained by the distribution)
4. `gatewayAddress` is set to `localhost:26500`, basically, Operate overwrites the previous value. And since the property name is different, Spring cannot recognize that `brokerContactPoint` and `gatewayAddress` are meant to be the same property.

To avoid overwriting the value, this PR uses `brokerContactPoint` when set, otherwise, the `gatewayAddress` is used to set up the Zeebe client.

## Related issues

closes #
