### PR TITLE
fix: Enable GraphQL auto-configuration only for tasklist-webapp

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/Application.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/Application.java
@@ -19,6 +19,7 @@ package io.camunda.tasklist;
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.AUTH_PROFILES;
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.DEFAULT_AUTH;
 
+import graphql.kickstart.autoconfigure.annotations.GraphQLAnnotationsAutoConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
 import java.util.HashMap;
@@ -27,7 +28,6 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration;
@@ -39,7 +39,11 @@ import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 import org.springframework.core.env.ConfigurableEnvironment;
 
-@SpringBootApplication
+@SpringBootApplication(
+    exclude = {
+      ElasticsearchClientAutoConfiguration.class,
+      GraphQLAnnotationsAutoConfiguration.class
+    })
 @ComponentScan(
     basePackages = "io.camunda.tasklist",
     excludeFilters = {
@@ -54,7 +58,6 @@ import org.springframework.core.env.ConfigurableEnvironment;
           pattern = "io\\.camunda\\.tasklist\\.archiver\\..*")
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@EnableAutoConfiguration(exclude = ElasticsearchClientAutoConfiguration.class)
 public class Application {
 
   public static final String TASKLIST_STATIC_RESOURCES_LOCATION =

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
@@ -16,6 +16,7 @@
  */
 package io.camunda.tasklist;
 
+import graphql.kickstart.autoconfigure.annotations.GraphQLAnnotationsAutoConfiguration;
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,6 +24,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.context.annotation.Import;
 
 @Configuration
 @ComponentScan(
@@ -32,6 +34,7 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
     name = "camunda.tasklist.webappEnabled",
     havingValue = "true",
     matchIfMissing = true)
+@Import(GraphQLAnnotationsAutoConfiguration.class)
 public class WebappModuleConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebappModuleConfiguration.class);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
@@ -20,11 +20,11 @@ import graphql.kickstart.autoconfigure.annotations.GraphQLAnnotationsAutoConfigu
 import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
-import org.springframework.context.annotation.Import;
 
 @Configuration
 @ComponentScan(
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.Import;
     name = "camunda.tasklist.webappEnabled",
     havingValue = "true",
     matchIfMissing = true)
-@Import(GraphQLAnnotationsAutoConfiguration.class)
+@ImportAutoConfiguration(GraphQLAnnotationsAutoConfiguration.class)
 public class WebappModuleConfiguration {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(WebappModuleConfiguration.class);

--- a/tasklist/webapp/src/main/resources/application-tasklist.yml
+++ b/tasklist/webapp/src/main/resources/application-tasklist.yml
@@ -1,11 +1,3 @@
-# overriding spring.autoconfigure.exclude to enable graphql.kickstart.autoconfigure.annotations.GraphQLAnnotationsAutoConfiguration
-spring.autoconfigure.exclude:
-  - org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration
-  - org.springframework.boot.actuate.autoconfigure.security.servlet.ManagementWebSecurityAutoConfiguration
-  - org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchRestClientAutoConfiguration
-  - org.springframework.boot.autoconfigure.ldap.LdapAutoConfiguration
-  - graphql.kickstart.autoconfigure.tools.GraphQLJavaToolsAutoConfiguration
----
 spring:
   config:
     activate:


### PR DESCRIPTION
## Description
Excluding `GraphQLAnnotationsAutoConfiguration`  is enough to disable all kickstart springboot auto configurations (it disables `@Conditional(OnSchemaOrSchemaProviderBean.class)` condition)
```
   GraphQLJavaToolsAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'graphql.kickstart.tools.SchemaParser' (OnClassCondition)

   GraphQLSpringWebfluxAutoConfiguration:
      Did not match:
         - did not find reactive web application classes (OnWebApplicationCondition)

   GraphQLWebAutoConfiguration:
      Did not match:
         - AnyNestedCondition 0 matched 2 did not; NestedCondition on OnSchemaOrSchemaProviderBean.OnSchemaProvider @ConditionalOnBean (types: graphql.kickstart.execution.config.GraphQLSchemaProvider; SearchStrategy: all) did not find any beans of type graphql.kickstart.execution.config.GraphQLSchemaProvider; NestedCondition on OnSchemaOrSchemaProviderBean.OnSchema @ConditionalOnBean (types: graphql.schema.GraphQLSchema; SearchStrategy: all) did not find any beans of type graphql.schema.GraphQLSchema (OnSchemaOrSchemaProviderBean)
      Matched:
         - @ConditionalOnClass found required class 'org.springframework.web.servlet.DispatcherServlet' (OnClassCondition)
         - found 'session' scope (OnWebApplicationCondition)
         - @ConditionalOnProperty (graphql.servlet.enabled=true) matched (OnPropertyCondition)

   GraphQLWebSecurityAutoConfiguration:
      Did not match:
         - AnyNestedCondition 0 matched 2 did not; NestedCondition on OnSchemaOrSchemaProviderBean.OnSchemaProvider @ConditionalOnBean (types: graphql.kickstart.execution.config.GraphQLSchemaProvider; SearchStrategy: all) did not find any beans of type graphql.kickstart.execution.config.GraphQLSchemaProvider; NestedCondition on OnSchemaOrSchemaProviderBean.OnSchema @ConditionalOnBean (types: graphql.schema.GraphQLSchema; SearchStrategy: all) did not find any beans of type graphql.schema.GraphQLSchema (OnSchemaOrSchemaProviderBean)
      Matched:
         - @ConditionalOnClass found required classes 'org.springframework.web.servlet.DispatcherServlet', 'org.springframework.security.authentication.DefaultAuthenticationEventPublisher' (OnClassCondition)
         - found 'session' scope (OnWebApplicationCondition)
         - @ConditionalOnProperty (graphql.servlet.enabled=true) matched (OnPropertyCondition)

   GraphQLWebsocketAutoConfiguration:
      Did not match:
         - @ConditionalOnClass did not find required class 'org.springframework.web.socket.server.standard.ServerEndpointRegistration' (OnClassCondition)
```
## Related issues

closes #18095
