### PR TITLE
Declare Zeebe dependencies

### DIFF
--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -58,6 +58,46 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-workflow-engine</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-logstreams</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-jackson</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-db</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-stream-platform</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>

--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -319,6 +319,24 @@
 
   <build>
     <plugins>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <usedDependencies>
+            <dependency>io.camunda:zeebe-workflow-engine</dependency>
+            <dependency>io.camunda:zeebe-scheduler</dependency>
+            <dependency>io.camunda:zeebe-util</dependency>
+            <dependency>io.camunda:zeebe-logstreams</dependency>
+            <dependency>io.camunda:zeebe-db</dependency>
+            <dependency>io.camunda:zeebe-stream-platform</dependency>
+            <dependency>io.camunda:zeebe-protocol-impl</dependency>
+            <dependency>io.camunda:zeebe-protocol-jackson</dependency>
+          </usedDependencies>
+        </configuration>
+      </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
## Description

This PR adds necessary Zeebe dependencies to the Spring SDK module, as these have been transient before, which caused the release build to fail, as the maven reactor built order was wrong.

With this changes the dry run is successful: https://github.com/camunda/zeebe/actions/runs/8869147190/job/24349518850
