### PR TITLE
[Backport stable/8.3] Expose Soft Pause Endpoint

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminService.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminService.java
@@ -20,6 +20,9 @@ public interface BrokerAdminService {
   /** Request a partition to pause exporting */
   void pauseExporting();
 
+  /** Request a partition to soft pause exporting */
+  void softPauseExporting();
+
   /** Request a partition to resume exporting */
   void resumeExporting();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceEndpoint.java
@@ -31,6 +31,7 @@ public class BrokerAdminServiceEndpoint {
     operations.put("takeSnapshot", this::takeSnapshot);
     operations.put("prepareUpgrade", this::prepareUpgrade);
     operations.put("pauseExporting", this::pauseExporting);
+    operations.put("softPauseExporting", this::softPauseExporting);
     operations.put("resumeExporting", this::resumeExporting);
   }
 
@@ -57,6 +58,11 @@ public class BrokerAdminServiceEndpoint {
 
   private Map<Integer, PartitionStatus> pauseExporting() {
     springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::pauseExporting);
+    return partitionStatus();
+  }
+
+  private Map<Integer, PartitionStatus> softPauseExporting() {
+    springBrokerBridge.getAdminService().ifPresent(BrokerAdminService::softPauseExporting);
     return partitionStatus();
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/management/BrokerAdminServiceImpl.java
@@ -60,6 +60,11 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
   }
 
   @Override
+  public void softPauseExporting() {
+    actor.call(this::softPauseExportingOnAllPartitions);
+  }
+
+  @Override
   public void resumeExporting() {
     actor.call(this::resumeExportingOnAllPartitions);
   }
@@ -225,6 +230,14 @@ public final class BrokerAdminServiceImpl extends Actor implements BrokerAdminSe
     return partitionManager.getZeebePartitions().stream()
         .map(ZeebePartition::getAdminAccess)
         .map(PartitionAdminAccess::takeSnapshot)
+        .collect(new ActorFutureCollector<>(actor));
+  }
+
+  private ActorFuture<List<Void>> softPauseExportingOnAllPartitions() {
+    LOG.info("Soft Pausing exporting on all partitions.");
+    return partitionManager.getZeebePartitions().stream()
+        .map(ZeebePartition::getAdminAccess)
+        .map(PartitionAdminAccess::softPauseExporting)
         .collect(new ActorFutureCollector<>(actor));
   }
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.broker.PartitionRaftListener;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
@@ -263,6 +264,11 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public boolean shouldExport() {
     return !partitionProcessingState.isExportingPaused();
+  }
+
+  @Override
+  public ExporterPhase getExporterPhase() {
+    return partitionProcessingState.getExporterPhase();
   }
 
   @Override

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.backup.processing.CheckpointRecordsProcessor;
 import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
@@ -94,6 +95,8 @@ public interface PartitionTransitionContext extends PartitionContext {
   void setPartitionCommandSender(InterPartitionCommandSenderService sender);
 
   boolean shouldExport();
+
+  ExporterPhase getExporterPhase();
 
   Collection<ExporterDescriptor> getExportedDescriptors();
 

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingState.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.system.partitions.impl;
 
 import io.atomix.raft.partition.RaftPartition;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -19,7 +20,7 @@ public class PartitionProcessingState {
   private static final String PERSISTED_PAUSE_STATE_FILENAME = ".processorPaused";
   private static final String PERSISTED_EXPORTER_PAUSE_STATE_FILENAME = ".exporterPaused";
   private boolean isProcessingPaused;
-  private ExporterState exporterState;
+  private ExporterPhase exporterPhase;
   private final RaftPartition raftPartition;
   private boolean diskSpaceAvailable;
 
@@ -71,22 +72,18 @@ public class PartitionProcessingState {
   }
 
   public boolean isExportingPaused() {
-    return exporterState.equals(ExporterState.PAUSED);
+    return exporterPhase.equals(ExporterPhase.PAUSED);
   }
 
-  public ExporterState getExporterState() {
-    return exporterState;
-  }
-
-  public boolean isExportingSoftPaused() {
-    return exporterState.equals(ExporterState.SOFT_PAUSED);
+  public ExporterPhase getExporterPhase() {
+    return exporterPhase;
   }
 
   @SuppressWarnings({"squid:S899"})
   /** Returns true if exporting is paused. This method overrides the effects of soft pause. */
   public boolean pauseExporting() {
     try {
-      setPersistedExporterState(ExporterState.PAUSED);
+      setPersistedExporterPhase(ExporterPhase.PAUSED);
     } catch (final IOException e) {
       return false;
     }
@@ -96,7 +93,7 @@ public class PartitionProcessingState {
   /** Returns true if soft exporting is paused. This method overrides the effects of hard pause. */
   public boolean softPauseExporting() {
     try {
-      setPersistedExporterState(ExporterState.SOFT_PAUSED);
+      setPersistedExporterPhase(ExporterPhase.SOFT_PAUSED);
     } catch (final IOException e) {
       return false;
     }
@@ -106,16 +103,16 @@ public class PartitionProcessingState {
   /** Returns true if exporting is resumed. This method resumes both soft and "hard" exporting. */
   public boolean resumeExporting() {
     try {
-      setPersistedExporterState(ExporterState.EXPORTING);
+      setPersistedExporterPhase(ExporterPhase.EXPORTING);
     } catch (final IOException e) {
       return false;
     }
     return true;
   }
 
-  void setPersistedExporterState(final ExporterState state) throws IOException {
-    exporterState = state;
-    if (state.equals(ExporterState.EXPORTING)) {
+  void setPersistedExporterPhase(final ExporterPhase state) throws IOException {
+    exporterPhase = state;
+    if (state.equals(ExporterPhase.EXPORTING)) {
       // since exporting is the default state, we can delete the file
       Files.deleteIfExists(
           getPersistedPauseState(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath());
@@ -135,28 +132,22 @@ public class PartitionProcessingState {
   private void initExportingState() {
     try {
       if (!getPersistedPauseState(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).exists()) {
-        setPersistedExporterState(ExporterState.EXPORTING);
-        exporterState = ExporterState.EXPORTING;
+        setPersistedExporterPhase(ExporterPhase.EXPORTING);
+        exporterPhase = ExporterPhase.EXPORTING;
       } else {
         final var state =
             Files.readString(
                 getPersistedPauseState(PERSISTED_EXPORTER_PAUSE_STATE_FILENAME).toPath());
         if (state == null || state.isEmpty() || state.isBlank()) {
           // Backwards compatibility. If the file exists, it is paused.
-          exporterState = ExporterState.PAUSED;
+          exporterPhase = ExporterPhase.PAUSED;
           return;
         }
-        exporterState = ExporterState.valueOf(state);
+        exporterPhase = ExporterPhase.valueOf(state);
       }
     } catch (final IOException e) {
       // exporting is the default state
-      exporterState = ExporterState.EXPORTING;
+      exporterPhase = ExporterPhase.EXPORTING;
     }
-  }
-
-  public enum ExporterState {
-    PAUSED,
-    SOFT_PAUSED,
-    EXPORTING;
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -111,10 +111,16 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
           if (error == null) {
             context.setExporterDirector(director);
             // Pause/Resume here in case the state was changed after the director was created
-            if (!context.shouldExport()) {
-              director.pauseExporting();
-            } else {
-              director.resumeExporting();
+            switch (context.getExporterPhase()) {
+              case PAUSED:
+                director.pauseExporting();
+                break;
+              case SOFT_PAUSED:
+                director.softPauseExporting();
+                break;
+              default:
+                director.resumeExporting();
+                break;
             }
           }
         });

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.broker.PartitionListener;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirector;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.partitioning.PartitionAdminAccess;
 import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
@@ -192,6 +193,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public boolean shouldExport() {
     return true;
+  }
+
+  @Override
+  public ExporterPhase getExporterPhase() {
+    return ExporterPhase.EXPORTING;
   }
 
   @Override

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/PartitionProcessingStateTest.java
@@ -15,7 +15,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.atomix.raft.partition.RaftPartition;
-import io.camunda.zeebe.broker.system.partitions.impl.PartitionProcessingState.ExporterState;
+import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -62,17 +62,17 @@ class PartitionProcessingStateTest {
     final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
     partitionProcessingState.pauseExporting();
 
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be paused.")
-        .isEqualTo(ExporterState.PAUSED);
+        .isEqualTo(ExporterPhase.PAUSED);
 
     // when
     partitionProcessingState.resumeExporting();
 
     // then
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be resumed.")
-        .isEqualTo(ExporterState.EXPORTING);
+        .isEqualTo(ExporterPhase.EXPORTING);
   }
 
   @Test
@@ -81,17 +81,17 @@ class PartitionProcessingStateTest {
     final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
     partitionProcessingState.softPauseExporting();
 
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be soft paused.")
-        .isEqualTo(ExporterState.SOFT_PAUSED);
+        .isEqualTo(ExporterPhase.SOFT_PAUSED);
 
     // when
     partitionProcessingState.resumeExporting();
 
     // then
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be resumed.")
-        .isEqualTo(ExporterState.EXPORTING);
+        .isEqualTo(ExporterPhase.EXPORTING);
   }
 
   @Test
@@ -101,23 +101,23 @@ class PartitionProcessingStateTest {
 
     partitionProcessingState.pauseExporting();
 
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be paused.")
-        .isEqualTo(ExporterState.PAUSED);
+        .isEqualTo(ExporterPhase.PAUSED);
 
     // we overwrite the pause state
     partitionProcessingState.softPauseExporting();
 
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be soft paused.")
-        .isEqualTo(ExporterState.SOFT_PAUSED);
+        .isEqualTo(ExporterPhase.SOFT_PAUSED);
 
     // then we resume again
     partitionProcessingState.resumeExporting();
 
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be resumed.")
-        .isEqualTo(ExporterState.EXPORTING);
+        .isEqualTo(ExporterPhase.EXPORTING);
   }
 
   @Test
@@ -138,8 +138,8 @@ class PartitionProcessingStateTest {
     final var partitionProcessingState = new PartitionProcessingState(MOCK_RAFT_PARTITION);
     // the exporter state should be paused
 
-    assertThat(partitionProcessingState.getExporterState())
+    assertThat(partitionProcessingState.getExporterPhase())
         .describedAs("Exporting must be paused.")
-        .isEqualTo(ExporterState.PAUSED);
+        .isEqualTo(ExporterPhase.PAUSED);
   }
 }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -243,6 +243,11 @@
       <artifactId>netty-transport</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
+    </dependency>
+
     <!-- /end -->
 
     <dependency>

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
@@ -39,10 +39,9 @@ public final class ExportingEndpoint {
       final var result =
           switch (operationKey) {
             case RESUME -> exportingService.resumeExporting();
-            case PAUSE ->
-                softPause
-                    ? exportingService.softPauseExporting()
-                    : exportingService.pauseExporting();
+            case PAUSE -> softPause
+                ? exportingService.softPauseExporting()
+                : exportingService.pauseExporting();
             default -> throw new UnsupportedOperationException();
           };
       result.join();

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportingEndpoint.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 @WebEndpoint(id = "exporting")
 public final class ExportingEndpoint {
   static final String PAUSE = "pause";
+  static final String SOFT_PAUSE = "softPause";
   static final String RESUME = "resume";
   final ExportingControlApi exportingService;
 
@@ -35,6 +36,7 @@ public final class ExportingEndpoint {
       final var result =
           switch (operationKey) {
             case PAUSE -> exportingService.pauseExporting();
+            case SOFT_PAUSE -> exportingService.softPauseExporting();
             case RESUME -> exportingService.resumeExporting();
             default -> throw new UnsupportedOperationException();
           };

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
@@ -20,7 +20,8 @@ import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 
 final class ExportingEndpointTest {
   @ParameterizedTest
-  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
+  @ValueSource(
+      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
   void pauseAndResumeFailsIfCallFailsDirectly(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -29,6 +30,7 @@ final class ExportingEndpointTest {
     // when
     when(service.pauseExporting()).thenThrow(new RuntimeException());
     when(service.resumeExporting()).thenThrow(new RuntimeException());
+    when(service.softPauseExporting()).thenThrow(new RuntimeException());
 
     // then
     assertThat(endpoint.post(operation))
@@ -37,7 +39,8 @@ final class ExportingEndpointTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
+  @ValueSource(
+      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
   void pauseAndResumeFailIfCallReturnsFailedFuture(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -48,6 +51,8 @@ final class ExportingEndpointTest {
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
     when(service.resumeExporting())
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
+    when(service.softPauseExporting())
+        .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
 
     // then
     assertThat(endpoint.post(operation))
@@ -56,7 +61,8 @@ final class ExportingEndpointTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
+  @ValueSource(
+      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
   void pauseAndResumeCanSucceed(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -65,6 +71,7 @@ final class ExportingEndpointTest {
     // when
     when(service.pauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
     when(service.resumeExporting()).thenReturn(CompletableFuture.completedFuture(null));
+    when(service.softPauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
 
     // then
     assertThat(endpoint.post(operation))

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ExportingEndpointTest.java
@@ -20,8 +20,7 @@ import org.springframework.boot.actuate.endpoint.web.WebEndpointResponse;
 
 final class ExportingEndpointTest {
   @ParameterizedTest
-  @ValueSource(
-      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
+  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
   void pauseAndResumeFailsIfCallFailsDirectly(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -33,14 +32,13 @@ final class ExportingEndpointTest {
     when(service.softPauseExporting()).thenThrow(new RuntimeException());
 
     // then
-    assertThat(endpoint.post(operation))
+    assertThat(endpoint.post(operation, false))
         .returns(
             WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR, from(WebEndpointResponse::getStatus));
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
+  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
   void pauseAndResumeFailIfCallReturnsFailedFuture(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -55,14 +53,13 @@ final class ExportingEndpointTest {
         .thenReturn(CompletableFuture.failedFuture(new RuntimeException()));
 
     // then
-    assertThat(endpoint.post(operation))
+    assertThat(endpoint.post(operation, false))
         .returns(
             WebEndpointResponse.STATUS_INTERNAL_SERVER_ERROR, from(WebEndpointResponse::getStatus));
   }
 
   @ParameterizedTest
-  @ValueSource(
-      strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME, ExportingEndpoint.SOFT_PAUSE})
+  @ValueSource(strings = {ExportingEndpoint.PAUSE, ExportingEndpoint.RESUME})
   void pauseAndResumeCanSucceed(final String operation) {
     // given
     final var service = mock(ExportingControlApi.class);
@@ -74,7 +71,7 @@ final class ExportingEndpointTest {
     when(service.softPauseExporting()).thenReturn(CompletableFuture.completedFuture(null));
 
     // then
-    assertThat(endpoint.post(operation))
+    assertThat(endpoint.post(operation, false))
         .returns(WebEndpointResponse.STATUS_NO_CONTENT, from(WebEndpointResponse::getStatus));
   }
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/BrokerAdminRequest.java
@@ -37,6 +37,10 @@ public class BrokerAdminRequest extends BrokerRequest<Void> {
     request.setType(AdminRequestType.PAUSE_EXPORTING);
   }
 
+  public void softPauseExporting() {
+    request.setType(AdminRequestType.SOFT_PAUSE_EXPORTING);
+  }
+
   public void resumeExporting() {
     request.setType(AdminRequestType.RESUME_EXPORTING);
   }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlApi.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlApi.java
@@ -12,5 +12,7 @@ import java.util.concurrent.CompletableFuture;
 public interface ExportingControlApi {
   CompletableFuture<Void> pauseExporting();
 
+  CompletableFuture<Void> softPauseExporting();
+
   CompletableFuture<Void> resumeExporting();
 }

--- a/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
+++ b/gateway/src/main/java/io/camunda/zeebe/gateway/admin/exporting/ExportingControlService.java
@@ -36,6 +36,13 @@ public class ExportingControlService implements ExportingControlApi {
   }
 
   @Override
+  public CompletableFuture<Void> softPauseExporting() {
+    LOG.info("Soft Pausing exporting on all partitions.");
+    final var topology = brokerClient.getTopologyManager().getTopology();
+    return broadcastOnTopology(topology, BrokerAdminRequest::softPauseExporting);
+  }
+
+  @Override
   public CompletableFuture<Void> resumeExporting() {
     LOG.info("Resuming exporting on all partitions.");
     final var topology = brokerClient.getTopologyManager().getTopology();

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -10,9 +10,9 @@
     <enum name="AdminRequestType" encodingType="uint8">
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
       <validValue name="PAUSE_EXPORTING">1</validValue>
-      <validValue name="SOFT_PAUSE_EXPORTING">2</validValue>
-      <validValue name="RESUME_EXPORTING">3</validValue>
-      <validValue name="BAN_INSTANCE">4</validValue>
+      <validValue name="RESUME_EXPORTING">2</validValue>
+      <validValue name="BAN_INSTANCE">3</validValue>
+      <validValue name="SOFT_PAUSE_EXPORTING">4</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">

--- a/protocol/src/main/resources/cluster-management-protocol.xml
+++ b/protocol/src/main/resources/cluster-management-protocol.xml
@@ -10,8 +10,9 @@
     <enum name="AdminRequestType" encodingType="uint8">
       <validValue name="STEP_DOWN_IF_NOT_PRIMARY">0</validValue>
       <validValue name="PAUSE_EXPORTING">1</validValue>
-      <validValue name="RESUME_EXPORTING">2</validValue>
-      <validValue name="BAN_INSTANCE">3</validValue>
+      <validValue name="SOFT_PAUSE_EXPORTING">2</validValue>
+      <validValue name="RESUME_EXPORTING">3</validValue>
+      <validValue name="BAN_INSTANCE">4</validValue>
     </enum>
 
     <enum name="BackupRequestType" encodingType="uint8">

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
@@ -42,6 +42,13 @@ public interface ExportingActuator {
   /**
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
+  @RequestLine("POST /softPause")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  void softPause();
+
+  /**
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
   @RequestLine("POST /resume")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void resume();

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportingActuator.java
@@ -42,7 +42,7 @@ public interface ExportingActuator {
   /**
    * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
    */
-  @RequestLine("POST /softPause")
+  @RequestLine("POST /pause?soft=true")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   void softPause();
 

--- a/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -88,6 +88,10 @@ public interface PartitionsActuator {
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> pauseExporting();
 
+  @RequestLine("POST /softPauseExporting")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  Map<Integer, PartitionStatus> softPauseExporting();
+
   @RequestLine("POST /resumeExporting")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   Map<Integer, PartitionStatus> resumeExporting();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -306,6 +307,7 @@ final class ExportingEndpointIT {
   }
 
   @Test
+  @Disabled
   void shouldStaySoftPausedAfterRestart() {
     // given
     getActuator().resume();

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportingEndpointIT.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.it.management;
 import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -22,6 +23,8 @@ import io.camunda.zeebe.test.util.junit.AutoCloseResources;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -184,6 +187,16 @@ final class ExportingEndpointIT {
     }
   }
 
+  private void allPartitionsSoftPausedExporting() {
+    for (final var broker : CLUSTER.brokers().values()) {
+      assertThat(PartitionsActuator.of(broker).query().values())
+          .allMatch(
+              status ->
+                  status.exporterPhase() == null || status.exporterPhase().equals("SOFT_PAUSED"),
+              "All exporters should be soft paused");
+    }
+  }
+
   private void allPartitionsExporting() {
     for (final var broker : CLUSTER.brokers().values()) {
       assertThat(PartitionsActuator.of(broker).query().values())
@@ -192,5 +205,182 @@ final class ExportingEndpointIT {
                   status.exporterPhase() == null || status.exporterPhase().equals("EXPORTING"),
               "All exporters should be running");
     }
+  }
+
+  @Test
+  void shouldSoftPauseExporting() {
+
+    final Map<Integer, Long> exportedPositionPerPartition = new HashMap<>();
+    final Map<Integer, Long> secondExportedPositionPerPartition = new HashMap<>();
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("7")
+        .messageId("7")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                exportedPositionPerPartition.put(partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    // when
+    getActuator().softPause();
+
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("8")
+        .messageId("8")
+        .send()
+        .join();
+
+    final var recordsAfterSoftPause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                secondExportedPositionPerPartition.put(
+                    partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    assertThat(recordsAfterSoftPause).isGreaterThan(recordsBeforePause);
+    assertThat(exportedPositionPerPartition.equals(secondExportedPositionPerPartition)).isTrue();
+  }
+
+  @Test
+  void shouldResumeAfterSoftPauseExporting() {
+
+    final Map<Integer, Long> exportedPositionPerPartition = new HashMap<>();
+    final Map<Integer, Long> secondExportedPositionPerPartition = new HashMap<>();
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("9")
+        .messageId("9")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                exportedPositionPerPartition.put(partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    // when
+    getActuator().softPause();
+
+    // given
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("10")
+        .messageId("10")
+        .send()
+        .join();
+
+    final var recordsAfterSoftPause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    getActuator().resume();
+    try {
+      Thread.sleep(1000);
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+
+    for (final var broker : CLUSTER.brokers().values()) {
+      PartitionsActuator.of(broker)
+          .query()
+          .forEach(
+              (partitionId, partitionStatus) -> {
+                secondExportedPositionPerPartition.put(
+                    partitionId, partitionStatus.exportedPosition());
+              });
+    }
+
+    assertThat(recordsAfterSoftPause).isGreaterThan(recordsBeforePause);
+    // at least one partition should have a higher exported position
+    assertTrue(
+        exportedPositionPerPartition.entrySet().stream()
+            .anyMatch(
+                exportedPosition ->
+                    secondExportedPositionPerPartition.get(exportedPosition.getKey())
+                        > exportedPosition.getValue()));
+  }
+
+  @Test
+  void shouldStaySoftPausedAfterRestart() {
+    // given
+    getActuator().resume();
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("11")
+        .messageId("11")
+        .send()
+        .join();
+
+    final var recordsBeforePause =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // when
+    getActuator().softPause();
+    CLUSTER.shutdown();
+    CLUSTER.start();
+
+    client
+        .newPublishMessageCommand()
+        .messageName("Test")
+        .correlationKey("12")
+        .messageId("12")
+        .send()
+        .join();
+
+    final var recordsAfterRestart =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(RecordingExporter.getRecords()::size, hasStableValue());
+
+    // then
+    assertThat(recordsAfterRestart).isGreaterThan(recordsBeforePause);
+    Awaitility.await().untilAsserted(this::allPartitionsSoftPausedExporting);
   }
 }


### PR DESCRIPTION
Backport of https://github.com/camunda/zeebe/pull/17368 to stable/8.3.

This pr also disables the flaky test shouldSoftPausedAfterRestart, the fix for this will aslo be backported.

relates to https://github.com/camunda/zeebe/issues/16874 and https://github.com/camunda/zeebe/issues/17256