### PR TITLE
fix: Prevent SaaS profile requests on public forms

### DIFF
--- a/tasklist/client/src/App.tsx
+++ b/tasklist/client/src/App.tsx
@@ -34,7 +34,6 @@ import {TrackPagination} from 'modules/tracking/TrackPagination';
 import {ReactQueryProvider} from 'modules/react-query/ReactQueryProvider';
 import {ErrorWithinLayout, FallbackErrorPage} from 'errorBoundaries';
 import {tracking} from 'modules/tracking';
-import {C3Provider} from 'C3Provider';
 
 const Wrapper: React.FC = () => {
   return (
@@ -93,15 +92,13 @@ const App: React.FC = () => {
 
   return (
     <ErrorBoundary FallbackComponent={FallbackErrorPage}>
-      <C3Provider>
-        <ThemeProvider>
-          <ReactQueryProvider>
-            <Notifications />
-            <NetworkStatusWatcher />
-            <RouterProvider router={router} />
-          </ReactQueryProvider>
-        </ThemeProvider>
-      </C3Provider>
+      <ThemeProvider>
+        <ReactQueryProvider>
+          <Notifications />
+          <NetworkStatusWatcher />
+          <RouterProvider router={router} />
+        </ReactQueryProvider>
+      </ThemeProvider>
     </ErrorBoundary>
   );
 };

--- a/tasklist/client/src/Layout/index.tsx
+++ b/tasklist/client/src/Layout/index.tsx
@@ -22,14 +22,17 @@ import {Header} from './Header';
 import {AuthenticationCheck} from 'AuthenticationCheck';
 import {pages} from 'modules/routing';
 import {OSNotifications} from 'OSNotifications';
+import {C3Provider} from 'C3Provider';
 
 const Layout: React.FC = () => {
   return (
-    <AuthenticationCheck redirectPath={pages.login}>
-      <OSNotifications />
-      <Header />
-      <Outlet />
-    </AuthenticationCheck>
+    <C3Provider>
+      <AuthenticationCheck redirectPath={pages.login}>
+        <OSNotifications />
+        <Header />
+        <Outlet />
+      </AuthenticationCheck>
+    </C3Provider>
   );
 };
 


### PR DESCRIPTION
## Description

We added the integration with the SaaS profile endpoints via https://github.com/camunda/tasklist/pull/4881 , but because of the placement of the provider we were making requests in the public forms