### PR TITLE
[Backport stable/8.3]: jobs incidents should not be resolved if retries are less than 0

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -29,6 +29,8 @@ import io.camunda.zeebe.util.Either;
 
 public final class IncidentResolveProcessor implements TypedRecordProcessor<IncidentRecord> {
 
+  public static final String NO_RETRIES_LEFT_MSG =
+      "Expected to resolve incident with key '%d', but job with key '%d' has no retries left. Please update the job retries and retry resolving the incident";
   public static final String NO_INCIDENT_FOUND_MSG =
       "Expected to resolve incident with key '%d', but no such incident was found";
   private static final String ELEMENT_NOT_IN_SUPPORTED_STATE_MSG =
@@ -72,10 +74,17 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
       return;
     }
 
+    final long jobKey = incident.getJobKey();
+    if (isJobRelatedIncident(jobKey) && jobState.getJob(jobKey).getRetries() <= 0) {
+      final var errorMessage = String.format(NO_RETRIES_LEFT_MSG, key, jobKey);
+      rejectResolveCommand(command, errorMessage, RejectionType.INVALID_STATE);
+      return;
+    }
+
     stateWriter.appendFollowUpEvent(key, IncidentIntent.RESOLVED, incident);
     responseWriter.writeEventOnCommand(key, IncidentIntent.RESOLVED, incident, command);
 
-    publishIncidentRelatedJob(incident.getJobKey());
+    publishIncidentRelatedJob(jobKey);
 
     // if it fails, a new incident is raised
     attemptToContinueProcessProcessing(command, incident);
@@ -93,9 +102,8 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   private void attemptToContinueProcessProcessing(
       final TypedRecord<IncidentRecord> command, final IncidentRecord incident) {
     final long jobKey = incident.getJobKey();
-    final boolean isJobIncident = jobKey > 0;
 
-    if (isJobIncident) {
+    if (isJobRelatedIncident(jobKey)) {
       return;
     }
 
@@ -145,10 +153,13 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   }
 
   private void publishIncidentRelatedJob(final long jobKey) {
-    final boolean isJobRelatedIncident = jobKey > 0;
-    if (isJobRelatedIncident) {
+    if (isJobRelatedIncident(jobKey)) {
       final JobRecord failedJobRecord = jobState.getJob(jobKey);
       jobActivationBehavior.publishWork(jobKey, failedJobRecord);
     }
+  }
+
+  private static boolean isJobRelatedIncident(final long jobKey) {
+    return jobKey > 0;
   }
 }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -217,6 +217,7 @@ public class ActivatableJobsPushTest {
         RecordingExporter.incidentRecords(CREATED).getFirst();
 
     // when an incident is resolved
+    ENGINE.job().withKey(jobKey).withType(jobType).withRetries(1).updateRetries();
     ENGINE.incident().ofInstance(incident.getValue().getProcessInstanceKey()).resolve();
 
     // then


### PR DESCRIPTION
Backport of https://github.com/camunda/zeebe/pull/17504 to stable/8.3.

## Description

It was possible to resolve job incidents when job retries were less or equal to 0 and to active the job again.
The check to verify that the job retries are greater than 0 was added to fix. We select less than 0 because of the known bug
https://github.com/camunda/zeebe/issues/15437
Job incident tests were missing the update job retries part and this is also fixed now by applying job update retries command.

## Related issues

closes #
