### PR TITLE
[Backport stable/8.4] fix: go client omit optional scope param if not set

### DIFF
--- a/clients/go/pkg/zbc/oauthCredentialsProvider.go
+++ b/clients/go/pkg/zbc/oauthCredentialsProvider.go
@@ -133,7 +133,6 @@ func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentials
 		TokenConfig: &clientcredentials.Config{
 			ClientID:       config.ClientID,
 			ClientSecret:   config.ClientSecret,
-			Scopes:         []string{config.Scope},
 			EndpointParams: map[string][]string{"audience": {config.Audience}},
 			TokenURL:       config.AuthorizationServerURL,
 			AuthStyle:      oauth2.AuthStyleInParams,
@@ -141,6 +140,10 @@ func NewOAuthCredentialsProvider(config *OAuthProviderConfig) (*OAuthCredentials
 		Audience: config.Audience,
 		Cache:    config.Cache,
 		timeout:  config.Timeout,
+	}
+
+	if config.Scope != "" {
+		provider.TokenConfig.Scopes = []string{config.Scope}
 	}
 
 	return &provider, nil

--- a/clients/go/pkg/zbc/oauthCredentialsProvider_test.go
+++ b/clients/go/pkg/zbc/oauthCredentialsProvider_test.go
@@ -858,6 +858,9 @@ func mockAuthorizationServerWithAudienceAndScope(t *testing.T, token *mutableTok
 
 		if scope != "" {
 			require.Equal(t, scope, query.Get("scope"))
+		} else {
+			// if the scope is empty the param should not be set at all
+			require.False(t, query.Has("scope"))
 		}
 
 		writer.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
# Description
Backport of #18154 to `stable/8.4`.

relates to #16015
original author: @megglos