### PR TITLE
ci: change integration test profile to be activated based on property

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -173,15 +173,15 @@ jobs:
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
           export ZBCTL_ROOT_DIR=${PWD}
 
-          # -DskipQaBuild -P-autoFormat
+          # -DskipQaBuild=true -P-autoFormat
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
           ./mvnw release:perform -B \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.dryRun }} \
-            -DskipQaBuild \
+            -DskipQaBuild=true \
             -P-autoFormat \
-            -Darguments='-T0.5C -P-autoFormat -DskipQaBuild -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -Darguments='-T0.5C -P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -179,6 +179,7 @@ jobs:
           ./mvnw release:perform -B \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.dryRun }} \
+            -DskipQaBuild \
             -P-autoFormat \
             -Darguments='-T0.5C -P-autoFormat -DskipQaBuild -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -179,9 +179,8 @@ jobs:
           ./mvnw release:perform -B \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.dryRun }} \
-            -DskipQaBuild \
             -P-autoFormat \
-            -Darguments='-T0.5C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -Darguments='-T0.5C -P-autoFormat -DskipQaBuild -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -139,10 +139,10 @@ jobs:
           #   version but before committing. Space delimited.
           #   We apply spotless to make sure that pom format is correct before committing.
           #
-          # -DpreparationGoals 
+          # -DpreparationGoals
           #   Goals to run as part of the preparation step, after transformation but before committing. Space delimited.
           #   Default is 'clean verify'; We want to skip all the checks and packaging (as it will be done again later) so we set it to empty
-          # 
+          #
           # -Darguments
           #   Additional arguments to pass to the Maven executions, separated by spaces.
           #   Per default it is not required, but the release plugin is configured in the camunda release plugin (and this property is used)
@@ -173,14 +173,15 @@ jobs:
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
           export ZBCTL_ROOT_DIR=${PWD}
 
-          # -P-integration-tests,-autoFormat
+          # -DskipQaBuild -P-autoFormat
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
           ./mvnw release:perform -B \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.dryRun }} \
-            -P-integration-tests,-autoFormat \
-            -Darguments='-T0.5C -P-integration-tests,-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -DskipQaBuild \
+            -P-autoFormat \
+            -Darguments='-T0.5C -P-autoFormat -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -76,7 +76,7 @@ jobs:
       # Run integration tests in parallel
       - name: Backend - Integration Tests
         run: |
-          mvn -f operate verify -T${{ env.LIMITS_CPU }} -P skipFrontendBuild,operateItStage1,integration-tests -B -Dfailsafe.rerunFailingTestsCount=2
+          mvn -f operate verify -T${{ env.LIMITS_CPU }} -P skipFrontendBuild,operateItStage1 -B -Dfailsafe.rerunFailingTestsCount=2
 
       # Reports: publish test metrics results
       - name: Publish Test Results

--- a/.github/workflows/operate-test-importer.yml
+++ b/.github/workflows/operate-test-importer.yml
@@ -7,5 +7,5 @@ jobs:
   run-importer-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: mvn -f operate verify -P skipFrontendBuild,operateItImport,integration-tests -B -Dfailsafe.rerunFailingTestsCount=2
+      command: mvn -f operate verify -P skipFrontendBuild,operateItImport -B -Dfailsafe.rerunFailingTestsCount=2
     secrets: inherit

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -240,13 +240,15 @@
 
     <!--
       The QA module is enabled per default, but having it in a profile allows us to exclude it easily.
-      That is useful for example for creating releases.
+      That is useful for example for creating releases. This profile is active if the skipQaBuild
+      property is not present, or is present and set to a value other than 'true'.
        -->
     <profile>
       <id>integration-tests-build</id>
       <activation>
         <property>
-          <name>!skipQaBuild</name>
+          <name>skipQaBuild</name>
+          <value>!true</value>
         </property>
       </activation>
       <modules>

--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -243,9 +243,11 @@
       That is useful for example for creating releases.
        -->
     <profile>
-      <id>integration-tests</id>
+      <id>integration-tests-build</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipQaBuild</name>
+        </property>
       </activation>
       <modules>
         <module>qa</module>

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -175,9 +175,11 @@
       That is useful for example for creating releases.
        -->
     <profile>
-      <id>integration-tests</id>
+      <id>integration-tests-build</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipQaBuild</name>
+        </property>
       </activation>
       <modules>
         <module>qa</module>

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -172,13 +172,15 @@
     </profile>
     <!--
       The QA module is enabled per default, but having it in a profile allows us to exclude it easily.
-      That is useful for example for creating releases.
+      That is useful for example for creating releases. This profile is active if the skipQaBuild
+      property is not present, or is present and set to a value other than 'true'.
        -->
     <profile>
       <id>integration-tests-build</id>
       <activation>
         <property>
-          <name>!skipQaBuild</name>
+          <name>skipQaBuild</name>
+          <value>!true</value>
         </property>
       </activation>
       <modules>

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -64,13 +64,15 @@
   <profiles>
     <!--
       The QA module is enabled by default, but having it in a profile allows us to exclude it easily.
-      That is useful for example for creating releases.
+      That is useful for example for creating releases. This profile is active if the skipQaBuild
+      property is not present, or is present and set to a value other than 'true'.
       -->
     <profile>
       <id>integration-tests-build</id>
       <activation>
         <property>
-          <name>!skipQaBuild</name>
+          <name>skipQaBuild</name>
+          <value>!true</value>
         </property>
       </activation>
       <modules>

--- a/zeebe/pom.xml
+++ b/zeebe/pom.xml
@@ -62,14 +62,16 @@
   </modules>
 
   <profiles>
-    <!-- 
+    <!--
       The QA module is enabled by default, but having it in a profile allows us to exclude it easily.
       That is useful for example for creating releases.
       -->
     <profile>
-      <id>integration-tests</id>
+      <id>integration-tests-build</id>
       <activation>
-        <activeByDefault>true</activeByDefault>
+        <property>
+          <name>!skipQaBuild</name>
+        </property>
       </activation>
       <modules>
         <module>qa</module>


### PR DESCRIPTION
## Description

Renames the 'integration-tests' profile to 'integration-tests-build'

Changes the 'integration-tests-build' profile to use property-based activation instad of activeByDefault. This allows for other maven profiles to be specified without automatic deactivation of this profile.

Logic is: profile is active unless skipQaBuilds property is provided. Behavior was tested to match how it was before.

Relevant slack discussions:

https://camunda.slack.com/archives/C06HTSPD5AP/p1714044873531379
https://camunda.slack.com/archives/C06HTSPD5AP/p1714045046184779

## Related issues

closes #
