### PR TITLE
feat: record writers are classified by use-case and source

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandler.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.jobstream;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.bootstrap.BrokerStartupContext;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.stream.job.ActivatedJob;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
@@ -83,7 +84,8 @@ final class RemoteJobStreamErrorHandler implements RemoteStreamErrorHandler<Acti
       final ActivatedJob job,
       final LogStreamWriter writer,
       final TaskResult result) {
-    final var writeResult = writer.tryWrite(result.getRecordBatch().entries());
+    final var writeResult =
+        writer.tryWrite(WriteContext.processingResult(), result.getRecordBatch().entries());
     if (writeResult.isLeft()) {
       FAILED_WRITER_LOGGER.warn(
           """

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionAdminAccess.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.engine.state.processing.DbBannedInstanceState;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -250,6 +251,6 @@ class ZeebePartitionAdminAccess implements PartitionAdminAccess {
             .rejectionReason("");
     final var entry =
         RecordBatchEntry.createEntry(processInstanceKey, recordMetadata, -1, errorRecord);
-    return writer.tryWrite(entry);
+    return writer.tryWrite(WriteContext.internal(), entry);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandler.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.transport.AsyncApiRequestHandler;
 import io.camunda.zeebe.broker.transport.ErrorResponseWriter;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
@@ -115,7 +116,9 @@ public final class BackupApiRequestHandler
             .requestId(requestId)
             .requestStreamId(requestStreamId);
     final var checkpointRecord = new CheckpointRecord().setCheckpointId(requestReader.backupId());
-    final var written = logStreamWriter.tryWrite(LogAppendEntry.of(metadata, checkpointRecord));
+    final var written =
+        logStreamWriter.tryWrite(
+            WriteContext.internal(), LogAppendEntry.of(metadata, checkpointRecord));
 
     if (written.isRight()) {
       // Response will be sent by the processor

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.transport.backpressure.BackpressureMetrics;
 import io.camunda.zeebe.broker.transport.backpressure.RequestLimiter;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.ErrorCode;
@@ -145,7 +146,7 @@ final class CommandApiRequestHandler
 
     if (logStreamWriter.canWriteEvents(1, appendEntry.getLength())) {
       return logStreamWriter
-          .tryWrite(appendEntry)
+          .tryWrite(WriteContext.userCommand(), appendEntry)
           .map(ignore -> true)
           .mapLeft(error -> errorWriter.mapWriteError(partitionId, error));
     } else {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverImpl.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.protocol.MessageHeaderDecoder;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
@@ -105,7 +106,8 @@ final class InterPartitionCommandReceiverImpl {
             .intent(CheckpointIntent.CREATE)
             .valueType(ValueType.CHECKPOINT);
     final var checkpointRecord = new CheckpointRecord().setCheckpointId(decoded.checkpointId);
-    return logStreamWriter.tryWrite(LogAppendEntry.of(metadata, checkpointRecord));
+    return logStreamWriter.tryWrite(
+        WriteContext.interPartition(), LogAppendEntry.of(metadata, checkpointRecord));
   }
 
   private Either<WriteFailure, Long> writeCommand(final DecodedMessage decoded) {
@@ -115,7 +117,7 @@ final class InterPartitionCommandReceiverImpl {
             .map(key -> LogAppendEntry.of(key, decoded.metadata(), decoded.command()))
             .orElseGet(() -> LogAppendEntry.of(decoded.metadata(), decoded.command()));
 
-    return logStreamWriter.tryWrite(appendEntry);
+    return logStreamWriter.tryWrite(WriteContext.interPartition(), appendEntry);
   }
 
   void setDiskSpaceAvailable(final boolean available) {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/jobstream/RemoteJobStreamErrorHandlerTest.java
@@ -45,7 +45,7 @@ final class RemoteJobStreamErrorHandlerTest {
     final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(Protocol.encodePartitionId(1, 1), new JobRecord());
     final var error = new RuntimeException("Failure");
-    handler.addWriter(1, (entries, ignored) -> Either.right(1L));
+    handler.addWriter(1, (context, entries, ignored) -> Either.right(1L));
 
     // when
     handler.handleError(error, job);
@@ -63,7 +63,7 @@ final class RemoteJobStreamErrorHandlerTest {
     // given
     final var handler = new RemoteJobStreamErrorHandler(jobErrorHandler);
     final var job = new TestActivatedJob(1, new JobRecord());
-    handler.addWriter(1, (entries, ignored) -> Either.right(1L));
+    handler.addWriter(1, (context, entries, ignored) -> Either.right(1L));
 
     // when
     handler.removeWriter(1);
@@ -81,7 +81,7 @@ final class RemoteJobStreamErrorHandlerTest {
     final var writtenEntries = new ArrayList<LogAppendEntry>();
     handler.addWriter(
         1,
-        (entries, ignored) -> {
+        (context, entries, ignored) -> {
           writtenEntries.addAll(entries);
           return Either.right(1L);
         });

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/backupapi/BackupApiRequestHandlerTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.backup.common.BackupIdentifierImpl;
 import io.camunda.zeebe.backup.common.BackupStatusImpl;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.encoding.BackupListResponse;
 import io.camunda.zeebe.protocol.impl.encoding.BackupRequest;
 import io.camunda.zeebe.protocol.impl.encoding.BackupStatusResponse;
@@ -114,7 +115,7 @@ final class BackupApiRequestHandlerTest {
     handleRequest(request);
 
     // then
-    verify(logStreamWriter, times(1)).tryWrite(any(LogAppendEntry.class));
+    verify(logStreamWriter, times(1)).tryWrite(any(WriteContext.class), any(LogAppendEntry.class));
   }
 
   @Test
@@ -139,7 +140,7 @@ final class BackupApiRequestHandlerTest {
         .extracting(Either::getLeft)
         .extracting(ErrorResponse::getErrorCode)
         .isEqualTo(ErrorCode.RESOURCE_EXHAUSTED);
-    verify(logStreamWriter, never()).tryWrite(any(LogAppendEntry.class));
+    verify(logStreamWriter, never()).tryWrite(any(WriteContext.class), any(LogAppendEntry.class));
   }
 
   @Test

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.encoding.ErrorResponse;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandRequest;
 import io.camunda.zeebe.protocol.impl.encoding.ExecuteCommandResponse;
@@ -40,7 +41,6 @@ import org.agrona.concurrent.UnsafeBuffer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 public class CommandApiRequestHandlerTest {
   @Rule public final ControlledActorSchedulerRule scheduler = new ControlledActorSchedulerRule();
@@ -170,7 +170,7 @@ public class CommandApiRequestHandlerTest {
     handleRequest(request);
 
     // then
-    verify(logWriter).tryWrite(Mockito.<LogAppendEntry>any());
+    verify(logWriter).tryWrite(any(WriteContext.class), any(LogAppendEntry.class));
   }
 
   @Test
@@ -178,7 +178,7 @@ public class CommandApiRequestHandlerTest {
     // given
     final var logWriter = mock(LogStreamWriter.class);
     when(logWriter.canWriteEvents(anyInt(), anyInt())).thenReturn(true);
-    when(logWriter.tryWrite(any(LogAppendEntry.class)))
+    when(logWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
         .thenReturn(Either.left(WriteFailure.CLOSED));
     handler.addPartition(0, logWriter, new NoopRequestLimiter<>());
     scheduler.workUntilDone();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -22,6 +22,7 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
@@ -60,21 +61,25 @@ final class InterPartitionCommandCheckpointTest {
   @Test
   void shouldHandleMissingCheckpoints() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
+    when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
+        .thenReturn(Either.right(1L));
 
     // when
     sendAndReceive(ValueType.DEPLOYMENT, DeploymentIntent.CREATE);
 
     // then
     verify(logStreamWriter, times(1))
-        .tryWrite(matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+        .tryWrite(
+            any(WriteContext.class),
+            matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
     verifyNoMoreInteractions(logStreamWriter);
   }
 
   @Test
   void shouldCreateFirstCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
+    when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
+        .thenReturn(Either.right(1L));
     sender.setCheckpointId(1);
 
     // when
@@ -82,16 +87,19 @@ final class InterPartitionCommandCheckpointTest {
 
     // then
     final var io = inOrder(logStreamWriter);
-    io.verify(logStreamWriter, times(1)).tryWrite(matchesCheckpoint(1));
+    io.verify(logStreamWriter, times(1)).tryWrite(any(WriteContext.class), matchesCheckpoint(1));
     io.verify(logStreamWriter, times(1))
-        .tryWrite(matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+        .tryWrite(
+            any(WriteContext.class),
+            matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
     io.verifyNoMoreInteractions();
   }
 
   @Test
   void shouldUpdateExistingCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
+    when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
+        .thenReturn(Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(17);
 
@@ -100,15 +108,18 @@ final class InterPartitionCommandCheckpointTest {
 
     // then
     final var io = inOrder(logStreamWriter);
-    io.verify(logStreamWriter).tryWrite(matchesCheckpoint(17));
+    io.verify(logStreamWriter).tryWrite(any(WriteContext.class), matchesCheckpoint(17));
     io.verify(logStreamWriter)
-        .tryWrite(matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+        .tryWrite(
+            any(WriteContext.class),
+            matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
   }
 
   @Test
   void shouldNotRecreateExistingCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
+    when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
+        .thenReturn(Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(5);
 
@@ -117,14 +128,17 @@ final class InterPartitionCommandCheckpointTest {
 
     // then
     verify(logStreamWriter)
-        .tryWrite(matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+        .tryWrite(
+            any(WriteContext.class),
+            matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
     verifyNoMoreInteractions(logStreamWriter);
   }
 
   @Test
   void shouldNotOverwriteNewerCheckpoint() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any())).thenReturn(Either.right(1L));
+    when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
+        .thenReturn(Either.right(1L));
     receiver.setCheckpointId(6);
     sender.setCheckpointId(5);
 
@@ -133,14 +147,16 @@ final class InterPartitionCommandCheckpointTest {
 
     // then
     verify(logStreamWriter)
-        .tryWrite(matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
+        .tryWrite(
+            any(WriteContext.class),
+            matchesMetadata(ValueType.DEPLOYMENT, DeploymentIntent.CREATE));
     verifyNoMoreInteractions(logStreamWriter);
   }
 
   @Test
   void shouldNotWriteCommandIfCheckpointCreateFailed() {
     // given
-    when(logStreamWriter.tryWrite(Mockito.<LogAppendEntry>any()))
+    when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
         .thenReturn(Either.left(WriteFailure.FULL), Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(17);
@@ -150,7 +166,9 @@ final class InterPartitionCommandCheckpointTest {
 
     // then
     verify(logStreamWriter)
-        .tryWrite(matchesMetadata(ValueType.CHECKPOINT, CheckpointIntent.CREATE));
+        .tryWrite(
+            any(WriteContext.class),
+            matchesMetadata(ValueType.CHECKPOINT, CheckpointIntent.CREATE));
     verifyNoMoreInteractions(logStreamWriter);
   }
 
@@ -182,7 +200,7 @@ final class InterPartitionCommandCheckpointTest {
     return Mockito.argThat(
         entry ->
             matchesMetadata(entry, ValueType.CHECKPOINT, CheckpointIntent.CREATE)
-                && entry.recordValue() instanceof CheckpointRecord checkpoint
+                && entry.recordValue() instanceof final CheckpointRecord checkpoint
                 && checkpoint.getCheckpointId() == checkpointId);
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandReceiverTest.java
@@ -22,6 +22,7 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.logstreams.impl.log.LogEntryDescriptor;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -36,7 +37,6 @@ import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 @Execution(ExecutionMode.CONCURRENT)
 final class InterPartitionCommandReceiverTest {
@@ -62,13 +62,14 @@ final class InterPartitionCommandReceiverTest {
     receiver.handleMessage(new MemberId("0"), sentMessage);
 
     // then - sent message can be written to log stream
-    verify(logStreamWriter).tryWrite(Mockito.<LogAppendEntry>any());
+    verify(logStreamWriter).tryWrite(any(WriteContext.class), any(LogAppendEntry.class));
   }
 
   private static LogStreamWriter getLogStreamWriter() {
     final var logStreamWriter =
         mock(LogStreamWriter.class, withSettings().defaultAnswer(Answers.RETURNS_SELF));
-    when(logStreamWriter.tryWrite(any(LogAppendEntry.class))).thenReturn(Either.right(1L));
+    when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
+        .thenReturn(Either.right(1L));
     return logStreamWriter;
   }
 
@@ -122,7 +123,7 @@ final class InterPartitionCommandReceiverTest {
 
     // then
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
-    verify(logStreamWriter).tryWrite(entryCaptor.capture());
+    verify(logStreamWriter).tryWrite(any(WriteContext.class), entryCaptor.capture());
     final var metadataWriter = entryCaptor.getValue().recordMetadata();
     final var metadataBuffer = new ExpandableArrayBuffer();
     final var metadata = new RecordMetadata();
@@ -159,7 +160,7 @@ final class InterPartitionCommandReceiverTest {
 
     // then
     final var entryCaptor = ArgumentCaptor.forClass(LogAppendEntry.class);
-    verify(logStreamWriter).tryWrite(entryCaptor.capture());
+    verify(logStreamWriter).tryWrite(any(WriteContext.class), entryCaptor.capture());
     final var valueWriter = entryCaptor.getValue().recordValue();
     assertThat(valueWriter).isEqualTo(recordValue);
   }
@@ -189,7 +190,7 @@ final class InterPartitionCommandReceiverTest {
     receiver.handleMessage(new MemberId("0"), sentMessage);
 
     // then
-    verify(logStreamWriter).tryWrite(entryCaptor.capture());
+    verify(logStreamWriter).tryWrite(any(WriteContext.class), entryCaptor.capture());
     assertThat(entryCaptor.getValue().key()).isEqualTo(recordKey);
   }
 
@@ -215,7 +216,7 @@ final class InterPartitionCommandReceiverTest {
     receiver.handleMessage(new MemberId("0"), sentMessage);
 
     // then
-    verify(logStreamWriter).tryWrite(entryCaptor.capture());
+    verify(logStreamWriter).tryWrite(any(WriteContext.class), entryCaptor.capture());
     assertThat(entryCaptor.getValue().key()).isEqualTo(LogEntryDescriptor.KEY_NULL_VALUE);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.client.CommandWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.util.SynchronousLogStream;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -135,7 +136,9 @@ public class StreamProcessingComposite implements CommandWriter {
 
   public long writeBatch(final RecordToWrite... recordsToWrite) {
     final var writer = streams.newLogStreamWriter(getLogName(partitionId));
-    return writeActor.submit(() -> writer.tryWrite(Arrays.asList(recordsToWrite)).get()).join();
+    return writeActor
+        .submit(() -> writer.tryWrite(WriteContext.internal(), Arrays.asList(recordsToWrite)).get())
+        .join();
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestInterPartitionCommandSender.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestInterPartitionCommandSender.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.util;
 
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -59,7 +60,7 @@ public class TestInterPartitionCommandSender implements InterPartitionCommandSen
       entry = LogAppendEntry.of(metadata, command);
     }
 
-    writer.tryWrite(entry);
+    writer.tryWrite(WriteContext.interPartition(), entry);
   }
 
   // Pre-initialize dedicated writers.

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.logstreams.util.SyncLogStream;
@@ -398,7 +399,9 @@ public final class TestStreams {
           .pollInSameThread()
           .pollDelay(Duration.ZERO)
           .pollInterval(Duration.ofMillis(50))
-          .until(() -> writer.tryWrite(entry, sourceRecordPosition), Either::isRight)
+          .until(
+              () -> writer.tryWrite(WriteContext.internal(), entry, sourceRecordPosition),
+              Either::isRight)
           .get();
     }
   }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -12,6 +12,7 @@ import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limit.VegasLimit;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection.AppendLimitExhausted;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.util.Either;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,7 +41,7 @@ public final class FlowControl {
    * @return An Optional containing a {@link InFlightAppend} if append was accepted, an empty
    *     Optional otherwise.
    */
-  public Either<Rejection, InFlightAppend> tryAcquire() {
+  public Either<Rejection, InFlightAppend> tryAcquire(final WriteContext context) {
     final var appendListener = appendLimiter.acquire(null).orElse(null);
     if (appendListener == null) {
       metrics.increaseDeferredAppends();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/SequencedBatch.java
@@ -32,7 +32,7 @@ public record SequencedBatch(
         firstPosition,
         sourcePosition,
         Objects.requireNonNull(entries, "must specify a list of entries"),
-        SequencedBatchSerializer.calculateBatchSize(entries));
+        SequencedBatchSerializer.calculateBatchLength(entries));
   }
 
   @Override

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/serializer/SequencedBatchSerializer.java
@@ -47,11 +47,11 @@ public final class SequencedBatchSerializer {
     }
   }
 
-  public static int calculateBatchSize(final List<LogAppendEntry> entries) {
-    return entries.stream().mapToInt(SequencedBatchSerializer::calculateEntrySize).sum();
+  public static int calculateBatchLength(final List<LogAppendEntry> entries) {
+    return entries.stream().mapToInt(SequencedBatchSerializer::calculateEntryLength).sum();
   }
 
-  private static int calculateEntrySize(final LogAppendEntry entry) {
+  private static int calculateEntryLength(final LogAppendEntry entry) {
     return DataFrameDescriptor.alignedLength(LogAppendEntrySerializer.framedLength(entry));
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
@@ -34,14 +34,15 @@ public interface LogStreamWriter {
    * @return the event position, a negative value if fails to write the event, or 0 if the value is
    *     empty
    */
-  default Either<WriteFailure, Long> tryWrite(final LogAppendEntry appendEntry) {
-    return tryWrite(appendEntry, LogEntryDescriptor.KEY_NULL_VALUE);
+  default Either<WriteFailure, Long> tryWrite(
+      final WriteContext context, final LogAppendEntry appendEntry) {
+    return tryWrite(context, appendEntry, LogEntryDescriptor.KEY_NULL_VALUE);
   }
 
   /** {@inheritDoc} */
   default Either<WriteFailure, Long> tryWrite(
-      final LogAppendEntry appendEntry, final long sourcePosition) {
-    return tryWrite(Collections.singletonList(appendEntry), sourcePosition);
+      final WriteContext context, final LogAppendEntry appendEntry, final long sourcePosition) {
+    return tryWrite(context, Collections.singletonList(appendEntry), sourcePosition);
   }
 
   /**
@@ -52,8 +53,9 @@ public interface LogStreamWriter {
    * @return the last (i.e. highest) event position, a negative value if fails to write the events,
    *     or 0 if the batch is empty
    */
-  default Either<WriteFailure, Long> tryWrite(final List<LogAppendEntry> appendEntries) {
-    return tryWrite(appendEntries, LogEntryDescriptor.KEY_NULL_VALUE);
+  default Either<WriteFailure, Long> tryWrite(
+      final WriteContext context, final List<LogAppendEntry> appendEntries) {
+    return tryWrite(context, appendEntries, LogEntryDescriptor.KEY_NULL_VALUE);
   }
 
   /**
@@ -66,7 +68,9 @@ public interface LogStreamWriter {
    *     or 0 if the batch is empty
    */
   Either<WriteFailure, Long> tryWrite(
-      final List<LogAppendEntry> appendEntries, final long sourcePosition);
+      final WriteContext context,
+      final List<LogAppendEntry> appendEntries,
+      final long sourcePosition);
 
   enum WriteFailure {
     CLOSED,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/WriteContext.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/WriteContext.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.logstreams.log;
+
+public sealed interface WriteContext {
+  static WriteContext userCommand() {
+    return UserCommand.INSTANCE;
+  }
+
+  static WriteContext processingResult() {
+    return ProcessingResult.INSTANCE;
+  }
+
+  static WriteContext interPartition() {
+    return InterPartition.INSTANCE;
+  }
+
+  static WriteContext scheduled() {
+    return Scheduled.INSTANCE;
+  }
+
+  static WriteContext internal() {
+    return Internal.INSTANCE;
+  }
+
+  final class UserCommand implements WriteContext {
+    private static final UserCommand INSTANCE = new UserCommand();
+  }
+
+  final class ProcessingResult implements WriteContext {
+    private static final ProcessingResult INSTANCE = new ProcessingResult();
+  }
+
+  final class InterPartition implements WriteContext {
+    private static final InterPartition INSTANCE = new InterPartition();
+  }
+
+  final class Scheduled implements WriteContext {
+    private static final Scheduled INSTANCE = new Scheduled();
+  }
+
+  final class Internal implements WriteContext {
+    private static final Internal INSTANCE = new Internal();
+  }
+}

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.logstreams.util.TestEntry;
@@ -79,7 +80,7 @@ final class LogStorageAppenderTest {
     final var entry = TestEntry.ofDefaults();
     // when
     logStorage.setPositionListener(i -> latch.countDown());
-    final var position = sequencer.tryWrite(entry).get();
+    final var position = sequencer.tryWrite(WriteContext.internal(), entry).get();
 
     // then
     assertThat(latch.await(5, TimeUnit.SECONDS)).as("value was written within 5 seconds").isTrue();
@@ -97,7 +98,7 @@ final class LogStorageAppenderTest {
 
     // when
     logStorage.setPositionListener(i -> latch.countDown());
-    final var highestPosition = sequencer.tryWrite(entries).get();
+    final var highestPosition = sequencer.tryWrite(WriteContext.internal(), entries).get();
     final var lowestPosition = highestPosition - 1;
 
     // then

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBatchReaderTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import io.camunda.zeebe.logstreams.log.LogStreamBatchReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.util.LogStreamReaderRule;
 import io.camunda.zeebe.logstreams.util.LogStreamRule;
 import io.camunda.zeebe.logstreams.util.TestEntry;
@@ -51,8 +52,10 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldReadEventsInBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofKey(1L), 1L).get();
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofKey(2L), 1L).get();
+    final long eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofKey(1L), 1L).get();
+    final long eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofKey(2L), 1L).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -77,8 +80,8 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldReadNextBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofKey(1L)).get();
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofKey(2L)).get();
+    final long eventPosition1 = writer.tryWrite(WriteContext.internal(), TestEntry.ofKey(1L)).get();
+    final long eventPosition2 = writer.tryWrite(WriteContext.internal(), TestEntry.ofKey(2L)).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -105,8 +108,10 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldReadEventsWithoutSourceEventPosition() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    final long eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -126,9 +131,12 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldNotIncludeEventsWithoutSourceEventPosition() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    final long eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    final long eventPosition3 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     // then
     assertThat(batchReader.hasNext()).isTrue();
@@ -155,9 +163,12 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldMoveBatchToHead() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L).get();
+    final long eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 1L).get();
+    final long eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 1L).get();
+    final long eventPosition3 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 2L).get();
 
     assertThat(batchReader.hasNext()).isTrue();
 
@@ -185,9 +196,11 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSkipEventsInBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
-    writer.tryWrite(TestEntry.ofDefaults(), 1L);
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L).get();
+    final long eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 1L).get();
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 1L);
+    final long eventPosition3 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 2L).get();
 
     assertThat(batchReader.hasNext()).isTrue();
 
@@ -206,8 +219,9 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToHeadIfNegative() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    writer.tryWrite(TestEntry.ofDefaults());
+    final long eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
 
     // when
     final var found = batchReader.seekToNextBatch(-1L);
@@ -224,9 +238,11 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToNextBatch() {
     // given
-    writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
+    final long eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    final long eventPosition3 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition2);
@@ -243,9 +259,11 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToNextEventWithinBatch() {
     // given
-    final long eventPosition1 = writer.tryWrite(TestEntry.ofDefaults(), 1L).get();
-    writer.tryWrite(TestEntry.ofDefaults(), 1L);
-    final long eventPosition3 = writer.tryWrite(TestEntry.ofDefaults(), 2L).get();
+    final long eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 1L).get();
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 1L);
+    final long eventPosition3 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults(), 2L).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition1);
@@ -262,8 +280,9 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToTailIfLastEvent() {
     // given
-    writer.tryWrite(TestEntry.ofDefaults());
-    final long eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
+    final long eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition2);
@@ -276,7 +295,8 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldSeekToNotExistingPosition() {
     // given
-    final var eventPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final var eventPosition =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     // when
     final var found = batchReader.seekToNextBatch(eventPosition + 1);
@@ -307,7 +327,7 @@ public class LogStreamBatchReaderTest {
   @Test
   public void shouldThrowNoSuchElementExceptionOnNextEvent() {
     // given
-    writer.tryWrite(TestEntry.ofKey(1));
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofKey(1));
 
     assertThat(batchReader.hasNext()).isTrue();
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderTest.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.util.LogStreamReaderRule;
 import io.camunda.zeebe.logstreams.util.LogStreamRule;
 import io.camunda.zeebe.logstreams.util.TestEntry;
@@ -77,7 +78,7 @@ public final class LogStreamReaderTest {
   public void shouldHaveNext() {
     // given
     final var entry = TestEntry.ofKey(5);
-    final long position = writer.tryWrite(entry).get();
+    final long position = writer.tryWrite(WriteContext.internal(), entry).get();
 
     // then
     assertThat(reader.hasNext()).isTrue();
@@ -98,7 +99,7 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldReturnPositionOfCurrentLoggedEvent() {
     // given
-    final long position = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long position = writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
     reader.seekToFirstEvent();
 
     // then
@@ -108,7 +109,7 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldReturnNoPositionIfNotActiveOrInitialized() {
     // given
-    writer.tryWrite(TestEntry.ofDefaults());
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
 
     // then
     assertThat(reader.getPosition()).isEqualTo(-1);
@@ -119,7 +120,7 @@ public final class LogStreamReaderTest {
     // given
     reader.close();
     final var entry = TestEntry.ofKey(5);
-    final long position = writer.tryWrite(entry).get();
+    final long position = writer.tryWrite(WriteContext.internal(), entry).get();
     reader = readerRule.resetReader();
 
     // then
@@ -131,9 +132,9 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldWrapAndSeekToEvent() {
     // given
-    writer.tryWrite(TestEntry.ofDefaults());
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
     final var entry = TestEntry.ofKey(5);
-    final long secondPos = writer.tryWrite(entry).get();
+    final long secondPos = writer.tryWrite(WriteContext.internal(), entry).get();
 
     // when
     reader = logStreamRule.newLogStreamReader();
@@ -170,7 +171,8 @@ public final class LogStreamReaderTest {
     final long seekedPosition = reader.seekToEnd();
 
     // when
-    final long newLastPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long newLastPosition =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     // then
     assertThat(lastEventPosition).isEqualTo(seekedPosition);
@@ -202,7 +204,7 @@ public final class LogStreamReaderTest {
     final var entries = IntStream.range(0, eventCount).mapToObj(TestEntry::ofKey).toList();
 
     // when
-    writer.tryWrite(entries);
+    writer.tryWrite(WriteContext.internal(), entries);
 
     // then
     assertReaderHasEntries(entries);
@@ -228,7 +230,7 @@ public final class LogStreamReaderTest {
     // given
     final int eventCount = 500;
     final var entries = IntStream.range(0, eventCount).mapToObj(TestEntry::ofKey).toList();
-    writer.tryWrite(entries);
+    writer.tryWrite(WriteContext.internal(), entries);
 
     // when
     assertReaderHasEntries(entries);
@@ -254,7 +256,8 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldSeekToFirstEvent() {
     // given
-    final long firstPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long firstPosition =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
     writeEvents(2);
 
     // when
@@ -268,7 +271,8 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldSeekToFirstPositionWhenPositionBeforeFirstEvent() {
     // given
-    final long firstPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long firstPosition =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
     writeEvents(2);
 
     // when
@@ -347,7 +351,8 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldSeekToFirstEventWhenNextIsNegative() {
     // given
-    final long firstEventPosition = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final long firstEventPosition =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
     writeEvents(10);
     reader.seekToEnd();
 
@@ -363,8 +368,9 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldPeekFirstEvent() {
     // given
-    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    writer.tryWrite(TestEntry.ofDefaults());
+    final var eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
 
     assertThat(reader.hasNext()).isTrue();
 
@@ -378,8 +384,10 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldPeekNextEvent() {
     // given
-    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    final var eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final var eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    final var eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     assertThat(reader.hasNext()).isTrue();
     assertThat(reader.next().getPosition()).isEqualTo(eventPosition1);
@@ -394,8 +402,10 @@ public final class LogStreamReaderTest {
   @Test
   public void shouldPeekAndReadNextEvent() {
     // given
-    final var eventPosition1 = writer.tryWrite(TestEntry.ofDefaults()).get();
-    final var eventPosition2 = writer.tryWrite(TestEntry.ofDefaults()).get();
+    final var eventPosition1 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
+    final var eventPosition2 =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     assertThat(reader.hasNext()).isTrue();
 
@@ -427,6 +437,6 @@ public final class LogStreamReaderTest {
             .mapToObj(TestEntry::ofKey)
             .collect(Collectors.toList());
 
-    return writer.tryWrite(entries).get();
+    return writer.tryWrite(WriteContext.internal(), entries).get();
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import io.camunda.zeebe.logstreams.util.TestEntry;
@@ -48,7 +49,7 @@ final class SequencerTest {
             new FlowControl(logStreamMetrics));
 
     // when
-    final var result = sequencer.tryWrite(TestEntry.ofDefaults());
+    final var result = sequencer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
 
     // then
     EitherAssert.assertThat(result).isRight().right().isEqualTo(initialPosition);
@@ -71,7 +72,7 @@ final class SequencerTest {
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
     // when
-    final var result = sequencer.tryWrite(entries);
+    final var result = sequencer.tryWrite(WriteContext.internal(), entries);
 
     // then
     EitherAssert.assertThat(result)
@@ -96,7 +97,7 @@ final class SequencerTest {
     final var entry = TestEntry.ofDefaults();
 
     // when
-    sequencer.tryWrite(entry);
+    sequencer.tryWrite(WriteContext.internal(), entry);
 
     // then
     Mockito.verify(logStorage).append(eq(1L), eq(1L), any(BufferWriter.class), any());
@@ -119,7 +120,7 @@ final class SequencerTest {
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
 
     // when
-    sequencer.tryWrite(entries);
+    sequencer.tryWrite(WriteContext.internal(), entries);
 
     // then
     Mockito.verify(logStorage).append(eq(1L), eq(3L), any(BufferWriter.class), any());
@@ -257,7 +258,7 @@ final class SequencerTest {
               var batchesWritten = 0L;
               var lastWrittenPosition = initialPosition - 1;
               while (batchesWritten < batchesToWrite) {
-                final var result = sequencer.tryWrite(batchToWrite);
+                final var result = sequencer.tryWrite(WriteContext.internal(), batchToWrite);
                 if (result.isRight()) {
                   if (isOnlyWriter) {
                     Assertions.assertThat(result.get())

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamTest.java
@@ -64,10 +64,11 @@ public final class LogStreamTest {
   public void shouldIncreasePositionOnRestart() {
     // given
     final var writer = logStream.newSyncLogStreamWriter();
-    writer.tryWrite(TestEntry.ofDefaults());
-    writer.tryWrite(TestEntry.ofDefaults());
-    writer.tryWrite(TestEntry.ofDefaults());
-    final long positionBeforeClose = writer.tryWrite(TestEntry.ofDefaults()).get();
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
+    writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
+    final long positionBeforeClose =
+        writer.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
     Awaitility.await("until everything is written")
         .until(logStream::getLastWrittenPosition, position -> position >= positionBeforeClose);
 
@@ -75,7 +76,8 @@ public final class LogStreamTest {
     logStream.close();
     logStreamRule.createLogStream();
     final var newWriter = logStreamRule.getLogStream().newLogStreamWriter();
-    final long positionAfterReOpen = newWriter.tryWrite(TestEntry.ofDefaults()).get();
+    final long positionAfterReOpen =
+        newWriter.tryWrite(WriteContext.internal(), TestEntry.ofDefaults()).get();
 
     // then
     assertThat(positionAfterReOpen).isGreaterThan(positionBeforeClose);
@@ -88,7 +90,7 @@ public final class LogStreamTest {
     logStream.getAsyncLogStream().registerRecordAvailableListener(latch::countDown);
 
     // when
-    logStreamRule.getLogStreamWriter().tryWrite(TestEntry.ofDefaults());
+    logStreamRule.getLogStreamWriter().tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
 
     // then
     assertThat(latch.await(2, TimeUnit.SECONDS)).isTrue();
@@ -105,7 +107,7 @@ public final class LogStreamTest {
     logStream.getAsyncLogStream().registerRecordAvailableListener(secondListener::countDown);
 
     // when
-    logStreamRule.getLogStreamWriter().tryWrite(TestEntry.ofDefaults());
+    logStreamRule.getLogStreamWriter().tryWrite(WriteContext.internal(), TestEntry.ofDefaults());
 
     // then
     assertThat(firstListener.await(2, TimeUnit.SECONDS)).isTrue();

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -52,7 +52,7 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldFailToWriteBatchWithoutEvents() {
     // when
-    final var result = writer.tryWrite(List.of());
+    final var result = writer.tryWrite(WriteContext.internal(), List.of());
 
     // then
     EitherAssert.assertThat(result).isLeft().left().isEqualTo(WriteFailure.INVALID_ARGUMENT);
@@ -73,7 +73,10 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldReturnPositionOfLastEvent() {
     // when
-    final long position = writer.tryWrite(List.of(TestEntry.ofKey(1), TestEntry.ofKey(2))).get();
+    final long position =
+        writer
+            .tryWrite(WriteContext.internal(), List.of(TestEntry.ofKey(1), TestEntry.ofKey(2)))
+            .get();
 
     // then
     assertThat(position).isGreaterThan(0);
@@ -201,7 +204,8 @@ public final class LogStreamWriterTest {
   @Test
   public void shouldFailToWriteEventWithoutValue() {
     // when
-    final var res = writer.tryWrite(TestEntry.builder().withRecordValue(null).build());
+    final var res =
+        writer.tryWrite(WriteContext.internal(), TestEntry.builder().withRecordValue(null).build());
 
     // then
     EitherAssert.assertThat(res).isLeft();
@@ -251,14 +255,15 @@ public final class LogStreamWriterTest {
   private long tryWrite(final LogAppendEntry entry) {
     return Awaitility.await("until dispatcher accepts entry")
         .pollInSameThread()
-        .until(() -> writer.tryWrite(entry), Either::isRight)
+        .until(() -> writer.tryWrite(WriteContext.internal(), entry), Either::isRight)
         .get();
   }
 
   private long tryWrite(final LogAppendEntry entry, final long sourcePosition) {
     return Awaitility.await("until dispatcher accepts entry")
         .pollInSameThread()
-        .until(() -> writer.tryWrite(entry, sourcePosition), Either::isRight)
+        .until(
+            () -> writer.tryWrite(WriteContext.internal(), entry, sourcePosition), Either::isRight)
         .get();
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStream.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStream.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter.WriteFailure;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
 import java.util.List;
@@ -118,8 +119,10 @@ public class SyncLogStream implements SynchronousLogStream {
 
     @Override
     public Either<WriteFailure, Long> tryWrite(
-        final List<LogAppendEntry> appendEntries, final long sourcePosition) {
-      return syncTryWrite(() -> delegate.tryWrite(appendEntries, sourcePosition));
+        final WriteContext context,
+        final List<LogAppendEntry> appendEntries,
+        final long sourcePosition) {
+      return syncTryWrite(() -> delegate.tryWrite(context, appendEntries, sourcePosition));
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -152,7 +153,9 @@ public class ProcessingScheduleServiceImpl
                   return true;
                 }
 
-                return logStreamWriter.tryWrite(recordBatch.entries()).isRight();
+                return logStreamWriter
+                    .tryWrite(WriteContext.scheduled(), recordBatch.entries())
+                    .isRight();
               },
               abortCondition);
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.error.ErrorRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -595,7 +596,8 @@ public final class ProcessingStateMachine {
           writeRetryStrategy.runWithRetry(
               () -> {
                 final var writeResult =
-                    logStreamWriter.tryWrite(pendingWrites, sourceRecordPosition);
+                    logStreamWriter.tryWrite(
+                        WriteContext.processingResult(), pendingWrites, sourceRecordPosition);
                 if (writeResult.isRight()) {
                   writtenPosition = writeResult.get();
                   return true;

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -20,6 +20,7 @@ import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -491,7 +492,9 @@ class ProcessingScheduleServiceTest {
 
     @Override
     public Either<WriteFailure, Long> tryWrite(
-        final List<LogAppendEntry> appendEntries, final long sourcePosition) {
+        final WriteContext context,
+        final List<LogAppendEntry> appendEntries,
+        final long sourcePosition) {
       if (!acceptWrites.get().getAsBoolean()) {
         return Either.left(WriteFailure.FULL);
       }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.logstreams.impl.log.LoggedEventImpl;
 import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.logstreams.util.SyncLogStream;
 import io.camunda.zeebe.logstreams.util.SynchronousLogStream;
@@ -344,7 +345,10 @@ public final class StreamPlatform {
   }
 
   public long writeBatch(final RecordToWrite... recordsToWrite) {
-    return logContext.setupWriter().tryWrite(Arrays.asList(recordsToWrite)).get();
+    return logContext
+        .setupWriter()
+        .tryWrite(WriteContext.internal(), Arrays.asList(recordsToWrite))
+        .get();
   }
 
   public void closeStreamProcessor() throws Exception {

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorInconsistentPositionTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamProcessorInconsistentPositionTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.stream.util.RecordToWrite;
@@ -38,6 +39,7 @@ final class StreamProcessorInconsistentPositionTest {
         // the same backend. Both logstream will open a dispatcher with start at position one.
 
         firstWriter.tryWrite(
+            WriteContext.internal(),
             List.of(
                 RecordToWrite.command()
                     .processInstance(
@@ -46,6 +48,7 @@ final class StreamProcessorInconsistentPositionTest {
                     .processInstance(
                         ProcessInstanceIntent.ACTIVATE_ELEMENT, Records.processInstance(1))));
         secondWriter.tryWrite(
+            WriteContext.internal(),
             List.of(
                 RecordToWrite.command()
                     .processInstance(


### PR DESCRIPTION
## Description

All record writers must now provide a `WriteContext`. This can be one of:
- UserCommand
- ProcessingResult
- InterPartition
- Scheduled
- Internal

For now, this information isn't used. In the future, we will use to decide when and how to apply flow control.

I've also included a small cleanup and refactoring of `Sequencer`, best reviewed commit by commit.

## Related issues

closes #18116
