### PR TITLE
feat: storing and exposing bpmXml on Tasklist V1 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,6 @@
     <module>operate</module>
     <module>tasklist</module>
     <module>identity</module>
-    <module>tasklist</module>
   </modules>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <module>operate</module>
     <module>tasklist</module>
     <module>identity</module>
+    <module>tasklist</module>
   </modules>
 
   <scm>

--- a/tasklist/common/src/main/java/io/camunda/tasklist/entities/ProcessEntity.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/entities/ProcessEntity.java
@@ -25,6 +25,7 @@ public class ProcessEntity extends TasklistZeebeEntity<ProcessEntity> {
   private String formId;
   private Boolean isFormEmbedded;
   private List<ProcessFlowNodeEntity> flowNodes = new ArrayList<>();
+  private String bpmnXml;
 
   public String getName() {
     return name;
@@ -98,8 +99,17 @@ public class ProcessEntity extends TasklistZeebeEntity<ProcessEntity> {
     return this;
   }
 
+  public String getBpmnXml() {
+    return bpmnXml;
+  }
+
+  public ProcessEntity setBpmnXml(final String bpmnXml) {
+    this.bpmnXml = bpmnXml;
+    return this;
+  }
+
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -117,7 +127,8 @@ public class ProcessEntity extends TasklistZeebeEntity<ProcessEntity> {
         && Objects.equals(formKey, that.formKey)
         && Objects.equals(formId, that.formId)
         && Objects.equals(isFormEmbedded, that.isFormEmbedded)
-        && Objects.equals(flowNodes, that.flowNodes);
+        && Objects.equals(flowNodes, that.flowNodes)
+        && Objects.equals(bpmnXml, that.bpmnXml);
   }
 
   @Override
@@ -131,6 +142,7 @@ public class ProcessEntity extends TasklistZeebeEntity<ProcessEntity> {
         formKey,
         formId,
         isFormEmbedded,
-        flowNodes);
+        flowNodes,
+        bpmnXml);
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/ProcessIndex.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/ProcessIndex.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class ProcessIndex extends AbstractIndexDescriptor implements Prio4Backup {
 
   public static final String INDEX_NAME = "process";
-  public static final String INDEX_VERSION = "8.4.0";
+  public static final String INDEX_VERSION = "8.6.0";
 
   public static final String ID = "id";
   public static final String KEY = "key";

--- a/tasklist/els-schema/src/main/resources/schema/es/change/8.6.0-0_process-bpmnXml.json
+++ b/tasklist/els-schema/src/main/resources/schema/es/change/8.6.0-0_process-bpmnXml.json
@@ -1,0 +1,8 @@
+{
+  "description": "Set JOB_WORKER implementation for 'task' index",
+  "@type": "processorStep",
+  "indexName": "process",
+  "version": "8.6.0",
+  "order": 0,
+  "content": "{\"set\": {\"field\": \"bpmnXml\", \"value\": \"\"}}"
+}

--- a/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-process.json
+++ b/tasklist/els-schema/src/main/resources/schema/es/create/index/tasklist-process.json
@@ -54,6 +54,9 @@
       },
       "tenantId": {
         "type": "keyword"
+      },
+      "bpmnXml" : {
+        "type" : "text"
       }
     }
   }

--- a/tasklist/els-schema/src/main/resources/schema/os/change/8.6.0-0_process-bpmnXml.json
+++ b/tasklist/els-schema/src/main/resources/schema/os/change/8.6.0-0_process-bpmnXml.json
@@ -1,0 +1,8 @@
+{
+  "description": "Set JOB_WORKER implementation for 'task' index",
+  "@type": "processorStep",
+  "indexName": "process",
+  "version": "8.6.0",
+  "order": 0,
+  "content": "{\"set\": {\"field\": \"bpmnXml\", \"value\": \"\"}}"
+}

--- a/tasklist/els-schema/src/main/resources/schema/os/create/index/tasklist-process.json
+++ b/tasklist/els-schema/src/main/resources/schema/os/create/index/tasklist-process.json
@@ -53,6 +53,9 @@
     },
     "tenantId": {
       "type": "keyword"
+    },
+    "bpmnXml" : {
+      "type" : "text"
     }
   }
 }

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
@@ -115,6 +115,7 @@ public class ProcessZeebeRecordProcessorElasticSearch {
     processEntity.setBpmnProcessId(process.getBpmnProcessId());
     processEntity.setVersion(process.getVersion());
     processEntity.setTenantId(process.getTenantId());
+    processEntity.setBpmnXml(new String(process.getResource()));
 
     final byte[] byteArray = process.getResource();
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
@@ -118,6 +118,7 @@ public class ProcessZeebeRecordProcessorElasticSearch {
     processEntity.setBpmnProcessId(process.getBpmnProcessId());
     processEntity.setVersion(process.getVersion());
     processEntity.setTenantId(process.getTenantId());
+    processEntity.setBpmnXml(new String(process.getResource()));
 
     final byte[] byteArray = process.getResource();
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
@@ -68,18 +68,20 @@ public class ProcessInternalController extends ApiErrorController {
       summary = "Returns the process by ProcessDefinitionKey",
       description = "Returns the process by ProcessDefinitionKey",
       responses = {
-          @ApiResponse(
-              description = "On success returned",
-              responseCode = "200",
-              useReturnTypeSchema = true),
-          @ApiResponse(
-              description = "Process Not Found",
-              responseCode = "404")
+        @ApiResponse(
+            description = "On success returned",
+            responseCode = "200",
+            useReturnTypeSchema = true),
+        @ApiResponse(description = "Process Not Found", responseCode = "404")
       })
   @GetMapping("{processDefinitionKey}")
-  public ResponseEntity<ProcessResponse> getProcess(@PathVariable final String processDefinitionKey){
-    final ProcessEntity processEntity = processStore.getProcessByProcessDefinitionKey(processDefinitionKey);
-    final ProcessResponse processResponse = new ProcessResponse().fromProcessEntity(processEntity, getStartEventFormIdByBpmnProcess(processEntity));
+  public ResponseEntity<ProcessResponse> getProcess(
+      @PathVariable final String processDefinitionKey) {
+    final ProcessEntity processEntity =
+        processStore.getProcessByProcessDefinitionKey(processDefinitionKey);
+    final ProcessResponse processResponse =
+        new ProcessResponse()
+            .fromProcessEntity(processEntity, getStartEventFormIdByBpmnProcess(processEntity));
     return ResponseEntity.ok(processResponse);
   }
 
@@ -124,7 +126,10 @@ public class ProcessInternalController extends ApiErrorController {
                 tenantId,
                 isStartedByForm)
             .stream()
-            .map(pe -> ProcessResponse.fromProcessEntityWithoutBpmnXml(pe, getStartEventFormIdByBpmnProcess(pe)))
+            .map(
+                pe ->
+                    ProcessResponse.fromProcessEntityWithoutBpmnXml(
+                        pe, getStartEventFormIdByBpmnProcess(pe)))
             .collect(Collectors.toList());
     return ResponseEntity.ok(processes);
   }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
@@ -78,7 +78,7 @@ public class ProcessInternalController extends ApiErrorController {
   public ResponseEntity<ProcessResponse> getProcess(
       @PathVariable final String processDefinitionKey) {
     final ProcessEntity processEntity =
-        processStore.getProcessByProcessDefinitionKey(processDefinitionKey);
+        processService.getProcessByProcessDefinitionKeyAndAccessRestriction(processDefinitionKey);
     final ProcessResponse processResponse =
         new ProcessResponse()
             .fromProcessEntity(processEntity, getStartEventFormIdByBpmnProcess(processEntity));
@@ -100,7 +100,7 @@ public class ProcessInternalController extends ApiErrorController {
               description =
                   "Used to search processes by processId, process name, and process definition id fields.")
           @RequestParam(defaultValue = StringUtils.EMPTY)
-          String query,
+          final String query,
       @Parameter(
               description =
                   "Identifies the tenant.<br>"
@@ -108,7 +108,7 @@ public class ProcessInternalController extends ApiErrorController {
                       + "If `tenantId` is provided, only processes for that tenant will be returned, or an empty list if the user does not have access to the provided tenant.<br>"
                       + "If multi-tenancy is disabled, this parameter will be ignored.")
           @RequestParam(required = false)
-          String tenantId,
+          final String tenantId,
       @Parameter(
               description =
                   "If this parameter is set (Default value `null`): <br>"
@@ -116,7 +116,7 @@ public class ProcessInternalController extends ApiErrorController {
                       + "`false`: It will return all the processes that are not started by a form <br>"
                       + "`null`: The filter is not applied")
           @RequestParam(required = false)
-          Boolean isStartedByForm) {
+          final Boolean isStartedByForm) {
 
     final var processes =
         processStore
@@ -135,13 +135,13 @@ public class ProcessInternalController extends ApiErrorController {
   }
 
   /** Retrieving the start event form id when exists. */
-  private String getStartEventFormIdByBpmnProcess(ProcessEntity process) {
+  private String getStartEventFormIdByBpmnProcess(final ProcessEntity process) {
     if (process.getIsFormEmbedded() != null && !process.getIsFormEmbedded()) {
       if (process.getFormId() != null) {
         try {
           final var form = formStore.getForm(process.getFormId(), process.getId(), null);
           return form.getBpmnId();
-        } catch (NotFoundException e) {
+        } catch (final NotFoundException e) {
           // Form not found, but maintain the Form ID in order to threat not found in front-end
           return process.getFormId();
         }
@@ -184,13 +184,13 @@ public class ProcessInternalController extends ApiErrorController {
   @PreAuthorize("hasPermission('write')")
   @PatchMapping("{bpmnProcessId}/start")
   public ResponseEntity<ProcessInstanceDTO> startProcessInstance(
-      @PathVariable String bpmnProcessId,
+      @PathVariable final String bpmnProcessId,
       @Parameter(
               description =
                   "Required for multi-tenancy setups to ensure the process starts for the intended tenant. In environments without multi-tenancy, this parameter is not considered.")
           @RequestParam(required = false)
-          String tenantId,
-      @RequestBody(required = false) StartProcessRequest startProcessRequest) {
+          final String tenantId,
+      @RequestBody(required = false) final StartProcessRequest startProcessRequest) {
     final var variables =
         requireNonNullElse(startProcessRequest, new StartProcessRequest()).getVariables();
     final var processInstance =
@@ -225,7 +225,7 @@ public class ProcessInternalController extends ApiErrorController {
       })
   @PreAuthorize("hasPermission('write')")
   @DeleteMapping("{processInstanceId}")
-  public ResponseEntity<?> deleteProcessInstance(@PathVariable String processInstanceId) {
+  public ResponseEntity<?> deleteProcessInstance(@PathVariable final String processInstanceId) {
 
     return switch (processInstanceStore.deleteProcessInstance(processInstanceId)) {
       case DELETED -> ResponseEntity.noContent().build();
@@ -295,7 +295,7 @@ public class ProcessInternalController extends ApiErrorController {
       })
   @GetMapping("{bpmnProcessId}/publicEndpoint")
   public ResponseEntity<ProcessPublicEndpointsResponse> getPublicEndpoint(
-      @PathVariable String bpmnProcessId,
+      @PathVariable final String bpmnProcessId,
       @Parameter(
               description =
                   "If using multi-tenancy, this parameter ensures the system fetches the public endpoint for the correct tenant. In environments without multi-tenancy, this parameter is not considered.")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
@@ -65,6 +65,25 @@ public class ProcessInternalController extends ApiErrorController {
   @Autowired private TenantService tenantService;
 
   @Operation(
+      summary = "Returns the process by ProcessDefinitionKey",
+      description = "Returns the process by ProcessDefinitionKey",
+      responses = {
+          @ApiResponse(
+              description = "On success returned",
+              responseCode = "200",
+              useReturnTypeSchema = true),
+          @ApiResponse(
+              description = "Process Not Found",
+              responseCode = "404")
+      })
+  @GetMapping("{processDefinitionKey}")
+  public ResponseEntity<ProcessResponse> getProcess(@PathVariable final String processDefinitionKey){
+    final ProcessEntity processEntity = processStore.getProcessByProcessDefinitionKey(processDefinitionKey);
+    final ProcessResponse processResponse = new ProcessResponse().fromProcessEntity(processEntity, getStartEventFormIdByBpmnProcess(processEntity));
+    return ResponseEntity.ok(processResponse);
+  }
+
+  @Operation(
       summary = "Returns the list of processes by search query",
       description = "Get the processes by `search` query.",
       responses = {
@@ -105,7 +124,7 @@ public class ProcessInternalController extends ApiErrorController {
                 tenantId,
                 isStartedByForm)
             .stream()
-            .map(pe -> ProcessResponse.fromProcessEntity(pe, getStartEventFormIdByBpmnProcess(pe)))
+            .map(pe -> ProcessResponse.fromProcessEntityWithoutBpmnXml(pe, getStartEventFormIdByBpmnProcess(pe)))
             .collect(Collectors.toList());
     return ResponseEntity.ok(processes);
   }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalController.java
@@ -72,6 +72,9 @@ public class ProcessInternalController extends ApiErrorController {
             description = "On success returned",
             responseCode = "200",
             useReturnTypeSchema = true),
+        @ApiResponse(
+            description = "Forbidden - User without privileges to read process",
+            responseCode = "403"),
         @ApiResponse(description = "Process Not Found", responseCode = "404")
       })
   @GetMapping("{processDefinitionKey}")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
@@ -37,6 +37,9 @@ public class ProcessResponse {
   @Schema(description = "The tenant ID associated with the process")
   private String tenantId;
 
+  @Schema(description = "The xml that represents the BPMN for the process")
+  private String bpmnXml;
+
   public String getId() {
     return id;
   }
@@ -100,54 +103,13 @@ public class ProcessResponse {
     return this;
   }
 
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
-    final ProcessResponse that = (ProcessResponse) o;
-    return Objects.equals(id, that.id)
-        && Objects.equals(name, that.name)
-        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
-        && Arrays.equals(sortValues, that.sortValues)
-        && Objects.equals(version, that.version)
-        && Objects.equals(startEventFormId, that.startEventFormId)
-        && Objects.equals(tenantId, that.tenantId);
+  public String getBpmnXml() {
+    return bpmnXml;
   }
 
-  @Override
-  public int hashCode() {
-    int result = Objects.hash(id, name, bpmnProcessId, version, startEventFormId, tenantId);
-    result = 31 * result + Arrays.hashCode(sortValues);
-    return result;
-  }
-
-  @Override
-  public String toString() {
-    return "ProcessResponse{"
-        + "id='"
-        + id
-        + '\''
-        + ", name='"
-        + name
-        + '\''
-        + ", bpmnProcessId='"
-        + bpmnProcessId
-        + '\''
-        + ", sortValues="
-        + Arrays.toString(sortValues)
-        + ", version="
-        + version
-        + ", startEventFormId='"
-        + startEventFormId
-        + '\''
-        + ", tenantId='"
-        + tenantId
-        + '\''
-        + '}';
+  public ProcessResponse setBpmnXml(final String bpmnXml) {
+    this.bpmnXml = bpmnXml;
+    return this;
   }
 
   public static ProcessResponse fromProcessEntity(ProcessEntity process, String startEventFormId) {
@@ -157,6 +119,35 @@ public class ProcessResponse {
         .setBpmnProcessId(process.getBpmnProcessId())
         .setVersion(process.getVersion())
         .setStartEventFormId(startEventFormId)
-        .setTenantId(process.getTenantId());
+        .setTenantId(process.getTenantId())
+        .setBpmnXml(process.getBpmnXml());
+  }
+
+  public static ProcessResponse fromProcessEntityWithoutBpmnXml(ProcessEntity process, String startEventFormId) {
+    process.setBpmnXml(null);
+    return fromProcessEntity(process, startEventFormId);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ProcessResponse that = (ProcessResponse) o;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name)
+        && Objects.equals(bpmnProcessId, that.bpmnProcessId)
+        && Objects.deepEquals(sortValues, that.sortValues) && Objects.equals(
+        version, that.version) && Objects.equals(startEventFormId, that.startEventFormId)
+        && Objects.equals(tenantId, that.tenantId) && Objects.equals(bpmnXml,
+        that.bpmnXml);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, bpmnProcessId, Arrays.hashCode(sortValues), version,
+        startEventFormId, tenantId, bpmnXml);
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
@@ -164,4 +164,32 @@ public class ProcessResponse {
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(bpmnXml, that.bpmnXml);
   }
+
+  @Override
+  public String toString() {
+    return "ProcessResponse{"
+        + "id='"
+        + id
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", bpmnProcessId='"
+        + bpmnProcessId
+        + '\''
+        + ", sortValues="
+        + Arrays.toString(sortValues)
+        + ", version="
+        + version
+        + ", startEventFormId='"
+        + startEventFormId
+        + '\''
+        + ", tenantId='"
+        + tenantId
+        + '\''
+        + ", bpmnXml='"
+        + bpmnXml
+        + '\''
+        + '}';
+  }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
@@ -44,7 +44,7 @@ public class ProcessResponse {
     return id;
   }
 
-  public ProcessResponse setId(String id) {
+  public ProcessResponse setId(final String id) {
     this.id = id;
     return this;
   }
@@ -53,7 +53,7 @@ public class ProcessResponse {
     return name;
   }
 
-  public ProcessResponse setName(String name) {
+  public ProcessResponse setName(final String name) {
     this.name = name;
     return this;
   }
@@ -62,7 +62,7 @@ public class ProcessResponse {
     return bpmnProcessId;
   }
 
-  public ProcessResponse setBpmnProcessId(String bpmnProcessId) {
+  public ProcessResponse setBpmnProcessId(final String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
     return this;
   }
@@ -71,7 +71,7 @@ public class ProcessResponse {
     return startEventFormId;
   }
 
-  public ProcessResponse setStartEventFormId(String startEventFormId) {
+  public ProcessResponse setStartEventFormId(final String startEventFormId) {
     this.startEventFormId = startEventFormId;
     return this;
   }
@@ -80,7 +80,7 @@ public class ProcessResponse {
     return sortValues;
   }
 
-  public ProcessResponse setSortValues(String[] sortValues) {
+  public ProcessResponse setSortValues(final String[] sortValues) {
     this.sortValues = sortValues;
     return this;
   }
@@ -89,7 +89,7 @@ public class ProcessResponse {
     return version;
   }
 
-  public ProcessResponse setVersion(Integer version) {
+  public ProcessResponse setVersion(final Integer version) {
     this.version = version;
     return this;
   }
@@ -98,7 +98,7 @@ public class ProcessResponse {
     return tenantId;
   }
 
-  public ProcessResponse setTenantId(String tenantId) {
+  public ProcessResponse setTenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }
@@ -112,21 +112,38 @@ public class ProcessResponse {
     return this;
   }
 
-  public static ProcessResponse fromProcessEntity(ProcessEntity process, String startEventFormId) {
+  public static ProcessResponse fromProcessEntity(
+      final ProcessEntity process, final String startEventFormId) {
+    return createWithoutBpmnXml(process, startEventFormId).setBpmnXml(process.getBpmnXml());
+  }
+
+  public static ProcessResponse fromProcessEntityWithoutBpmnXml(
+      final ProcessEntity process, final String startEventFormId) {
+    return createWithoutBpmnXml(process, startEventFormId);
+  }
+
+  private static ProcessResponse createWithoutBpmnXml(
+      final ProcessEntity process, final String startEventFormId) {
     return new ProcessResponse()
         .setId(process.getId())
         .setName(process.getName())
         .setBpmnProcessId(process.getBpmnProcessId())
         .setVersion(process.getVersion())
         .setStartEventFormId(startEventFormId)
-        .setTenantId(process.getTenantId())
-        .setBpmnXml(process.getBpmnXml());
+        .setTenantId(process.getTenantId());
   }
 
-  public static ProcessResponse fromProcessEntityWithoutBpmnXml(
-      ProcessEntity process, String startEventFormId) {
-    process.setBpmnXml(null);
-    return fromProcessEntity(process, startEventFormId);
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        id,
+        name,
+        bpmnProcessId,
+        Arrays.hashCode(sortValues),
+        version,
+        startEventFormId,
+        tenantId,
+        bpmnXml);
   }
 
   @Override
@@ -146,18 +163,5 @@ public class ProcessResponse {
         && Objects.equals(startEventFormId, that.startEventFormId)
         && Objects.equals(tenantId, that.tenantId)
         && Objects.equals(bpmnXml, that.bpmnXml);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        id,
-        name,
-        bpmnProcessId,
-        Arrays.hashCode(sortValues),
-        version,
-        startEventFormId,
-        tenantId,
-        bpmnXml);
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/ProcessResponse.java
@@ -123,7 +123,8 @@ public class ProcessResponse {
         .setBpmnXml(process.getBpmnXml());
   }
 
-  public static ProcessResponse fromProcessEntityWithoutBpmnXml(ProcessEntity process, String startEventFormId) {
+  public static ProcessResponse fromProcessEntityWithoutBpmnXml(
+      ProcessEntity process, String startEventFormId) {
     process.setBpmnXml(null);
     return fromProcessEntity(process, startEventFormId);
   }
@@ -137,17 +138,26 @@ public class ProcessResponse {
       return false;
     }
     final ProcessResponse that = (ProcessResponse) o;
-    return Objects.equals(id, that.id) && Objects.equals(name, that.name)
+    return Objects.equals(id, that.id)
+        && Objects.equals(name, that.name)
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
-        && Objects.deepEquals(sortValues, that.sortValues) && Objects.equals(
-        version, that.version) && Objects.equals(startEventFormId, that.startEventFormId)
-        && Objects.equals(tenantId, that.tenantId) && Objects.equals(bpmnXml,
-        that.bpmnXml);
+        && Objects.deepEquals(sortValues, that.sortValues)
+        && Objects.equals(version, that.version)
+        && Objects.equals(startEventFormId, that.startEventFormId)
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(bpmnXml, that.bpmnXml);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, bpmnProcessId, Arrays.hashCode(sortValues), version,
-        startEventFormId, tenantId, bpmnXml);
+    return Objects.hash(
+        id,
+        name,
+        bpmnProcessId,
+        Arrays.hashCode(sortValues),
+        version,
+        startEventFormId,
+        tenantId,
+        bpmnXml);
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorization.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorization.java
@@ -15,22 +15,34 @@ import java.util.List;
 
 public class IdentityAuthorization implements Serializable {
 
-  private static final String PROCESS_DEFINITION = "process-definition";
   // TODO - the UPDATE_PROCESS_INSTANCE is being used temporarily until we have the new permission
-  private static final String PROCESS_PERMISSION = "START_PROCESS_INSTANCE";
+  public static final String PROCESS_PERMISSION_START = "START_PROCESS_INSTANCE";
+  public static final String PROCESS_PERMISSION_READ = "READ";
+  private static final String PROCESS_DEFINITION = "process-definition";
   private List<String> processesAllowedToStart;
+  private final List<String> processesAllowedToRead;
 
-  public IdentityAuthorization(List<Authorization> authorizations) {
+  public IdentityAuthorization(final List<Authorization> authorizations) {
     processesAllowedToStart = new ArrayList<String>();
-    for (Authorization authorization : authorizations) {
-      if (authorization.getResourceType().equals(PROCESS_DEFINITION)
-          && authorization.getPermissions().contains(PROCESS_PERMISSION)) {
-        if (authorization.getResourceKey().equals(IdentityProperties.ALL_RESOURCES)) {
-          processesAllowedToStart.clear();
-          processesAllowedToStart.add(IdentityProperties.ALL_RESOURCES);
-          break;
-        } else {
-          processesAllowedToStart.add(authorization.getResourceKey());
+    processesAllowedToRead = new ArrayList<String>();
+    for (final Authorization authorization : authorizations) {
+      if (authorization.getResourceType().equals(PROCESS_DEFINITION)) {
+        if (authorization.getPermissions().contains(PROCESS_PERMISSION_START)) {
+          if (authorization.getResourceKey().equals(IdentityProperties.ALL_RESOURCES)) {
+            processesAllowedToStart.clear();
+            processesAllowedToStart.add(IdentityProperties.ALL_RESOURCES);
+          } else {
+            processesAllowedToStart.add(authorization.getResourceKey());
+          }
+        }
+
+        if (authorization.getPermissions().contains(PROCESS_PERMISSION_READ)) {
+          if (authorization.getResourceKey().equals(IdentityProperties.ALL_RESOURCES)) {
+            processesAllowedToRead.clear();
+            processesAllowedToRead.add(IdentityProperties.ALL_RESOURCES);
+          } else {
+            processesAllowedToRead.add(authorization.getResourceKey());
+          }
         }
       }
     }
@@ -40,8 +52,13 @@ public class IdentityAuthorization implements Serializable {
     return processesAllowedToStart;
   }
 
-  public IdentityAuthorization setProcessesAllowedToStart(List<String> processesAllowedToStart) {
+  public IdentityAuthorization setProcessesAllowedToStart(
+      final List<String> processesAllowedToStart) {
     this.processesAllowedToStart = processesAllowedToStart;
     return this;
+  }
+
+  public List<String> getProcessesAllowedToRead() {
+    return processesAllowedToRead;
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorization.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorization.java
@@ -27,23 +27,23 @@ public class IdentityAuthorization implements Serializable {
     processesAllowedToRead = new ArrayList<String>();
     for (final Authorization authorization : authorizations) {
       if (authorization.getResourceType().equals(PROCESS_DEFINITION)) {
-        if (authorization.getPermissions().contains(PROCESS_PERMISSION_START)) {
-          if (authorization.getResourceKey().equals(IdentityProperties.ALL_RESOURCES)) {
-            processesAllowedToStart.clear();
-            processesAllowedToStart.add(IdentityProperties.ALL_RESOURCES);
-          } else {
-            processesAllowedToStart.add(authorization.getResourceKey());
-          }
-        }
+        addPermissions(authorization, processesAllowedToStart, PROCESS_PERMISSION_START);
+        addPermissions(authorization, processesAllowedToRead, PROCESS_PERMISSION_READ);
+      }
+    }
+  }
 
-        if (authorization.getPermissions().contains(PROCESS_PERMISSION_READ)) {
-          if (authorization.getResourceKey().equals(IdentityProperties.ALL_RESOURCES)) {
-            processesAllowedToRead.clear();
-            processesAllowedToRead.add(IdentityProperties.ALL_RESOURCES);
-          } else {
-            processesAllowedToRead.add(authorization.getResourceKey());
-          }
-        }
+  private void addPermissions(
+      final Authorization authorization,
+      final List<String> processesAllowed,
+      final String expectedPermission) {
+    if (!processesAllowed.contains(IdentityProperties.ALL_RESOURCES)
+        && authorization.getPermissions().contains(expectedPermission)) {
+      if (authorization.getResourceKey().equals(IdentityProperties.ALL_RESOURCES)) {
+        processesAllowed.clear();
+        processesAllowed.add(IdentityProperties.ALL_RESOURCES);
+      } else {
+        processesAllowed.add(authorization.getResourceKey());
       }
     }
   }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationService.java
@@ -15,6 +15,7 @@ import io.camunda.tasklist.webapp.security.sso.TokenAuthentication;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,15 +41,11 @@ public class IdentityAuthorizationService {
     // Extract access token based on authentication type
     if (authentication instanceof IdentityAuthentication) {
       accessToken = ((IdentityAuthentication) authentication).getTokens().getAccessToken();
-      return identity.authentication().verifyToken(accessToken).getUserDetails().getGroups();
+      return identity.authentication().getGroups(accessToken);
     } else if (authentication instanceof TokenAuthentication) {
       accessToken = ((TokenAuthentication) authentication).getAccessToken();
       final String organization = ((TokenAuthentication) authentication).getOrganization();
-      return identity
-          .authentication()
-          .verifyToken(accessToken, organization)
-          .getUserDetails()
-          .getGroups();
+      return identity.authentication().getGroups(accessToken, organization);
     }
 
     // Fallback groups if authentication type is unrecognized or access token is null
@@ -71,67 +68,54 @@ public class IdentityAuthorizationService {
     return getFromAuthorization(IdentityAuthorization.PROCESS_PERMISSION_START);
   }
 
-  private List<String> getFromAuthorization(final String type) {
-    if (tasklistProperties.getIdentity().isResourcePermissionsEnabled()
-        && tasklistProperties.getIdentity().getBaseUrl() != null) {
-      final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-      if (authentication instanceof IdentityAuthentication) {
-        final IdentityAuthentication identityAuthentication =
-            (IdentityAuthentication) authentication;
-        return switch (type) {
-          case IdentityAuthorization.PROCESS_PERMISSION_READ ->
-              identityAuthentication.getAuthorizations().getProcessesAllowedToRead();
-          case IdentityAuthorization.PROCESS_PERMISSION_START ->
-              identityAuthentication.getAuthorizations().getProcessesAllowedToStart();
-          default -> null;
-        };
-      } else if (authentication instanceof JwtAuthenticationToken) {
-        final JwtAuthenticationToken jwtAuthenticationToken =
-            (JwtAuthenticationToken) authentication;
-        final Identity identity = SpringContextHolder.getBean(Identity.class);
-
-        return switch (type) {
-          case IdentityAuthorization.PROCESS_PERMISSION_READ ->
-              new IdentityAuthorization(
-                      identity
-                          .authorizations()
-                          .forToken(jwtAuthenticationToken.getToken().getTokenValue()))
-                  .getProcessesAllowedToRead();
-          case IdentityAuthorization.PROCESS_PERMISSION_START ->
-              new IdentityAuthorization(
-                      identity
-                          .authorizations()
-                          .forToken(jwtAuthenticationToken.getToken().getTokenValue()))
-                  .getProcessesAllowedToStart();
-          default -> null;
-        };
-
-      } else if (authentication instanceof TokenAuthentication) {
-        final Identity identity = SpringContextHolder.getBean(Identity.class);
-
-        return switch (type) {
-          case IdentityAuthorization.PROCESS_PERMISSION_READ ->
-              new IdentityAuthorization(
-                      identity
-                          .authorizations()
-                          .forToken(
-                              ((TokenAuthentication) authentication).getAccessToken(),
-                              ((TokenAuthentication) authentication).getOrganization()))
-                  .getProcessesAllowedToRead();
-          case IdentityAuthorization.PROCESS_PERMISSION_START ->
-              new IdentityAuthorization(
-                      identity
-                          .authorizations()
-                          .forToken(
-                              ((TokenAuthentication) authentication).getAccessToken(),
-                              ((TokenAuthentication) authentication).getOrganization()))
-                  .getProcessesAllowedToStart();
-          default -> null;
-        };
-      }
+  private Optional<IdentityAuthorization> getIdentityAuthorization() {
+    if (!tasklistProperties.getIdentity().isResourcePermissionsEnabled()
+        || tasklistProperties.getIdentity().getBaseUrl() == null) {
+      return Optional.empty();
     }
-    final List<String> result = new ArrayList<String>();
-    result.add(IdentityProperties.ALL_RESOURCES);
-    return result;
+
+    final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    return switch (authentication) {
+      case final IdentityAuthentication identityAuthentication ->
+          Optional.of(identityAuthentication.getAuthorizations());
+      case final JwtAuthenticationToken jwtAuthenticationToken -> {
+        final Identity identity = SpringContextHolder.getBean(Identity.class);
+        yield Optional.of(
+            new IdentityAuthorization(
+                identity
+                    .authorizations()
+                    .forToken(jwtAuthenticationToken.getToken().getTokenValue())));
+      }
+
+      case final TokenAuthentication tokenAuthentication -> {
+        final Identity identity = SpringContextHolder.getBean(Identity.class);
+        yield Optional.of(
+            new IdentityAuthorization(
+                identity
+                    .authorizations()
+                    .forToken(
+                        tokenAuthentication.getAccessToken(),
+                        tokenAuthentication.getOrganization())));
+      }
+      default -> Optional.empty();
+    };
+  }
+
+  private List<String> getFromAuthorization(final String type) {
+    final Optional<IdentityAuthorization> optIdentityAuthorization = getIdentityAuthorization();
+    if (optIdentityAuthorization.isEmpty()) {
+      return Collections.singletonList(IdentityProperties.ALL_RESOURCES);
+    }
+
+    final IdentityAuthorization identityAuthorization = optIdentityAuthorization.get();
+
+    return switch (type) {
+      case IdentityAuthorization.PROCESS_PERMISSION_READ ->
+          identityAuthorization.getProcessesAllowedToRead();
+      case IdentityAuthorization.PROCESS_PERMISSION_START ->
+          identityAuthorization.getProcessesAllowedToStart();
+      default -> Collections.emptyList();
+    };
   }
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
@@ -8,12 +8,16 @@
 package io.camunda.tasklist.webapp.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.tasklist.entities.ProcessEntity;
 import io.camunda.tasklist.exceptions.TasklistRuntimeException;
+import io.camunda.tasklist.property.IdentityProperties;
+import io.camunda.tasklist.store.ProcessStore;
 import io.camunda.tasklist.webapp.graphql.entity.ProcessInstanceDTO;
 import io.camunda.tasklist.webapp.graphql.entity.VariableInputDTO;
 import io.camunda.tasklist.webapp.rest.exception.ForbiddenActionException;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
+import io.camunda.tasklist.webapp.security.UserReader;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
 import io.camunda.tasklist.webapp.security.tenant.TenantService;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -43,6 +47,27 @@ public class ProcessService {
   @Autowired private TenantService tenantService;
 
   @Autowired private IdentityAuthorizationService identityAuthorizationService;
+
+  @Autowired private UserReader userReader;
+
+  @Autowired private ProcessStore processStore;
+
+  public ProcessEntity getProcessByProcessDefinitionKeyAndAccessRestriction(
+      final String processDefinitionKey) {
+
+    final ProcessEntity processEntity =
+        processStore.getProcessByProcessDefinitionKey(processDefinitionKey);
+
+    final List<String> processReadAuthorizations =
+        identityAuthorizationService.getProcessReadFromAuthorization();
+
+    if (processReadAuthorizations.contains(processEntity.getBpmnProcessId())
+        || processReadAuthorizations.contains(IdentityProperties.ALL_RESOURCES)) {
+      return processEntity;
+    } else {
+      throw new ForbiddenActionException("Resource cannot be accessed");
+    }
+  }
 
   public ProcessInstanceDTO startProcessInstance(
       final String processDefinitionKey, final String tenantId) {
@@ -87,7 +112,7 @@ public class ProcessService {
     try {
       processInstanceEvent = createProcessInstanceCommandStep3.send().join();
       LOGGER.debug("Process instance created for process [{}]", processDefinitionKey);
-    } catch (ClientStatusException ex) {
+    } catch (final ClientStatusException ex) {
       if (Status.Code.NOT_FOUND.equals(ex.getStatusCode())) {
         throw new NotFoundApiException(
             String.format(
@@ -96,14 +121,14 @@ public class ProcessService {
             ex);
       }
       throw new TasklistRuntimeException(ex.getMessage(), ex);
-    } catch (ClientException ex) {
+    } catch (final ClientException ex) {
       throw new TasklistRuntimeException(ex.getMessage(), ex);
     }
 
     return new ProcessInstanceDTO().setId(processInstanceEvent.getProcessInstanceKey());
   }
 
-  private Object extractTypedValue(VariableInputDTO variable) {
+  private Object extractTypedValue(final VariableInputDTO variable) {
     if (variable.getValue().equals("null")) {
       return objectMapper
           .nullNode(); // JSON Object null must be instanced like "null", also should not send to
@@ -112,7 +137,7 @@ public class ProcessService {
 
     try {
       return objectMapper.readValue(variable.getValue(), Object.class);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(e.getMessage(), e);
     }
   }

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerTest.java
@@ -399,8 +399,6 @@ class ProcessInternalControllerTest {
       assertThat(result).isEqualTo(expectedEndpointsResponse);
     }
 
-
-
     @Test
     void getPublicEndpointsByBpmnProcessIdWhenTenantIdIsInvalid() throws Exception {
       // given
@@ -433,7 +431,7 @@ class ProcessInternalControllerTest {
   }
 
   @Nested
-  class GetProcessTests{
+  class GetProcessTests {
     @Test
     void getProcess() throws Exception {
       final var processDefinitionKey = "225599880022";
@@ -450,25 +448,48 @@ class ProcessInternalControllerTest {
               .setTenantId(DEFAULT_TENANT_IDENTIFIER);
 
       final var expectedProcessReturn =
-          new ProcessResponse().setId(processDefinitionKey).setName("Register car for rent").setBpmnProcessId("registerCarForRent").setVersion(1).setBpmnXml("<abc></abc>").setTenantId(DEFAULT_TENANT_IDENTIFIER);
+          new ProcessResponse()
+              .setId(processDefinitionKey)
+              .setName("Register car for rent")
+              .setBpmnProcessId("registerCarForRent")
+              .setVersion(1)
+              .setBpmnXml("<abc></abc>")
+              .setTenantId(DEFAULT_TENANT_IDENTIFIER);
 
-      when(processStore.getProcessByProcessDefinitionKey(processDefinitionKey)).thenReturn(providedProcessEntity);
-      final var response = mockMvc.perform(get(
-          TasklistURIs.PROCESSES_URL_V1.concat(String.format("/%s", processDefinitionKey))
-      )).andDo(print()).andReturn().getResponse();
+      when(processStore.getProcessByProcessDefinitionKey(processDefinitionKey))
+          .thenReturn(providedProcessEntity);
+      final var response =
+          mockMvc
+              .perform(
+                  get(
+                      TasklistURIs.PROCESSES_URL_V1.concat(
+                          String.format("/%s", processDefinitionKey))))
+              .andDo(print())
+              .andReturn()
+              .getResponse();
       assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
-      final ProcessResponse responseObject = CommonUtils.OBJECT_MAPPER.readValue(response.getContentAsString(), new TypeReference<ProcessResponse>() {});
+      final ProcessResponse responseObject =
+          CommonUtils.OBJECT_MAPPER.readValue(
+              response.getContentAsString(), new TypeReference<ProcessResponse>() {});
       assertThat(responseObject).isEqualTo(expectedProcessReturn);
     }
 
     @Test
     void getProcessShouldReturn404() throws Exception {
       final String processDefinitionKey = "shouldReturn404";
-      final String errorMessage = String.format("Process with key %s not found", processDefinitionKey);
-      when(processStore.getProcessByProcessDefinitionKey(processDefinitionKey)).thenThrow(new NotFoundException(errorMessage));
-      final var response = mockMvc.perform(get(
-          TasklistURIs.PROCESSES_URL_V1.concat(String.format("/%s", processDefinitionKey))
-      )).andDo(print()).andReturn().getResponse();
+      final String errorMessage =
+          String.format("Process with key %s not found", processDefinitionKey);
+      when(processStore.getProcessByProcessDefinitionKey(processDefinitionKey))
+          .thenThrow(new NotFoundException(errorMessage));
+      final var response =
+          mockMvc
+              .perform(
+                  get(
+                      TasklistURIs.PROCESSES_URL_V1.concat(
+                          String.format("/%s", processDefinitionKey))))
+              .andDo(print())
+              .andReturn()
+              .getResponse();
 
       assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
       assertThat(response.getContentAsString()).contains(errorMessage);

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/ProcessInternalControllerTest.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import io.camunda.tasklist.entities.FormEntity;
 import io.camunda.tasklist.entities.ProcessEntity;
 import io.camunda.tasklist.enums.DeletionStatus;
+import io.camunda.tasklist.exceptions.NotFoundException;
 import io.camunda.tasklist.property.FeatureFlagProperties;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.store.FormStore;
@@ -398,6 +399,8 @@ class ProcessInternalControllerTest {
       assertThat(result).isEqualTo(expectedEndpointsResponse);
     }
 
+
+
     @Test
     void getPublicEndpointsByBpmnProcessIdWhenTenantIdIsInvalid() throws Exception {
       // given
@@ -426,6 +429,49 @@ class ProcessInternalControllerTest {
       // then
       assertThat(result.getStatus()).isEqualTo(HttpStatus.BAD_REQUEST.value());
       assertThat(result.getMessage()).isEqualTo("Invalid Tenant");
+    }
+  }
+
+  @Nested
+  class GetProcessTests{
+    @Test
+    void getProcess() throws Exception {
+      final var processDefinitionKey = "225599880022";
+      final var providedProcessEntity =
+          new ProcessEntity()
+              .setId(processDefinitionKey)
+              .setName("Register car for rent")
+              .setBpmnProcessId("registerCarForRent")
+              .setVersion(1)
+              .setFormKey("camunda-forms:bpmn:userTaskForm_111")
+              .setBpmnXml("<abc></abc>")
+              .setStartedByForm(true)
+              .setIsFormEmbedded(false)
+              .setTenantId(DEFAULT_TENANT_IDENTIFIER);
+
+      final var expectedProcessReturn =
+          new ProcessResponse().setId(processDefinitionKey).setName("Register car for rent").setBpmnProcessId("registerCarForRent").setVersion(1).setBpmnXml("<abc></abc>").setTenantId(DEFAULT_TENANT_IDENTIFIER);
+
+      when(processStore.getProcessByProcessDefinitionKey(processDefinitionKey)).thenReturn(providedProcessEntity);
+      final var response = mockMvc.perform(get(
+          TasklistURIs.PROCESSES_URL_V1.concat(String.format("/%s", processDefinitionKey))
+      )).andDo(print()).andReturn().getResponse();
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+      final ProcessResponse responseObject = CommonUtils.OBJECT_MAPPER.readValue(response.getContentAsString(), new TypeReference<ProcessResponse>() {});
+      assertThat(responseObject).isEqualTo(expectedProcessReturn);
+    }
+
+    @Test
+    void getProcessShouldReturn404() throws Exception {
+      final String processDefinitionKey = "shouldReturn404";
+      final String errorMessage = String.format("Process with key %s not found", processDefinitionKey);
+      when(processStore.getProcessByProcessDefinitionKey(processDefinitionKey)).thenThrow(new NotFoundException(errorMessage));
+      final var response = mockMvc.perform(get(
+          TasklistURIs.PROCESSES_URL_V1.concat(String.format("/%s", processDefinitionKey))
+      )).andDo(print()).andReturn().getResponse();
+
+      assertThat(response.getStatus()).isEqualTo(HttpStatus.NOT_FOUND.value());
+      assertThat(response.getContentAsString()).contains(errorMessage);
     }
   }
 }


### PR DESCRIPTION
## Description

- Adding a new field on Process Index to store the bpmn xml;
- Exposing the new field into a new API method v1/internal/processes/{processDefinitionKey};
- New field is being ignored in v1/internal/processes/search to avoid a big response and bpmnXml should not be used there.

## Related issues

Closes https://github.com/camunda/tasklist/issues/4900
