### PR TITLE
fix: fix shouldStaySoftPausedAfterRestart

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.jar.ThreadContextUtil;
 import java.time.Duration;
@@ -202,11 +201,6 @@ final class ExporterContainer implements Controller {
   void undoSoftPauseExporter() {
     exporterIsSoftPaused = false;
     updateExporterState(lastAcknowledgedPosition, lastExportedMetadata);
-  }
-
-  @VisibleForTesting
-  public boolean isExporterIsSoftPaused() {
-    return exporterIsSoftPaused;
   }
 
   private void export(final Record<?> record) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.jar.ThreadContextUtil;
 import java.time.Duration;
@@ -195,6 +196,11 @@ final class ExporterContainer implements Controller {
   void undoSoftPauseExporter() {
     exporterIsSoftPaused = false;
     updateExporterState(lastAcknowledgedPosition, lastExportedMetadata);
+  }
+
+  @VisibleForTesting
+  public boolean isExporterIsSoftPaused() {
+    return exporterIsSoftPaused;
   }
 
   private void export(final Record<?> record) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -56,10 +56,16 @@ final class ExporterContainer implements Controller {
   }
 
   void initContainer(
-      final ActorControl actor, final ExporterMetrics metrics, final ExportersState state) {
+      final ActorControl actor,
+      final ExporterMetrics metrics,
+      final ExportersState state,
+      final ExporterPhase phase) {
     this.actor = actor;
     this.metrics = metrics;
     exportersState = state;
+    if (phase == ExporterPhase.SOFT_PAUSED) {
+      softPauseExporter();
+    }
   }
 
   void initPosition() {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -318,7 +318,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
   private void initContainers() throws Exception {
     for (final ExporterContainer container : containers) {
-      container.initContainer(actor, metrics, state);
+      container.initContainer(actor, metrics, state, exporterPhase);
       container.configureExporter();
     }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
+import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -521,6 +522,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       return CompletableActorFuture.completed(ExportersState.VALUE_NOT_FOUND);
     }
     return actor.call(() -> state.getLowestPosition());
+  }
+
+  @VisibleForTesting
+  public boolean areAllExporterContainersSoftPaused() {
+    return containers.stream().allMatch(ExporterContainer::isExporterIsSoftPaused);
   }
 
   private static class RecordExporter {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -31,7 +31,6 @@ import io.camunda.zeebe.scheduler.retry.RetryStrategy;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
-import io.camunda.zeebe.util.VisibleForTesting;
 import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
@@ -522,11 +521,6 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       return CompletableActorFuture.completed(ExportersState.VALUE_NOT_FOUND);
     }
     return actor.call(() -> state.getLowestPosition());
-  }
-
-  @VisibleForTesting
-  public boolean areAllExporterContainersSoftPaused() {
-    return containers.stream().allMatch(ExporterContainer::isExporterIsSoftPaused);
   }
 
   private static class RecordExporter {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -67,7 +67,7 @@ public final class ExporterContainerRuntime implements CloseableSilently {
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor, final int partitionId) {
     final var container = new ExporterContainer(descriptor, partitionId);
-    container.initContainer(actor.getActorControl(), metrics, state);
+    container.initContainer(actor.getActorControl(), metrics, state, ExporterPhase.EXPORTING);
 
     return container;
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -677,6 +677,9 @@ public final class ExporterDirectorTest {
     writeEvent();
     writeEvent();
 
+    exporters.get(0).shouldAutoUpdatePosition(true);
+    exporters.get(1).shouldAutoUpdatePosition(true);
+
     waitUntil(() -> exporters.get(0).getExportedRecords().size() == 2);
     waitUntil(() -> exporters.get(1).getExportedRecords().size() == 2);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -686,8 +686,6 @@ public final class ExporterDirectorTest {
     // then the position will not be updated.
     assertThat(rule.getExportersState().getPosition(EXPORTER_ID_1)).isEqualTo(-1);
     assertThat(rule.getExportersState().getPosition(EXPORTER_ID_2)).isEqualTo(-1);
-
-    assertThat(rule.getDirector().areAllExporterContainersSoftPaused()).isTrue();
   }
 
   private long writeEvent() {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -664,6 +664,29 @@ public final class ExporterDirectorTest {
     assertThat(exporters.get(1).getExportedRecords()).isEmpty();
   }
 
+  @Test
+  public void shouldStartContainersSoftPaused() {
+    // All containers of an exporter should be initialized as soft paused if this is also
+    // the exporter director phase on initialization. This is to prevent that the
+    // that exporter containers can start to update the exported position before the exporter
+    // director is ready. When soft paused new events are exported the position should not update.
+
+    // when
+    rule.startExporterDirector(exporterDescriptors, ExporterPhase.SOFT_PAUSED);
+
+    writeEvent();
+    writeEvent();
+
+    waitUntil(() -> exporters.get(0).getExportedRecords().size() == 2);
+    waitUntil(() -> exporters.get(1).getExportedRecords().size() == 2);
+
+    // then the position will not be updated.
+    assertThat(rule.getExportersState().getPosition(EXPORTER_ID_1)).isEqualTo(-1);
+    assertThat(rule.getExportersState().getPosition(EXPORTER_ID_2)).isEqualTo(-1);
+
+    assertThat(rule.getDirector().areAllExporterContainersSoftPaused()).isTrue();
+  }
+
   private long writeEvent() {
     final DeploymentRecord event = new DeploymentRecord();
     return rule.writeEvent(DeploymentIntent.CREATED, event);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -98,6 +98,11 @@ public final class ExporterRule implements TestRule {
   }
 
   public void startExporterDirector(final List<ExporterDescriptor> exporterDescriptors) {
+    startExporterDirector(exporterDescriptors, ExporterPhase.EXPORTING);
+  }
+
+  public void startExporterDirector(
+      final List<ExporterDescriptor> exporterDescriptors, final ExporterPhase phase) {
     final var stream = streams.getLogStream(STREAM_NAME);
     final var runtimeFolder = streams.createRuntimeFolder(stream);
     capturedZeebeDb = spy(zeebeDbFactory.createDb(runtimeFolder.toFile()));
@@ -114,7 +119,7 @@ public final class ExporterRule implements TestRule {
             .descriptors(exporterDescriptors)
             .positionsToSkipFilter(positionsToSkipFilter);
 
-    director = new ExporterDirector(context, ExporterPhase.EXPORTING);
+    director = new ExporterDirector(context, phase);
     director.startAsync(actorSchedulerRule.get()).join();
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -327,6 +327,7 @@ final class ExportingEndpointIT {
 
     // when
     getActuator().softPause();
+    Awaitility.await().untilAsserted(this::allPartitionsSoftPausedExporting);
     CLUSTER.shutdown();
     CLUSTER.start();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -307,7 +306,6 @@ final class ExportingEndpointIT {
   }
 
   @Test
-  @Disabled
   void shouldStaySoftPausedAfterRestart() {
     // given
     getActuator().resume();


### PR DESCRIPTION
## Description

The issue was eventually possible to reproduce locally by running until failure dozens of times.

It seems that the origin of the flakyness of the test came from the fact that during the initialization of the exporter director that was soft paused there was a small interval between the creation of the exporter containers and setting their phase after the exporter director was ready, where the container could have time to recover from a snapshot and increment the exporter position before being set as soft paused.

The solution for this is to set the exporter container phase during its creation.
Another test shouldStartContainerSoftPaused was added to asssert the new logic.

## Related issues
closes https://github.com/camunda/zeebe/issues/17836
closes https://github.com/camunda/zeebe/issues/18410