### PR TITLE
[Backport stable/8.2] Soft pause information is persisted across all replicas.

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/MultiPartitionAdminAccess.java
@@ -50,6 +50,11 @@ final class MultiPartitionAdminAccess implements PartitionAdminAccess {
   }
 
   @Override
+  public ActorFuture<Void> softPauseExporting() {
+    return callOnEachPartition(PartitionAdminAccess::softPauseExporting);
+  }
+
+  @Override
   public ActorFuture<Void> resumeExporting() {
     return callOnEachPartition(PartitionAdminAccess::resumeExporting);
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/NoOpPartitionAdminAccess.java
@@ -35,6 +35,12 @@ public final class NoOpPartitionAdminAccess implements PartitionAdminAccess {
   }
 
   @Override
+  public ActorFuture<Void> softPauseExporting() {
+    logCall();
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
   public ActorFuture<Void> resumeExporting() {
     logCall();
     return CompletableActorFuture.completed(null);

--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionAdminAccess.java
@@ -17,6 +17,8 @@ public interface PartitionAdminAccess {
 
   ActorFuture<Void> pauseExporting();
 
+  ActorFuture<Void> softPauseExporting();
+
   ActorFuture<Void> resumeExporting();
 
   ActorFuture<Void> pauseProcessing();

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControl.java
@@ -34,5 +34,7 @@ public interface PartitionAdminControl {
 
   boolean pauseExporting() throws IOException;
 
+  boolean softPauseExporting() throws IOException;
+
   boolean resumeExporting() throws IOException;
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -91,6 +91,11 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   }
 
   @Override
+  public boolean softPauseExporting() throws IOException {
+    return partitionProcessingStateSupplier.get().softPauseExporting();
+  }
+
+  @Override
   public boolean resumeExporting() throws IOException {
     return partitionProcessingStateSupplier.get().resumeExporting();
   }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -91,7 +91,7 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
   }
 
   @Override
-  public boolean softPauseExporting() throws IOException {
+  public boolean softPauseExporting() {
     return partitionProcessingStateSupplier.get().softPauseExporting();
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionAdminControlImpl.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.system.partitions;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
+import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState.ExporterState;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
@@ -72,7 +73,7 @@ public class PartitionAdminControlImpl implements PartitionAdminControl {
 
   @Override
   public boolean shouldExport() {
-    return !partitionProcessingStateSupplier.get().isExportingPaused();
+    return !partitionProcessingStateSupplier.get().getExporterState().equals(ExporterState.PAUSED);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState.ExporterState;
-import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderService;

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -23,6 +23,8 @@ import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.impl.AsyncSnapshotDirector;
 import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState;
+import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState.ExporterState;
+import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.broker.transport.backupapi.BackupApiRequestHandler;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandReceiverActor;
 import io.camunda.zeebe.broker.transport.partitionapi.InterPartitionCommandSenderService;
@@ -248,7 +250,7 @@ public class PartitionStartupAndTransitionContextImpl
 
   @Override
   public boolean shouldExport() {
-    return !partitionProcessingState.isExportingPaused();
+    return !partitionProcessingState.getExporterState().equals(ExporterState.PAUSED);
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -120,12 +120,12 @@ public class PartitionProcessingState {
 
     final File persistedExporterPauseState =
         getPersistedPauseState(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME);
-    persistedExporterPauseState.createNewFile();
     Files.writeString(
         persistedExporterPauseState.toPath(),
         state.name(),
         StandardCharsets.UTF_8,
-        StandardOpenOption.DSYNC);
+        StandardOpenOption.DSYNC,
+        StandardOpenOption.CREATE);
   }
 
   private void initExportingState() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -135,7 +135,8 @@ public class PartitionProcessingState {
                 getPersistedPauseState(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath());
         if (state == null || state.isEmpty() || state.isBlank()) {
           // Backwards compatibility. If the file exists, it is paused.
-          setPersistedExporterState(ExporterState.PAUSED);
+          exporterState = ExporterState.PAUSED;
+          return;
         }
         exporterState = ExporterState.valueOf(state);
       }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -78,6 +78,10 @@ public class PartitionProcessingState {
     return exporterState.equals(PAUSED);
   }
 
+  public boolean isExportingSoftPaused() {
+    return exporterState.equals(SOFT_PAUSED);
+  }
+
   @SuppressWarnings({"squid:S899"})
   /** Returns true if exporting is paused. This method overrides the effects of soft pause. */
   public boolean pauseExporting() {

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -70,12 +70,8 @@ public class PartitionProcessingState {
     return isDiskSpaceAvailable() && !isProcessingPaused();
   }
 
-  public boolean isExportingPaused() {
-    return exporterState.equals(ExporterState.PAUSED);
-  }
-
-  public boolean isExportingSoftPaused() {
-    return exporterState.equals(ExporterState.SOFT_PAUSED);
+  public ExporterState getExporterState() {
+    return exporterState;
   }
 
   @SuppressWarnings({"squid:S899"})

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.io.TempDir;
 class PartitionProcessingStateTest {
   private static final String PERSISTED_PAUSE_STATE_FILENAME = ".processorPaused";
   private static final String PERSISTED_EXPORTER_PAUSE_STATE_FILENAME = ".exporterPaused";
-  private static @TempDir Path TEST_DIR;
+  private static @TempDir Path testDir;
   private static final RaftPartition MOCK_RAFT_PARTITION =
       mock(RaftPartition.class, RETURNS_DEEP_STUBS);
 
   @BeforeAll
   static void setUp() {
-    when(MOCK_RAFT_PARTITION.dataDirectory().toPath()).thenReturn(TEST_DIR);
+    when(MOCK_RAFT_PARTITION.dataDirectory().toPath()).thenReturn(testDir);
   }
 
   @Test
@@ -114,5 +114,27 @@ class PartitionProcessingStateTest {
     assertThat(partitionProcessingState.getExporterState())
         .describedAs("Exporting must be resumed.")
         .isEqualTo(ExporterState.EXPORTING);
+  }
+
+  @Test
+  void shouldAssureBackwardCompatibility() throws IOException {
+    // Before the functionality to soft pause the exporter, the previous implementation did not
+    // have the exporter state saved onto to the file. It determined the exporter state based on
+    // the existence of the file (if it exists, then the exporter is paused).
+    // see the changes in: https://github.com/camunda/zeebe/pull/16869
+
+    // Create an empty file for pauseState
+    final File persistedExporterPauseState =
+        testDir.resolve(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toFile();
+
+    persistedExporterPauseState.createNewFile();
+    assertThat(persistedExporterPauseState).describedAs("Exporter State file exists.").exists();
+
+    // Then initialize Partition ProcessingState
+    final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
+
+    assertThat(partitionProcessingState.getExporterState())
+        .describedAs("Exporting must be paused.")
+        .isEqualTo(ExporterState.PAUSED);
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.broker.system.partitions.impl;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.raft.partition.RaftPartition;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+class PartitionProcessingStateTest {
+  private static final String PERSISTED_PAUSE_STATE_FILENAME = ".processorPaused";
+  private static final String PERSISTED_EXPORTER_PAUSE_STATE_FILENAME = ".exporterPaused";
+  private static final String testDir = "src/test/resources";
+  private static final Path pathToExporterState =
+      new File(testDir + PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath();
+  private static final Path pathToProcessorState =
+      new File(testDir + PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath();
+  private static final RaftPartition mockRaftPartition =
+      mock(RaftPartition.class, RETURNS_DEEP_STUBS);
+
+  private static final File processorStateFile = mock(File.class);
+  private static final File exporterStateFile = mock(File.class);
+
+  @BeforeAll
+  static void beforeAll() {
+
+    when(mockRaftPartition
+            .dataDirectory()
+            .toPath()
+            .resolve(PERSISTED_PAUSE_STATE_FILENAME)
+            .toFile())
+        .thenReturn(processorStateFile);
+    when(mockRaftPartition
+            .dataDirectory()
+            .toPath()
+            .resolve(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME)
+            .toFile())
+        .thenReturn(exporterStateFile);
+    when(processorStateFile.toPath()).thenReturn(pathToProcessorState);
+    when(exporterStateFile.toPath()).thenReturn(pathToExporterState);
+  }
+
+  @AfterAll
+  static void afterAll() {
+    pathToExporterState.toFile().delete();
+    pathToProcessorState.toFile().delete();
+  }
+
+  @Test
+  void shouldPauseAndResumeProcessing() throws IOException {
+    // given
+    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
+    when(processorStateFile.exists()).thenReturn(true);
+    partitionProcessingState.pauseProcessing();
+
+    assertTrue(partitionProcessingState.isProcessingPaused());
+
+    // when
+    when(processorStateFile.exists()).thenReturn(false);
+    partitionProcessingState.resumeProcessing();
+
+    // then
+    assertFalse(partitionProcessingState.isProcessingPaused());
+  }
+
+  @Test
+  void shouldPauseAndResumeExporting() {
+    // given
+    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
+    partitionProcessingState.pauseExporting();
+
+    assertTrue(partitionProcessingState.isExportingPaused());
+
+    // when
+    partitionProcessingState.resumeExporting();
+
+    // then
+    assertFalse(partitionProcessingState.isExportingPaused());
+  }
+
+  @Test
+  void shouldSoftPauseAndResumeExporter() {
+    // given
+    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
+    partitionProcessingState.softPauseExporting();
+
+    assertTrue(partitionProcessingState.isExportingSoftPaused());
+
+    // when
+    partitionProcessingState.resumeExporting();
+
+    // then
+    assertFalse(partitionProcessingState.isExportingSoftPaused());
+  }
+
+  @Test
+  void shouldOverwriteExporterStates() {
+    // given
+    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
+
+    partitionProcessingState.pauseExporting();
+
+    assertTrue(partitionProcessingState.isExportingPaused());
+
+    // we overwrite the pause state
+    partitionProcessingState.softPauseExporting();
+
+    assertTrue(partitionProcessingState.isExportingSoftPaused());
+
+    // then we resume again
+    partitionProcessingState.resumeExporting();
+
+    assertFalse(partitionProcessingState.isExportingPaused());
+  }
+}

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
@@ -35,7 +35,7 @@ class PartitionProcessingStateTest {
   private static final File exporterStateFile = mock(File.class);
 
   @BeforeAll
-  static void beforeAll() {
+  static void beforeAll() throws IOException {
 
     when(mockRaftPartition
             .dataDirectory()

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
@@ -23,53 +23,52 @@ import org.junit.jupiter.api.Test;
 class PartitionProcessingStateTest {
   private static final String PERSISTED_PAUSE_STATE_FILENAME = ".processorPaused";
   private static final String PERSISTED_EXPORTER_PAUSE_STATE_FILENAME = ".exporterPaused";
-  private static final String testDir = "src/test/resources";
-  private static final Path pathToExporterState =
-      new File(testDir + PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath();
-  private static final Path pathToProcessorState =
-      new File(testDir + PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath();
-  private static final RaftPartition mockRaftPartition =
+  private static final String TEST_DIR = "src/test/resources";
+  private static final Path PATH_TO_EXPORTER_STATE =
+      new File(TEST_DIR + PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath();
+  private static final Path PATH_TO_PROCESSOR_STATE =
+      new File(TEST_DIR + PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath();
+  private static final RaftPartition MOCK_RAFT_PARTITION =
       mock(RaftPartition.class, RETURNS_DEEP_STUBS);
 
-  private static final File processorStateFile = mock(File.class);
-  private static final File exporterStateFile = mock(File.class);
+  private static final File PROCESSOR_STATE_FILE = mock(File.class);
+  private static final File EXPORTER_STATE_FILE = mock(File.class);
 
   @BeforeAll
-  static void beforeAll() throws IOException {
-
-    when(mockRaftPartition
+  static void setUp() {
+    when(MOCK_RAFT_PARTITION
             .dataDirectory()
             .toPath()
             .resolve(PERSISTED_PAUSE_STATE_FILENAME)
             .toFile())
-        .thenReturn(processorStateFile);
-    when(mockRaftPartition
+        .thenReturn(PROCESSOR_STATE_FILE);
+    when(MOCK_RAFT_PARTITION
             .dataDirectory()
             .toPath()
             .resolve(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME)
             .toFile())
-        .thenReturn(exporterStateFile);
-    when(processorStateFile.toPath()).thenReturn(pathToProcessorState);
-    when(exporterStateFile.toPath()).thenReturn(pathToExporterState);
+        .thenReturn(EXPORTER_STATE_FILE);
+    when(PROCESSOR_STATE_FILE.toPath()).thenReturn(PATH_TO_PROCESSOR_STATE);
+    when(EXPORTER_STATE_FILE.toPath()).thenReturn(PATH_TO_EXPORTER_STATE);
   }
 
   @AfterAll
   static void afterAll() {
-    pathToExporterState.toFile().delete();
-    pathToProcessorState.toFile().delete();
+    PATH_TO_EXPORTER_STATE.toFile().delete();
+    PATH_TO_PROCESSOR_STATE.toFile().delete();
   }
 
   @Test
   void shouldPauseAndResumeProcessing() throws IOException {
     // given
-    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
-    when(processorStateFile.exists()).thenReturn(true);
+    final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
+    when(PROCESSOR_STATE_FILE.exists()).thenReturn(true);
     partitionProcessingState.pauseProcessing();
 
     assertTrue(partitionProcessingState.isProcessingPaused());
 
     // when
-    when(processorStateFile.exists()).thenReturn(false);
+    when(PROCESSOR_STATE_FILE.exists()).thenReturn(false);
     partitionProcessingState.resumeProcessing();
 
     // then
@@ -79,7 +78,7 @@ class PartitionProcessingStateTest {
   @Test
   void shouldPauseAndResumeExporting() {
     // given
-    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
+    final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
     partitionProcessingState.pauseExporting();
 
     assertTrue(partitionProcessingState.isExportingPaused());
@@ -94,7 +93,7 @@ class PartitionProcessingStateTest {
   @Test
   void shouldSoftPauseAndResumeExporter() {
     // given
-    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
+    final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
     partitionProcessingState.softPauseExporting();
 
     assertTrue(partitionProcessingState.isExportingSoftPaused());
@@ -109,7 +108,7 @@ class PartitionProcessingStateTest {
   @Test
   void shouldOverwriteExporterStates() {
     // given
-    final var partitionProcessingState = new PartitionProcessingState(mockRaftPartition);
+    final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
 
     partitionProcessingState.pauseExporting();
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.it.management;
 
 import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -73,8 +74,22 @@ final class ExportingEndpointIT {
     // when
     getActuator().pause();
 
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("2")
+        .messageId("2")
+        .send()
+        .join();
+
+    final var recordsAfterPause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
     // then
-    RecordingExporter.records().limit(recordsBeforePause + 1).await();
+    assertEquals(recordsAfterPause, recordsBeforePause);
     Awaitility.await().untilAsserted(this::allPartitionsPausedExporting);
   }
 
@@ -82,17 +97,18 @@ final class ExportingEndpointIT {
   void shouldResumeExporting() {
     // given
     final var actuator = getActuator();
+
     actuator.pause();
 
     client
         .newPublishMessageCommand()
         .messageName("Test")
-        .correlationKey("1")
-        .messageId("2")
+        .correlationKey("3")
+        .messageId("3")
         .send()
         .join();
 
-    final var recordsBeforePause =
+    final var recordsBeforeResume =
         Awaitility.await()
             .atMost(Duration.ofSeconds(30))
             .during(Duration.ofSeconds(5))
@@ -101,8 +117,14 @@ final class ExportingEndpointIT {
     // when
     getActuator().resume();
 
+    final var recordsAfterResume =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
     // then
-    RecordingExporter.records().limit(recordsBeforePause + 1).await();
+    assertThat(recordsAfterResume).isGreaterThan(recordsBeforeResume);
     Awaitility.await().untilAsserted(this::allPartitionsExporting);
   }
 
@@ -115,7 +137,7 @@ final class ExportingEndpointIT {
         .newPublishMessageCommand()
         .messageName("Test")
         .correlationKey("5")
-        .messageId("3")
+        .messageId("5")
         .send()
         .join();
 
@@ -130,8 +152,22 @@ final class ExportingEndpointIT {
     CLUSTER.shutdown();
     CLUSTER.start();
 
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("6")
+        .messageId("6")
+        .send()
+        .join();
+
+    final var recordsAfterRestart =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
     // then
-    RecordingExporter.records().limit(recordsBeforePause + 1).await();
+    assertEquals(recordsAfterRestart, recordsBeforePause);
     Awaitility.await().untilAsserted(this::allPartitionsPausedExporting);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.it.management;
+
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.actuator.ExportingActuator;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+@AutoCloseResources
+final class ExportingEndpointIT {
+  @TestZeebe
+  private static final TestCluster CLUSTER =
+      TestCluster.builder()
+          .useRecordingExporter(true)
+          .withBrokersCount(2)
+          .withPartitionsCount(2)
+          .withReplicationFactor(1)
+          .withEmbeddedGateway(true)
+          .build();
+
+  @AutoCloseResource private final ZeebeClient client = CLUSTER.newClientBuilder().build();
+
+  @BeforeAll
+  static void beforeAll() {
+    try (final var client = CLUSTER.newClientBuilder().build()) {
+      client
+          .newDeployResourceCommand()
+          .addProcessModel(
+              Bpmn.createExecutableProcess("processId").startEvent().endEvent().done(),
+              "process.bpmn")
+          .send()
+          .join();
+    }
+  }
+
+  @Test
+  void shouldPauseExporting() {
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("1")
+        .messageId("1")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // when
+    getActuator().pause();
+
+    // then
+    RecordingExporter.records().limit(recordsBeforePause + 1).await();
+    Awaitility.await().untilAsserted(this::allPartitionsPausedExporting);
+  }
+
+  @Test
+  void shouldResumeExporting() {
+    // given
+    final var actuator = getActuator();
+    actuator.pause();
+
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("1")
+        .messageId("2")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // when
+    getActuator().resume();
+
+    // then
+    RecordingExporter.records().limit(recordsBeforePause + 1).await();
+    Awaitility.await().untilAsserted(this::allPartitionsExporting);
+  }
+
+  @Test
+  void shouldStayPausedAfterRestart() {
+    // given
+    // in case this test gets run right after shouldPauseExporting
+    getActuator().resume();
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("5")
+        .messageId("3")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // when
+    getActuator().pause();
+    CLUSTER.shutdown();
+    CLUSTER.start();
+
+    // then
+    RecordingExporter.records().limit(recordsBeforePause + 1).await();
+    Awaitility.await().untilAsserted(this::allPartitionsPausedExporting);
+  }
+
+  private ExportingActuator getActuator() {
+    return ExportingActuator.of(CLUSTER.availableGateway());
+  }
+
+  private void allPartitionsPausedExporting() {
+    for (final var broker : CLUSTER.brokers().values()) {
+      assertThat(PartitionsActuator.of(broker).query().values())
+          .allMatch(
+              status -> status.exporterPhase() == null || status.exporterPhase().equals("PAUSED"),
+              "All exporters should be paused");
+    }
+  }
+
+  private void allPartitionsExporting() {
+    for (final var broker : CLUSTER.brokers().values()) {
+      assertThat(PartitionsActuator.of(broker).query().values())
+          .allMatch(
+              status ->
+                  status.exporterPhase() == null || status.exporterPhase().equals("EXPORTING"),
+              "All exporters should be running");
+    }
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/camunda/zeebe/pull/16869 to stable/8.2.

relates to https://github.com/camunda/zeebe/issues/16642

`CONFLICT (modify/delete): zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java deleted in HEAD and modified in 9b09ee83e2 (test: add test to assert that paused state is persisted after broker shutdown).  Version 9b09ee83e2 (test: add test to assert that paused state is persisted after broker shutdown) of zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java left in tree.`

The file had been deleted, so I just added it in full.   

`
CONFLICT (file location): 
zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java added in da57c7ec5f (test: add PartitionProcessingStateTest) inside a directory that was renamed in HEAD, suggesting it should perhaps be moved to broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java.
`

The directory where PartitionProcessingStateTest was added had been renamed. Just moved to the new place.

`
Auto-merging broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
CONFLICT (content): Merge conflict in broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
error: could not apply 2b023def66... refactor: refactor get of exporter state.
`

Merge conflic in PartitionStartupAndTransitionContextImpl.java for the import of `io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler`