### PR TITLE
refactor: zeebe configuration properties

### DIFF
--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
@@ -49,7 +49,7 @@ public @interface JobWorker {
    * the worker will stop activating new jobs in order to not overwhelm the client and give other
    * workers the chance to work on the jobs. The worker will try to activate new jobs again when
    * jobs are completed (or marked as failed). If no maximum is set then the default, from the
-   * ZeebeClientConfiguration, is used. <br>
+   * ZeebeClientConfigurationImpl, is used. <br>
    * <br>
    * Considerations: A greater value can avoid situations in which the client waits idle for the
    * broker to provide more jobs. This can improve the worker's throughput. The memory used by the
@@ -64,7 +64,7 @@ public @interface JobWorker {
   /**
    * Set the request timeout (in seconds) for activate job request used to poll for new job. If no
    * request timeout is set then the default is used from the {@link
-   * io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
+   * io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfigurationImpl}
    */
   long requestTimeout() default -1L;
 
@@ -73,7 +73,7 @@ public @interface JobWorker {
    * automatically try to always activate new jobs after completing jobs. If no jobs can be
    * activated after completing the worker will periodically poll for new jobs. If no poll interval
    * is set then the default is used from the {@link
-   * io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfiguration}
+   * io.camunda.zeebe.client.ZeebeClientConfiguration ZeebeClientConfigurationImpl}
    */
   long pollInterval() default -1L;
 

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -20,7 +20,6 @@ import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfiguration
 import static org.springframework.util.StringUtils.hasText;
 
 import io.camunda.zeebe.client.CredentialsProvider;
-import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.zeebe.client.impl.util.Environment;
@@ -45,9 +44,11 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-public class ZeebeClientConfigurationSpringImpl implements ZeebeClientConfiguration {
+public class ZeebeClientConfigurationImpl
+    implements io.camunda.zeebe.client.ZeebeClientConfiguration {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientConfiguration.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(io.camunda.zeebe.client.ZeebeClientConfiguration.class);
   private final Map<String, Object> configCache = new HashMap<>();
   private final ZeebeClientConfigurationProperties properties;
   private final CamundaClientProperties camundaClientProperties;
@@ -57,7 +58,7 @@ public class ZeebeClientConfigurationSpringImpl implements ZeebeClientConfigurat
   private final ZeebeClientExecutorService zeebeClientExecutorService;
 
   @Autowired
-  public ZeebeClientConfigurationSpringImpl(
+  public ZeebeClientConfigurationImpl(
       final ZeebeClientConfigurationProperties properties,
       final CamundaClientProperties camundaClientProperties,
       final Authentication authentication,
@@ -91,12 +92,22 @@ public class ZeebeClientConfigurationSpringImpl implements ZeebeClientConfigurat
 
   @Override
   public URI getRestAddress() {
-    return URI.create(camundaClientProperties.getZeebe().getBaseUrl().toString());
+    return getOrLegacyOrDefault(
+        "RestAddress",
+        () -> camundaClientProperties.getZeebe().getRestAddress(),
+        () -> properties.getBroker().getRestAddress(),
+        DEFAULT.getRestAddress(),
+        configCache);
   }
 
   @Override
   public URI getGrpcAddress() {
-    return URI.create(camundaClientProperties.getZeebe().getGatewayUrl().toString());
+    return getOrLegacyOrDefault(
+        "GrpcAddress",
+        () -> camundaClientProperties.getZeebe().getGrpcAddress(),
+        () -> properties.getBroker().getGrpcAddress(),
+        DEFAULT.getRestAddress(),
+        configCache);
   }
 
   @Override
@@ -375,7 +386,7 @@ public class ZeebeClientConfigurationSpringImpl implements ZeebeClientConfigurat
 
   @Override
   public String toString() {
-    return "ZeebeClientConfiguration{"
+    return "ZeebeClientConfigurationImpl{"
         + "properties="
         + properties
         + ", camundaClientProperties="

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientProdAutoConfiguration.java
@@ -16,7 +16,6 @@
 package io.camunda.zeebe.spring.client.configuration;
 
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeClientImpl;
 import io.camunda.zeebe.client.impl.util.ExecutorResource;
@@ -59,25 +58,25 @@ public class ZeebeClientProdAutoConfiguration {
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeClientProdAutoConfiguration.class);
 
   @Bean
-  public ZeebeClientConfiguration zeebeClientConfiguration(
+  public ZeebeClientConfigurationImpl zeebeClientConfiguration(
       final ZeebeClientConfigurationProperties properties,
       final CamundaClientProperties camundaClientProperties,
       final Authentication authentication,
       final JsonMapper jsonMapper,
       final List<ClientInterceptor> interceptors,
       final ZeebeClientExecutorService zeebeClientExecutorService) {
-    return new ZeebeClientConfigurationSpringImpl(
+    return new ZeebeClientConfigurationImpl(
         properties,
         camundaClientProperties,
         authentication,
         jsonMapper,
         interceptors,
-        zeebeClientExecutorService);
+        zeebeClientExecutorService) {};
   }
 
   @Bean(destroyMethod = "close")
-  public ZeebeClient zeebeClient(final ZeebeClientConfiguration configuration) {
-    LOG.info("Creating ZeebeClient using ZeebeClientConfiguration [" + configuration + "]");
+  public ZeebeClient zeebeClient(final ZeebeClientConfigurationImpl configuration) {
+    LOG.info("Creating ZeebeClient using ZeebeClientConfigurationImpl [" + configuration + "]");
     final ScheduledExecutorService jobWorkerExecutor = configuration.jobWorkerExecutor();
     if (jobWorkerExecutor != null) {
       final ManagedChannel managedChannel = ZeebeClientImpl.buildChannel(configuration);

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/CamundaClientProperties.java
@@ -30,10 +30,6 @@ public class CamundaClientProperties {
   private String region;
   @NestedConfigurationProperty private List<String> tenantIds;
   @NestedConfigurationProperty private AuthProperties auth;
-
-  @NestedConfigurationProperty private ApiProperties operate;
-  @NestedConfigurationProperty private ApiProperties tasklist;
-  @NestedConfigurationProperty private ApiProperties optimize;
   @NestedConfigurationProperty private ApiProperties identity;
   @NestedConfigurationProperty private ZeebeClientProperties zeebe;
 
@@ -41,7 +37,7 @@ public class CamundaClientProperties {
     return mode;
   }
 
-  public void setMode(ClientMode mode) {
+  public void setMode(final ClientMode mode) {
     this.mode = mode;
   }
 
@@ -49,39 +45,15 @@ public class CamundaClientProperties {
     return auth;
   }
 
-  public void setAuth(AuthProperties auth) {
+  public void setAuth(final AuthProperties auth) {
     this.auth = auth;
-  }
-
-  public ApiProperties getOperate() {
-    return operate;
-  }
-
-  public void setOperate(ApiProperties operate) {
-    this.operate = operate;
-  }
-
-  public ApiProperties getTasklist() {
-    return tasklist;
-  }
-
-  public void setTasklist(ApiProperties tasklist) {
-    this.tasklist = tasklist;
-  }
-
-  public ApiProperties getOptimize() {
-    return optimize;
-  }
-
-  public void setOptimize(ApiProperties optimize) {
-    this.optimize = optimize;
   }
 
   public ZeebeClientProperties getZeebe() {
     return zeebe;
   }
 
-  public void setZeebe(ZeebeClientProperties zeebe) {
+  public void setZeebe(final ZeebeClientProperties zeebe) {
     this.zeebe = zeebe;
   }
 
@@ -89,7 +61,7 @@ public class CamundaClientProperties {
     return identity;
   }
 
-  public void setIdentity(ApiProperties identity) {
+  public void setIdentity(final ApiProperties identity) {
     this.identity = identity;
   }
 
@@ -97,7 +69,7 @@ public class CamundaClientProperties {
     return tenantIds;
   }
 
-  public void setTenantIds(List<String> tenantIds) {
+  public void setTenantIds(final List<String> tenantIds) {
     this.tenantIds = tenantIds;
   }
 
@@ -105,7 +77,7 @@ public class CamundaClientProperties {
     return clusterId;
   }
 
-  public void setClusterId(String clusterId) {
+  public void setClusterId(final String clusterId) {
     this.clusterId = clusterId;
   }
 
@@ -113,7 +85,7 @@ public class CamundaClientProperties {
     return region;
   }
 
-  public void setRegion(String region) {
+  public void setRegion(final String region) {
     this.region = region;
   }
 

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -268,9 +268,8 @@ public class ZeebeClientConfigurationProperties {
     }
   }
 
-  // TODO fix annotation
   @Deprecated
-  @DeprecatedConfigurationProperty(replacement = "TODO")
+  @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.grpc-address")
   public URI getGrpcAddress() {
     if (connectionMode != null && !connectionMode.isEmpty()) {
       LOGGER.info("Using connection mode '{}' to connect to Zeebe GRPC", connectionMode);
@@ -288,9 +287,8 @@ public class ZeebeClientConfigurationProperties {
     }
   }
 
-  // TODO fix annotation
   @Deprecated
-  @DeprecatedConfigurationProperty(replacement = "TODO")
+  @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.rest-address")
   public URI getRestAddress() {
     if (connectionMode != null && !connectionMode.isEmpty()) {
       LOGGER.info("Using connection mode '{}' to connect to Zeebe REST", connectionMode);
@@ -508,7 +506,6 @@ public class ZeebeClientConfigurationProperties {
         + CONNECTION_MODE_ADDRESS;
   }
 
-  // TODO fix annotations
   public static class Broker {
     /**
      * @deprecated since 8.5 for removal with 8.8, replaced by {@link Broker#getGrpcAddress()}
@@ -525,7 +522,7 @@ public class ZeebeClientConfigurationProperties {
      * @see ZeebeClientConfiguration#getGatewayAddress()
      */
     @Deprecated
-    @DeprecatedConfigurationProperty(replacement = "TODO")
+    @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.gateway-url")
     public String getGatewayAddress() {
       if (gatewayAddress != null) {
         return gatewayAddress;
@@ -544,7 +541,7 @@ public class ZeebeClientConfigurationProperties {
     }
 
     @Deprecated
-    @DeprecatedConfigurationProperty(replacement = "TODO")
+    @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.grpc-address")
     public URI getGrpcAddress() {
       if (grpcAddress != null) {
         return grpcAddress;
@@ -553,12 +550,13 @@ public class ZeebeClientConfigurationProperties {
       }
     }
 
+    @Deprecated
     public void setGrpcAddress(final URI grpcAddress) {
       this.grpcAddress = grpcAddress;
     }
 
     @Deprecated
-    @DeprecatedConfigurationProperty(replacement = "TODO")
+    @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.rest-address")
     public URI getRestAddress() {
       if (restAddress != null) {
         return restAddress;
@@ -567,6 +565,7 @@ public class ZeebeClientConfigurationProperties {
       }
     }
 
+    @Deprecated
     public void setRestAddress(final URI restAddress) {
       this.restAddress = restAddress;
     }
@@ -577,6 +576,7 @@ public class ZeebeClientConfigurationProperties {
       return keepAlive;
     }
 
+    @Deprecated
     public void setKeepAlive(final Duration keepAlive) {
       this.keepAlive = keepAlive;
     }
@@ -752,16 +752,14 @@ public class ZeebeClientConfigurationProperties {
       return String.format("%s.%s.%s:%d", clusterId, region, baseUrl, port);
     }
 
-    // TODO fix annotation
     @Deprecated
-    @DeprecatedConfigurationProperty(replacement = "TODO")
+    @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.grpc-address")
     public URI getGrpcAddress() {
       return URI.create(String.format("https://%s.%s.%s:%d", clusterId, region, baseUrl, port));
     }
 
-    // TODO fix annotation
     @Deprecated
-    @DeprecatedConfigurationProperty(replacement = "TODO")
+    @DeprecatedConfigurationProperty(replacement = "camunda.client.zeebe.rest-address")
     public URI getRestAddress() {
       return URI.create(String.format("https://%s.%s:%d/%s", region, baseUrl, port, clusterId));
     }

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -16,6 +16,7 @@
 package io.camunda.zeebe.spring.client.properties.common;
 
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
+import java.net.URI;
 import java.net.URL;
 import java.time.Duration;
 import java.util.Map;
@@ -32,12 +33,14 @@ public class ZeebeClientProperties extends ApiProperties {
   private Map<String, ZeebeWorkerValue> override;
   private URL gatewayUrl;
   private boolean preferRestOverGrpc;
+  private URI grpcAddress;
+  private URI restAddress;
 
   public ZeebeWorkerValue getDefaults() {
     return defaults;
   }
 
-  public void setDefaults(ZeebeWorkerValue defaults) {
+  public void setDefaults(final ZeebeWorkerValue defaults) {
     this.defaults = defaults;
   }
 
@@ -45,7 +48,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return override;
   }
 
-  public void setOverride(Map<String, ZeebeWorkerValue> override) {
+  public void setOverride(final Map<String, ZeebeWorkerValue> override) {
     this.override = override;
   }
 
@@ -53,7 +56,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return executionThreads;
   }
 
-  public void setExecutionThreads(Integer executionThreads) {
+  public void setExecutionThreads(final Integer executionThreads) {
     this.executionThreads = executionThreads;
   }
 
@@ -61,7 +64,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return messageTimeToLive;
   }
 
-  public void setMessageTimeToLive(Duration messageTimeToLive) {
+  public void setMessageTimeToLive(final Duration messageTimeToLive) {
     this.messageTimeToLive = messageTimeToLive;
   }
 
@@ -69,7 +72,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return requestTimeout;
   }
 
-  public void setRequestTimeout(Duration requestTimeout) {
+  public void setRequestTimeout(final Duration requestTimeout) {
     this.requestTimeout = requestTimeout;
   }
 
@@ -77,7 +80,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return caCertificatePath;
   }
 
-  public void setCaCertificatePath(String caCertificatePath) {
+  public void setCaCertificatePath(final String caCertificatePath) {
     this.caCertificatePath = caCertificatePath;
   }
 
@@ -85,7 +88,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return keepAlive;
   }
 
-  public void setKeepAlive(Duration keepAlive) {
+  public void setKeepAlive(final Duration keepAlive) {
     this.keepAlive = keepAlive;
   }
 
@@ -93,7 +96,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return overrideAuthority;
   }
 
-  public void setOverrideAuthority(String overrideAuthority) {
+  public void setOverrideAuthority(final String overrideAuthority) {
     this.overrideAuthority = overrideAuthority;
   }
 
@@ -101,7 +104,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return maxMessageSize;
   }
 
-  public void setMaxMessageSize(Integer maxMessageSize) {
+  public void setMaxMessageSize(final Integer maxMessageSize) {
     this.maxMessageSize = maxMessageSize;
   }
 
@@ -109,7 +112,7 @@ public class ZeebeClientProperties extends ApiProperties {
     return gatewayUrl;
   }
 
-  public void setGatewayUrl(URL gatewayUrl) {
+  public void setGatewayUrl(final URL gatewayUrl) {
     this.gatewayUrl = gatewayUrl;
   }
 
@@ -117,7 +120,23 @@ public class ZeebeClientProperties extends ApiProperties {
     return preferRestOverGrpc;
   }
 
-  public void setPreferRestOverGrpc(boolean preferRestOverGrpc) {
+  public void setPreferRestOverGrpc(final boolean preferRestOverGrpc) {
     this.preferRestOverGrpc = preferRestOverGrpc;
+  }
+
+  public URI getGrpcAddress() {
+    return grpcAddress;
+  }
+
+  public void setGrpcAddress(final URI grpcAddress) {
+    this.grpcAddress = grpcAddress;
+  }
+
+  public URI getRestAddress() {
+    return restAddress;
+  }
+
+  public void setRestAddress(final URI restAddress) {
+    this.restAddress = restAddress;
   }
 }

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplOidcTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplOidcTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientAllAutoConfiguration;
-import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationSpringImpl.IdentityCredentialsProvider;
+import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationImpl.IdentityCredentialsProvider;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
 import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
 import org.junit.jupiter.api.Test;
@@ -31,13 +31,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
     classes = {ZeebeClientAllAutoConfiguration.class, ZeebeClientProdAutoConfiguration.class},
     properties = {
-      "camunda.client.mode=saas",
-      "camunda.client.cluster-id=12345",
-      "camunda.client.region=bru-2",
+      "camunda.client.mode=oidc",
       "camunda.client.auth.client-id=my-client-id",
       "camunda.client.auth.client-secret=my-client-secret"
     })
-public class ZeebeClientConfigurationSaasTest {
+public class ZeebeClientConfigurationImplOidcTest {
   @Autowired ZeebeClientConfiguration zeebeClientConfiguration;
   @Autowired JsonMapper jsonMapper;
   @Autowired ZeebeClientExecutorService zeebeClientExecutorService;
@@ -55,8 +53,7 @@ public class ZeebeClientConfigurationSaasTest {
 
   @Test
   void shouldHaveGatewayAddress() {
-    assertThat(zeebeClientConfiguration.getGatewayAddress())
-        .isEqualTo("12345.bru-2.zeebe.camunda.io:443");
+    assertThat(zeebeClientConfiguration.getGatewayAddress()).isEqualTo("localhost:26500");
   }
 
   @Test
@@ -115,7 +112,7 @@ public class ZeebeClientConfigurationSaasTest {
 
   @Test
   void shouldHavePlaintextConnectionEnabled() {
-    assertThat(zeebeClientConfiguration.isPlaintextConnectionEnabled()).isEqualTo(false);
+    assertThat(zeebeClientConfiguration.isPlaintextConnectionEnabled()).isEqualTo(true);
   }
 
   @Test

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
@@ -21,7 +21,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientAllAutoConfiguration;
-import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationSpringImpl.IdentityCredentialsProvider;
+import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationImpl.IdentityCredentialsProvider;
 import io.camunda.zeebe.spring.client.configuration.ZeebeClientProdAutoConfiguration;
 import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
 import org.junit.jupiter.api.Test;
@@ -31,11 +31,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
     classes = {ZeebeClientAllAutoConfiguration.class, ZeebeClientProdAutoConfiguration.class},
     properties = {
-      "camunda.client.mode=oidc",
+      "camunda.client.mode=saas",
+      "camunda.client.cluster-id=12345",
+      "camunda.client.region=bru-2",
       "camunda.client.auth.client-id=my-client-id",
       "camunda.client.auth.client-secret=my-client-secret"
     })
-public class ZeebeClientConfigurationOidcTest {
+public class ZeebeClientConfigurationImplSaasTest {
   @Autowired ZeebeClientConfiguration zeebeClientConfiguration;
   @Autowired JsonMapper jsonMapper;
   @Autowired ZeebeClientExecutorService zeebeClientExecutorService;
@@ -53,7 +55,8 @@ public class ZeebeClientConfigurationOidcTest {
 
   @Test
   void shouldHaveGatewayAddress() {
-    assertThat(zeebeClientConfiguration.getGatewayAddress()).isEqualTo("localhost:26500");
+    assertThat(zeebeClientConfiguration.getGatewayAddress())
+        .isEqualTo("12345.bru-2.zeebe.camunda.io:443");
   }
 
   @Test
@@ -112,7 +115,7 @@ public class ZeebeClientConfigurationOidcTest {
 
   @Test
   void shouldHavePlaintextConnectionEnabled() {
-    assertThat(zeebeClientConfiguration.isPlaintextConnectionEnabled()).isEqualTo(true);
+    assertThat(zeebeClientConfiguration.isPlaintextConnectionEnabled()).isEqualTo(false);
   }
 
   @Test

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplTest.java
@@ -18,10 +18,9 @@ package io.camunda.zeebe.spring.client.config;
 import static org.assertj.core.api.Assertions.*;
 
 import io.camunda.zeebe.client.CredentialsProvider;
-import io.camunda.zeebe.client.ZeebeClientConfiguration;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
-import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationSpringImpl;
+import io.camunda.zeebe.spring.client.configuration.ZeebeClientConfigurationImpl;
 import io.camunda.zeebe.spring.client.jobhandling.ZeebeClientExecutorService;
 import io.camunda.zeebe.spring.client.properties.CamundaClientProperties;
 import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
@@ -33,15 +32,15 @@ import java.util.Map.Entry;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.env.MockEnvironment;
 
-public class ZeebeClientConfigurationTest {
-  private static ZeebeClientConfiguration configuration(
+public class ZeebeClientConfigurationImplTest {
+  private static ZeebeClientConfigurationImpl configuration(
       final ZeebeClientConfigurationProperties legacyProperties,
       final CamundaClientProperties properties,
       final Authentication authentication,
       final JsonMapper jsonMapper,
       final List<ClientInterceptor> interceptors,
       final ZeebeClientExecutorService executorService) {
-    return new ZeebeClientConfigurationSpringImpl(
+    return new ZeebeClientConfigurationImpl(
         legacyProperties, properties, authentication, jsonMapper, interceptors, executorService);
   }
 
@@ -75,7 +74,7 @@ public class ZeebeClientConfigurationTest {
 
   @Test
   void shouldCreateSingletonCredentialProvider() {
-    final ZeebeClientConfiguration configuration =
+    final ZeebeClientConfigurationImpl configuration =
         configuration(
             legacyProperties(),
             properties(),

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/legacy/ZeebeClientStarterAutoConfigurationTest.java
@@ -60,7 +60,6 @@ import org.springframework.test.util.ReflectionTestUtils;
     classes = {
       CamundaAutoConfiguration.class,
       ZeebeClientStarterAutoConfigurationTest.TestConfig.class,
-      ZeebeClientStarterAutoConfigurationTest.TestConfig.class,
       JsonMapperConfiguration.class
     })
 public class ZeebeClientStarterAutoConfigurationTest {


### PR DESCRIPTION
## Description

- Deprecated older zeebe configuration properties related to Grpc and Rest address
- Added support for both new and old (legacy) properties, where missing
- Removed reference to other Camunda product

## Related issues

closes #17884 
closes #17885 
