### PR TITLE
deps: exclude react-router-dom from renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -79,6 +79,7 @@
     {
       "description": "Exclude react-router-dom until refactoring is done in Operate (see issue #17736)",
       "matchManagers": ["npm", "nvm"],
+      "matchFileNames": ["operate/**"],
       "matchPackagePatterns": [
         "react-router-dom"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,6 +77,14 @@
       "enabled": false
     },
     {
+      "description": "Exclude react-router-dom until refactoring is done in Operate (see issue #17736)",
+      "matchManagers": ["npm", "nvm"],
+      "matchPackagePatterns": [
+        "react-router-dom"
+      ],
+      "enabled": false
+    },
+    {
       "description": "This additional prefix is used to skip Operate backend tests.",
       "matchManagers": ["npm", "nvm"],
       "additionalBranchPrefix": "fe-"


### PR DESCRIPTION
## Description

This temporarily prevents renovate from opening PRs for `react-router-dom` dependency, until issues are fixed in Operate (see Related to https://github.com/camunda/zeebe/issues/17736).

See discussion in https://github.com/camunda/zeebe/pull/17215#issuecomment-2074797768

## Related issues

Related to https://github.com/camunda/zeebe/issues/17736, https://github.com/camunda/zeebe/pull/17215