### PR TITLE
deps: Update dependency org.camunda.feel:feel-engine to v1.17.7

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -92,7 +92,7 @@
     <version.testcontainers>1.19.7</version.testcontainers>
     <version.netflix.concurrency>0.5.0</version.netflix.concurrency>
     <version.zeebe-test-container>3.6.3</version.zeebe-test-container>
-    <version.feel-scala>1.17.6</version.feel-scala>
+    <version.feel-scala>1.17.7</version.feel-scala>
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>
     <version.spring>6.1.6</version.spring>


### PR DESCRIPTION
## Description
I didn't see a PR automatically generated by renovate to take care of this. So I created it manually. 

This is to port the changes made in https://github.com/camunda/feel-scala/pull/838 to zeebe.
## Related issues

closes #15209
