### PR TITLE
fix: Make SnapshotStore IO bounded.

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.startup.steps;
 
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
@@ -27,7 +28,8 @@ public final class SnapshotStoreStep implements StartupStep<PartitionStartupCont
         new FileBasedSnapshotStore(
             context.partitionMetadata().id().id(), context.partitionDirectory());
 
-    final var submit = context.schedulingService().submitActor(snapshotStore);
+    final var submit =
+        context.schedulingService().submitActor(snapshotStore, SchedulingHints.ioBound());
     context
         .concurrencyControl()
         .runOnCompletion(


### PR DESCRIPTION

## Description 

This should be IO-bounded as before since most of the IO work is for taking snapshots.

## Related issues

closes https://github.com/camunda/zeebe/issues/17717
