### PR TITLE
feat: Implement Execution Listener support for subprocess elements

### DIFF
--- a/zeebe/bpmn-model/revapi.json
+++ b/zeebe/bpmn-model/revapi.json
@@ -67,12 +67,12 @@
           "newType": "java.util.function.Consumer<B extends io.camunda.zeebe.model.bpmn.builder.AbstractBoundaryEventBuilder<B>>"
         },
         {
-          "justification": "The EL-related builder methods from `AbstractServiceTaskBuilder` were moved to the `AbstractTaskBuilder` parent class . This is okay because execution listeners was not officially supported yet.",
+          "justification": "The EL-related builder methods from `AbstractServiceTaskBuilder` were moved to the `AbstractActivityBuilder` parent class . This is okay because execution listeners was not officially supported yet.",
           "code": "java.method.returnTypeErasureChanged",
           "package": "io.camunda.zeebe.model.bpmn.builder",
           "classQualifiedName": "io.camunda.zeebe.model.bpmn.builder.AbstractServiceTaskBuilder",
           "oldType": "io.camunda.zeebe.model.bpmn.builder.AbstractServiceTaskBuilder",
-          "newType": "io.camunda.zeebe.model.bpmn.builder.AbstractTaskBuilder"
+          "newType": "io.camunda.zeebe.model.bpmn.builder.AbstractActivityBuilder"
         }
       ]
     }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractActivityBuilder.java
@@ -32,14 +32,17 @@ import java.util.function.Consumer;
  */
 public abstract class AbstractActivityBuilder<
         B extends AbstractActivityBuilder<B, E>, E extends Activity>
-    extends AbstractFlowNodeBuilder<B, E> implements ZeebeVariablesMappingBuilder<B> {
+    extends AbstractFlowNodeBuilder<B, E>
+    implements ZeebeVariablesMappingBuilder<B>, ZeebeExecutionListenersBuilder<B> {
 
   private final ZeebeVariablesMappingBuilder<B> variablesMappingBuilder;
+  private final ZeebeExecutionListenersBuilder<B> zeebeExecutionListenersBuilder;
 
   protected AbstractActivityBuilder(
       final BpmnModelInstance modelInstance, final E element, final Class<?> selfType) {
     super(modelInstance, element, selfType);
     variablesMappingBuilder = new ZeebeVariableMappingBuilderImpl<>(myself);
+    zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
   }
 
   public BoundaryEventBuilder boundaryEvent() {
@@ -161,5 +164,31 @@ public abstract class AbstractActivityBuilder<
   @Override
   public B zeebeOutput(final String source, final String target) {
     return variablesMappingBuilder.zeebeOutput(source, target);
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type);
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type);
+  }
+
+  @Override
+  public B zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
+    return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractEventSubProcessBuilder.java
@@ -27,11 +27,15 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeOutput;
 import java.util.function.Consumer;
 
 public class AbstractEventSubProcessBuilder<B extends AbstractEventSubProcessBuilder<B>>
-    extends AbstractFlowElementBuilder<B, SubProcess> implements ZeebeVariablesMappingBuilder<B> {
+    extends AbstractFlowElementBuilder<B, SubProcess>
+    implements ZeebeVariablesMappingBuilder<B>, ZeebeExecutionListenersBuilder<B> {
+
+  private final ZeebeExecutionListenersBuilder<B> zeebeExecutionListenersBuilder;
 
   protected AbstractEventSubProcessBuilder(
       final BpmnModelInstance modelInstance, final SubProcess element, final Class<?> selfType) {
     super(modelInstance, element, selfType);
+    zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
   }
 
   public StartEventBuilder startEvent() {
@@ -96,5 +100,31 @@ public class AbstractEventSubProcessBuilder<B extends AbstractEventSubProcessBui
     input.setTarget(target);
 
     return myself;
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeStartExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type);
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type, retries);
+  }
+
+  @Override
+  public B zeebeEndExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type);
+  }
+
+  @Override
+  public B zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
+    return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractTaskBuilder.java
@@ -18,46 +18,16 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.Task;
-import java.util.function.Consumer;
 
 /**
  * @author Sebastian Menski
  */
 public class AbstractTaskBuilder<B extends AbstractTaskBuilder<B, E>, E extends Task>
-    extends AbstractActivityBuilder<B, E> implements ZeebeExecutionListenersBuilder<B> {
-
-  private final ZeebeExecutionListenersBuilder<B> zeebeExecutionListenersBuilder;
+    extends AbstractActivityBuilder<B, E> {
 
   public AbstractTaskBuilder(
       final BpmnModelInstance modelInstance, final E element, final Class<?> selfType) {
     super(modelInstance, element, selfType);
-    zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
-  }
-
-  @Override
-  public B zeebeStartExecutionListener(final String type, final String retries) {
-    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
-  }
-
-  @Override
-  public B zeebeStartExecutionListener(final String type) {
-    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type);
-  }
-
-  @Override
-  public B zeebeEndExecutionListener(final String type, final String retries) {
-    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type, retries);
-  }
-
-  @Override
-  public B zeebeEndExecutionListener(final String type) {
-    return zeebeExecutionListenersBuilder.zeebeEndExecutionListener(type);
-  }
-
-  @Override
-  public B zeebeExecutionListener(
-      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
-    return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
   }
 
   /** camunda extensions */

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -20,7 +20,7 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListeners;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -32,9 +32,11 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 public class ExecutionListenersValidator implements ModelElementValidator<ZeebeExecutionListeners> {
 
   private static final Set<String> ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS =
-      new HashSet<>(
+      new LinkedHashSet<>(
           Arrays.asList(
               BpmnModelConstants.BPMN_ELEMENT_PROCESS,
+              BpmnModelConstants.BPMN_ELEMENT_SUB_PROCESS,
+              BpmnModelConstants.BPMN_ELEMENT_CALL_ACTIVITY,
               BpmnModelConstants.BPMN_ELEMENT_TASK,
               BpmnModelConstants.BPMN_ELEMENT_SEND_TASK,
               BpmnModelConstants.BPMN_ELEMENT_SERVICE_TASK,

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -134,8 +134,8 @@ public class ZeebeExecutionListenersValidationTest {
         expect(
             ZeebeExecutionListeners.class,
             "Execution listeners are not supported for the 'startEvent' element. "
-                + "Currently, only [process, scriptTask, task, serviceTask, businessRuleTask, manualTask, "
-                + "sendTask, receiveTask, userTask] elements can have execution listeners."));
+                + "Currently, only [process, subProcess, callActivity, task, sendTask, serviceTask, "
+                + "scriptTask, userTask, receiveTask, businessRuleTask, manualTask] elements can have execution listeners."));
   }
 
   @Test

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/EventSubProcessProcessor.java
@@ -43,24 +43,29 @@ public final class EventSubProcessProcessor
   @Override
   public Either<Failure, ?> onActivate(
       final ExecutableFlowElementContainer element, final BpmnElementContext activating) {
-    return variableMappingBehavior
-        .applyInputMappings(activating, element)
-        .thenDo(
-            ok -> {
-              final var activated =
-                  stateTransitionBehavior.transitionToActivated(activating, element.getEventType());
-              stateTransitionBehavior.activateChildInstance(
-                  activated, element.getStartEvents().getFirst());
-            });
+    return variableMappingBehavior.applyInputMappings(activating, element);
+  }
+
+  @Override
+  public Either<Failure, ?> finalizeActivation(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+    final var activated =
+        stateTransitionBehavior.transitionToActivated(context, element.getEventType());
+    stateTransitionBehavior.activateChildInstance(activated, element.getStartEvents().getFirst());
+    return SUCCESS;
   }
 
   @Override
   public Either<Failure, ?> onComplete(
       final ExecutableFlowElementContainer element, final BpmnElementContext completing) {
 
-    return variableMappingBehavior
-        .applyOutputMappings(completing, element)
-        .flatMap(ok -> stateTransitionBehavior.transitionToCompleted(element, completing));
+    return variableMappingBehavior.applyOutputMappings(completing, element);
+  }
+
+  @Override
+  public Either<Failure, ?> finalizeCompletion(
+      final ExecutableFlowElementContainer element, final BpmnElementContext context) {
+    return stateTransitionBehavior.transitionToCompleted(element, context);
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -33,6 +34,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -41,6 +43,7 @@ public class ExecutionListenerTest {
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   private static final String PROCESS_ID = "process";
+  private static final String SUB_PROCESS_ID = "sub_".concat(PROCESS_ID);
   private static final String SERVICE_TASK_TYPE = "test_service_task";
   private static final String START_EL_TYPE = "start_execution_listener_job";
   private static final String END_EL_TYPE = "end_execution_listener_job";
@@ -756,6 +759,296 @@ public class ExecutionListenerTest {
   }
 
   // process related tests: end
+  // subprocess related tests: start
+
+  @Test
+  public void shouldCompleteEmbeddedSubProcessWithMultipleExecutionListeners() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .zeebeStartExecutionListener(START_EL_TYPE)
+                .zeebeEndExecutionListener(END_EL_TYPE)
+                .startEvent()
+                .manualTask()
+                .subProcess(
+                    SUB_PROCESS_ID,
+                    s ->
+                        s.zeebeStartExecutionListener(START_EL_TYPE + "_sub")
+                            .zeebeEndExecutionListener(END_EL_TYPE + "_sub")
+                            .embeddedSubProcess()
+                            .startEvent()
+                            .manualTask()
+                            .endEvent())
+                .manualTask()
+                .endEvent()
+                .done());
+
+    // when: complete process start EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+    // complete sub-process start/end EL jobs
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_sub").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_sub").complete();
+
+    // complete process end EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE).complete();
+
+    // then: EL jobs completed in expected order
+    assertThat(
+            RecordingExporter.jobRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withJobKind(JobKind.EXECUTION_LISTENER)
+                .withIntent(JobIntent.COMPLETED)
+                .filter(
+                    r -> Set.of(PROCESS_ID, SUB_PROCESS_ID).contains(r.getValue().getElementId()))
+                .limit(4))
+        .extracting(r -> r.getValue().getType())
+        .containsExactly(START_EL_TYPE, START_EL_TYPE + "_sub", END_EL_TYPE + "_sub", END_EL_TYPE);
+
+    // assert the process instance has completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.SUB_PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldAccessVariableFromEmbeddedSubProcessStartListenerInSubProcessServiceTask() {
+    // given
+    final long processInstanceKey =
+        createProcessInstance(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .startEvent()
+                .subProcess(
+                    SUB_PROCESS_ID,
+                    s ->
+                        s.zeebeStartExecutionListener(START_EL_TYPE + "_sub")
+                            .embeddedSubProcess()
+                            .startEvent()
+                            .serviceTask("task", b -> b.zeebeJobType(SERVICE_TASK_TYPE + "_sub"))
+                            .endEvent())
+                .manualTask()
+                .endEvent()
+                .done());
+
+    // when: complete subprocess start EL job with variables
+    ENGINE
+        .job()
+        .ofInstance(processInstanceKey)
+        .withType(START_EL_TYPE + "_sub")
+        .withVariable("baz", 42)
+        .complete();
+
+    // then: assert the variable was created after start EL completion
+    assertThat(records().withValueTypes(ValueType.JOB, ValueType.VARIABLE).onlyEvents().limit(3))
+        .extracting(Record::getValueType, Record::getIntent)
+        .containsExactly(
+            tuple(ValueType.JOB, JobIntent.CREATED),
+            tuple(ValueType.JOB, JobIntent.COMPLETED),
+            tuple(ValueType.VARIABLE, VariableIntent.CREATED));
+
+    // `baz` variable accessible in subprocess service task job
+    final Optional<JobRecordValue> jobActivated =
+        ENGINE.jobs().withType(SERVICE_TASK_TYPE + "_sub").activate().getValue().getJobs().stream()
+            .filter(job -> job.getProcessInstanceKey() == processInstanceKey)
+            .findFirst();
+
+    assertThat(jobActivated)
+        .hasValueSatisfying(job -> assertThat(job.getVariables()).contains(entry("baz", 42)));
+  }
+
+  @Test
+  public void shouldCompleteCallActivitySubProcessWithMultipleExecutionListeners() {
+    // given
+    final var childProcess =
+        Bpmn.createExecutableProcess(SUB_PROCESS_ID)
+            .startEvent()
+            .serviceTask("task", b -> b.zeebeJobType(SERVICE_TASK_TYPE + "_sub"))
+            .endEvent()
+            .done();
+
+    final var parentProcess =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .zeebeStartExecutionListener(START_EL_TYPE)
+            .startEvent()
+            .callActivity(SUB_PROCESS_ID, c -> c.zeebeProcessId(SUB_PROCESS_ID))
+            .zeebeStartExecutionListener(START_EL_TYPE + "_sub")
+            .zeebeEndExecutionListener(END_EL_TYPE + "_sub_1")
+            .zeebeEndExecutionListener(END_EL_TYPE + "_sub_2")
+            .manualTask()
+            .endEvent()
+            .done();
+
+    ENGINE
+        .deployment()
+        .withXmlResource("parent.xml", parentProcess)
+        .withXmlResource("child.xml", childProcess)
+        .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // when: complete parent process start EL job
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE).complete();
+    // complete sub-process EL and service task jobs
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_sub").complete();
+    completeJobFromSubProcess(SERVICE_TASK_TYPE + "_sub");
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_sub_1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_sub_2").complete();
+
+    // then: jobs completed in expected order
+    assertThat(RecordingExporter.jobRecords().withIntent(JobIntent.COMPLETED).limit(5))
+        .extracting(r -> r.getValue().getElementId(), r -> r.getValue().getType())
+        .containsExactly(
+            tuple(PROCESS_ID, START_EL_TYPE),
+            tuple(SUB_PROCESS_ID, START_EL_TYPE + "_sub"),
+            tuple("task", SERVICE_TASK_TYPE + "_sub"),
+            tuple(SUB_PROCESS_ID, END_EL_TYPE + "_sub_1"),
+            tuple(SUB_PROCESS_ID, END_EL_TYPE + "_sub_2"));
+
+    // assert the process instance with call activity completed as expected
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(r -> r.getValue().getBpmnElementType(), Record::getIntent)
+        .containsSubsequence(
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.MANUAL_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldCompleteEventSubProcessWithMultipleExecutionListeners() {
+    final var messageName = "subprocess-event";
+
+    final String messageSubprocessId = "message-event-subprocess";
+    ENGINE
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(PROCESS_ID)
+                .eventSubProcess(
+                    messageSubprocessId,
+                    sub ->
+                        sub.zeebeStartExecutionListener(START_EL_TYPE + "_sub_1")
+                            .zeebeStartExecutionListener(START_EL_TYPE + "_sub_2")
+                            .zeebeEndExecutionListener(END_EL_TYPE + "_sub")
+                            .startEvent("startEvent_sub")
+                            .interrupting(false)
+                            .message(m -> m.name(messageName).zeebeCorrelationKeyExpression("key"))
+                            .serviceTask(
+                                "task_sub", t -> t.zeebeJobType(SERVICE_TASK_TYPE + "_sub"))
+                            .endEvent("endEvent_sub"))
+                .startEvent("startEvent")
+                .serviceTask("task", t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                .endEvent("endEvent")
+                .done())
+        .deploy();
+
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withStartInstruction("task")
+            .withVariable("key", "key-1")
+            .create();
+
+    // when
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.message().withName(messageName).withCorrelationKey("key-1").publish();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_sub_1").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_sub_2").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE + "_sub").complete();
+    ENGINE.job().ofInstance(processInstanceKey).withType(END_EL_TYPE + "_sub").complete();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limitToProcessInstanceCompleted())
+        .extracting(
+            record -> record.getValue().getElementId(),
+            record -> record.getValue().getBpmnElementType(),
+            Record::getIntent)
+        .containsSequence(
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple("task", BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ACTIVATE_ELEMENT))
+        .containsSubsequence(
+            tuple(
+                messageSubprocessId,
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.ELEMENT_ACTIVATING),
+            tuple(
+                messageSubprocessId,
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(
+                messageSubprocessId,
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(
+                messageSubprocessId,
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(
+                "task_sub", BpmnElementType.SERVICE_TASK, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(
+                messageSubprocessId,
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.ELEMENT_COMPLETING),
+            tuple(
+                messageSubprocessId,
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+            tuple(
+                messageSubprocessId,
+                BpmnElementType.EVENT_SUB_PROCESS,
+                ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  // subprocess related tests: end
 
   // test util methods
   private static long createProcessInstance(final BpmnModelInstance modelInstance) {
@@ -773,6 +1066,16 @@ public class ExecutionListenerTest {
             .getFirst()
             .getKey();
     ENGINE.job().ofInstance(processInstanceKey).withKey(jobKey).complete();
+  }
+
+  private void completeJobFromSubProcess(final String jobType) {
+    ENGINE
+        .jobs()
+        .withType(jobType)
+        .activate()
+        .getValue()
+        .getJobKeys()
+        .forEach(jobKey -> ENGINE.job().withKey(jobKey).complete());
   }
 
   private static void assertVariable(


### PR DESCRIPTION
## Description
This pull request introduces Execution Listener support across various subprocess types within the Zeebe workflow engine. By enhancing EL capabilities to include subprocesses, we can offer more granular control and detailed monitoring at different levels of process execution.

### Key Changes:
- **Embedded Subprocesses:** ELs are now triggered at the start and end of each embedded subprocess, enabling fine-grained process management and improved monitoring within complex workflows.
- **Call Activities:** ELs can now be executed for call activities (reusable subprocesses).
- **Event Subprocesses:** Supports ELs for event-driven subprocesses.
- **Configuration:** Users can now configure ELs for each subprocess type using the Java builder API.

## Related issues
closes #16213 
