### PR TITLE
ci: instruct renovate to update stable branches first

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,9 +5,9 @@
   ],
   "commitMessagePrefix": "deps:",
   "baseBranches": [
-    "main",
     "/^stable\\/8\\..*/",
-    "stable/operate-8.5"
+    "stable/operate-8.5",
+    "main"
   ],
   "dependencyDashboard": true,
   "prConcurrentLimit": 30,


### PR DESCRIPTION
## Description

We want to prefer stable branches over `main` in cases of rate-limiting of PRs. Mainly because supported releases from stable branches are created at least month, potentially more often, while from `main` we only have a supported release every 6 months.

For context see https://camunda.slack.com/archives/C06HTSPD5AP/p1714113271915279
