### PR TITLE
ci: Update backport.yml

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,8 +9,9 @@ jobs:
     name: Create backport PRs
     runs-on: ubuntu-latest
     # Only run when pull request is merged
-    # or when a comment containing `/backport` is created by someone other than the backport-action
-    # bot user (user id: 97796249)
+    # or when a comment starting with `/backport` is created by someone other than the
+    # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
+    # own PAT as `github_token`, that you should replace this id with yours.
     if: >
       (
         github.event_name == 'pull_request' &&
@@ -19,7 +20,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.id != 97796249 &&
-        contains(github.event.comment.body, '/backport')
+        startsWith(github.event.comment.body, '/backport')
       )
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

Adjusting the configuration of the backport workflow to avoid a comment from the bot will trigger the backport workflow again. 

To trigger the backport workflow, the comment must start with `/backport`, instead of containing the term.

This change follows the recommendation on the backport GitHub project page [here](https://github.com/korthout/backport-action?tab=readme-ov-file#trigger-using-a-comment).

## Related issues
