### PR TITLE
[Backport stable/8.5] fix: do not short-circuit retry for force configure request

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -230,19 +230,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   @Override
   public CompletableFuture<ForceConfigureResponse> onForceConfigure(
       final ForceConfigureRequest request) {
-    final Configuration currentConfiguration = raft.getCluster().getConfiguration();
-    if (currentConfiguration != null // this is not expected in a leader
-        && request.newMembers().equals(currentConfiguration.allMembers())) {
-      // It is likely that the previous force configure was successfully completed, and this is a
-      // retry. So just respond success.
-      return CompletableFuture.completedFuture(
-          logResponse(
-              ForceConfigureResponse.builder()
-                  .withStatus(Status.OK)
-                  .withIndex(currentConfiguration.index())
-                  .withTerm(currentConfiguration.term())
-                  .build()));
-    }
 
     // Do not force-configure when you are leader.
     raft.transition(Role.FOLLOWER);


### PR DESCRIPTION
# Description
Backport of #17641 to `stable/8.5`.

relates to #17334
original author: @deepthidevaki