### PR TITLE
feat: zeebe should write the requestid in the exported events/records

### DIFF
--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/RecordImpl.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/RecordImpl.java
@@ -39,6 +39,8 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
 
   private Map<String, Object> authorizations;
 
+  private long requestId;
+
   public RecordImpl() {}
 
   @Override
@@ -92,13 +94,22 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
   }
 
   @Override
-  public ValueType getValueType() {
-    return valueType;
+  public Map<String, Object> getAuthorizations() {
+    return authorizations;
+  }
+
+  public void setAuthorizations(final Map<String, Object> authorizations) {
+    this.authorizations = authorizations;
   }
 
   @Override
-  public Map<String, Object> getAuthorizations() {
-    return authorizations;
+  public int getRecordVersion() {
+    return recordVersion;
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return valueType;
   }
 
   @Override
@@ -106,70 +117,71 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
     return value;
   }
 
-  public void setValue(T value) {
+  @Override
+  public long getRequestId() {
+    return requestId;
+  }
+
+  public void setRequestId(final long requestId) {
+    this.requestId = requestId;
+  }
+
+  public void setValue(final T value) {
     this.value = value;
   }
 
-  public void setRejectionReason(String rejectionReason) {
-    this.rejectionReason = rejectionReason;
+  public void setValueType(final ValueType valueType) {
+    this.valueType = valueType;
+  }
+
+  public RecordImpl<T> setRecordVersion(final int recordVersion) {
+    this.recordVersion = recordVersion;
+    return this;
   }
 
   public void setBrokerVersion(final String brokerVersion) {
     this.brokerVersion = brokerVersion;
   }
 
-  public void setRejectionType(RejectionType rejectionType) {
+  public void setRejectionReason(final String rejectionReason) {
+    this.rejectionReason = rejectionReason;
+  }
+
+  public void setRejectionType(final RejectionType rejectionType) {
     this.rejectionType = rejectionType;
   }
 
-  public void setRecordType(RecordType recordType) {
+  public void setRecordType(final RecordType recordType) {
     this.recordType = recordType;
   }
 
-  public void setPartitionId(int partitionId) {
+  public void setPartitionId(final int partitionId) {
     this.partitionId = partitionId;
   }
 
-  public void setIntent(Intent intent) {
+  public void setIntent(final Intent intent) {
     this.intent = intent;
   }
 
-  public void setTimestamp(long timestamp) {
+  public void setTimestamp(final long timestamp) {
     this.timestamp = timestamp;
   }
 
-  public void setKey(long key) {
+  public void setKey(final long key) {
     this.key = key;
   }
 
-  public void setSourceRecordPosition(long sourceRecordPosition) {
+  public void setSourceRecordPosition(final long sourceRecordPosition) {
     this.sourceRecordPosition = sourceRecordPosition;
   }
 
-  public void setPosition(long position) {
+  public void setPosition(final long position) {
     this.position = position;
-  }
-
-  public void setValueType(ValueType valueType) {
-    this.valueType = valueType;
-  }
-
-  public void setAuthorizations(Map<String, Object> authorizations) {
-    this.authorizations = authorizations;
   }
 
   @Override
   public Record<T> clone() {
     throw new UnsupportedOperationException("Clone not implemented");
-  }
-
-  public int getRecordVersion() {
-    return recordVersion;
-  }
-
-  public RecordImpl<T> setRecordVersion(int recordVersion) {
-    this.recordVersion = recordVersion;
-    return this;
   }
 
   @Override
@@ -203,6 +215,8 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
         + (authorizations == null ? "null" : String.format("[size='%d']", authorizations.size()))
         + ", value="
         + value
+        + ", requestId="
+        + requestId
         + '}';
   }
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/RecordImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/RecordImpl.java
@@ -38,6 +38,7 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
   private T value;
 
   private Map<String, Object> authorizations;
+  private long requestId;
 
   public RecordImpl() {}
 
@@ -113,6 +114,15 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
   @Override
   public T getValue() {
     return value;
+  }
+
+  @Override
+  public long getRequestId() {
+    return requestId;
+  }
+
+  public void setRequestId(final long requestId) {
+    this.requestId = requestId;
   }
 
   public void setValue(final T value) {
@@ -204,6 +214,8 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
         + (authorizations == null ? "null" : String.format("[size='%d']", authorizations.size()))
         + ", value="
         + value
+        + ", requestId="
+        + requestId
         + '}';
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -90,7 +90,8 @@ public final class CheckpointCreateProcessor {
             .recordType(RecordType.EVENT)
             .intent(resultIntent)
             .rejectionType(RejectionType.NULL_VAL)
-            .rejectionReason(""));
+            .rejectionReason("")
+            .requestId(command.getRequestId()));
 
     if (command.hasRequestMetadata()) {
       resultBuilder.withResponse(

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -108,8 +108,5 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
     public boolean canWriteEventOfLength(final int eventLength) {
       return false;
     }
-
-    @Override
-    public void setRequestId(final long requestId) {}
   }
 }

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -108,5 +108,8 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
     public boolean canWriteEventOfLength(final int eventLength) {
       return false;
     }
+
+    @Override
+    public void setRequestId(final long requestId) {}
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import java.time.Duration;
 import java.util.List;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 
 /**
  * Context that is utilized during broker startup and shutdown process. It contains dependencies
@@ -112,4 +113,8 @@ public interface BrokerStartupContext {
   BrokerClient getBrokerClient();
 
   Duration getShutdownTimeout();
+
+  SnowflakeIdGenerator getRequestIdGenerator();
+
+  void setRequestIdGenerator(SnowflakeIdGenerator requestIdGenerator);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -36,6 +36,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 
 public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
@@ -55,6 +56,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private AtomixServerTransport gatewayBrokerTransport;
+  private SnowflakeIdGenerator requestIdGenerator;
   private ManagedMessagingService commandApiMessagingService;
   private CommandApiServiceImpl commandApiService;
   private AdminApiRequestHandler adminApiService;
@@ -308,5 +310,15 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public Duration getShutdownTimeout() {
     return shutdownTimeout;
+  }
+
+  @Override
+  public SnowflakeIdGenerator getRequestIdGenerator() {
+    return requestIdGenerator;
+  }
+
+  @Override
+  public void setRequestIdGenerator(final SnowflakeIdGenerator requestIdGenerator) {
+    this.requestIdGenerator = requestIdGenerator;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -55,6 +55,7 @@ public final class BrokerStartupProcess {
     result.add(new MonitoringServerStep());
 
     result.add(new ApiMessagingServiceStep());
+    result.add(new RequestIdGeneratorStep());
     result.add(new GatewayBrokerTransportStep());
     result.add(new CommandApiServiceStep());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -40,12 +40,12 @@ final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
       final ActorFuture<BrokerStartupContext> startupFuture) {
 
     final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
-    final var brokerInfo = brokerStartupContext.getBrokerInfo();
     final var schedulingService = brokerStartupContext.getActorSchedulingService();
     final var messagingService = brokerStartupContext.getApiMessagingService();
+    final var requestIdGenerator = brokerStartupContext.getRequestIdGenerator();
 
     final var atomixServerTransport =
-        new AtomixServerTransport(messagingService, brokerInfo.getNodeId());
+        new AtomixServerTransport(messagingService, requestIdGenerator);
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(atomixServerTransport),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStep.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.startup.StartupStep;
+import org.agrona.concurrent.SnowflakeIdGenerator;
+import org.agrona.concurrent.SystemEpochClock;
+
+public class RequestIdGeneratorStep implements StartupStep<BrokerStartupContext> {
+  // Unix epoch time for January 1, 2023 1:00:00 AM GMT+01:00
+  private static final long TIMESTAMP_OFFSET_2023 = 1672531200000L;
+
+  @Override
+  public String getName() {
+    return "Request Id Generator";
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> startup(
+      final BrokerStartupContext brokerStartupContext) {
+    final ActorFuture<BrokerStartupContext> started =
+        brokerStartupContext.getConcurrencyControl().createFuture();
+
+    final var brokerInfo = brokerStartupContext.getBrokerInfo();
+
+    final var requestIdGenerator =
+        new SnowflakeIdGenerator(
+            SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
+            SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
+            brokerInfo.getNodeId(),
+            TIMESTAMP_OFFSET_2023,
+            SystemEpochClock.INSTANCE);
+
+    brokerStartupContext.setRequestIdGenerator(requestIdGenerator);
+    started.complete(brokerStartupContext);
+    return started;
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> shutdown(
+      final BrokerStartupContext brokerStartupContext) {
+    final ActorFuture<BrokerStartupContext> stopFuture =
+        brokerStartupContext.getConcurrencyControl().createFuture();
+
+    brokerStartupContext.setRequestIdGenerator(null);
+
+    stopFuture.complete(brokerStartupContext);
+    return stopFuture;
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
@@ -9,10 +9,9 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -25,45 +24,40 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Random;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class GatewayBrokerTransportStepTest {
+class RequestIdGeneratorStepTest {
   private static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
-  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
-
-  private final ActorScheduler mockActorSchedulingService = mock(ActorScheduler.class);
-
   private BrokerStartupContextImpl testBrokerStartupContext;
   private final BrokerInfo mockBrokerInfo = mock(BrokerInfo.class);
+  private final TestConcurrencyControl spyConcurrencyControl = spy(new TestConcurrencyControl());
 
-  private final GatewayBrokerTransportStep sut = new GatewayBrokerTransportStep();
+  private final RequestIdGeneratorStep sut = new RequestIdGeneratorStep();
 
   @BeforeEach
   void setUp() {
-    when(mockActorSchedulingService.submitActor(any()))
-        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
 
     testBrokerStartupContext =
         new BrokerStartupContextImpl(
             mockBrokerInfo,
             TEST_BROKER_CONFIG,
             mock(SpringBrokerBridge.class),
-            mockActorSchedulingService,
+            mock(ActorScheduler.class),
             mock(BrokerHealthCheckService.class),
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
             mock(BrokerClient.class),
             Collections.emptyList(),
             TEST_SHUTDOWN_TIMEOUT);
-    testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
+    testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);
   }
 
   @Test
@@ -72,7 +66,7 @@ class GatewayBrokerTransportStepTest {
     final var actual = sut.getName();
 
     // then
-    assertThat(actual).isSameAs("Broker Transport");
+    assertThat(actual).isSameAs("Request Id Generator");
   }
 
   @Nested
@@ -82,13 +76,14 @@ class GatewayBrokerTransportStepTest {
 
     @BeforeEach
     void setUp() {
-      startupFuture = CONCURRENCY_CONTROL.createFuture();
+      startupFuture = spyConcurrencyControl.createFuture();
+      when(spyConcurrencyControl.<BrokerStartupContext>createFuture()).thenReturn(startupFuture);
     }
 
     @Test
     void shouldCompleteFuture() {
       // when
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      sut.startup(testBrokerStartupContext);
 
       // then
       assertThat(startupFuture).succeedsWithin(TIME_OUT);
@@ -96,55 +91,49 @@ class GatewayBrokerTransportStepTest {
     }
 
     @Test
-    void shouldStartAndInstallTransport() {
+    void shouldStartAndInstallRequestIdGenerator() {
       // when
       final int randomNodeId = new Random().nextInt(10);
       when(mockBrokerInfo.getNodeId()).thenReturn(randomNodeId);
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      sut.startup(testBrokerStartupContext);
       await().until(startupFuture::isDone);
 
       // then
-      final var transport = testBrokerStartupContext.getGatewayBrokerTransport();
+      final var requestIdGenerator = testBrokerStartupContext.getRequestIdGenerator();
 
-      assertThat(transport).isNotNull();
-      verify(mockActorSchedulingService).submitActor(transport);
+      assertThat(requestIdGenerator).isNotNull();
+      assertThat(requestIdGenerator.nodeId()).isEqualTo(randomNodeId);
     }
   }
 
   @Nested
   class ShutdownBehavior {
 
-    private AtomixServerTransport mockTransport;
-
     private ActorFuture<BrokerStartupContext> shutdownFuture;
 
     @BeforeEach
     void setUp() {
-
-      mockTransport = mock(AtomixServerTransport.class);
-      when(mockTransport.closeAsync()).thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
-
-      testBrokerStartupContext.setGatewayBrokerTransport(mockTransport);
-
-      shutdownFuture = CONCURRENCY_CONTROL.createFuture();
+      final var mockIdGenerator = mock(SnowflakeIdGenerator.class);
+      testBrokerStartupContext.setRequestIdGenerator(mockIdGenerator);
+      shutdownFuture = spyConcurrencyControl.createFuture();
+      when(spyConcurrencyControl.<BrokerStartupContext>createFuture()).thenReturn(shutdownFuture);
     }
 
     @Test
-    void shouldStopAndUninstallServerTransport() {
+    void shouldStopAndUninstallRequestIdGenerator() {
       // when
-      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      sut.shutdown(testBrokerStartupContext);
       await().until(shutdownFuture::isDone);
 
       // then
-      verify(mockTransport).closeAsync();
-      final var serverTransport = testBrokerStartupContext.getGatewayBrokerTransport();
-      assertThat(serverTransport).isNull();
+      final var requestIdGenerator = testBrokerStartupContext.getRequestIdGenerator();
+      assertThat(requestIdGenerator).isNull();
     }
 
     @Test
     void shouldCompleteFuture() {
       // when
-      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      sut.shutdown(testBrokerStartupContext);
 
       // then
       assertThat(shutdownFuture).succeedsWithin(TIME_OUT);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
@@ -33,7 +33,8 @@ final class ResultBuilderBackedRejectionWriter extends AbstractResultBuilderBack
             .recordType(RecordType.COMMAND_REJECTION)
             .intent(command.getIntent())
             .rejectionType(rejectionType)
-            .rejectionReason(reason);
+            .rejectionReason(reason)
+            .requestId(command.getRequestId());
     resultBuilder().appendRecord(command.getKey(), command.getValue(), metadata);
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -50,6 +50,9 @@
         },
         "sequence": {
           "type": "long"
+        },
+        "requestId": {
+          "type": "long"
         }
       }
     }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -50,6 +50,9 @@
         },
         "sequence": {
           "type": "long"
+        },
+        "requestId": {
+          "type": "long"
         }
       }
     }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -34,6 +34,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final String brokerVersion;
   private final AuthInfo authorization;
   private final int recordVersion;
+  private long requestId;
 
   public CopiedRecord(
       final T recordValue,
@@ -58,6 +59,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     brokerVersion = metadata.getBrokerVersion().toString();
     authorization = metadata.getAuthorization();
     recordVersion = metadata.getRecordVersion();
+    requestId = metadata.getRequestId();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -162,6 +164,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public T getValue() {
     return recordValue;
+  }
+
+  @Override
+  public long getRequestId() {
+    return requestId;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -204,6 +204,7 @@ final class JsonSerializableToJsonTest {
             ]
           },
           "recordVersion": 10,
+          "requestId":23,
           "sourceRecordPosition": 231,
           "value": {
             "processesMetadata": [
@@ -267,6 +268,7 @@ final class JsonSerializableToJsonTest {
             ]
           },
           "recordVersion": 1,
+          "requestId":-1,
           "value": {
               "resources": [],
               "decisionRequirementsMetadata": [],

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 
 public final class StubBroker implements AutoCloseable {
 
@@ -90,7 +91,9 @@ public final class StubBroker implements AutoCloseable {
     cluster.start().join();
 
     final var transportFactory = new TransportFactory(scheduler);
-    serverTransport = transportFactory.createServerTransport(nodeId, cluster.getMessagingService());
+    final var requestIdGenerator = new SnowflakeIdGenerator(nodeId);
+    serverTransport =
+        transportFactory.createServerTransport(cluster.getMessagingService(), requestIdGenerator);
 
     channelHandler = new StubRequestHandler(msgPackHelper);
     serverTransport.subscribe(partitionId, RequestType.COMMAND, channelHandler);

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -129,6 +129,8 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
    */
   T getValue();
 
+  long getRequestId();
+
   /**
    * Creates a deep copy of the current record. Can be used to collect records.
    *

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -130,6 +130,9 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   T getValue();
 
   /**
+   * The RequestId is a unique id generated at the gateway broker transport and is attached to every
+   * client request
+   *
    * @return the id of the request that produced this record
    */
   long getRequestId();

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -129,6 +129,9 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
    */
   T getValue();
 
+  /**
+   * @return the id of the request that produced this record
+   */
   long getRequestId();
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -87,6 +87,4 @@ public interface ProcessingResultBuilder {
   ProcessingResult build();
 
   boolean canWriteEventOfLength(int eventLength);
-
-  void setRequestId(long requestId);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -87,4 +87,6 @@ public interface ProcessingResultBuilder {
   ProcessingResult build();
 
   boolean canWriteEventOfLength(int eventLength);
+
+  void setRequestId(long requestId);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/TypedRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/records/TypedRecord.java
@@ -24,8 +24,6 @@ public interface TypedRecord<T extends UnifiedRecordValue> extends Record<T> {
 
   int getRequestStreamId();
 
-  long getRequestId();
-
   int getLength();
 
   default boolean hasRequestMetadata() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -118,8 +118,9 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
     return mutableRecordBatch.canAppendRecordOfLength(eventLength);
   }
 
-  public void setRequestId(final long requestId) {
+  public ProcessingResultBuilder withRequestId(final long requestId) {
     this.requestId = requestId;
+    return this;
   }
 
   record ProcessingResponseImpl(RecordBatchEntry responseValue, long requestId, int requestStreamId)

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -118,7 +118,6 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
     return mutableRecordBatch.canAppendRecordOfLength(eventLength);
   }
 
-  @Override
   public void setRequestId(final long requestId) {
     this.requestId = requestId;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -362,6 +362,8 @@ public final class ProcessingStateMachine {
 
       final var command = pendingCommands.removeFirst();
 
+      processingResultBuilder.setRequestId(command.getRequestId());
+
       currentProcessor =
           recordProcessors.stream()
               .filter(p -> p.accepts(command.getValueType()))

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -32,7 +32,6 @@ import io.camunda.zeebe.stream.api.EmptyProcessingResult;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.ProcessingResponse;
 import io.camunda.zeebe.stream.api.ProcessingResult;
-import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.stream.api.RecordProcessor;
 import io.camunda.zeebe.stream.api.records.ExceededBatchRecordSizeException;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
@@ -342,7 +341,7 @@ public final class ProcessingStateMachine {
    * commands are created.
    */
   private void batchProcessing(final TypedRecord<?> initialCommand) {
-    final ProcessingResultBuilder processingResultBuilder =
+    final var processingResultBuilder =
         new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
     var lastProcessingResultSize = 0;
 
@@ -362,6 +361,8 @@ public final class ProcessingStateMachine {
 
       final var command = pendingCommands.removeFirst();
 
+      // propagate the request id from the initial command to the processingResultBuilder to be
+      // appended to the followup events
       processingResultBuilder.setRequestId(command.getRequestId());
 
       currentProcessor =
@@ -527,7 +528,7 @@ public final class ProcessingStateMachine {
 
   private void tryRejectingIfUserCommand(final String errorMessage) {
     final var rejectionReason = errorMessage != null ? errorMessage : "";
-    final ProcessingResultBuilder processingResultBuilder =
+    final var processingResultBuilder =
         new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
     final var errorRecord = new ErrorRecord();
     errorRecord.initErrorRecord(
@@ -568,7 +569,7 @@ public final class ProcessingStateMachine {
     zeebeDbTransaction = transactionContext.getCurrentTransaction();
     zeebeDbTransaction.run(
         () -> {
-          final ProcessingResultBuilder processingResultBuilder =
+          final var processingResultBuilder =
               new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
           processingResultBuilder.setRequestId(typedCommand.getRequestId());
           currentProcessingResult =

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -540,7 +540,9 @@ public final class ProcessingStateMachine {
             .intent(ErrorIntent.CREATED)
             .recordVersion(RecordMetadata.DEFAULT_RECORD_VERSION)
             .rejectionType(RejectionType.NULL_VAL)
-            .rejectionReason("");
+            .rejectionReason("")
+            .requestId(typedCommand.getRequestId());
+    processingResultBuilder.setRequestId(typedCommand.getRequestId());
     processingResultBuilder.appendRecord(currentRecord.getKey(), errorRecord, recordMetadata);
     processingResultBuilder.withResponse(
         RecordType.COMMAND_REJECTION,
@@ -568,6 +570,7 @@ public final class ProcessingStateMachine {
         () -> {
           final ProcessingResultBuilder processingResultBuilder =
               new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
+          processingResultBuilder.setRequestId(typedCommand.getRequestId());
           currentProcessingResult =
               currentProcessor.onProcessingError(
                   processingException, typedCommand, processingResultBuilder);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -104,6 +104,11 @@ public final class TypedRecordImpl implements TypedRecord {
   }
 
   @Override
+  public long getRequestId() {
+    return metadata.getRequestId();
+  }
+
+  @Override
   public Record copyOf() {
     return CopiedRecords.createCopiedRecord(getPartitionId(), rawEvent);
   }
@@ -122,12 +127,6 @@ public final class TypedRecordImpl implements TypedRecord {
   @JsonIgnore
   public int getRequestStreamId() {
     return metadata.getRequestStreamId();
-  }
-
-  @Override
-  @JsonIgnore
-  public long getRequestId() {
-    return metadata.getRequestId();
   }
 
   @Override

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
@@ -55,6 +55,11 @@ public final class RecordToWrite implements LogAppendEntry {
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
   }
 
+  public static RecordToWrite command(final long requestId) {
+    final RecordMetadata recordMetadata = new RecordMetadata();
+    return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND).requestId(requestId));
+  }
+
   public static RecordToWrite userCommand() {
     final RecordMetadata recordMetadata = new RecordMetadata().requestId(100).requestStreamId(10);
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -126,6 +126,11 @@ public final class RecordingExporterTest {
     }
 
     @Override
+    public long getRequestId() {
+      return 0;
+    }
+
+    @Override
     public Record<TestValue> copyOf() {
       return this;
     }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.transport.stream.impl.RemoteStreamerImpl;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.IdGenerator;
 
 public final class TransportFactory {
 
@@ -36,8 +37,10 @@ public final class TransportFactory {
   }
 
   public ServerTransport createServerTransport(
-      final int nodeId, final MessagingService messagingService) {
-    final var atomixServerTransport = new AtomixServerTransport(messagingService, nodeId);
+      final MessagingService messagingService, final IdGenerator requestIdGenerator) {
+
+    final var atomixServerTransport =
+        new AtomixServerTransport(messagingService, requestIdGenerator);
     actorSchedulingService.submitActor(atomixServerTransport);
     return atomixServerTransport;
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -19,8 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.IdGenerator;
-import org.agrona.concurrent.SnowflakeIdGenerator;
-import org.agrona.concurrent.SystemEpochClock;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
@@ -28,8 +26,6 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private static final String API_TOPIC_FORMAT = "%s-api-%d";
-  // Unix epoch time for January 1, 2023 1:00:00 AM GMT+01:00
-  private static final long TIMESTAMP_OFFSET_2023 = 1672531200000L;
   private static final String ERROR_MSG_MISSING_PARTITON_MAP =
       "Node already unsubscribed from partition %d, this can only happen when atomix does not cleanly remove its handlers.";
 
@@ -37,18 +33,13 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
       partitionsRequestMap;
   private final MessagingService messagingService;
 
-  private final IdGenerator idGenerator;
+  private final IdGenerator requestIdGenerator;
 
-  public AtomixServerTransport(final MessagingService messagingService, final int nodeId) {
+  public AtomixServerTransport(
+      final MessagingService messagingService, final IdGenerator requestIdGenerator) {
     this.messagingService = messagingService;
+    this.requestIdGenerator = requestIdGenerator;
     partitionsRequestMap = new Int2ObjectHashMap<>();
-    this.idGenerator =
-        new SnowflakeIdGenerator(
-            SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
-            SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
-            nodeId,
-            TIMESTAMP_OFFSET_2023,
-            SystemEpochClock.INSTANCE);
   }
 
   @Override
@@ -114,7 +105,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     final var completableFuture = new CompletableFuture<byte[]>();
     actor.call(
         () -> {
-          final long requestId = idGenerator.nextId();
+          final long requestId = requestIdGenerator.nextId();
           final var requestMap = partitionsRequestMap.get(partitionId);
           if (requestMap == null) {
             final var errorMsg = String.format(ERROR_MSG_MISSING_PARTITON_MAP, partitionId);

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -80,6 +81,7 @@ public class AtomixTransportTest {
 
   @Parameters(name = "{0}")
   public static Collection<Object[]> data() {
+    final SnowflakeIdGenerator requestIdGenerator = new SnowflakeIdGenerator(0);
     return Arrays.asList(
         new Object[][] {
           {
@@ -92,7 +94,8 @@ public class AtomixTransportTest {
             (Function<AtomixCluster, ServerTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
-                  return transportFactory.createServerTransport(0, messagingService);
+                  return transportFactory.createServerTransport(
+                      messagingService, requestIdGenerator);
                 }
           },
           {
@@ -115,7 +118,8 @@ public class AtomixTransportTest {
                     nettyMessagingService.start().join();
                   }
 
-                  return transportFactory.createServerTransport(0, nettyMessagingService);
+                  return transportFactory.createServerTransport(
+                      nettyMessagingService, requestIdGenerator);
                 }
           }
         });
@@ -426,7 +430,7 @@ public class AtomixTransportTest {
     private ServerResponseImpl serverResponse;
 
     DirectlyResponder() {
-      this.requestConsumer = (bytes -> {});
+      requestConsumer = (bytes -> {});
     }
 
     DirectlyResponder(final Consumer<byte[]> requestConsumer) {


### PR DESCRIPTION
## Description
Zeebe should write the requestid in the exported events/records
- Moved `requestId` to `Record` interface
- Added requestId to zeebe-record-template
- Populated requestId in processingResultBuilder to have the same requestId appended in follow-up commands
- move RequestIdGenerator instantiation to be a broker startup step
   - this way the request id generation is not an implementation detail anymore, rather an explicit part of the engine
   - we can then ensure we have only one id generator per broker and hence the requestId is unique per cluster

## Related issues

closes #17637
