### PR TITLE
GHA: Docker build - use correct reference

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -83,7 +83,7 @@ runs:
       uses: docker/build-push-action@v5
       with:
         context: .
-        file: ${{ input.dockerfile }}
+        file: ${{ inputs.dockerfile }}
         tags: ${{ steps.get-image.outputs.result }}
         load: ${{ inputs.push != 'true' }}
         push: ${{ inputs.push }}


### PR DESCRIPTION
## Description

DryRun was failing because the wrong value was referenced. https://github.com/camunda/zeebe/actions/runs/8815369892/job/24197804438

PR uses correct variable: `inputs`
