### PR TITLE
fix: Filter non string permissions

### DIFF
--- a/tasklist/client/src/modules/queries/useCurrentUser.tsx
+++ b/tasklist/client/src/modules/queries/useCurrentUser.tsx
@@ -28,12 +28,16 @@ function useCurrentUser() {
 
       if (response !== null) {
         const currentUser = await response.json();
+        const permissions: unknown[] = currentUser?.permissions ?? [];
 
         return {
           ...currentUser,
-          permissions: currentUser?.permissions?.map((permission: string) =>
-            permission.toLowerCase(),
-          ),
+          permissions: permissions
+            .filter<string>(
+              (permission): permission is string =>
+                typeof permission === 'string',
+            )
+            .map((permission) => permission.toLowerCase()),
         };
       }
 


### PR DESCRIPTION
## Description
In some cases backend is not returning string elements in the permissions array. This is a temporary fix until they do root cause fix.

## Related issues

Related to #17688
