### PR TITLE
fix: do not short-circuit retry for force configure request

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -230,19 +230,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   @Override
   public CompletableFuture<ForceConfigureResponse> onForceConfigure(
       final ForceConfigureRequest request) {
-    final Configuration currentConfiguration = raft.getCluster().getConfiguration();
-    if (currentConfiguration != null // this is not expected in a leader
-        && request.newMembers().equals(currentConfiguration.allMembers())) {
-      // It is likely that the previous force configure was successfully completed, and this is a
-      // retry. So just respond success.
-      return CompletableFuture.completedFuture(
-          logResponse(
-              ForceConfigureResponse.builder()
-                  .withStatus(Status.OK)
-                  .withIndex(currentConfiguration.index())
-                  .withTerm(currentConfiguration.term())
-                  .build()));
-    }
 
     // Do not force-configure when you are leader.
     raft.transition(Role.FOLLOWER);


### PR DESCRIPTION
## Description

In the first attempt, both members received the force configure request, the current leader steps down. When the leader role is started the leader comes out of force configuration and also sends the new configuration to the follower. However, it is possible that the first request was interpreted as failed because either the response was lost or the the pod got restarted before it could mark it as completed. When the request is retried, the follower that receives the request accepts its, overwrites the local configuration with force configuration and send the request to the current leader. The current leader sees that the membership already matches the requested configuration, so it simply accepts the requests without overwriting the local configuration. As a result, the follower remains in the force configuration state because the leader will never re-send the normal configuration.

To fix this, we remove the optimization where the leader short-circuit the duplicate force request. Instead, the leader always overwrites the local configuration and go through the whole force configuration process. This is ok because at worst, it will go through another leader election.

## Related issues

closes #17334 
