### PR TITLE
ci: increased renovate throughput

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,7 @@
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 30,
+  "prHourlyLimit": 2,
   "updateNotScheduled": false,
   "schedule": [
     "after 10pm every weekday",

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,8 +14,7 @@
   "prHourlyLimit": 2,
   "updateNotScheduled": false,
   "schedule": [
-    "after 10pm every weekday",
-    "before 6am every weekday"
+    "at any time"
   ],
   "helmv3": {
     "registryAliases": {


### PR DESCRIPTION
## Description

This configures renovate to run 24/7 with a limit of 2PRs/h. (Which is also the renovate default)

In the context of the mono-repo migration we figured a need to increase the throughput to reduce the chances of accumulating a backlog of due updates.

See this thread for further context https://camunda.slack.com/archives/C06HTSPD5AP/p1713860175922809

