### PR TITLE
fix: set github token

### DIFF
--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -12,6 +12,8 @@ jobs:
   extract-renovate-pr-status:
     name: Extract renovate PR status details
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     permissions:
       checks: read
       pull-requests: write


### PR DESCRIPTION
## Description

To use gh cli in GHA we need to set the token

![2024-04-24_11-57](https://github.com/camunda/zeebe/assets/2758593/32801825-47d9-4d59-a3c0-8ab591fd5a10)

https://github.com/camunda/zeebe/actions/runs/8814660582/job/24195001217
