### PR TITLE
ci: collect build status of operate & tasklist merge queue jobs

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -72,6 +72,7 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
+            secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
             secret/data/products/operate/ci/github-actions OPERATE_CI_ALERT_WEBHOOK_URL;
@@ -146,3 +147,12 @@ jobs:
         if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         run: |
           mvn -f operate org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -P -docker,skipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+
+      #########################################################################
+      # Collect information about build status for central statistics with CI Analytics
+      - uses: camunda/infra-global-github-actions/submit-build-status@main
+        if: always()
+        with:
+          build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
+          gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+          big_query_table_name: "ci-30-162810:prod_ci_analytics.build_status_v2"

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -71,6 +71,7 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
+            secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
             secret/data/products/tasklist/ci/tasklist REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/tasklist/ci/tasklist REGISTRY_HUB_DOCKER_COM_PSW;
 
@@ -148,3 +149,12 @@ jobs:
         if: ${{ env.IS_DEFAULT_BRANCH == 'true' }}
         run: |
           mvn -f tasklist org.sonatype.plugins:nexus-staging-maven-plugin:deploy-staged -DskipTests=true -P -docker,skipFrontendBuild -B -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+
+      #########################################################################
+      # Collect information about build status for central statistics with CI Analytics
+      - uses: camunda/infra-global-github-actions/submit-build-status@main
+        if: always()
+        with:
+          build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
+          gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+          big_query_table_name: "ci-30-162810:prod_ci_analytics.build_status_v2"


### PR DESCRIPTION
## Description

As a follow-up to #17517 a minimal implementation to get observability data for [CI Analytics](https://confluence.camunda.com/display/HAN/CI+Analytics) feature of Operate & Tasklist merge queue tasks.

This monitoring could be added to many more jobs by the teams, I wanted to focus on the merge queue which impacts all teams cross-functionally first.