### PR TITLE
[Backport stable/8.4] Exporter can soft pause and resume

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -115,6 +115,13 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     return actor.close();
   }
 
+  /**
+   * This method enables us to pause the exporting of records. No records are exported until resume
+   * exporting is invoked.
+   *
+   * <p>If the exporter is soft paused and pauseExporting is called, the exporter will be "hard"
+   * paused.
+   */
   public ActorFuture<Void> pauseExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case pausing is a no-op.
@@ -129,6 +136,14 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         });
   }
 
+  /**
+   * When the exporter is soft paused, we keep exporting the records without updating the exporter
+   * state. Upon resuming, the exporter is updated with the position and metadata of the last
+   * exported record.
+   *
+   * <p>If the exporter is hard paused and softPauseExporting is called, the exporter will be soft
+   * paused.
+   */
   public ActorFuture<Void> softPauseExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case pausing is a no-op.
@@ -144,6 +159,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         });
   }
 
+  /**
+   * This method enables us to resume the exporting of records after it has been paused. It works
+   * both to resume the "soft pause" state and the "paused" state. Upon resuming, the exporter is
+   * updated with the position and metadata of the last exported record.
+   */
   public ActorFuture<Void> resumeExporting() {
     if (actor.isClosed()) {
       // Actor can be closed when there are no exporters. In that case resuming is a no-op.

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -75,7 +75,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private volatile HealthReport healthReport = HealthReport.healthy(this);
 
   private boolean inExportingPhase;
-  private boolean isPaused;
+  private boolean isHardPaused;
   private ExporterPhase exporterPhase;
   private final PartitionMessagingService partitionMessagingService;
   private final String exporterPositionsTopic;
@@ -99,7 +99,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     exportingRetryStrategy = new BackOffRetryStrategy(actor, Duration.ofSeconds(10));
     recordWrapStrategy = new EndlessRetryStrategy(actor);
     zeebeDb = context.getZeebeDb();
-    isPaused = shouldPauseOnStart;
+    isHardPaused = shouldPauseOnStart;
     partitionMessagingService = context.getPartitionMessagingService();
     exporterPositionsTopic = String.format(EXPORTER_STATE_TOPIC_FORMAT, partitionId);
     exporterMode = context.getExporterMode();
@@ -124,8 +124,23 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     }
     return actor.call(
         () -> {
-          isPaused = true;
+          isHardPaused = true;
           exporterPhase = ExporterPhase.PAUSED;
+        });
+  }
+
+  public ActorFuture<Void> softPauseExporting() {
+    if (actor.isClosed()) {
+      // Actor can be closed when there are no exporters. In that case pausing is a no-op.
+      // This is safe because the pausing state is persisted and will be applied later if exporters
+      // are added.
+      return CompletableActorFuture.completed(null);
+    }
+    return actor.call(
+        () -> {
+          isHardPaused = false;
+          containers.stream().forEach(ExporterContainer::softPauseExporter);
+          exporterPhase = ExporterPhase.SOFT_PAUSED;
         });
   }
 
@@ -139,7 +154,10 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     return actor.call(
         () -> {
-          isPaused = false;
+          isHardPaused = false;
+          if (exporterPhase == ExporterPhase.SOFT_PAUSED) {
+            containers.stream().forEach(ExporterContainer::undoSoftPauseExporter);
+          }
           exporterPhase = ExporterPhase.EXPORTING;
           if (exporterMode == ExporterMode.ACTIVE) {
             actor.submit(this::readNextEvent);
@@ -338,7 +356,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
         throw new IllegalStateException(
             String.format(ERROR_MESSAGE_RECOVER_FROM_SNAPSHOT_FAILED, snapshotPosition, getName()));
       }
-      if (!isPaused) {
+      if (!isHardPaused) {
         exporterPhase = ExporterPhase.EXPORTING;
         actor.submit(this::readNextEvent);
       } else {
@@ -403,7 +421,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   }
 
   private boolean shouldExport() {
-    return isOpened.get() && logStreamReader.hasNext() && !inExportingPhase && !isPaused;
+    return isOpened.get() && logStreamReader.hasNext() && !inExportingPhase && !isHardPaused;
   }
 
   private void exportEvent(final LoggedEvent event) {

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
@@ -10,5 +10,6 @@ package io.camunda.zeebe.broker.exporter.stream;
 public enum ExporterPhase {
   EXPORTING,
   PAUSED,
+  SOFT_PAUSED,
   CLOSED
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterPhase.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
+// The PAUSED phase is when the exporter is paused, and the exporter is not exporting records.
+// The SOFT_PAUSED phase is when we keep exporting the records without updating the exporter state.
 public enum ExporterPhase {
   EXPORTING,
   PAUSED,

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -275,23 +275,25 @@ final class ExporterContainerTest {
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
+    final byte[] metadata = "metadata".getBytes();
     final var recordMetadata = new RecordMetadata().requestId(1L);
     exporterContainer.exportRecord(recordMetadata, mockedRecord);
 
-    // when
-    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition(), metadata);
     awaitPreviousCall();
 
-    // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
     assertThat(exporterContainer.getPosition()).isZero();
+    assertThat(exporterContainer.readMetadata()).isNotPresent();
 
+    // when
     exporterContainer.undoSoftPauseExporter();
     awaitPreviousCall();
 
     // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
     assertThat(exporterContainer.getPosition()).isEqualTo(1);
+    assertThat(exporterContainer.readMetadata()).isPresent().hasValue(metadata);
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -142,7 +142,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(mockedRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test
@@ -166,7 +166,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(secondRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test
@@ -211,8 +211,8 @@ final class ExporterContainerTest {
 
     // then
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
-    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
+    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isZero();
   }
 
   @Test
@@ -242,6 +242,59 @@ final class ExporterContainerTest {
   }
 
   @Test
+  void shouldNotUpdateExporterPositionIfSoftPaused() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    runtime.getState().setPosition(EXPORTER_ID, 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+    exporterContainer.softPauseExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata();
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isZero();
+  }
+
+  @Test
+  void shouldUpdatePositionWhenResumedAfterSoftPaused() throws Exception {
+    // given
+    exporterContainer.configureExporter();
+    runtime.getState().setPosition(EXPORTER_ID, 0);
+    exporterContainer.initPosition();
+    exporterContainer.openExporter();
+    exporterContainer.softPauseExporter();
+
+    final var mockedRecord = mock(TypedRecord.class);
+    when(mockedRecord.getPosition()).thenReturn(1L);
+    final var recordMetadata = new RecordMetadata().requestId(1L);
+    exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+    // when
+    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isZero();
+
+    exporterContainer.undoSoftPauseExporter();
+    awaitPreviousCall();
+
+    // then
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+    assertThat(exporterContainer.getPosition()).isEqualTo(1);
+  }
+
+  @Test
   void shouldUpdatePositionsWhenRecordIsFiltered() throws Exception {
     // given
     exporterContainer.configureExporter();
@@ -258,7 +311,7 @@ final class ExporterContainerTest {
 
     // then
     assertThat(exporter.getRecord()).isNull();
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
     assertThat(exporterContainer.getPosition()).isEqualTo(1);
   }
 
@@ -310,7 +363,7 @@ final class ExporterContainerTest {
     assertThat(exporter.getRecord()).isNotNull();
     assertThat(exporter.getRecord()).isEqualTo(firstRecord);
     assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(0);
+    assertThat(exporterContainer.getPosition()).isZero();
   }
 
   @Test

--- a/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -71,6 +71,7 @@ public final class ExporterDirectorPauseTest {
 
     // then
     verify(exporter, timeout(TIMEOUT).times(1)).export(any());
+    assertThat(exporter.getController().getLastExportedRecordPosition()).isEqualTo(-1L);
   }
 
   @Test
@@ -87,6 +88,7 @@ public final class ExporterDirectorPauseTest {
 
     // then
     verify(exporter, timeout(TIMEOUT).times(1)).export(any());
+    assertThat(exporter.getController().getLastExportedRecordPosition()).isZero();
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #16345 to `stable/8.4`.

relates to camunda/zeebe#16642 camunda/zeebe#16344
original author: @rodrigo-lourenco-lopes