### PR TITLE
ci: add integration-test profile to reenable nightly operate worklow

### DIFF
--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -7,5 +7,5 @@ jobs:
   run-importer-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: mvn -f operate verify -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
+      command: mvn -f operate verify -P skipFrontendBuild,operateItImport,integration-tests -B -Dfailsafe.rerunFailingTestsCount=2
     secrets: inherit


### PR DESCRIPTION
## Description

Add the new integration test profile to fix the operate integration test workflow

## Related issues

closes #
