### PR TITLE
ci: revert use zeebe runners for more jobs

### DIFF
--- a/.github/actions/build-operate-setup/action.yml
+++ b/.github/actions/build-operate-setup/action.yml
@@ -43,4 +43,4 @@ runs:
             "username": "${{ inputs.nexusUsername }}",
             "password": "${{ inputs.nexusPassword }}"
           }]
-        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
+        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'

--- a/.github/actions/build-tasklist-setup/action.yml
+++ b/.github/actions/build-tasklist-setup/action.yml
@@ -43,4 +43,4 @@ runs:
             "username": "${{ inputs.nexusUsername }}",
             "password": "${{ inputs.nexusPassword }}"
           }]
-        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "zeebe,zeebe-snapshots", "name": "camunda Nexus"}]'
+        mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ${{ (github.event_name == 'pull_request' && (startsWith(inputs.branch, 'fe-') || (startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')))) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && (startsWith(inputs.branch, 'fe-') || (startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')))) && 'ubuntu-latest' || 'gcp-core-8-default' }}
     timeout-minutes: 20
     steps:
       # Setup: checkout branch

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -38,7 +38,7 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: ${{ (github.event_name == 'pull_request' && startsWith(inputs.branch, 'fe-')) && 'ubuntu-latest' || 'self-hosted' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && startsWith(inputs.branch, 'fe-')) && 'ubuntu-latest' || 'gcp-core-8-default' }}
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -40,7 +40,7 @@ env:
 jobs:
   integration-tests:
     name: Test
-    runs-on: self-hosted
+    runs-on: ${{ 'gcp-core-16-default' }}
     if: ${{ !startsWith(inputs.branch, 'fe-') && !startsWith(inputs.branch, 'renovate/') }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Reverts camunda/zeebe#17908 - fyi @oleschoenburg 

Using just the `self-hosted` label is a no-go ([ref](https://confluence.camunda.com/display/HAN/Github+Actions+Self-Hosted+Runners#GithubActionsSelfHostedRunners-Usage)) as it confuses the ARC controllers (on the Infra and Zeebe side) and causes massive runner pod overprovisioning (to my understanding, in both team's k8s clusters) - see [example](https://camunda.slack.com/archives/C070TKRS1HT/p1714154278485249) for Infra.

Why: all SH runners have a self-hosted label added by default, and if there are 2 GH SH ARC controllers in the org following the same repo (one from Infra, one from Zeebe), and a job has a non-unique combination of labels (e.g., combination exists for both our teams - `self-hosted` is non-unique and can be served by both Infra and Zeebe controllers, `gcp-core-8-default` is unique for Infra controller; `[ self-hosted, linux, amd64, "16" ]` is unique for Zeebe controller), they'll both provision a runner (hopefully just 1 each), and only one of them will actually pick a job, another would be idle for a long time, burning resources and not scaling down properly, potentially also reaching cloud provider quota.

Full-context: https://camunda.slack.com/archives/C070TKRS1HT/p1714156965553979