### PR TITLE
deps: example to exclude certain dependencies from Renovate automerge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -112,6 +112,9 @@
     {
       "description": "Automerge all updates with green CI.",
       "matchPackagePatterns": ["*"],
+      "excludePackagePatterns": [
+        "@types/react"
+      ],
       "automerge": true,
       "addLabels": ["automerge"]
     }


### PR DESCRIPTION
## Description

Now that #17416 enabled Renovate automerge for all dependencies there can be the use case where a (potentially frontend) dependency actually passes CI but still breaks the application.

For those cases it can be useful to temporarily disable automerge for specific dependencies only.

This PR demonstrates how the Renovate configuration can be extended to do that for the (NPM) package identified as `@types/react`. The list can be extended for other packages.

## Related issues

Related to #17416
