### PR TITLE
fix: Fix react-query migration

### DIFF
--- a/tasklist/client/src/Tasks/AvailableTasks/index.tsx
+++ b/tasklist/client/src/Tasks/AvailableTasks/index.tsx
@@ -42,8 +42,8 @@ const AvailableTasks: React.FC<Props> = ({
   const taskRef = useRef<HTMLDivElement | null>(null);
   const scrollableListRef = useRef<HTMLDivElement | null>(null);
   const {filter} = useTaskFilters();
-  const {data, isInitialLoading} = useCurrentUser();
-  const isLoading = isInitialLoading || loading;
+  const {data, isLoading: isLoadingUser} = useCurrentUser();
+  const isLoading = isLoadingUser || loading;
 
   useEffect(() => {
     scrollableListRef?.current?.scrollTo?.(0, 0);

--- a/tasklist/client/src/Tasks/EmptyPage/index.tsx
+++ b/tasklist/client/src/Tasks/EmptyPage/index.tsx
@@ -29,7 +29,7 @@ import styles from './styles.module.scss';
 
 const EmptyPage: React.FC = () => {
   const filters = useTaskFilters();
-  const {isLoading: isLoadingTasks, data} = useTasks(filters);
+  const {isPending, data} = useTasks(filters);
   const tasks = data?.pages.flat() ?? [];
   const hasNoTasks = tasks.length === 0;
   const isOldUser = getStateLocally('hasCompletedTask') === true;
@@ -49,7 +49,7 @@ const EmptyPage: React.FC = () => {
     });
   }, [searchParams, setSearchParams]);
 
-  if (isLoadingTasks) {
+  if (isPending) {
     return <span data-testid="loading-state" />;
   }
 

--- a/tasklist/client/src/Tasks/Task/Details/index.tsx
+++ b/tasklist/client/src/Tasks/Task/Details/index.tsx
@@ -92,7 +92,7 @@ const Details: React.FC<Props> = ({
   const {mutateAsync: assignTask, isPending: assignIsPending} = useAssignTask();
   const {mutateAsync: unassignTask, isPending: unassignIsPending} =
     useUnassignTask();
-  const isLoading = (assignIsPending || unassignIsPending) ?? false;
+  const isPending = (assignIsPending || unassignIsPending) ?? false;
 
   const handleClick = async () => {
     try {
@@ -131,7 +131,7 @@ const Details: React.FC<Props> = ({
   };
 
   function getAsyncActionButtonStatus() {
-    if (isLoading || assignmentStatus !== 'off') {
+    if (isPending || assignmentStatus !== 'off') {
       const ACTIVE_STATES: AssignmentStatus[] = ['assigning', 'unassigning'];
 
       return ACTIVE_STATES.includes(assignmentStatus) ? 'active' : 'finished';
@@ -217,7 +217,7 @@ const Details: React.FC<Props> = ({
                       size: 'sm',
                       type: 'button',
                       onClick: handleClick,
-                      disabled: isLoading,
+                      disabled: isPending,
                       autoFocus: true,
                       id: 'main-content',
                     }}

--- a/tasklist/client/src/Tasks/Task/FormJS/index.tsx
+++ b/tasklist/client/src/Tasks/Task/FormJS/index.tsx
@@ -85,7 +85,7 @@ const FormJS: React.FC<Props> = ({
   const [submissionState, setSubmissionState] =
     useState<InlineLoadingStatus>('inactive');
   const {assignee, taskState, formVersion} = task;
-  const {data, isInitialLoading} = useForm(
+  const {data, isLoading} = useForm(
     {
       id,
       processDefinitionKey,
@@ -105,7 +105,7 @@ const FormJS: React.FC<Props> = ({
       variableNames: extractedVariables,
     },
     {
-      enabled: !isInitialLoading && extractedVariables.length > 0,
+      enabled: !isLoading && extractedVariables.length > 0,
       refetchOnReconnect: assignee === null,
       refetchOnWindowFocus: assignee === null,
     },

--- a/tasklist/client/src/Tasks/Task/Variables/index.tsx
+++ b/tasklist/client/src/Tasks/Task/Variables/index.tsx
@@ -123,7 +123,7 @@ const Variables: React.FC<Props> = ({
   const {hasPermission} = usePermissions(['write']);
   const {
     data,
-    isInitialLoading,
+    isLoading,
     fetchFullVariable,
     variablesLoadingFullValue,
     status,
@@ -149,7 +149,7 @@ const Variables: React.FC<Props> = ({
     values.newVariables?.some((variable) => variable === undefined);
   const variables = data ?? [];
 
-  if (isInitialLoading) {
+  if (isLoading) {
     return null;
   }
 

--- a/tasklist/client/src/Tasks/index.tsx
+++ b/tasklist/client/src/Tasks/index.tsx
@@ -86,13 +86,8 @@ function useAutoSelectNextTaskSideEffects() {
 
 const Tasks: React.FC = observer(() => {
   const filters = useTaskFilters();
-  const {
-    fetchPreviousTasks,
-    fetchNextTasks,
-    isInitialLoading,
-    isLoading,
-    data,
-  } = useTasks(filters);
+  const {fetchPreviousTasks, fetchNextTasks, isLoading, isPending, data} =
+    useTasks(filters);
   const tasks = data?.pages.flat() ?? [];
 
   useAutoSelectNextTaskSideEffects();
@@ -108,9 +103,9 @@ const Tasks: React.FC = observer(() => {
   return (
     <main className={styles.container}>
       <Stack as="section" className={styles.tasksPanel} aria-label="Left panel">
-        <Filters disabled={isLoading} />
+        <Filters disabled={isPending} />
         <AvailableTasks
-          loading={isInitialLoading}
+          loading={isLoading}
           onScrollDown={fetchNextTasks}
           onScrollUp={fetchPreviousTasks}
           tasks={tasks}


### PR DESCRIPTION
## Description

[There were some leftover issues with the `react-query` migration](https://tanstack.com/query/latest/docs/framework/react/guides/migrating-to-v5#status-loading-has-been-changed-to-status-pending-and-isloading-has-been-changed-to-ispending-and-isinitialloading-has-now-been-renamed-to-isloading), this PR addresses it