### PR TITLE
refactor: use different application yaml file name per component

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationWithPersistentSessionsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationWithPersistentSessionsIT.java
@@ -64,7 +64,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.InsufficientAuthenticationException;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
@@ -111,7 +110,6 @@ import org.springframework.test.context.junit4.SpringRunner;
       "camunda.operate.persistentSessionsEnabled=true"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@TestPropertySource(locations = {"/application.yml", "/application-identity-auth.yml"})
 @ActiveProfiles({IDENTITY_AUTH_PROFILE, "test"})
 public class AuthenticationWithPersistentSessionsIT implements AuthenticationTestable {
 

--- a/operate/webapp/src/main/java/io/camunda/operate/Application.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/Application.java
@@ -70,6 +70,9 @@ public class Application {
     // Must be removed with the single application.
     System.setProperty("spring.web.resources.add-mappings", "true");
     final SpringApplication springApplication = new SpringApplication(Application.class);
+    // add "operate" profile, so that application-operate.yml gets loaded. This is a way to not
+    // load other components' 'application-{component}.yml'
+    springApplication.setAdditionalProfiles("operate");
     springApplication.setAddCommandLineProperties(true);
     springApplication.addListeners(new ApplicationErrorListener());
     setDefaultProperties(springApplication);

--- a/operate/webapp/src/main/resources/application-operate.yml
+++ b/operate/webapp/src/main/resources/application-operate.yml
@@ -1,3 +1,12 @@
+spring:
+  config:
+    activate:
+      on-profile: "identity-auth"
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${camunda.identity.issuer:${camunda.operate.identity.issuerUrl:}}
 # Fallback Identity configuration for deprecated env variable naming
 camunda:
   identity:

--- a/operate/webapp/src/main/resources/application.yml
+++ b/operate/webapp/src/main/resources/application.yml
@@ -1,9 +1,0 @@
-spring:
-  config:
-    activate:
-      on-profile: "identity-auth"
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          issuer-uri: ${camunda.identity.issuer:${camunda.operate.identity.issuerUrl:}}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/Application.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/Application.java
@@ -72,6 +72,9 @@ public class Application {
     // Must be removed with the single application.
     System.setProperty("spring.web.resources.add-mappings", "true");
     final SpringApplication springApplication = new SpringApplication(Application.class);
+    // add "tasklist" profile, so that application-tasklist.yml gets loaded. This is a way to not
+    // load other components' 'application-{component}.yml'
+    springApplication.setAdditionalProfiles("tasklist");
     // use fully qualified names as bean name, as we have classes with same names for different
     // versions of importer
     springApplication.setAddCommandLineProperties(true);

--- a/tasklist/webapp/src/main/resources/application-sso-auth.yml
+++ b/tasklist/webapp/src/main/resources/application-sso-auth.yml
@@ -1,6 +1,0 @@
-camunda:
-  identity:
-    type: AUTH0
-    baseUrl: ${camunda.tasklist.identity.baseUrl:${CAMUNDA_TASKLIST_IDENTITY_BASEURL:}}
-    issuer: ${camunda.tasklist.identity.issuerUrl:${CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL:}}
-    issuerBackendUrl: ${camunda.tasklist.identity.issuerBackendUrl:${CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL:}}

--- a/tasklist/webapp/src/main/resources/application-tasklist.yml
+++ b/tasklist/webapp/src/main/resources/application-tasklist.yml
@@ -16,4 +16,22 @@ camunda:
     clientSecret: ${camunda.tasklist.identity.clientSecret:${CAMUNDA_TASKLIST_IDENTITY_CLIENT_SECRET:}}
     audience: ${camunda.tasklist.identity.audience:}
     baseUrl: ${camunda.tasklist.identity.baseUrl:}
-
+---
+spring:
+  config:
+    activate:
+      on-profile: "sso-auth"
+camunda:
+  identity:
+    type: AUTH0
+    baseUrl: ${camunda.tasklist.identity.baseUrl:${CAMUNDA_TASKLIST_IDENTITY_BASEURL:}}
+    issuer: ${camunda.tasklist.identity.issuerUrl:${CAMUNDA_TASKLIST_IDENTITY_ISSUER_URL:}}
+    issuerBackendUrl: ${camunda.tasklist.identity.issuerBackendUrl:${CAMUNDA_TASKLIST_IDENTITY_ISSUER_BACKEND_URL:}}
+---
+spring:
+  config:
+    activate:
+      on-profile: "dev"
+graphql:
+  tools:
+    introspection-enabled: true

--- a/tasklist/webapp/src/main/resources/application.yml
+++ b/tasklist/webapp/src/main/resources/application.yml
@@ -1,8 +1,0 @@
-spring:
-  config:
-    activate:
-      on-profile: "dev"
-graphql:
-  tools:
-    introspection-enabled: true
-


### PR DESCRIPTION
## Description
with the current application configuration files, `camunda.identity.*` parameters are overriden by other webapp `application.yml`. 
Example: when starting Tasklist using the single distribution, and having identity enabled (`identity-auth` spring profile), `camunda.identity.*` parameters are overriden with the values set in operate-webapp `application.yml`.

Solving this situation, by having different `application-{component}.yml` files that get only loaded when the related component is started.

## Related issues

closes #
