### PR TITLE
fix: set TransportOptions for OpenSearch requests

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/opensearch/ExtendedOpenSearchClient.java
+++ b/operate/common/src/main/java/io/camunda/operate/opensearch/ExtendedOpenSearchClient.java
@@ -47,12 +47,12 @@ public class ExtendedOpenSearchClient extends OpenSearchClient {
   private static final String DOCUMENT_ATTR =
       "org.opensearch.client:Deserializer:_global.search.TDocument";
 
-  public ExtendedOpenSearchClient(OpenSearchTransport transport) {
+  public ExtendedOpenSearchClient(final OpenSearchTransport transport) {
     super(transport);
   }
 
   private static <R> SimpleEndpoint<Map<String, Object>, R> arbitraryEndpoint(
-      String method, String path, JsonpDeserializer<R> responseParser) {
+      final String method, final String path, final JsonpDeserializer<R> responseParser) {
     return new SimpleEndpoint<>(
         request -> method, // Request method
         request -> path, // Request path
@@ -66,11 +66,11 @@ public class ExtendedOpenSearchClient extends OpenSearchClient {
     return ((JacksonJsonpMapper) transport.jsonpMapper()).objectMapper();
   }
 
-  private Map<String, Object> jsonToMap(String json) throws JsonProcessingException {
+  private Map<String, Object> jsonToMap(final String json) throws JsonProcessingException {
     return objectMapper().readValue(json, new TypeReference<>() {});
   }
 
-  private String json(SearchRequest request) {
+  private String json(final SearchRequest request) {
     final ByteArrayOutputStream baos = new ByteArrayOutputStream();
     final JsonGenerator generator = transport.jsonpMapper().jsonProvider().createGenerator(baos);
     request.serialize(generator, transport.jsonpMapper());
@@ -88,7 +88,7 @@ public class ExtendedOpenSearchClient extends OpenSearchClient {
   /*
 
   */
-  private String fixSearchAfter(String json) {
+  private String fixSearchAfter(final String json) {
     final Matcher m = SEARCH_AFTER_PATTERN.matcher(json);
     if (m.find()) {
       final var searchAfter = m.group(1); // Find "searchAfter" block in search request
@@ -103,7 +103,7 @@ public class ExtendedOpenSearchClient extends OpenSearchClient {
   }
 
   public <TDocument> SearchResponse<TDocument> fixedSearch(
-      SearchRequest request, Class<TDocument> tDocumentClass)
+      final SearchRequest request, final Class<TDocument> tDocumentClass)
       throws IOException, OpenSearchException {
     final var path = format("/%s/_search", join(",", request.index()));
     JsonEndpoint<Map<String, Object>, SearchResponse<Object>, ErrorResponse> endpoint =
@@ -117,24 +117,24 @@ public class ExtendedOpenSearchClient extends OpenSearchClient {
     return (SearchResponse<TDocument>) arbitraryRequest(requestJson, endpoint);
   }
 
-  public Map<String, Object> searchAsMap(SearchRequest request)
+  public Map<String, Object> searchAsMap(final SearchRequest request)
       throws IOException, OpenSearchException {
     final JsonEndpoint<SearchRequest, HashMap, ErrorResponse> endpoint =
         SearchRequest._ENDPOINT.withResponseDeserializer(getDeserializer(HashMap.class));
-
-    return transport.performRequest(request, endpoint, null);
+    return transport.performRequest(request, endpoint, transport.options());
   }
 
-  public Map<String, Object> arbitraryRequest(String method, String path, String json)
+  public Map<String, Object> arbitraryRequest(
+      final String method, final String path, final String json)
       throws IOException, OpenSearchException {
     final JsonEndpoint<Map<String, Object>, HashMap, ErrorResponse> endpoint =
-        arbitraryEndpoint(method, path, this.getDeserializer(HashMap.class));
+        arbitraryEndpoint(method, path, getDeserializer(HashMap.class));
     return arbitraryRequest(json, endpoint);
   }
 
   private <R> R arbitraryRequest(
-      String json, JsonEndpoint<Map<String, Object>, R, ErrorResponse> endpoint)
+      final String json, final JsonEndpoint<Map<String, Object>, R, ErrorResponse> endpoint)
       throws IOException, OpenSearchException {
-    return transport.performRequest(jsonToMap(json), endpoint, null);
+    return transport.performRequest(jsonToMap(json), endpoint, transport.options());
   }
 }

--- a/operate/common/src/test/java/io/camunda/operate/opensearch/ExtendedOpenSearchClientTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/opensearch/ExtendedOpenSearchClientTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.opensearch;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.transport.Endpoint;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.TransportOptions;
+
+@ExtendWith(MockitoExtension.class)
+class ExtendedOpenSearchClientTest {
+
+  private @Mock OpenSearchTransport transport;
+  private ExtendedOpenSearchClient extendedClient;
+
+  @BeforeEach
+  void setUp() {
+    extendedClient = new ExtendedOpenSearchClient(transport);
+    assertThat(extendedClient).isNotNull();
+  }
+
+  @Test
+  void shouldUseTransportOptionsInArbitraryRequest() throws IOException {
+    when(transport.jsonpMapper()).thenReturn(new JacksonJsonpMapper());
+    when(transport.options()).thenReturn(mock(TransportOptions.class));
+    extendedClient.arbitraryRequest("GET", "/_snapshot/backups/camunda-part-1", "{}");
+    verify(transport).performRequest(anyMap(), any(Endpoint.class), any(TransportOptions.class));
+  }
+
+  @Test
+  void shouldUseTransportOptionsInSearchAsMap() throws IOException {
+    when(transport.options()).thenReturn(mock(TransportOptions.class));
+    extendedClient.searchAsMap(new SearchRequest.Builder().build());
+    verify(transport)
+        .performRequest(any(SearchRequest.class), any(Endpoint.class), any(TransportOptions.class));
+  }
+}


### PR DESCRIPTION
## Description

* Sets `TransportOptions` in requests
* Add test that `TransportOptions` are always set
~~* Use OpenSearch `2.5.0` docker image in developer environment (`docker-compose.yml`)~~
* Needs backport to all 8.x branches which uses OpenSearch.

## Related issues

Related with #17552 
