### PR TITLE
[backport stable/8.5] deps: Update version.bouncycastle to v1.78.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
     <version.agrona>1.20.0</version.agrona>
     <version.assertj>3.25.3</version.assertj>
     <version.awaitility>4.2.1</version.awaitility>
-    <version.bouncycastle>1.77</version.bouncycastle>
+    <version.bouncycastle>1.78.1</version.bouncycastle>
     <version.camunda>7.20.0</version.camunda>
     <version.checkstyle>10.14.2</version.checkstyle>
     <version.commons-lang>3.14.0</version.commons-lang>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe/pull/17624

## Related issues

To resolve https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6612984
