### PR TITLE
ci: change operate build runner to 8 core

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ${{ (github.event_name == 'pull_request' && (startsWith(inputs.branch, 'fe-') || (startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')))) && 'ubuntu-latest' || 'gcp-core-16-default' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (startsWith(inputs.branch, 'fe-') || (startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')))) && 'ubuntu-latest' || 'gcp-core-8-default' }}
     timeout-minutes: 20
     steps:
       # Setup: checkout branch


### PR DESCRIPTION
## Description

Change the runner type for operate to gcp-core-8-default to reduce the wait time for available runners

## Related issues

closes #
