### PR TITLE
Use project zeebe version in Spring sdk

### DIFF
--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -58,6 +58,46 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-logstreams</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-db</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-stream-platform</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -319,6 +319,24 @@
 
   <build>
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>io.camunda:zeebe-workflow-engine</dependency>
+            <dependency>io.camunda:zeebe-scheduler</dependency>
+            <dependency>io.camunda:zeebe-util</dependency>
+            <dependency>io.camunda:zeebe-logstreams</dependency>
+            <dependency>io.camunda:zeebe-db</dependency>
+            <dependency>io.camunda:zeebe-stream-platform</dependency>
+            <dependency>io.camunda:zeebe-protocol-impl</dependency>
+            <dependency>io.camunda:zeebe-protocol-jackson</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -39,7 +39,6 @@
     <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <zeebe-process-test.version>8.5.0</zeebe-process-test.version>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <zeebe.version>8.5.0</zeebe.version>
     <identity.version>8.5.0</identity.version>
     <java-jwt.version>4.4.0</java-jwt.version>
     <junit-platform-commons.version>1.10.2</junit-platform-commons.version>
@@ -234,7 +233,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-bpmn-model</artifactId>
-      <version>${zeebe.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION

## Description

[Release dry run fails with](https://github.com/camunda/zeebe/actions/runs/8841727035/job/24279266197#step:13:2358):

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project camunda-8-root: The artifact (io.camunda:zeebe-bpmn-model) requires a different version (0.8.2) than what is found (8.5.0) for the expression (zeebe.version) in the project (io.camunda:spring-boot-starter-camunda-sdk). -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project camunda-8-root: The artifact (io.camunda:zeebe-bpmn-model) requires a different version (0.8.2) than what is found (8.5.0) for the expression (zeebe.version) in the project (io.camunda:spring-boot-starter-camunda-sdk).
```

Use the project as the zeebe version, instead of using an older one.

