### PR TITLE
build: slim down Operate docker image

### DIFF
--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -68,8 +68,6 @@ WORKDIR ${OPE_HOME}
 VOLUME /tmp
 VOLUME ${OPE_HOME}/logs
 
-COPY --from=prepare /tmp/operate ${OPE_HOME}
-
 RUN addgroup --gid 1001 camunda && \
     adduser -D -h ${OPE_HOME} -G camunda -u 1001 camunda && \
     # These directories are to be mounted by users, eagerly creating them and setting ownership
@@ -77,6 +75,8 @@ RUN addgroup --gid 1001 camunda && \
     mkdir ${OPE_HOME}/logs && \
     chown -R 1001:0 ${OPE_HOME} && \
     chmod -R 0775 ${OPE_HOME}
+
+COPY --from=prepare --chown=1001:0 --chmod=0775 /tmp/operate ${OPE_HOME}
 
 USER 1001:1001
 


### PR DESCRIPTION
## Description

The current Operate SNAPSHOT docker image has a size of ~800 MB (and compressed ~590MB). When checking the layer, it adds another ~250MB layer when setting the permissions and creating the `logs` folder:

![image](https://github.com/camunda/zeebe/assets/2368139/07fd069d-f945-4c37-a422-a0d05983634b)

After changing the order, first setting the permissions and creating the `logs` folder, and only then copying the distribution into the target folder, it avoids adding another layer of ~250MB:

![image](https://github.com/camunda/zeebe/assets/2368139/f9f02e37-6eca-4c32-af91-6c5596bd1152)

So, in total the Operate Docker image size is about ~540MB (instead ~800MB).

Please note: Added `--chmod=0775` to the copy command, that way it allows to build Docker image on Windows that can be executed locally.

## Related issues

closes #
