### PR TITLE
fix: use raw REST calls for OpenSearch repository API

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchSnapshotOperations.java
@@ -18,10 +18,10 @@ package io.camunda.operate.store.opensearch.client.sync;
 
 import static java.lang.String.format;
 
+import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.store.opensearch.response.OpenSearchGetSnapshotResponse;
 import io.camunda.operate.store.opensearch.response.OpenSearchSnapshotInfo;
 import io.camunda.operate.store.opensearch.response.SnapshotState;
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.opensearch.client.opensearch.OpenSearchClient;
@@ -34,16 +34,37 @@ public class OpenSearchSnapshotOperations extends OpenSearchSyncOperation {
     super(logger, openSearchClient);
   }
 
-  public GetRepositoryResponse getRepository(final GetRepositoryRequest.Builder requestBuilder)
-      throws IOException {
-    return openSearchClient.snapshot().getRepository(requestBuilder.build());
+  public Map<String, Object> getRepository(final GetRepositoryRequest.Builder requestBuilder) {
+    final var request = requestBuilder.build();
+    final var names = request.name();
+    if (names.isEmpty()) {
+      throw new OperateRuntimeException("Get repository needs at least one name.");
+    }
+    if (names.size() > 1) {
+      logger.warn(
+          "More than one repository names given: {} . Use only first one: {}", names, names.get(0));
+    }
+    final var repository = names.get(0);
+    return withExtendedOpenSearchClient(
+        extendedOpenSearchClient ->
+            safe(
+                () ->
+                    extendedOpenSearchClient.arbitraryRequest(
+                        "GET", String.format("/_snapshot/%s", repository), "{}"),
+                e -> format("Failed to get repository %s", repository)));
   }
 
-  public OpenSearchGetSnapshotResponse get(final GetSnapshotRequest.Builder requestBuilder)
-      throws IOException {
+  public OpenSearchGetSnapshotResponse get(final GetSnapshotRequest.Builder requestBuilder) {
     final var request = requestBuilder.build();
     final var repository = request.repository();
-    final var snapshot = request.snapshot().get(0);
+    final var snapshots = request.snapshot();
+    if (snapshots.size() > 1) {
+      logger.warn(
+          "More than one snapshot names given: {} . Use only first one: {}",
+          snapshots,
+          snapshots.get(0));
+    }
+    final var snapshot = snapshots.get(0);
     final var result =
         withExtendedOpenSearchClient(
             extendedOpenSearchClient ->

--- a/operate/schema/src/test/java/io/camunda/operate/schema/store/opensearch/client/sync/OpenSearchSnapshotOperationsTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/store/opensearch/client/sync/OpenSearchSnapshotOperationsTest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.schema.store.opensearch.client.sync;
+
+import static io.camunda.operate.store.opensearch.dsl.RequestDSL.getSnapshotRequestBuilder;
+import static io.camunda.operate.store.opensearch.dsl.RequestDSL.repositoryRequestBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.opensearch.ExtendedOpenSearchClient;
+import io.camunda.operate.store.opensearch.client.sync.OpenSearchSnapshotOperations;
+import io.camunda.operate.store.opensearch.response.OpenSearchSnapshotInfo;
+import io.camunda.operate.store.opensearch.response.SnapshotState;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.snapshot.GetRepositoryRequest;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class OpenSearchSnapshotOperationsTest {
+
+  @Mock ExtendedOpenSearchClient openSearchClient;
+
+  @Mock Logger logger;
+
+  private OpenSearchSnapshotOperations snapshotOperations;
+
+  @BeforeEach
+  void setUp() {
+    snapshotOperations = new OpenSearchSnapshotOperations(logger, openSearchClient);
+    assertThat(snapshotOperations).isNotNull();
+  }
+
+  @Test
+  void shouldThrowExceptionForNoRepository() {
+    final var exception =
+        assertThrows(
+            OperateRuntimeException.class,
+            () -> snapshotOperations.getRepository(new GetRepositoryRequest.Builder()));
+    assertThat(exception.getMessage()).isEqualTo("Get repository needs at least one name.");
+  }
+
+  @Test
+  void shouldGetRepository() throws IOException {
+    final var response =
+        snapshotOperations.getRepository(repositoryRequestBuilder("test-repository"));
+    assertThat(response).isNotNull();
+    verify(openSearchClient).arbitraryRequest("GET", "/_snapshot/test-repository", "{}");
+  }
+
+  @Test
+  void shouldGetOnlyFirstRepository() throws IOException {
+    final var response =
+        snapshotOperations.getRepository(
+            new GetRepositoryRequest.Builder().name("test-repository", "test-repository2"));
+    assertThat(response).isNotNull();
+    verify(openSearchClient).arbitraryRequest("GET", "/_snapshot/test-repository", "{}");
+  }
+
+  @Test
+  void shouldThrowExceptionIfCantGetRepository() throws Exception {
+    when(openSearchClient.arbitraryRequest(
+            "GET", "/_snapshot/test-repository-does-not-exist", "{}"))
+        .thenThrow(IOException.class);
+    final var exception =
+        assertThrows(
+            OperateRuntimeException.class,
+            () -> snapshotOperations.getRepository(repositoryRequestBuilder("test-repository")));
+    assertThat(exception).hasMessage("Failed to get repository test-repository");
+  }
+
+  @Test
+  void shouldGetSnapshot() throws IOException {
+    final Map<String, Object> openSearchResponse =
+        Map.of(
+            "snapshots",
+            List.of(
+                Map.of(
+                    "snapshot",
+                    "snapshot-name",
+                    "uuid",
+                    "uuid-value",
+                    "state",
+                    "STARTED",
+                    "start_time_in_millis",
+                    23L,
+                    "metadata",
+                    Map.of(),
+                    "failures",
+                    List.of())));
+    when(openSearchClient.arbitraryRequest("GET", "/_snapshot/test-repository/test-snapshot", "{}"))
+        .thenReturn(openSearchResponse);
+    final var response =
+        snapshotOperations.get(getSnapshotRequestBuilder("test-repository", "test-snapshot"));
+    assertThat(response.snapshots()).hasSize(1);
+    final var snapshotInfo = response.snapshots().get(0);
+    assertSnapshotInfo(snapshotInfo);
+  }
+
+  @Test
+  void shouldThrowExceptionIfCantGetSnapshot() throws Exception {
+    when(openSearchClient.arbitraryRequest("GET", "/_snapshot/test-repository/test-snapshot", "{}"))
+        .thenThrow(new IOException("Connection error"));
+    final var exception =
+        assertThrows(
+            OperateRuntimeException.class,
+            () ->
+                snapshotOperations.get(
+                    getSnapshotRequestBuilder("test-repository", "test-snapshot")));
+    assertThat(exception)
+        .hasMessage("Failed to get snapshot test-snapshot in repository test-repository");
+    assertThat(exception.getCause()).isInstanceOf(IOException.class);
+  }
+
+  private void assertSnapshotInfo(final OpenSearchSnapshotInfo snapshotInfo) {
+    assertThat(snapshotInfo.getState()).isEqualTo(SnapshotState.STARTED);
+    assertThat(snapshotInfo.getStartTimeInMillis()).isEqualTo(23L);
+    assertThat(snapshotInfo.getMetadata()).isEmpty();
+    assertThat(snapshotInfo.getFailures()).isEmpty();
+    assertThat(snapshotInfo.getUuid()).isEqualTo("uuid-value");
+    assertThat(snapshotInfo.getSnapshot()).isEqualTo("snapshot-name");
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
@@ -23,7 +23,6 @@ import static java.util.stream.Collectors.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.OpensearchCondition;
-import io.camunda.operate.exceptions.OperateOpensearchConnectionException;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
 import io.camunda.operate.store.opensearch.response.OpenSearchGetSnapshotResponse;
@@ -38,7 +37,6 @@ import io.camunda.operate.webapp.management.dto.BackupStateDto;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDetailDto;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
-import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
@@ -71,7 +69,7 @@ public class OpensearchBackupRepository implements BackupRepository {
   }
 
   @Override
-  public void deleteSnapshot(String repositoryName, String snapshotName) {
+  public void deleteSnapshot(final String repositoryName, final String snapshotName) {
     final var requestBuilder = deleteSnapshotRequestBuilder(repositoryName, snapshotName);
     richOpenSearchClient
         .async()
@@ -95,29 +93,13 @@ public class OpensearchBackupRepository implements BackupRepository {
             });
   }
 
-  private boolean isSnapshotMissingException(Throwable t) {
-    return t instanceof OpenSearchException
-        && t.getMessage().contains(SNAPSHOT_MISSING_EXCEPTION_TYPE);
-  }
-
-  private boolean isRepositoryMissingException(Exception e) {
-    return e instanceof OpenSearchException
-        && e.getMessage().contains(REPOSITORY_MISSING_EXCEPTION_TYPE);
-  }
-
   @Override
-  public void validateRepositoryExists(String repositoryName) {
+  public void validateRepositoryExists(final String repositoryName) {
     try {
       final var repositoryResponse =
           richOpenSearchClient.snapshot().getRepository(repositoryRequestBuilder(repositoryName));
       LOGGER.debug("Repository {} exists", repositoryResponse);
-    } catch (IOException e) {
-      final String reason =
-          format(
-              "Encountered an error connecting to Opensearch while retrieving repository with name [%s].",
-              repositoryName);
-      throw new OperateOpensearchConnectionException(reason, e);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       if (isRepositoryMissingException(e)) {
         final String reason = noRepositoryErrorMessage(repositoryName);
         throw new OperateRuntimeException(reason);
@@ -130,25 +112,15 @@ public class OpensearchBackupRepository implements BackupRepository {
     }
   }
 
-  private static String noRepositoryErrorMessage(String repositoryName) {
-    return format("No repository with name [%s] could be found.", repositoryName);
-  }
-
   @Override
-  public void validateNoDuplicateBackupId(String repositoryName, Long backupId) {
+  public void validateNoDuplicateBackupId(final String repositoryName, final Long backupId) {
     final String snapshot = Metadata.buildSnapshotNamePrefix(backupId) + "*";
 
     final OpenSearchGetSnapshotResponse response;
     try {
       response =
           richOpenSearchClient.snapshot().get(getSnapshotRequestBuilder(repositoryName, snapshot));
-    } catch (IOException e) {
-      final String reason =
-          format(
-              "Encountered an error connecting to Opensearch while searching for duplicate backup. Repository name: [%s].",
-              repositoryName);
-      throw new OperateOpensearchConnectionException(reason, e);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       if (isSnapshotMissingException(e)) {
         // no snapshot with given backupID exists
         return;
@@ -172,8 +144,65 @@ public class OpensearchBackupRepository implements BackupRepository {
   }
 
   @Override
+  public GetBackupStateResponseDto getBackupState(
+      final String repositoryName, final Long backupId) {
+    final List<OpenSearchSnapshotInfo> snapshots = findSnapshots(repositoryName, backupId);
+    return toGetBackupStateResponseDto(backupId, snapshots);
+  }
+
+  @Override
+  public List<GetBackupStateResponseDto> getBackups(final String repositoryName) {
+    final var requestBuilder =
+        getSnapshotRequestBuilder(repositoryName, Metadata.SNAPSHOT_NAME_PREFIX + "*");
+    final OpenSearchGetSnapshotResponse response;
+    try {
+      response = richOpenSearchClient.snapshot().get(requestBuilder);
+      final List<OpenSearchSnapshotInfo> snapshots =
+          response.snapshots().stream()
+              .sorted(Comparator.comparing(OpenSearchSnapshotInfo::getStartTimeInMillis).reversed())
+              .toList();
+
+      final LinkedHashMap<Long, List<OpenSearchSnapshotInfo>> groupedSnapshotInfos =
+          snapshots.stream()
+              .collect(
+                  groupingBy(
+                      si -> {
+                        final Metadata metadata =
+                            objectMapper.convertValue(si.getMetadata(), Metadata.class);
+                        Long backupId = metadata.getBackupId();
+                        // backward compatibility with v. 8.1
+                        if (backupId == null) {
+                          backupId = Metadata.extractBackupIdFromSnapshotName(si.getSnapshot());
+                        }
+                        return backupId;
+                      },
+                      LinkedHashMap::new,
+                      toList()));
+
+      return groupedSnapshotInfos.entrySet().stream()
+          .map(entry -> toGetBackupStateResponseDto(entry.getKey(), entry.getValue()))
+          .toList();
+
+    } catch (final Exception e) {
+      if (isRepositoryMissingException(e)) {
+        final String reason = noRepositoryErrorMessage(repositoryName);
+        throw new OperateRuntimeException(reason);
+      }
+      if (isSnapshotMissingException(e)) {
+        // no snapshots exist
+        return new ArrayList<>();
+      }
+      final String reason =
+          format("Exception occurred when searching for backups: %s", e.getMessage());
+      throw new OperateRuntimeException(reason, e);
+    }
+  }
+
+  @Override
   public void executeSnapshotting(
-      BackupService.SnapshotRequest snapshotRequest, Runnable onSuccess, Runnable onFailure) {
+      final BackupService.SnapshotRequest snapshotRequest,
+      final Runnable onSuccess,
+      final Runnable onFailure) {
     final Long backupId = backupId(snapshotRequest);
     final var metadata = snapshotRequest.metadata();
     final Map<String, JsonData> metadataJson =
@@ -246,12 +275,28 @@ public class OpensearchBackupRepository implements BackupRepository {
             });
   }
 
-  private Long backupId(BackupService.SnapshotRequest snapshotRequest) {
+  private boolean isSnapshotMissingException(final Throwable t) {
+    return t instanceof OpenSearchException
+        && t.getMessage().contains(SNAPSHOT_MISSING_EXCEPTION_TYPE);
+  }
+
+  private boolean isRepositoryMissingException(final Exception e) {
+    return e instanceof OpenSearchException
+        && e.getMessage().contains(REPOSITORY_MISSING_EXCEPTION_TYPE);
+  }
+
+  private static String noRepositoryErrorMessage(final String repositoryName) {
+    return format("No repository with name [%s] could be found.", repositoryName);
+  }
+
+  private Long backupId(final BackupService.SnapshotRequest snapshotRequest) {
     return Metadata.extractBackupIdFromSnapshotName(snapshotRequest.snapshotName());
   }
 
   private void handleSnapshotReceived(
-      OpenSearchSnapshotInfo snapshotInfo, Runnable onSuccess, Runnable onFailure) {
+      final OpenSearchSnapshotInfo snapshotInfo,
+      final Runnable onSuccess,
+      final Runnable onFailure) {
     if (SUCCESS.equals(snapshotInfo.getState())) {
       LOGGER.info("Snapshot done: {}", snapshotInfo.getUuid());
       onSuccess.run();
@@ -267,7 +312,7 @@ public class OpensearchBackupRepository implements BackupRepository {
   }
 
   private void handleSnapshotReceived(
-      SnapshotInfo snapshotInfo, Runnable onSuccess, Runnable onFailure) {
+      final SnapshotInfo snapshotInfo, final Runnable onSuccess, final Runnable onFailure) {
     if (SUCCESS.equals(SnapshotState.valueOf(snapshotInfo.state()))) {
       LOGGER.info("Snapshot done: {}", snapshotInfo.uuid());
       onSuccess.run();
@@ -283,7 +328,8 @@ public class OpensearchBackupRepository implements BackupRepository {
     }
   }
 
-  private List<OpenSearchSnapshotInfo> findSnapshots(String repositoryName, Long backupId) {
+  private List<OpenSearchSnapshotInfo> findSnapshots(
+      final String repositoryName, final Long backupId) {
     final var requestBuilder =
         getSnapshotRequestBuilder(repositoryName, Metadata.buildSnapshotNamePrefix(backupId) + "*");
 
@@ -291,13 +337,7 @@ public class OpensearchBackupRepository implements BackupRepository {
     try {
       response = richOpenSearchClient.snapshot().get(requestBuilder);
       return response.snapshots();
-    } catch (IOException e) {
-      final String reason =
-          format(
-              "Encountered an error connecting to Opensearch while searching for snapshots. Repository name: [%s].",
-              repositoryName);
-      throw new OperateOpensearchConnectionException(reason, e);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       if (isSnapshotMissingException(e)) {
         // no snapshot with given backupID exists
         throw new ResourceNotFoundException(format("No backup with id [%s] found.", backupId));
@@ -312,14 +352,8 @@ public class OpensearchBackupRepository implements BackupRepository {
     }
   }
 
-  @Override
-  public GetBackupStateResponseDto getBackupState(String repositoryName, Long backupId) {
-    final List<OpenSearchSnapshotInfo> snapshots = findSnapshots(repositoryName, backupId);
-    return toGetBackupStateResponseDto(backupId, snapshots);
-  }
-
   private BackupStateDto getState(
-      List<OpenSearchSnapshotInfo> snapshots, Integer expectedSnapshotsCount) {
+      final List<OpenSearchSnapshotInfo> snapshots, final Integer expectedSnapshotsCount) {
     if (snapshots.size() == expectedSnapshotsCount
         && snapshots.stream().map(OpenSearchSnapshotInfo::getState).allMatch(SUCCESS::equals)) {
       return BackupStateDto.COMPLETED;
@@ -337,7 +371,7 @@ public class OpensearchBackupRepository implements BackupRepository {
   }
 
   private GetBackupStateResponseDto toGetBackupStateResponseDto(
-      Long backupId, List<OpenSearchSnapshotInfo> snapshots) {
+      final Long backupId, final List<OpenSearchSnapshotInfo> snapshots) {
     final GetBackupStateResponseDto response = new GetBackupStateResponseDto(backupId);
     final Metadata metadata =
         objectMapper.convertValue(snapshots.get(0).getMetadata(), Metadata.class);
@@ -355,9 +389,9 @@ public class OpensearchBackupRepository implements BackupRepository {
   }
 
   private List<GetBackupStateResponseDetailDto> getBackupStateDetails(
-      List<OpenSearchSnapshotInfo> snapshots) {
+      final List<OpenSearchSnapshotInfo> snapshots) {
     final List<GetBackupStateResponseDetailDto> details = new ArrayList<>();
-    for (OpenSearchSnapshotInfo snapshot : snapshots) {
+    for (final OpenSearchSnapshotInfo snapshot : snapshots) {
       final GetBackupStateResponseDetailDto detail = new GetBackupStateResponseDetailDto();
       detail.setSnapshotName(snapshot.getSnapshot());
       detail.setStartTime(
@@ -374,9 +408,9 @@ public class OpensearchBackupRepository implements BackupRepository {
   }
 
   private String getFailureReason(
-      List<OpenSearchSnapshotInfo> snapshots,
-      BackupStateDto state,
-      Integer expectedSnapshotsCount) {
+      final List<OpenSearchSnapshotInfo> snapshots,
+      final BackupStateDto state,
+      final Integer expectedSnapshotsCount) {
     if (state == BackupStateDto.FAILED) {
       final String failedSnapshots =
           snapshots.stream()
@@ -399,59 +433,5 @@ public class OpensearchBackupRepository implements BackupRepository {
       }
     }
     return null;
-  }
-
-  @Override
-  public List<GetBackupStateResponseDto> getBackups(String repositoryName) {
-    final var requestBuilder =
-        getSnapshotRequestBuilder(repositoryName, Metadata.SNAPSHOT_NAME_PREFIX + "*");
-    final OpenSearchGetSnapshotResponse response;
-    try {
-      response = richOpenSearchClient.snapshot().get(requestBuilder);
-      final List<OpenSearchSnapshotInfo> snapshots =
-          response.snapshots().stream()
-              .sorted(Comparator.comparing(OpenSearchSnapshotInfo::getStartTimeInMillis).reversed())
-              .toList();
-
-      final LinkedHashMap<Long, List<OpenSearchSnapshotInfo>> groupedSnapshotInfos =
-          snapshots.stream()
-              .collect(
-                  groupingBy(
-                      si -> {
-                        final Metadata metadata =
-                            objectMapper.convertValue(si.getMetadata(), Metadata.class);
-                        Long backupId = metadata.getBackupId();
-                        // backward compatibility with v. 8.1
-                        if (backupId == null) {
-                          backupId = Metadata.extractBackupIdFromSnapshotName(si.getSnapshot());
-                        }
-                        return backupId;
-                      },
-                      LinkedHashMap::new,
-                      toList()));
-
-      return groupedSnapshotInfos.entrySet().stream()
-          .map(entry -> toGetBackupStateResponseDto(entry.getKey(), entry.getValue()))
-          .toList();
-
-    } catch (IOException e) {
-      final String reason =
-          format(
-              "Encountered an error connecting to Opensearch while searching for snapshots. Repository name: [%s].",
-              repositoryName);
-      throw new OperateOpensearchConnectionException(reason, e);
-    } catch (Exception e) {
-      if (isRepositoryMissingException(e)) {
-        final String reason = noRepositoryErrorMessage(repositoryName);
-        throw new OperateRuntimeException(reason);
-      }
-      if (isSnapshotMissingException(e)) {
-        // no snapshots exist
-        return new ArrayList<>();
-      }
-      final String reason =
-          format("Exception occurred when searching for backups: %s", e.getMessage());
-      throw new OperateRuntimeException(reason, e);
-    }
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -36,9 +36,9 @@ import io.camunda.operate.webapp.backup.BackupService;
 import io.camunda.operate.webapp.backup.Metadata;
 import io.camunda.operate.webapp.management.dto.BackupStateDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
-import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -83,7 +83,7 @@ class OpensearchBackupRepositoryTest {
   }
 
   @Test
-  void getBackupsReturnsEmptyListOfBackups() throws Exception {
+  void getBackupsReturnsEmptyListOfBackups() {
     mockSynchronSnapshotOperations();
 
     final var response = new OpenSearchGetSnapshotResponse();
@@ -93,7 +93,7 @@ class OpensearchBackupRepositoryTest {
   }
 
   @Test
-  void getBackupsReturnsNotEmptyListOfBackups() throws Exception {
+  void getBackupsReturnsNotEmptyListOfBackups() {
     final var metadata =
         new Metadata().setBackupId(5L).setVersion("1").setPartNo(1).setPartCount(3);
     final var snapshotInfos =
@@ -198,7 +198,7 @@ class OpensearchBackupRepositoryTest {
   }
 
   @Test
-  void getBackupState() throws IOException {
+  void getBackupState() {
     mockSynchronSnapshotOperations();
     mockObjectMapperForMetadata(new Metadata().setPartCount(3));
 
@@ -226,16 +226,15 @@ class OpensearchBackupRepositoryTest {
   }
 
   @Test
-  void validateRepositoryExistsSuccess() throws IOException {
+  void validateRepositoryExistsSuccess() {
     mockSynchronSnapshotOperations();
-    when(openSearchSnapshotOperations.getRepository(any()))
-        .thenReturn(new GetRepositoryResponse.Builder().build());
+    when(openSearchSnapshotOperations.getRepository(any())).thenReturn(Map.of());
 
     repository.validateRepositoryExists("repo");
   }
 
   @Test
-  void validateRepositoryExistsFailed() throws IOException {
+  void validateRepositoryExistsFailed() {
     mockSynchronSnapshotOperations();
     when(openSearchSnapshotOperations.getRepository(any()))
         .thenThrow(
@@ -256,7 +255,7 @@ class OpensearchBackupRepositoryTest {
   }
 
   @Test
-  void validateNoDuplicateBackupIdSuccess() throws IOException {
+  void validateNoDuplicateBackupIdSuccess() {
     mockSynchronSnapshotOperations();
     when(openSearchSnapshotOperations.get(any())).thenReturn(new OpenSearchGetSnapshotResponse());
 
@@ -264,7 +263,7 @@ class OpensearchBackupRepositoryTest {
   }
 
   @Test
-  void validateNoDuplicateBackupIdFailed() throws IOException {
+  void validateNoDuplicateBackupIdFailed() {
     mockSynchronSnapshotOperations();
     when(openSearchSnapshotOperations.get(any()))
         .thenReturn(


### PR DESCRIPTION
## Description

* Use "raw" REST calls to OpenSearch snapshot API
* Add unit tests for OpenSearchSnapshotOperations
* Clean up

Related with https://github.com/camunda/zeebe/issues/17552