### PR TITLE
CI: Add issues to operate project

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -47,3 +47,11 @@ jobs:
           github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
           labeled: kind/task
           label-operator: NOT
+      - id: add-to-operate
+        name: Add to Operate project
+        uses: actions/add-to-project@v1.0.1
+        if: ${{ steps.has-project.outputs.result == 'false' }}
+        with:
+          project-url: https://github.com/orgs/camunda/projects/24
+          github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
+          labeled: component/operate

--- a/.github/workflows/operate-labeled.yml
+++ b/.github/workflows/operate-labeled.yml
@@ -1,0 +1,40 @@
+name: Assign labeled issues to operate project
+on:
+  issues:
+    types:
+      - labeled
+jobs:
+  add-to-projects:
+    name: Add issue to operate project if relevant component label added
+    runs-on: ubuntu-latest
+    if: ${{ github.event.label.name == 'component/operate' }}
+    steps:
+      - id: get_project_count
+        uses: octokit/graphql-action@v2.3.1
+        with:
+          # API https://docs.github.com/en/graphql/reference/objects#issue
+          query: |
+            query getProjectCount($owner:String!, $repo:String!, $issue: Int!) {
+              repository(name: $repo, owner: $owner) {
+                issue: issue(number: $issue) {
+                  projectsV2 {
+                    totalCount
+                  }
+                }
+              }
+            }
+          variables: |
+            owner: "camunda"
+            repo: "zeebe"
+            issue: ${{ github.event.issue.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}
+      - id: has-project
+        run: echo "result=${{ fromJSON(steps.get_project_count.outputs.data).repository.issue.projectsV2.totalCount > 0 }}" >> $GITHUB_OUTPUT
+      - id: add-to-operate
+        name: Add to Operate project
+        uses: actions/add-to-project@v1.0.1
+        if: ${{ steps.has-project.outputs.result == 'false' }}
+        with:
+          project-url: https://github.com/orgs/camunda/projects/24
+          github-token: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
## Description
Since we now track changes across two repos we need to make sure operate issues from mono-repo get added to out project board and not get missed.

Changes made:
- updated add-to-project.yml to add new issues labeled component/operate to our project board
- added new workflow: operate-labeled.yml, to also ensure issues labled after the fact also get added to our board

## Related issues

closes #
