### PR TITLE
[Backport stable/8.3] Fix broken job stream aggregation across stream restarts

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -113,7 +113,7 @@ public final class ActivateJobsCommandImpl
 
   @Override
   public ZeebeFuture<ActivateJobsResponse> send() {
-
+    builder.clearTenantIds();
     if (customTenantIds.isEmpty()) {
       builder.addAllTenantIds(defaultTenantIds);
     } else {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -81,7 +81,7 @@ public final class StreamJobsCommandImpl
 
   @Override
   public ZeebeFuture<StreamJobsResponse> send() {
-
+    builder.clearTenantIds();
     if (customTenantIds.isEmpty()) {
       builder.addAllTenantIds(defaultTenantIds);
     } else {
@@ -157,6 +157,7 @@ public final class StreamJobsCommandImpl
   public StreamJobsCommandStep3 tenantIds(final List<String> tenantIds) {
     customTenantIds.clear();
     customTenantIds.addAll(tenantIds);
+    System.out.println("Tenants: " + customTenantIds);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/StreamJobsCommandImpl.java
@@ -157,7 +157,6 @@ public final class StreamJobsCommandImpl
   public StreamJobsCommandStep3 tenantIds(final List<String> tenantIds) {
     customTenantIds.clear();
     customTenantIds.addAll(tenantIds);
-    System.out.println("Tenants: " + customTenantIds);
     return this;
   }
 

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/JobStreamEndpoint.java
@@ -126,7 +126,8 @@ public final class JobStreamEndpoint {
     return new Metadata(
         BufferUtil.bufferAsString(properties.worker()),
         Duration.ofMillis(properties.timeout()),
-        properties.fetchVariables().stream().map(BufferUtil::bufferAsString).toList());
+        properties.fetchVariables().stream().map(BufferUtil::bufferAsString).toList(),
+        properties.tenantIds());
   }
 
   /** View model for the combined list of all remote and client job streams. */
@@ -147,7 +148,11 @@ public final class JobStreamEndpoint {
       implements JobStream {}
 
   /** View model for the {@link JobActivationProperties} of a job stream. */
-  public record Metadata(String worker, Duration timeout, Collection<String> fetchVariables) {}
+  public record Metadata(
+      String worker,
+      Duration timeout,
+      Collection<String> fetchVariables,
+      Collection<String> tenantIds) {}
 
   /** View model for a remote job stream ID */
   public record RemoteStreamId(UUID id, String receiver) {}


### PR DESCRIPTION
# Description
Backport of #17545 to `stable/8.3`.

> [!Note]
> There was a very small conflict in the `JobStreamEndpoint` actuator around the `Metadata` record, I guess because of the annotations, but nothing major.

relates to #17513
original author: @npepinpe