### PR TITLE
deps: exclude msw from renovate updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,11 +77,12 @@
       "enabled": false
     },
     {
-      "description": "Exclude react-router-dom until refactoring is done in Operate (see issue #17736)",
+      "description": "Exclude frontend deps until migration is done in Operate (see issues #17736, #17844)",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["operate/**"],
       "matchPackagePatterns": [
-        "react-router-dom"
+        "react-router-dom",
+        "msw"
       ],
       "enabled": false
     },


### PR DESCRIPTION
## Description

This temporarily prevents renovate from opening PRs for msw dependency, until issues are fixed in Operate (see https://github.com/camunda/zeebe/issues/17844).

## Related issues

related to https://github.com/camunda/zeebe/issues/17844
