### PR TITLE
[Backport stable/8.3] fix: Make SnapshotStore IO bounded.

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.partitioning.startup.steps;
 
 import io.camunda.zeebe.broker.partitioning.startup.PartitionStartupContext;
+import io.camunda.zeebe.scheduler.SchedulingHints;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupStep;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
@@ -27,7 +28,8 @@ public final class SnapshotStoreStep implements StartupStep<PartitionStartupCont
         new FileBasedSnapshotStore(
             context.partitionMetadata().id().id(), context.partitionDirectory());
 
-    final var submit = context.schedulingService().submitActor(snapshotStore);
+    final var submit =
+        context.schedulingService().submitActor(snapshotStore, SchedulingHints.ioBound());
     context
         .concurrencyControl()
         .runOnCompletion(


### PR DESCRIPTION
# Description
Backport of #17718 to `stable/8.3`.

relates to camunda/zeebe#17717
original author: @rodrigo-lourenco-lopes