### PR TITLE
fix: migrate http-middleware-proxy to v2

### DIFF
--- a/operate/client/src/setupProxy.js
+++ b/operate/client/src/setupProxy.js
@@ -21,9 +21,10 @@ const BASENAME = process.env.BASENAME === undefined ? '' : process.env.BASENAME;
 
 module.exports = function (app) {
   app.use(
-    [`${BASENAME}/api`, `${BASENAME}/client-config.js`],
+    BASENAME,
     createProxyMiddleware({
       target: `http://localhost:${process.env.IS_E2E ? '8081' : '8080'}`,
+      pathFilter: ['/client-config.js', '/api'],
     }),
   );
 };


### PR DESCRIPTION
## Description

After the [http-middleware-proxy major update](https://github.com/camunda/zeebe/pull/17790), the frontend dev environment of Operate was broken. This PR contains a fix:

- migrate Operate to http-middleware-proxy v2 according to https://github.com/chimurai/http-proxy-middleware/blob/master/MIGRATION.md#v3-breaking-changes

## Related issues

closes #
