### PR TITLE
fix: Disable flaky test shouldStaySoftPausedAfterRestart 

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -306,6 +307,7 @@ final class ExportingEndpointIT {
   }
 
   @Test
+  @Disabled
   void shouldStaySoftPausedAfterRestart() {
     // given
     getActuator().resume();


### PR DESCRIPTION
## Description

This PR disables shouldStaySoftPausedAfterRestart until the flakyness can be solved.

## Related issues

relates to https://github.com/camunda/zeebe/issues/17836