### PR TITLE
fix: use upsert instead of update for updates to UserTaskEntity

### DIFF
--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/UserTaskZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/UserTaskZeebeRecordProcessor.java
@@ -164,8 +164,11 @@ public class UserTaskZeebeRecordProcessor {
       final Map<String, Object> updateFields,
       final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.update(
-        userTaskTemplate.getFullQualifiedName(), userTaskEntity.getId(), updateFields);
+    batchRequest.upsert(
+        userTaskTemplate.getFullQualifiedName(),
+        userTaskEntity.getId(),
+        userTaskEntity,
+        updateFields);
     LOGGER.debug(
         "Updated UserTaskEntity {} with update fields {} to batch request",
         userTaskEntity.getId(),

--- a/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/v8_5/processors/UserTaskZeebeRecordProcessorTest.java
+++ b/operate/importer-8_5/src/test/java/io/camunda/operate/zeebeimport/v8_5/processors/UserTaskZeebeRecordProcessorTest.java
@@ -117,7 +117,7 @@ class UserTaskZeebeRecordProcessorTest {
             1L,
             "elementId",
             "element id");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -140,7 +140,7 @@ class UserTaskZeebeRecordProcessorTest {
     /* then */
     final Map<String, Object> expectedUpdateFields =
         Map.of("assignee", "Homer Simpson", "action", "assign");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -163,7 +163,7 @@ class UserTaskZeebeRecordProcessorTest {
     userTaskZeebeRecordProcessor.processUserTaskRecord(batchRequest, userTaskRecord);
     /* then */
     final Map<String, Object> expectedUpdateFields = Map.of("assignee", "", "action", "assign");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -199,7 +199,7 @@ class UserTaskZeebeRecordProcessorTest {
             "update",
             "changedAttributes",
             List.of("candidateUserList", "candidateGroupList", "dueDate"));
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test // https://github.com/camunda/zeebe/issues/17611
@@ -249,7 +249,7 @@ class UserTaskZeebeRecordProcessorTest {
                 "dueDate",
                 "followUpDate",
                 "attribute-not-exist"));
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -278,7 +278,7 @@ class UserTaskZeebeRecordProcessorTest {
             "complete",
             "variables",
             objectMapper.writeValueAsString(variablesDueCompletion));
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -299,6 +299,14 @@ class UserTaskZeebeRecordProcessorTest {
     userTaskZeebeRecordProcessor.processUserTaskRecord(batchRequest, userTaskRecord);
     /* then */
     final Map<String, Object> expectedUpdateFields = Map.of("action", "");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
+  }
+
+  private void verifyUpsert(
+      final BatchRequest batchRequest, final Map<String, Object> expectedUpdateFields)
+      throws PersistenceException {
+    verify(batchRequest)
+        .upsert(
+            eq("user-task-index"), eq("1"), any(UserTaskEntity.class), eq(expectedUpdateFields));
   }
 }

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/v8_6/processors/UserTaskZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/v8_6/processors/UserTaskZeebeRecordProcessor.java
@@ -164,8 +164,11 @@ public class UserTaskZeebeRecordProcessor {
       final Map<String, Object> updateFields,
       final BatchRequest batchRequest)
       throws PersistenceException {
-    batchRequest.update(
-        userTaskTemplate.getFullQualifiedName(), userTaskEntity.getId(), updateFields);
+    batchRequest.upsert(
+        userTaskTemplate.getFullQualifiedName(),
+        userTaskEntity.getId(),
+        userTaskEntity,
+        updateFields);
     LOGGER.debug(
         "Updated UserTaskEntity {} with update fields {} to batch request",
         userTaskEntity.getId(),

--- a/operate/importer-8_6/src/test/java/io/camunda/operate/zeebeimport/v8_6/processors/UserTaskZeebeRecordProcessorTest.java
+++ b/operate/importer-8_6/src/test/java/io/camunda/operate/zeebeimport/v8_6/processors/UserTaskZeebeRecordProcessorTest.java
@@ -117,7 +117,7 @@ class UserTaskZeebeRecordProcessorTest {
             1L,
             "elementId",
             "element id");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -140,7 +140,7 @@ class UserTaskZeebeRecordProcessorTest {
     /* then */
     final Map<String, Object> expectedUpdateFields =
         Map.of("assignee", "Homer Simpson", "action", "assign");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -163,10 +163,9 @@ class UserTaskZeebeRecordProcessorTest {
     userTaskZeebeRecordProcessor.processUserTaskRecord(batchRequest, userTaskRecord);
     /* then */
     final Map<String, Object> expectedUpdateFields = Map.of("assignee", "", "action", "assign");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
-  @Test
   void updatedEvent() throws PersistenceException {
     /* given */
     final var batchRequest = mock(BatchRequest.class);
@@ -179,7 +178,7 @@ class UserTaskZeebeRecordProcessorTest {
             .withCandidateGroupsList(List.of("Simpsons", "Flanders"))
             .withDueDate("2023-05-23T01:02:03+01:00")
             .withAction("update")
-            .withChangedAttributes(List.of("candidateUsersList", "candidateGroupsList", "dueDate"))
+            .withChangedAttributes(List.of("candidateUserList", "candidateGroupList", "dueDate"))
             .build();
     when(userTaskTemplate.getFullQualifiedName()).thenReturn("user-task-index");
     when(userTaskRecord.getIntent()).thenReturn(UserTaskIntent.UPDATED);
@@ -198,8 +197,8 @@ class UserTaskZeebeRecordProcessorTest {
             "action",
             "update",
             "changedAttributes",
-            List.of("candidateUsersList", "candidateGroupsList", "dueDate"));
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+            List.of("candidateUserList", "candidateGroupList", "dueDate"));
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test // https://github.com/camunda/zeebe/issues/17611
@@ -249,7 +248,7 @@ class UserTaskZeebeRecordProcessorTest {
                 "dueDate",
                 "followUpDate",
                 "attribute-not-exist"));
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -278,7 +277,7 @@ class UserTaskZeebeRecordProcessorTest {
             "complete",
             "variables",
             objectMapper.writeValueAsString(variablesDueCompletion));
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
   }
 
   @Test
@@ -299,6 +298,14 @@ class UserTaskZeebeRecordProcessorTest {
     userTaskZeebeRecordProcessor.processUserTaskRecord(batchRequest, userTaskRecord);
     /* then */
     final Map<String, Object> expectedUpdateFields = Map.of("action", "");
-    verify(batchRequest).update("user-task-index", "1", expectedUpdateFields);
+    verifyUpsert(batchRequest, expectedUpdateFields);
+  }
+
+  private void verifyUpsert(
+      final BatchRequest batchRequest, final Map<String, Object> expectedUpdateFields)
+      throws PersistenceException {
+    verify(batchRequest)
+        .upsert(
+            eq("user-task-index"), eq("1"), any(UserTaskEntity.class), eq(expectedUpdateFields));
   }
 }


### PR DESCRIPTION
## Description

* Use `upsert` instead of `update` in update `UserTaskEntity`

## Related issues

closes #17615 
