### PR TITLE
ci: don't submit CI Analytics without secret available

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -151,7 +151,7 @@ jobs:
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics
       - uses: camunda/infra-global-github-actions/submit-build-status@main
-        if: always()
+        if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
         with:
           build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
           gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -153,7 +153,7 @@ jobs:
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics
       - uses: camunda/infra-global-github-actions/submit-build-status@main
-        if: always()
+        if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
         with:
           build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
           gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"


### PR DESCRIPTION
## Description

The secret might not be available if the Git checkout fails (merge queue got cancelled) even before the secrets get retrieved.

This will prevent misleading errors like in https://camunda.slack.com/archives/C06HTSPD5AP/p1713969515800199 where it appears as if the CI Analytics submission has a problem (run `if: always()` to also catch failing build data) but actually an earlier step already failed.

Examples showing that this PR solves the problem as advertised:

* [run 1](https://github.com/camunda/zeebe/actions/runs/8830520145/job/24243834333?pr=17817) was made to fail before it could actually retrieve secrets, CI Analytics submission didn't run thus and didn't cause more errors - the only visible error is the (intentional) root cause
* [run 2](https://github.com/camunda/zeebe/actions/runs/8830520141/job/24243834202?pr=17817) was made to fail after it set up and retrieved secrets, CI Analytics submission behaves as usual when build errors happen after the setup