### PR TITLE
fix: not recreating process and form indexes for E2E Tests

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
@@ -19,6 +19,7 @@ package io.camunda.tasklist.webapp.api.rest.v1.controllers.internal;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.es.RetryElasticsearchClient;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.indices.FormIndex;
 import io.camunda.tasklist.schema.indices.ProcessIndex;
 import io.camunda.tasklist.schema.manager.SchemaManager;
 import io.camunda.tasklist.webapp.es.cache.ProcessCache;
@@ -63,6 +64,8 @@ public class DevUtilExternalController {
 
   @Autowired private TasklistProperties tasklistProperties;
 
+  @Autowired private FormIndex formIndex;
+
   @Operation(
       summary = "Get details about the current user.",
       responses = {
@@ -79,13 +82,11 @@ public class DevUtilExternalController {
         retryElasticsearchClient
             .getIndexNames(tasklistProperties.getElasticsearch().getIndexPrefix() + "*")
             .stream()
-            .filter(f -> !f.equals(processIndex.getFullQualifiedName()))
+            .filter(
+                f ->
+                    !f.equals(processIndex.getFullQualifiedName())
+                        && !f.equals(formIndex.getFullQualifiedName()))
             .collect(Collectors.toSet());
-
-    System.out.println("indexes: ");
-    for (final String i : indices) {
-      System.out.println(i);
-    }
 
     deleteRequest.indices(indices.toArray(new String[indices.size()]));
     esClient.indices().delete(deleteRequest, RequestOptions.DEFAULT);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
@@ -17,6 +17,9 @@
 package io.camunda.tasklist.webapp.api.rest.v1.controllers.internal;
 
 import io.camunda.tasklist.data.DataGenerator;
+import io.camunda.tasklist.es.RetryElasticsearchClient;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.schema.indices.ProcessIndex;
 import io.camunda.tasklist.schema.manager.SchemaManager;
 import io.camunda.tasklist.webapp.es.cache.ProcessCache;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
@@ -25,6 +28,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -50,7 +55,13 @@ public class DevUtilExternalController {
 
   @Autowired private SearchEngineUserDetailsService searchEngineUserDetailsService;
 
+  @Autowired private RetryElasticsearchClient retryElasticsearchClient;
+
   @Autowired private ProcessCache processCache;
+
+  @Autowired private ProcessIndex processIndex;
+
+  @Autowired private TasklistProperties tasklistProperties;
 
   @Operation(
       summary = "Get details about the current user.",
@@ -63,7 +74,20 @@ public class DevUtilExternalController {
   @PostMapping("recreateData")
   public ResponseEntity<?> recreateData() throws IOException {
     final DeleteIndexRequest deleteRequest = new DeleteIndexRequest();
-    deleteRequest.indices("_all");
+
+    final Set<String> indices =
+        retryElasticsearchClient
+            .getIndexNames(tasklistProperties.getElasticsearch().getIndexPrefix() + "*")
+            .stream()
+            .filter(f -> !f.equals(processIndex.getFullQualifiedName()))
+            .collect(Collectors.toSet());
+
+    System.out.println("indexes: ");
+    for (final String i : indices) {
+      System.out.println(i);
+    }
+
+    deleteRequest.indices(indices.toArray(new String[indices.size()]));
     esClient.indices().delete(deleteRequest, RequestOptions.DEFAULT);
     processCache.clearCache();
     schemaManager.createSchema();

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/cache/ProcessCache.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/cache/ProcessCache.java
@@ -32,11 +32,11 @@ import org.springframework.stereotype.Component;
 public class ProcessCache {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
-  private static final int CACHE_MAX_SIZE = 200;
-  private final Map<String, ProcessCacheEntity> cache = new ConcurrentHashMap<>();
+  private static final int CACHE_MAX_SIZE = 100;
+  private Map<String, ProcessCacheEntity> cache = new ConcurrentHashMap<>();
   @Autowired private ProcessStore processStore;
 
-  private ProcessCacheEntity getProcessCacheEntity(final String processId) {
+  private ProcessCacheEntity getProcessCacheEntity(String processId) {
     if (cache.get(processId) == null) {
       final Optional<ProcessEntity> processMaybe = readProcessByKey(processId);
       if (processMaybe.isPresent()) {
@@ -47,7 +47,7 @@ public class ProcessCache {
     return cache.get(processId);
   }
 
-  public String getProcessName(final String processId) {
+  public String getProcessName(String processId) {
     final ProcessCacheEntity cachedProcessData = getProcessCacheEntity(processId);
     if (cachedProcessData != null) {
       return cachedProcessData.getName();
@@ -56,7 +56,7 @@ public class ProcessCache {
     }
   }
 
-  public String getTaskName(final String processId, final String flowNodeBpmnId) {
+  public String getTaskName(String processId, String flowNodeBpmnId) {
     final ProcessCacheEntity cachedProcessData = getProcessCacheEntity(processId);
     if (cachedProcessData != null) {
       return cachedProcessData.getFlowNodeNames().get(flowNodeBpmnId);
@@ -65,15 +65,15 @@ public class ProcessCache {
     }
   }
 
-  private Optional<ProcessEntity> readProcessByKey(final String processId) {
+  private Optional<ProcessEntity> readProcessByKey(String processId) {
     try {
       return Optional.of(processStore.getProcess(processId));
-    } catch (final TasklistRuntimeException ex) {
+    } catch (TasklistRuntimeException ex) {
       return Optional.empty();
     }
   }
 
-  public void putToCache(final String processId, final ProcessEntity process) {
+  public void putToCache(String processId, ProcessEntity process) {
     if (cache.size() >= CACHE_MAX_SIZE) {
       // remove 1st element
       final Iterator<String> iterator = cache.keySet().iterator();

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/cache/ProcessCache.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/cache/ProcessCache.java
@@ -32,11 +32,11 @@ import org.springframework.stereotype.Component;
 public class ProcessCache {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessCache.class);
-  private static final int CACHE_MAX_SIZE = 100;
-  private Map<String, ProcessCacheEntity> cache = new ConcurrentHashMap<>();
+  private static final int CACHE_MAX_SIZE = 200;
+  private final Map<String, ProcessCacheEntity> cache = new ConcurrentHashMap<>();
   @Autowired private ProcessStore processStore;
 
-  private ProcessCacheEntity getProcessCacheEntity(String processId) {
+  private ProcessCacheEntity getProcessCacheEntity(final String processId) {
     if (cache.get(processId) == null) {
       final Optional<ProcessEntity> processMaybe = readProcessByKey(processId);
       if (processMaybe.isPresent()) {
@@ -47,7 +47,7 @@ public class ProcessCache {
     return cache.get(processId);
   }
 
-  public String getProcessName(String processId) {
+  public String getProcessName(final String processId) {
     final ProcessCacheEntity cachedProcessData = getProcessCacheEntity(processId);
     if (cachedProcessData != null) {
       return cachedProcessData.getName();
@@ -56,7 +56,7 @@ public class ProcessCache {
     }
   }
 
-  public String getTaskName(String processId, String flowNodeBpmnId) {
+  public String getTaskName(final String processId, final String flowNodeBpmnId) {
     final ProcessCacheEntity cachedProcessData = getProcessCacheEntity(processId);
     if (cachedProcessData != null) {
       return cachedProcessData.getFlowNodeNames().get(flowNodeBpmnId);
@@ -65,15 +65,15 @@ public class ProcessCache {
     }
   }
 
-  private Optional<ProcessEntity> readProcessByKey(String processId) {
+  private Optional<ProcessEntity> readProcessByKey(final String processId) {
     try {
       return Optional.of(processStore.getProcess(processId));
-    } catch (TasklistRuntimeException ex) {
+    } catch (final TasklistRuntimeException ex) {
       return Optional.empty();
     }
   }
 
-  public void putToCache(String processId, ProcessEntity process) {
+  public void putToCache(final String processId, final ProcessEntity process) {
     if (cache.size() >= CACHE_MAX_SIZE) {
       // remove 1st element
       final Iterator<String> iterator = cache.keySet().iterator();


### PR DESCRIPTION
## Description

I'm removing from the cleaning indexes of Tasklist E2E tests the recreation of Process and Form indexes. E2E tests are doing the same deployments for each test - when there is no change in the process/form, Zeebe does not sent them again trough exporters/importers and then the subsequent tests were not consistent as Processes and Forms index were not populated properly (despite a deploy command is being sent, nothing reaches exporters/importers as there are no changes)

## Related issues

closes #
