### PR TITLE
feat: add mixpanel tracking for batch modification feature

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.test.tsx
@@ -33,6 +33,7 @@ import {
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
 import * as hooks from 'App/Processes/ListView/InstancesTable/useOperationApply';
+import {tracking} from 'modules/tracking';
 
 jest.mock('App/Processes/ListView/InstancesTable/useOperationApply');
 
@@ -109,6 +110,7 @@ describe('BatchModificationSummaryModal', () => {
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
     mockFetchProcessXML().withSuccess(mockProcessXML);
 
+    const trackSpy = jest.spyOn(tracking, 'track');
     const applyBatchOperationMock = jest.fn();
     jest.spyOn(hooks, 'default').mockImplementation(() => ({
       applyBatchOperation: applyBatchOperationMock,
@@ -141,6 +143,9 @@ describe('BatchModificationSummaryModal', () => {
       ],
       onSuccess: expect.any(Function),
       operationType: 'MODIFY_PROCESS_INSTANCE',
+    });
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'batch-move-modification-apply-button-clicked',
     });
   });
 });

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/BatchModificationSummaryModal/index.tsx
@@ -28,6 +28,7 @@ import {processStatisticsBatchModificationStore} from 'modules/stores/processSta
 import {Title, DataTable} from './styled';
 import useOperationApply from '../../useOperationApply';
 import {panelStatesStore} from 'modules/stores/panelStates';
+import {tracking} from 'modules/tracking';
 
 const BatchModificationSummaryModal: React.FC<StateProps> = observer(
   ({open, setOpen}) => {
@@ -93,6 +94,9 @@ const BatchModificationSummaryModal: React.FC<StateProps> = observer(
           if (isPrimaryButtonDisabled) {
             return;
           }
+          tracking.track({
+            eventName: 'batch-move-modification-apply-button-clicked',
+          });
           setOpen(false);
           batchModificationStore.reset();
           applyBatchOperation({

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/index.test.tsx
@@ -21,9 +21,9 @@ import {render, screen} from 'modules/testing-library';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {processInstancesStore} from 'modules/stores/processInstances';
 import {batchModificationStore} from 'modules/stores/batchModification';
-import {BatchModificationFooter} from '.';
+import {BatchModificationFooter} from '..';
 
-jest.mock('./BatchModificationSummaryModal', () => ({
+jest.mock('../BatchModificationSummaryModal', () => ({
   BatchModificationSummaryModal: () => (
     <div>MockedBatchModificationSummaryModal</div>
   ),

--- a/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/tracking.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/BatchModificationFooter/tests/tracking.test.tsx
@@ -15,53 +15,20 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {Button} from '@carbon/react';
-import {observer} from 'mobx-react';
-import {batchModificationStore} from 'modules/stores/batchModification';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
-import {ModalStateManager} from 'modules/components/ModalStateManager';
-import {BatchModificationSummaryModal} from './BatchModificationSummaryModal';
-import {Stack} from './styled';
+import {render, screen} from 'modules/testing-library';
+import {BatchModificationFooter} from '..';
 import {tracking} from 'modules/tracking';
 
-const BatchModificationFooter: React.FC = observer(() => {
-  const isButtonDisabled =
-    processInstancesSelectionStore.selectedProcessInstanceCount < 1 ||
-    batchModificationStore.state.selectedTargetFlowNodeId === null;
+describe('BatchModificationFooter - tracking', () => {
+  const trackSpy = jest.spyOn(tracking, 'track');
 
-  return (
-    <>
-      <Stack orientation="horizontal" gap={5}>
-        <Button
-          kind="secondary"
-          size="sm"
-          onClick={() => {
-            tracking.track({
-              eventName: 'batch-move-modification-exit-button-clicked',
-            });
-            batchModificationStore.reset();
-          }}
-        >
-          Exit
-        </Button>
-        <ModalStateManager
-          renderLauncher={({setOpen}) => (
-            <Button
-              size="sm"
-              disabled={isButtonDisabled}
-              onClick={() => setOpen(true)}
-            >
-              Apply Modification
-            </Button>
-          )}
-        >
-          {({open, setOpen}) => (
-            <BatchModificationSummaryModal open={open} setOpen={setOpen} />
-          )}
-        </ModalStateManager>
-      </Stack>
-    </>
-  );
+  it('should track exit click', async () => {
+    const {user} = render(<BatchModificationFooter />);
+
+    await user.click(screen.getByRole('button', {name: /exit/i}));
+
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'batch-move-modification-exit-button-clicked',
+    });
+  });
 });
-
-export {BatchModificationFooter};

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/index.tsx
@@ -46,6 +46,7 @@ import {currentTheme} from 'modules/stores/currentTheme';
 import {getStateLocally, storeStateLocally} from 'modules/utils/localStorage';
 import {Checkbox} from './styled';
 import {batchModificationStore} from 'modules/stores/batchModification';
+import {tracking} from 'modules/tracking';
 
 const MoveAction: React.FC = observer(() => {
   const location = useLocation();
@@ -111,6 +112,9 @@ const MoveAction: React.FC = observer(() => {
           <TableBatchAction
             renderIcon={Move}
             onClick={() => {
+              tracking.track({
+                eventName: 'batch-move-modification-move-button-clicked',
+              });
               if (getStateLocally()?.hideMoveModificationHelperModal) {
                 batchModificationStore.enable();
               } else {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/tests/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/tests/index.test.tsx
@@ -25,8 +25,8 @@ import {
   fetchProcessXml,
   getProcessInstance,
   getWrapper,
-} from '../mocks';
-import {MoveAction} from '.';
+} from '../../mocks';
+import {MoveAction} from '..';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {open} from 'modules/mocks/diagrams';
 import {batchModificationStore} from 'modules/stores/batchModification';

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/tests/permissions.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/tests/permissions.test.tsx
@@ -16,7 +16,7 @@
  */
 
 import {render, screen} from '@testing-library/react';
-import {MoveAction} from '.';
+import {MoveAction} from '..';
 import {MemoryRouter} from 'react-router-dom';
 import {useEffect} from 'react';
 import {authenticationStore} from 'modules/stores/authentication';

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/tests/tracking.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MoveAction/tests/tracking.test.tsx
@@ -15,53 +15,42 @@
  * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 
-import {Button} from '@carbon/react';
-import {observer} from 'mobx-react';
-import {batchModificationStore} from 'modules/stores/batchModification';
-import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
-import {ModalStateManager} from 'modules/components/ModalStateManager';
-import {BatchModificationSummaryModal} from './BatchModificationSummaryModal';
-import {Stack} from './styled';
+import {render, screen} from 'modules/testing-library';
+import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
+import {mockProcessInstances} from 'modules/testUtils';
+import {fetchProcessInstances, fetchProcessXml, getWrapper} from '../../mocks';
+import {MoveAction} from '..';
+import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
+import {open} from 'modules/mocks/diagrams';
 import {tracking} from 'modules/tracking';
 
-const BatchModificationFooter: React.FC = observer(() => {
-  const isButtonDisabled =
-    processInstancesSelectionStore.selectedProcessInstanceCount < 1 ||
-    batchModificationStore.state.selectedTargetFlowNodeId === null;
+const PROCESS_ID = 'MoveModificationProcess';
+const mockProcessXML = open('MoveModificationProcess.bpmn');
 
-  return (
-    <>
-      <Stack orientation="horizontal" gap={5}>
-        <Button
-          kind="secondary"
-          size="sm"
-          onClick={() => {
-            tracking.track({
-              eventName: 'batch-move-modification-exit-button-clicked',
-            });
-            batchModificationStore.reset();
-          }}
-        >
-          Exit
-        </Button>
-        <ModalStateManager
-          renderLauncher={({setOpen}) => (
-            <Button
-              size="sm"
-              disabled={isButtonDisabled}
-              onClick={() => setOpen(true)}
-            >
-              Apply Modification
-            </Button>
-          )}
-        >
-          {({open, setOpen}) => (
-            <BatchModificationSummaryModal open={open} setOpen={setOpen} />
-          )}
-        </ModalStateManager>
-      </Stack>
-    </>
-  );
+describe('<MoveAction /> - tracking', () => {
+  it('should track move button click', async () => {
+    const trackSpy = jest.spyOn(tracking, 'track');
+
+    mockFetchProcessInstances().withSuccess(mockProcessInstances);
+    mockFetchProcessXML().withSuccess(mockProcessXML);
+
+    const {user} = render(<MoveAction />, {
+      wrapper: getWrapper(
+        `/processes?process=${PROCESS_ID}&version=1&flowNodeId=Task`,
+      ),
+    });
+
+    await fetchProcessInstances(screen, user);
+    await fetchProcessXml(screen, user);
+
+    await user.click(
+      screen.getByRole('button', {name: /select all instances/i}),
+    );
+
+    await user.click(screen.getByRole('button', {name: /move/i}));
+
+    expect(trackSpy).toHaveBeenCalledWith({
+      eventName: 'batch-move-modification-move-button-clicked',
+    });
+  });
 });
-
-export {BatchModificationFooter};

--- a/operate/client/src/modules/tracking/index.ts
+++ b/operate/client/src/modules/tracking/index.ts
@@ -19,6 +19,11 @@ import {Mixpanel} from 'mixpanel-browser';
 import {getStage} from './getStage';
 
 const EVENT_PREFIX = 'operate:';
+
+/**
+ * These are all available events for mixpanel tracking. If a new event is introduced,
+ * it needs to be added here first.
+ */
 type Events =
   | {
       eventName: 'navigation';
@@ -270,6 +275,9 @@ type Events =
   | {
       eventName: 'open-tasklist-link-clicked';
     }
+  /**
+   * Process instance migration
+   */
   | {
       eventName: 'process-instance-migration-button-clicked';
     }
@@ -278,6 +286,18 @@ type Events =
     }
   | {
       eventName: 'process-instance-migration-confirmed';
+    }
+  /**
+   * Process instance batch modification
+   */
+  | {
+      eventName: 'batch-move-modification-move-button-clicked';
+    }
+  | {
+      eventName: 'batch-move-modification-exit-button-clicked';
+    }
+  | {
+      eventName: 'batch-move-modification-apply-button-clicked';
     };
 
 const STAGE_ENV = getStage(window.location.host);


### PR DESCRIPTION
## Description

The following events have been implemented: 

> Track when users click on Move from Instances list table

`batch-move-modification-move-button-clicked`

> Track if users click “Exit” button to discard accidental clicks

`batch-move-modification-exit-button-clicked'`

> Track “Apply” modal button to confirm Batch move

`batch-move-modification-apply-button-clicked`

## Related issues

closes https://github.com/camunda/operate/issues/6273
