### PR TITLE
fix: return raw-strings instead of json strings

### DIFF
--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -30,10 +30,10 @@ jobs:
           for pr in "${prs[@]}"
           do 
             # extracting the data to create a nice message
-            title=$(echo $pr | jq '.title')
-            prNumber=$(echo $pr | jq '.number')
-            createdAt=$(echo $pr | jq '.createdAt')
-            status=$(echo $pr | jq '.mergeStateStatus')
+            title=$(echo $pr | jq --raw-output '.title')
+            prNumber=$(echo $pr | jq --raw-output '.number')
+            createdAt=$(echo $pr | jq --raw-output '.createdAt')
+            status=$(echo $pr | jq --raw-output '.mergeStateStatus')
             
             renovateStatusString+="\nPR <https://github.com/camunda/zeebe/pull/$prNumber|$prNumber>: $title (open since $createdAt) status: $status"
           done

--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -35,7 +35,7 @@ jobs:
             createdAt=$(echo $pr | jq --raw-output '.createdAt')
             status=$(echo $pr | jq --raw-output '.mergeStateStatus')
             
-            renovateStatusString+="\nPR <https://github.com/camunda/zeebe/pull/$prNumber|$prNumber>: $title (open since $createdAt) status: $status"
+            renovateStatusString+="\n • <https://github.com/camunda/zeebe/pull/$prNumber|PR $prNumber ($status)>: $title (created $createdAt)"
           done
 
           echo "status=${renovateStatusString}" >> $GITHUB_OUTPUT
@@ -56,7 +56,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": ":fyi: *Daily Renovate status:* :fyi:"
+                    "text": ":renovate-party: *Daily Renovate status:* :renovate-party:"
                   }
                 },
                 {


### PR DESCRIPTION


## Description

Slack notification fails because of invalid format, as the returned strings have too many quotes. See recent [try](https://github.com/camunda/zeebe/actions/runs/8815451895/job/24197458220)

![2024-04-24_13-04](https://github.com/camunda/zeebe/assets/2758593/86b5e166-2caf-489f-80c0-7fcecef738e9)

Adjusting output of `jq` to print raw-strings

```
       •   --raw-output / -r:

           With  this  option,  if the filter´s result is a string then it will be written directly to standard output rather than being formatted as a JSON string with
           quotes. This can be useful for making jq filters talk to non-JSON-based systems.

```

Tested this on command line (before):


```
$ echo $renovateStatusString 
\nPR <https://github.com/camunda/zeebe/pull/17724|17724>: "deps: Update version.byte-buddy to v1.14.14 (main)" (open since "2024-04-24T10:14:36Z") status: "UNSTABLE"\nPR <https://github.com/camunda/zeebe/pull/17712|17712>: "deps: Update dependency org.wiremock:wiremock-standalone to v3.5.4 (main)" (open since "2024-04-24T09:36:27Z") status: "UNSTABLE"\nPR <https://github.com/camunda/zeebe/pull/17531|17531>: "deps: Update bitnami/keycloak Docker tag to v22.0.5 (main)" (open since "2024-04-17T00:24:53Z") status: "UNKNOWN"\nPR <https://github.com/camunda/zeebe/pull/17471|17471>: "deps: Update hashicorp/vault-action action to v3 (main)" (open since "2024-04-15T12:46:46Z") status: "BLOCKED"\nPR <https://github.com/camunda/zeebe/pull/17407|17407>: "deps: Update postgres Docker tag to v15.6 (main)" (open since "2024-04-10T04:12:33Z") status: "BLOCKED"\nPR <https://github.com/camunda/zeebe/pull/17215|17215>: "deps: Update dependency react-router-dom to v6.23.0 (main)" (open since "2024-04-02T03:07:12Z") status: "BLOCKED"
```

After:

```
$ echo $renovateStatusString 
\nPR <https://github.com/camunda/zeebe/pull/17724|17724>: deps: Update version.byte-buddy to v1.14.14 (main) (open since 2024-04-24T10:14:36Z) status: UNSTABLE\nPR <https://github.com/camunda/zeebe/pull/17712|17712>: deps: Update dependency org.wiremock:wiremock-standalone to v3.5.4 (main) (open since 2024-04-24T09:36:27Z) status: UNSTABLE\nPR <https://github.com/camunda/zeebe/pull/17531|17531>: deps: Update bitnami/keycloak Docker tag to v22.0.5 (main) (open since 2024-04-17T00:24:53Z) status: UNKNOWN\nPR <https://github.com/camunda/zeebe/pull/17471|17471>: deps: Update hashicorp/vault-action action to v3 (main) (open since 2024-04-15T12:46:46Z) status: BLOCKED\nPR <https://github.com/camunda/zeebe/pull/17407|17407>: deps: Update postgres Docker tag to v15.6 (main) (open since 2024-04-10T04:12:33Z) status: BLOCKED\nPR <https://github.com/camunda/zeebe/pull/17215|17215>: deps: Update dependency react-router-dom to v6.23.0 (main) (open since 2024-04-02T03:07:12Z) status: BLOCKED
```
