### PR TITLE
deps: Update dependency org.springframework:spring-framework-bom to v6.0.19 (stable/8.2)

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -95,7 +95,7 @@
     <version.feel-scala>1.16.3</version.feel-scala>
     <version.dmn-scala>1.8.1</version.dmn-scala>
     <version.rest-assured>5.3.2</version.rest-assured>
-    <version.spring>6.0.18</version.spring>
+    <version.spring>6.0.19</version.spring>
     <version.spring-boot>3.1.6</version.spring-boot>
     <version.concurrentunit>0.4.6</version.concurrentunit>
     <version.kryo>5.4.0</version.kryo>


### PR DESCRIPTION
## Description

Renovate hasn't picked this update up yet, want to make sure we have it in the May patch.

## Related issues

https://jira.camunda.com/browse/SEC-1003
