### PR TITLE
[backport stable/8.2] deps: Update version.bouncycastle to v1.78.1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -39,7 +39,7 @@
     <version.agrona>1.17.2</version.agrona>
     <version.assertj>3.24.2</version.assertj>
     <version.awaitility>4.2.0</version.awaitility>
-    <version.bouncycastle>1.77</version.bouncycastle>
+    <version.bouncycastle>1.78.1</version.bouncycastle>
     <version.camunda>7.18.0</version.camunda>
     <version.checkstyle>10.9.3</version.checkstyle>
     <version.commons-lang>3.12.0</version.commons-lang>


### PR DESCRIPTION
## Description

Backport of https://github.com/camunda/zeebe/pull/17624 / https://github.com/camunda/zeebe/pull/17628 / https://github.com/camunda/zeebe/pull/17667 / https://github.com/camunda/zeebe/pull/17671https://github.com/camunda/zeebe/pull/17671

## Related issues

To resolve https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-6612984