### PR TITLE
test: disable CSRF for e2e tests

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Build backend
         run: mvn clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Operate
-        run: mvn -q -B spring-boot:start -pl operate/webapp -Dspring-boot.run.fork=true
+        run: mvn -q -B spring-boot:start -pl operate/webapp -Dspring-boot.run.fork=true -DCAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED=false
       - name: Run tests
         working-directory: ./operate/client
         run: yarn run test:e2e:ci


### PR DESCRIPTION
## Description

Start Operate with flag `CAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED=false` in the e2e test worklfow.

This is needed for the e2e test to run properly.

## Related issues

related to https://github.com/camunda/operate/issues/6613
