### PR TITLE
Introduce integration-tests profile for tasklist

### DIFF
--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -25,7 +25,6 @@
     <module>importer</module>
     <module>archiver</module>
     <module>webapp</module>
-    <module>qa</module>
     <module>../tasklist-distro</module>
     <module>mvc-auth-commons</module>
     <module>test-coverage</module>
@@ -171,6 +170,19 @@
           </plugin>
         </plugins>
       </build>
+    </profile>
+    <!--
+      The QA module is enabled per default, but having it in a profile allows us to exclude it easily.
+      That is useful for example for creating releases.
+       -->
+    <profile>
+      <id>integration-tests</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <modules>
+        <module>qa</module>
+      </modules>
     </profile>
   </profiles>
 

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -27,7 +27,6 @@
     <module>webapp</module>
     <module>../tasklist-distro</module>
     <module>mvc-auth-commons</module>
-    <module>test-coverage</module>
   </modules>
 
   <properties>
@@ -182,6 +181,7 @@
       </activation>
       <modules>
         <module>qa</module>
+        <module>test-coverage</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
## Description

Similar to the other components via https://github.com/camunda/zeebe/pull/17497

Add integration-tests profile to the Tasklist component, which is enabled by default, but allows to disable QA completely.

This makes it possible during release to completely exclude IT/QA compilation and releasing

## Related issues

related discussion on slack https://camunda.slack.com/archives/C06HTSPD5AP/p1713899094661879?thread_ts=1713884927.185089&cid=C06HTSPD5AP

related https://github.com/camunda/zeebe/issues/17435


