### PR TITLE
test: fix test selectors for username and password fields

### DIFF
--- a/operate/client/e2e-playwright/pages/Login.ts
+++ b/operate/client/e2e-playwright/pages/Login.ts
@@ -27,8 +27,8 @@ export class Login {
 
   constructor(page: Page) {
     this.page = page;
-    this.usernameInput = page.getByLabel('Username');
-    this.passwordInput = page.getByLabel('Password');
+    this.usernameInput = page.getByLabel(/^username$/i);
+    this.passwordInput = page.getByLabel(/^password$/i);
     this.loginButton = page.getByRole('button', {name: 'Login'});
     this.errorMessage = page.getByRole('alert').first();
   }

--- a/operate/client/e2e-playwright/test-fixtures.ts
+++ b/operate/client/e2e-playwright/test-fixtures.ts
@@ -80,8 +80,8 @@ const test = base.extend<
       // Important: make sure we authenticate in a clean environment by unsetting storage state.
       const page = await browser.newPage({storageState: undefined});
       await page.goto(`${baseURL}/login`);
-      await page.getByLabel('Username').fill('demo');
-      await page.getByLabel('Password').fill('demo');
+      await page.getByLabel(/^username$/i).fill('demo');
+      await page.getByLabel(/^password$/i).fill('demo');
       await page.getByRole('button', {name: 'Login'}).click();
 
       await page.waitForURL(`${baseURL}`);

--- a/operate/client/src/App/Login/index.test.tsx
+++ b/operate/client/src/App/Login/index.test.tsx
@@ -65,8 +65,8 @@ describe('<Login />', () => {
       wrapper: createWrapper(Paths.login()),
     });
 
-    await user.type(screen.getByLabelText(/username/i), 'demo');
-    await user.type(screen.getByLabelText(/password/i), 'demo');
+    await user.type(screen.getByLabelText(/^username$/i), 'demo');
+    await user.type(screen.getByLabelText(/^password$/i), 'demo');
     await user.click(screen.getByRole('button', {name: 'Login'}));
 
     await waitFor(() =>
@@ -81,8 +81,8 @@ describe('<Login />', () => {
       wrapper: createWrapper(),
     });
 
-    await user.type(screen.getByLabelText(/username/i), 'demo');
-    await user.type(screen.getByLabelText(/password/i), 'demo');
+    await user.type(screen.getByLabelText(/^username$/i), 'demo');
+    await user.type(screen.getByLabelText(/^password$/i), 'demo');
     await user.click(screen.getByRole('button', {name: 'Login'}));
 
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
@@ -105,8 +105,8 @@ describe('<Login />', () => {
 
     await user.click(screen.getByText(/emulate auth check/i));
 
-    await user.type(screen.getByLabelText(/username/i), 'demo');
-    await user.type(screen.getByLabelText(/password/i), 'demo');
+    await user.type(screen.getByLabelText(/^username$/i), 'demo');
+    await user.type(screen.getByLabelText(/^password$/i), 'demo');
     await user.click(screen.getByRole('button', {name: 'Login'}));
 
     await waitFor(() =>
@@ -122,44 +122,44 @@ describe('<Login />', () => {
 
     await user.click(screen.getByRole('button', {name: /login/i}));
 
-    expect(screen.getByLabelText(/username/i)).toHaveAccessibleDescription(
+    expect(screen.getByLabelText(/^username$/i)).toHaveAccessibleDescription(
       /username is required/i,
     );
-    expect(screen.getByLabelText(/username/i)).toBeInvalid();
-    expect(screen.getByLabelText(/password/i)).toHaveAccessibleDescription(
+    expect(screen.getByLabelText(/^username$/i)).toBeInvalid();
+    expect(screen.getByLabelText(/^password$/i)).toHaveAccessibleDescription(
       /password is required/i,
     );
-    expect(screen.getByLabelText(/password/i)).toBeInvalid();
+    expect(screen.getByLabelText(/^password$/i)).toBeInvalid();
     expect(screen.getByTestId('pathname')).toHaveTextContent('/login');
 
-    await user.type(screen.getByLabelText(/username/i), 'demo');
+    await user.type(screen.getByLabelText(/^username$/i), 'demo');
     await user.click(screen.getByRole('button', {name: /login/i}));
 
-    expect(screen.getByLabelText(/password/i)).not.toHaveAccessibleDescription(
-      /username is required/i,
-    );
-    expect(screen.getByLabelText(/username/i)).toBeValid();
-    expect(screen.getByLabelText(/password/i)).toHaveAccessibleDescription(
+    expect(
+      screen.getByLabelText(/^password$/i),
+    ).not.toHaveAccessibleDescription(/username is required/i);
+    expect(screen.getByLabelText(/^username$/i)).toBeValid();
+    expect(screen.getByLabelText(/^password$/i)).toHaveAccessibleDescription(
       /password is required/i,
     );
-    expect(screen.getByLabelText(/password/i)).toBeInvalid();
+    expect(screen.getByLabelText(/^password$/i)).toBeInvalid();
     expect(screen.getByTestId('pathname')).toHaveTextContent('/login');
 
-    await user.clear(screen.getByLabelText(/username/i));
-    await user.type(screen.getByLabelText(/password/i), 'demo');
+    await user.clear(screen.getByLabelText(/^username$/i));
+    await user.type(screen.getByLabelText(/^password$/i), 'demo');
     await user.click(screen.getByRole('button', {name: /login/i}));
 
-    expect(screen.getByLabelText(/password/i)).not.toHaveAccessibleDescription(
-      /password is required/i,
-    );
-    expect(screen.getByLabelText(/password/i)).toBeValid();
-    expect(screen.getByLabelText(/username/i)).toHaveAccessibleDescription(
+    expect(
+      screen.getByLabelText(/^password$/i),
+    ).not.toHaveAccessibleDescription(/password is required/i);
+    expect(screen.getByLabelText(/^password$/i)).toBeValid();
+    expect(screen.getByLabelText(/^username$/i)).toHaveAccessibleDescription(
       /username is required/i,
     );
-    expect(screen.getByLabelText(/username/i)).toBeInvalid();
+    expect(screen.getByLabelText(/^username$/i)).toBeInvalid();
     expect(screen.getByTestId('pathname')).toHaveTextContent('/login');
 
-    await user.type(screen.getByLabelText(/username/i), 'demo');
+    await user.type(screen.getByLabelText(/^username$/i), 'demo');
     await user.click(screen.getByRole('button', {name: /login/i}));
 
     expect(screen.getByTestId('pathname')).toHaveTextContent('/login');
@@ -175,8 +175,8 @@ describe('<Login />', () => {
       wrapper: createWrapper(),
     });
 
-    await user.type(screen.getByLabelText(/username/i), 'wrong');
-    await user.type(screen.getByLabelText(/password/i), 'credentials');
+    await user.type(screen.getByLabelText(/^username$/i), 'wrong');
+    await user.type(screen.getByLabelText(/^password$/i), 'credentials');
     await user.click(screen.getByRole('button', {name: 'Login'}));
 
     expect(await screen.findByText(LOGIN_ERROR)).toBeInTheDocument();
@@ -189,8 +189,8 @@ describe('<Login />', () => {
       wrapper: createWrapper(),
     });
 
-    await user.type(screen.getByLabelText(/username/i), 'demo');
-    await user.type(screen.getByLabelText(/password/i), 'demo');
+    await user.type(screen.getByLabelText(/^username$/i), 'demo');
+    await user.type(screen.getByLabelText(/^password$/i), 'demo');
     await user.click(screen.getByRole('button', {name: 'Login'}));
 
     expect(await screen.findByText(GENERIC_ERROR)).toBeInTheDocument();
@@ -207,8 +207,8 @@ describe('<Login />', () => {
       wrapper: createWrapper(),
     });
 
-    await user.type(screen.getByLabelText(/username/i), 'demo');
-    await user.type(screen.getByLabelText(/password/i), 'demo');
+    await user.type(screen.getByLabelText(/^username$/i), 'demo');
+    await user.type(screen.getByLabelText(/^password$/i), 'demo');
     await user.click(screen.getByRole('button', {name: 'Login'}));
 
     expect(await screen.findByText(GENERIC_ERROR)).toBeInTheDocument();


### PR DESCRIPTION
## Description

The `@carbon/react` [dependency update](https://github.com/camunda/zeebe/pull/17838) caused broken frontend and e2e tests. This PR contains a fix:

- fix test selectors for username and password fields in jest and e2e tests

## Related issues

closes #
