### PR TITLE
[Backport stable/8.2] Exporter can soft pause and resume

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -143,6 +143,11 @@ final class ExporterContainer implements Controller {
   }
 
   @Override
+  public long getLastExportedRecordPosition() {
+    return getPosition();
+  }
+
+  @Override
   public Optional<byte[]> readMetadata() {
     return Optional.ofNullable(exportersState.getExporterMetadata(getId()))
         .filter(metadata -> metadata.capacity() > 0)

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -36,7 +36,10 @@ final class ExporterContainer implements Controller {
   private final ExporterContext context;
   private final Exporter exporter;
   private long position;
+  private boolean exporterIsSoftPaused = false;
   private long lastUnacknowledgedPosition;
+  private long lastAcknowledgedPosition;
+  private byte[] lastExportedMetadata;
   private ExportersState exportersState;
   private ExporterMetrics metrics;
   private ActorControl actor;
@@ -87,11 +90,11 @@ final class ExporterContainer implements Controller {
   }
 
   /**
-   * Updates the exporter's position if it is up to date - that is, if it's last acknowledged
+   * Updates the exporter's position if it is up-to-date - that is, if it's last acknowledged
    * position is greater than or equal to its last unacknowledged position. This is safe to do when
    * skipping records as it means we passed no record to this exporter between both.
    *
-   * @param eventPosition the new, up to date position
+   * @param eventPosition the new, up-to-date position
    */
   void updatePositionOnSkipIfUpToDate(final long eventPosition) {
     if (position >= lastUnacknowledgedPosition && position < eventPosition) {
@@ -109,15 +112,17 @@ final class ExporterContainer implements Controller {
 
   private void updateExporterState(final long eventPosition, final byte[] metadata) {
     if (position < eventPosition) {
-
-      DirectBuffer metadataBuffer = null;
-      if (metadata != null) {
-        metadataBuffer = BufferUtil.wrapArray(metadata);
+      lastAcknowledgedPosition = eventPosition;
+      lastExportedMetadata = metadata;
+      if (!exporterIsSoftPaused) {
+        DirectBuffer metadataBuffer = null;
+        if (metadata != null) {
+          metadataBuffer = BufferUtil.wrapArray(metadata);
+        }
+        exportersState.setExporterState(getId(), eventPosition, metadataBuffer);
+        metrics.setLastUpdatedExportedPosition(getId(), eventPosition);
+        position = eventPosition;
       }
-      exportersState.setExporterState(getId(), eventPosition, metadataBuffer);
-
-      metrics.setLastUpdatedExportedPosition(getId(), eventPosition);
-      position = eventPosition;
     }
   }
 
@@ -174,6 +179,15 @@ final class ExporterContainer implements Controller {
       context.getLogger().warn("Error on exporting record with key {}", typedEvent.getKey(), ex);
       return false;
     }
+  }
+
+  void softPauseExporter() {
+    exporterIsSoftPaused = true;
+  }
+
+  void undoSoftPauseExporter() {
+    exporterIsSoftPaused = false;
+    updateExporterState(lastAcknowledgedPosition, lastExportedMetadata);
   }
 
   private void export(final Record<?> record) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -113,6 +113,13 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     return actor.close();
   }
 
+  /**
+   * This method enables us to pause the exporting of records. No records are exported until resume
+   * exporting is invoked.
+   *
+   * <p>If the exporter is soft paused and pauseExporting is called, the exporter will be "hard"
+   * paused.
+   */
   public ActorFuture<Void> pauseExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case pausing is a no-op.
@@ -127,6 +134,14 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         });
   }
 
+  /**
+   * When the exporter is soft paused, we keep exporting the records without updating the exporter
+   * state. Upon resuming, the exporter is updated with the position and metadata of the last
+   * exported record.
+   *
+   * <p>If the exporter is hard paused and softPauseExporting is called, the exporter will be soft
+   * paused.
+   */
   public ActorFuture<Void> softPauseExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case pausing is a no-op.
@@ -142,6 +157,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         });
   }
 
+  /**
+   * This method enables us to resume the exporting of records after it has been paused. It works
+   * both to resume the "soft pause" state and the "paused" state. Upon resuming, the exporter is
+   * updated with the position and metadata of the last exported record.
+   */
   public ActorFuture<Void> resumeExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case resuming is a no-op.

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -75,7 +75,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private volatile HealthReport healthReport = HealthReport.healthy(this);
 
   private boolean inExportingPhase;
-  private boolean isPaused;
+  private boolean isHardPaused;
   private ExporterPhase exporterPhase;
   private final PartitionMessagingService partitionMessagingService;
   private final String exporterPositionsTopic;
@@ -97,7 +97,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
     recordWrapStrategy = new EndlessRetryStrategy(actor);
     zeebeDb = context.getZeebeDb();
-    isPaused = shouldPauseOnStart;
+    isHardPaused = shouldPauseOnStart;
     partitionMessagingService = context.getPartitionMessagingService();
     exporterPositionsTopic = String.format(EXPORTER_STATE_TOPIC_FORMAT, partitionId);
     exporterMode = context.getExporterMode();
@@ -122,8 +122,23 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     }
     return actor.call(
         () -> {
-          isPaused = true;
+          isHardPaused = true;
           exporterPhase = ExporterPhase.PAUSED;
+        });
+  }
+
+  public ActorFuture<Void> softPauseExporting() {
+    if (actor.isClosed()) {
+      // Actor can be closed when there are no exporters. In that case pausing is a no-op.
+      // This is safe because the pausing state is persisted and will be applied later if exporters
+      // are added.
+      return CompletableActorFuture.completed(null);
+    }
+    return actor.call(
+        () -> {
+          isHardPaused = false;
+          containers.stream().forEach(ExporterContainer::softPauseExporter);
+          exporterPhase = ExporterPhase.SOFT_PAUSED;
         });
   }
 
@@ -137,7 +152,10 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     return actor.call(
         () -> {
-          isPaused = false;
+          isHardPaused = false;
+          if (exporterPhase == ExporterPhase.SOFT_PAUSED) {
+            containers.stream().forEach(ExporterContainer::undoSoftPauseExporter);
+          }
           exporterPhase = ExporterPhase.EXPORTING;
           if (exporterMode == ExporterMode.ACTIVE) {
             actor.submit(this::readNextEvent);
@@ -336,7 +354,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         throw new IllegalStateException(
             String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
       }
-      if (!isPaused) {
+      if (!isHardPaused) {
         exporterPhase = ExporterPhase.EXPORTING;
         actor.submit(this::readNextEvent);
       } else {
@@ -401,7 +419,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   private boolean shouldExport() {
-    return isOpened.get() && logStreamReader.hasNext() && !inExportingPhase && !isPaused;
+    return isOpened.get() && logStreamReader.hasNext() && !inExportingPhase && !isHardPaused;
   }
 
   private void exportEvent(final LoggedEvent event) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
@@ -10,5 +10,6 @@ package io.camunda.zeebe.broker.exporter.stream;
 public enum ExporterPhase {
   EXPORTING,
   PAUSED,
+  SOFT_PAUSED,
   CLOSED
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
+// The PAUSED phase is when the exporter is paused, and the exporter is not exporting records.
+// The SOFT_PAUSED phase is when we keep exporting the records without updating the exporter state.
 public enum ExporterPhase {
   EXPORTING,
   PAUSED,

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -140,7 +140,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(mockedRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test
@@ -164,7 +164,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(secondRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test
@@ -209,8 +209,8 @@ final class ExporterContainerTest {
 
     // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
-    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
+    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isZero();
   }
 
   @Test
@@ -240,6 +240,59 @@ final class ExporterContainerTest {
   }
 
   @Test
+  void shouldNotUpdateExporterPositionIfSoftPaused() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    runtime.getState().setPosition(EXPORTER_ID, 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+    exporterContainer.softPauseExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isZero();
+  }
+
+  @Test
+  void shouldUpdatePositionWhenResumedAfterSoftPaused() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    runtime.getState().setPosition(EXPORTER_ID, 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+    exporterContainer.softPauseExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata().requestId(1L);
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isZero();
+
+    exporterContainer.undoSoftPauseExporter();
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(1);
+  }
+
+  @Test
   void shouldUpdatePositionsWhenRecordIsFiltered() throws Exception {
     // given
     exporterContainer.configureExporter();
@@ -256,7 +309,7 @@ final class ExporterContainerTest {
 
     // then
     assertThat(exporter.getRecord()).isNull();
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
     assertThat(exporterContainer.getPosition()).isEqualTo(1);
   }
 
@@ -308,7 +361,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(firstRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -273,23 +273,25 @@ final class ExporterContainerTest {
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
+    final byte[] metadata = "metadata".getBytes();
     final var recordMetadata = new RecordMetadata().requestId(1L);
     exporterContainer.exportRecord(recordMetadata, mockedRecord);
 
-    // when
-    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition(), metadata);
     awaitPreviousCall();
 
-    // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
     assertThat(exporterContainer.getPosition()).isZero();
+    assertThat(exporterContainer.readMetadata()).isNotPresent();
 
+    // when
     exporterContainer.undoSoftPauseExporter();
     awaitPreviousCall();
 
     // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
     assertThat(exporterContainer.getPosition()).isEqualTo(1);
+    assertThat(exporterContainer.readMetadata()).isPresent().hasValue(metadata);
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -71,6 +71,7 @@ public final class ExporterDirectorPauseTest {
 
     // then
     verify(exporter, timeout(TIMEOUT).times(1)).export(any());
+    assertThat(exporter.getController().getLastExportedRecordPosition()).isEqualTo(-1L);
   }
 
   @Test
@@ -87,6 +88,7 @@ public final class ExporterDirectorPauseTest {
 
     // then
     verify(exporter, timeout(TIMEOUT).times(1)).export(any());
+    assertThat(exporter.getController().getLastExportedRecordPosition()).isZero();
   }
 
   @Test

--- a/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
+++ b/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Controller.java
@@ -48,6 +48,9 @@ public interface Controller {
    */
   ScheduledTask scheduleCancellableTask(final Duration delay, final Runnable task);
 
+  /** Gets the last acknowledged exported record position. */
+  long getLastExportedRecordPosition();
+
   /**
    * Read arbitrary metadata of the exporter that was stored previously by using the exporter
    * controller.

--- a/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
+++ b/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestController.java
@@ -70,6 +70,11 @@ public final class ExporterTestController implements Controller {
   }
 
   @Override
+  public long getLastExportedRecordPosition() {
+    return getPosition();
+  }
+
+  @Override
   public Optional<byte[]> readMetadata() {
     return exporterMetadata.get();
   }


### PR DESCRIPTION
# Description
Backport of #16345 to `stable/8.2`.

relates to camunda/zeebe#16642 camunda/zeebe#16344
original author: @rodrigo-lourenco-lopes