### PR TITLE
ci: use zeebe runners for more jobs

### DIFF
--- a/.github/actions/build-operate-setup/action.yml
+++ b/.github/actions/build-operate-setup/action.yml
@@ -43,4 +43,4 @@ runs:
             "username": "${{ inputs.nexusUsername }}",
             "password": "${{ inputs.nexusPassword }}"
           }]
-        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'

--- a/.github/actions/build-tasklist-setup/action.yml
+++ b/.github/actions/build-tasklist-setup/action.yml
@@ -43,4 +43,4 @@ runs:
             "username": "${{ inputs.nexusUsername }}",
             "password": "${{ inputs.nexusPassword }}"
           }]
-        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ${{ (github.event_name == 'pull_request' && (startsWith(inputs.branch, 'fe-') || (startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')))) && 'ubuntu-latest' || 'gcp-core-8-default' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (startsWith(inputs.branch, 'fe-') || (startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')))) && 'ubuntu-latest' || 'self-hosted' }}
     timeout-minutes: 20
     steps:
       # Setup: checkout branch

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ${{ (github.event_name == 'pull_request' && startsWith(inputs.branch, 'fe-')) && 'ubuntu-latest' || 'gcp-core-8-default' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && startsWith(inputs.branch, 'fe-')) && 'ubuntu-latest' || 'self-hosted' }}
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   integration-tests:
     name: Test
-    runs-on: ${{ 'gcp-core-16-default' }}
+    runs-on: self-hosted
     if: ${{ !startsWith(inputs.branch, 'fe-') && !startsWith(inputs.branch, 'renovate/') }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Uses the Zeebe runners to:
1. Build Operate
2. Build Tasklist
3. Run Tasklist tests

I've not changed the following jobs:
1. Operate docker and playwright tests. These run on 2-core machines which we don't have for Zeebe.
2. Operate e2e tests. These run on 4-core machines which we also don't have.
3. General Operate tests. These run on 32-core machines which we also don't have.
