### PR TITLE
Add daily renovate status

### DIFF
--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -40,7 +40,7 @@ jobs:
             createdAt=$(echo $pr | jq '.createdAt')
             status=$(echo $pr | jq '.mergeStateStatus')
             
-            renovateStatusString+="\nPR $prNumber: $title (open since $createdAt) status: $status"
+            renovateStatusString+="\nPR <https://github.com/camunda/zeebe/pull/$prNumber|$prNumber>: $title (open since $createdAt) status: $status"
           done
 
           echo "status=${renovateStatusString}" >> $GITHUB_OUTPUT

--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -48,7 +48,6 @@ jobs:
     name: Send slack notification for Renovate PR status
     runs-on: ubuntu-latest
     needs: extract-renovate-pr-status
-    if: false
     steps:
       - id: slack-notify
         name: Send slack notification to DevEx

--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -1,0 +1,79 @@
+# This workflow runs our daily scheduled acceptance tests. It runs each test suite against the
+# development head (e.g. main) and all officially supported branches.
+#
+# As this is meant to be run via scheduling, the workflow itself only runs on the default branch
+# (e.g. main), so any changes you make will affect any other branches we test via this workflow.
+name: Daily Renovate status
+
+on:
+  workflow_dispatch: { }
+  schedule:
+    # Runs at 10:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
+    - cron: '0 10 * * 1-5'
+
+env:
+  # This URL is used as the business key for the various QA workflows
+  BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+jobs:
+  extract-renovate-pr-status:
+    name: Extract renovate PR status details
+    runs-on: ubuntu-latest
+    permissions:
+      checks: read
+      pull-requests: write
+    outputs:
+      status: ${{ steps.check-prs.outputs.status }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: check-prs
+        name: Check for renovate PRs
+        run: |
+          renovatePrs=$(gh pr list --author 'app/renovate' --json=title,number,createdAt,mergeStateStatus)
+          readarray -t prs < <( echo $renovatePrs | jq -c '.[]')
+          renovateStatusString=""
+          for pr in "${prs[@]}"
+          do 
+            # extracting the data to create a nice message
+            title=$(echo $pr | jq '.title')
+            prNumber=$(echo $pr | jq '.number')
+            createdAt=$(echo $pr | jq '.createdAt')
+            status=$(echo $pr | jq '.mergeStateStatus')
+            
+            renovateStatusString+="\nPR $prNumber: $title (open since $createdAt) status: $status"
+          done
+
+          echo "status=${renovateStatusString}" >> $GITHUB_OUTPUT
+  slack-notify:
+    name: Send slack notification for Renovate PR status
+    runs-on: ubuntu-latest
+    needs: extract-renovate-pr-status
+    if: false
+    steps:
+      - id: slack-notify
+        name: Send slack notification to DevEx
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":fyi: *Daily Renovate status:* :fyi:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "${{ needs.extract-renovate-pr-status.outputs.status }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -1,8 +1,5 @@
-# This workflow runs our daily scheduled acceptance tests. It runs each test suite against the
-# development head (e.g. main) and all officially supported branches.
-#
-# As this is meant to be run via scheduling, the workflow itself only runs on the default branch
-# (e.g. main), so any changes you make will affect any other branches we test via this workflow.
+# This workflow sends daily statistics about open renovate PRs.
+# The statistics includes the reference to the PR, when it was opened and the current status.
 name: Daily Renovate status
 
 on:

--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -11,10 +11,6 @@ on:
     # Runs at 10:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 10 * * 1-5'
 
-env:
-  # This URL is used as the business key for the various QA workflows
-  BUILD_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
 jobs:
   extract-renovate-pr-status:
     name: Extract renovate PR status details


### PR DESCRIPTION
## Description

We currently have the issue that we built up quite[ a lot of dependencies (backlog)](https://github.com/camunda/zeebe/issues/12605) that need to be updated by renovate. Since PRs not getting merged due to CI or other reasons, we can't work on our backlog effectively.

![Peek 2024-04-23 16-44](https://github.com/camunda/zeebe/assets/2758593/452fe383-b993-4cbd-a7c8-d7545076a1cd)

This PR add a new workflow that is run every day at around 10 to check the renovate status (open PRs, when they have been created, and what the merge status is). This should give us a bit more visibility in this topic. 

Unfortunately, I can't test the GitHub actions without hitting main, but I tested of course the script locally.

Example output:

```
$ echo $renovateStatusString 
\nPR <https://github.com/camunda/zeebe/pull/17531|17531>: "deps: Update bitnami/keycloak Docker tag to v22.0.5 (main)" (open since "2024-04-17T00:24:53Z") status: "UNKNOWN"\nPR <https://github.com/camunda/zeebe/pull/17471|17471>: "deps: Update hashicorp/vault-action action to v3 (main)" (open since "2024-04-15T12:46:46Z") status: "UNKNOWN"\nPR <https://github.com/camunda/zeebe/pull/17407|17407>: "deps: Update postgres Docker tag to v15.6 (main)" (open since "2024-04-10T04:12:33Z") status: "UNKNOWN"\nPR <https://github.com/camunda/zeebe/pull/17215|17215>: "deps: Update dependency react-router-dom to v6.23.0 (main)" (open since "2024-04-02T03:07:12Z") status: "UNKNOWN"
```