### PR TITLE
ci: allow using partial reports of failed version compatibility check runs

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -25,7 +25,7 @@ jobs:
         id: get-last-run-id
         run: |
           runs=$(gh api /repos/camunda/zeebe/actions/workflows/zeebe-version-compatibility.yml/runs)
-          last_run_id=$(echo $runs | jq 'first(.workflow_runs[] | select((.status=="completed") and (.conclusion=="success")).id)')
+          last_run_id=$(echo $runs | jq 'first(.workflow_runs[] | select(.status=="completed").id)')
           echo "last_run_id=$last_run_id" >> $GITHUB_OUTPUT
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description
Even when a previous run fails (for example because it timed out), we can use the report to continue where we left of.
This will help the workflow to make progress now that we released new versions: https://github.com/camunda/zeebe/actions/workflows/zeebe-version-compatibility.yml