### PR TITLE
feat: Return failed/successful operations count together with batch operation

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/BatchOperationRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/BatchOperationRestServiceIT.java
@@ -16,6 +16,7 @@ import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.reader.BatchOperationReader;
 import io.camunda.operate.webapp.rest.BatchOperationRestService;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationRequestDto;
+import io.camunda.operate.webapp.transform.DataAggregator;
 import org.junit.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -30,8 +31,9 @@ import org.springframework.test.web.servlet.MvcResult;
 public class BatchOperationRestServiceIT extends OperateAbstractIT {
 
   @MockBean private BatchOperationReader batchOperationReader;
+  @MockBean private DataAggregator dataAggregator;
 
-  private ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper = new ObjectMapper();
 
   @Test
   public void testGetBatchOperationWithNoPageSize() throws Exception {
@@ -76,7 +78,7 @@ public class BatchOperationRestServiceIT extends OperateAbstractIT {
     assertErrorMessageContains(mvcResult, "searchBefore must be an array of two values.");
   }
 
-  protected MvcResult postRequestThatShouldFail(Object query) throws Exception {
+  protected MvcResult postRequestThatShouldFail(final Object query) throws Exception {
     return postRequestThatShouldFail(BatchOperationRestService.BATCH_OPERATIONS_URL, query);
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/InternalAPIErrorControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/InternalAPIErrorControllerIT.java
@@ -21,6 +21,7 @@ import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.rest.exception.InternalAPIException;
 import io.camunda.operate.webapp.rest.exception.NotAuthorizedException;
 import io.camunda.operate.webapp.rest.exception.NotFoundException;
+import io.camunda.operate.webapp.transform.DataAggregator;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +52,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 @AutoConfigureMockMvc
 public class InternalAPIErrorControllerIT {
   private static final String EXCEPTION_MESSAGE = "profile exception message";
+  @MockBean DataAggregator dataAggregator;
   @Autowired private MockMvc mockMvc;
   @MockBean private OperationReader operationReader;
   @MockBean private OperateProfileService mockProfileService;

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/BatchOperationTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/BatchOperationTemplate.java
@@ -24,6 +24,8 @@ public class BatchOperationTemplate extends AbstractTemplateDescriptor implement
   public static final String INSTANCES_COUNT = "instancesCount";
   public static final String OPERATIONS_TOTAL_COUNT = "operationsTotalCount";
   public static final String OPERATIONS_FINISHED_COUNT = "operationsFinishedCount";
+  public static final String FAILED_OPERATIONS_COUNT = "failedOperationsCount";
+  public static final String COMPLETED_OPERATIONS_COUNT = "completedOperationsCount";
 
   @Override
   public String getIndexName() {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
@@ -36,6 +36,7 @@ public class OperationTemplate extends AbstractTemplateDescriptor
   public static final String MODIFIY_INSTRUCTIONS = "modifyInstructions";
   public static final String MIGRATION_PLAN = "migrationPlan";
   public static final String METADATA_AGGREGATION = "metadataAggregation";
+  public static final String BATCH_OPERATION_ID_AGGREGATION = "batchOperationIdAggregation";
 
   @Override
   public String getIndexName() {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
@@ -35,6 +35,7 @@ public class OperationTemplate extends AbstractTemplateDescriptor
   public static final String USERNAME = "username";
   public static final String MODIFIY_INSTRUCTIONS = "modifyInstructions";
   public static final String MIGRATION_PLAN = "migrationPlan";
+  public static final String METADATA_AGGREGATION = "metadataAggregation";
 
   @Override
   public String getIndexName() {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/OperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/OperationReader.java
@@ -84,7 +84,7 @@ public class OperationReader extends AbstractReader
    * @return
    */
   @Override
-  public List<OperationEntity> acquireOperations(int batchSize) {
+  public List<OperationEntity> acquireOperations(final int batchSize) {
     final TermQueryBuilder scheduledOperationsQuery =
         termQuery(OperationTemplate.STATE, SCHEDULED_OPERATION);
     final TermQueryBuilder lockedOperationsQuery =
@@ -111,7 +111,7 @@ public class OperationReader extends AbstractReader
       final SearchResponse searchResponse = esClient.search(searchRequest, RequestOptions.DEFAULT);
       return ElasticsearchUtil.mapSearchHits(
           searchResponse.getHits().getHits(), objectMapper, OperationEntity.class);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while acquiring operations for execution: %s", e.getMessage());
@@ -122,7 +122,7 @@ public class OperationReader extends AbstractReader
 
   @Override
   public Map<Long, List<OperationEntity>> getOperationsPerProcessInstanceKey(
-      List<Long> processInstanceKeys) {
+      final List<Long> processInstanceKeys) {
     final Map<Long, List<OperationEntity>> result = new HashMap<>();
 
     final TermsQueryBuilder processInstanceKeysQ =
@@ -148,7 +148,7 @@ public class OperationReader extends AbstractReader
             final List<OperationEntity> operationEntities =
                 ElasticsearchUtil.mapSearchHits(
                     hits.getHits(), objectMapper, OperationEntity.class);
-            for (OperationEntity operationEntity : operationEntities) {
+            for (final OperationEntity operationEntity : operationEntities) {
               CollectionUtil.addToMap(
                   result, operationEntity.getProcessInstanceKey(), operationEntity);
             }
@@ -156,7 +156,7 @@ public class OperationReader extends AbstractReader
           null);
 
       return result;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining operations per process instance id: %s",
@@ -167,7 +167,8 @@ public class OperationReader extends AbstractReader
   }
 
   @Override
-  public Map<Long, List<OperationEntity>> getOperationsPerIncidentKey(String processInstanceId) {
+  public Map<Long, List<OperationEntity>> getOperationsPerIncidentKey(
+      final String processInstanceId) {
     final Map<Long, List<OperationEntity>> result = new HashMap<>();
 
     final TermQueryBuilder processInstanceKeysQ =
@@ -192,13 +193,13 @@ public class OperationReader extends AbstractReader
             final List<OperationEntity> operationEntities =
                 ElasticsearchUtil.mapSearchHits(
                     hits.getHits(), objectMapper, OperationEntity.class);
-            for (OperationEntity operationEntity : operationEntities) {
+            for (final OperationEntity operationEntity : operationEntities) {
               CollectionUtil.addToMap(result, operationEntity.getIncidentKey(), operationEntity);
             }
           },
           null);
       return result;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining operations per incident id: %s", e.getMessage());
@@ -209,7 +210,7 @@ public class OperationReader extends AbstractReader
 
   @Override
   public Map<String, List<OperationEntity>> getUpdateOperationsPerVariableName(
-      Long processInstanceKey, Long scopeKey) {
+      final Long processInstanceKey, final Long scopeKey) {
     final Map<String, List<OperationEntity>> result = new HashMap<>();
 
     final TermQueryBuilder processInstanceKeyQuery =
@@ -234,13 +235,13 @@ public class OperationReader extends AbstractReader
             final List<OperationEntity> operationEntities =
                 ElasticsearchUtil.mapSearchHits(
                     hits.getHits(), objectMapper, OperationEntity.class);
-            for (OperationEntity operationEntity : operationEntities) {
+            for (final OperationEntity operationEntity : operationEntities) {
               CollectionUtil.addToMap(result, operationEntity.getVariableName(), operationEntity);
             }
           },
           null);
       return result;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while obtaining operations per variable name: %s",
@@ -251,7 +252,7 @@ public class OperationReader extends AbstractReader
   }
 
   @Override
-  public List<OperationEntity> getOperationsByProcessInstanceKey(Long processInstanceKey) {
+  public List<OperationEntity> getOperationsByProcessInstanceKey(final Long processInstanceKey) {
 
     final TermQueryBuilder processInstanceQ =
         processInstanceKey == null ? null : termQuery(PROCESS_INSTANCE_KEY, processInstanceKey);
@@ -262,7 +263,7 @@ public class OperationReader extends AbstractReader
             .source(new SearchSourceBuilder().query(query).sort(ID, SortOrder.ASC));
     try {
       return ElasticsearchUtil.scroll(searchRequest, OperationEntity.class, objectMapper, esClient);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining operations: %s", e.getMessage());
       LOGGER.error(message, e);
@@ -272,7 +273,7 @@ public class OperationReader extends AbstractReader
 
   // this query will be extended
   @Override
-  public List<BatchOperationEntity> getBatchOperations(int pageSize) {
+  public List<BatchOperationEntity> getBatchOperations(final int pageSize) {
     final String username = userService.getCurrentUser().getUsername();
     final TermQueryBuilder isOfCurrentUser = termQuery(BatchOperationTemplate.USERNAME, username);
     final SearchRequest searchRequest =
@@ -286,7 +287,7 @@ public class OperationReader extends AbstractReader
           esClient.search(searchRequest, RequestOptions.DEFAULT).getHits().getHits(),
           objectMapper,
           BatchOperationEntity.class);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining batch operations: %s", e.getMessage());
       throw new OperateRuntimeException(message, e);
@@ -294,7 +295,7 @@ public class OperationReader extends AbstractReader
   }
 
   @Override
-  public List<OperationDto> getOperationsByBatchOperationId(String batchOperationId) {
+  public List<OperationDto> getOperationsByBatchOperationId(final String batchOperationId) {
     final TermQueryBuilder operationIdQ = termQuery(BATCH_OPERATION_ID, batchOperationId);
     final SearchRequest searchRequest =
         ElasticsearchUtil.createSearchRequest(operationTemplate, ALL)
@@ -303,7 +304,7 @@ public class OperationReader extends AbstractReader
       final List<OperationEntity> operationEntities =
           ElasticsearchUtil.scroll(searchRequest, OperationEntity.class, objectMapper, esClient);
       return DtoCreator.create(operationEntities, OperationDto.class);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while searching for operation with batchOperationId: %s",
@@ -315,7 +316,10 @@ public class OperationReader extends AbstractReader
 
   @Override
   public List<OperationDto> getOperations(
-      OperationType operationType, String processInstanceId, String scopeId, String variableName) {
+      final OperationType operationType,
+      final String processInstanceId,
+      final String scopeId,
+      final String variableName) {
     final TermQueryBuilder operationTypeQ = termQuery(TYPE, operationType);
     final TermQueryBuilder processInstanceKeyQ = termQuery(PROCESS_INSTANCE_KEY, processInstanceId);
     final TermQueryBuilder scopeKeyQ = termQuery(SCOPE_KEY, scopeId);
@@ -331,7 +335,7 @@ public class OperationReader extends AbstractReader
       final List<OperationEntity> operationEntities =
           ElasticsearchUtil.scroll(searchRequest, OperationEntity.class, objectMapper, esClient);
       return DtoCreator.create(operationEntities, OperationDto.class);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while searching for operation.", e.getMessage());
       LOGGER.error(message, e);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/transform/ElasticsearchDataAggregator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/transform/ElasticsearchDataAggregator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.elasticsearch.transform;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.conditions.ElasticsearchCondition;
+import io.camunda.operate.entities.BatchOperationEntity;
+import io.camunda.operate.entities.OperationState;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.OperationTemplate;
+import io.camunda.operate.webapp.elasticsearch.reader.OperationReader;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
+import io.camunda.operate.webapp.transform.DataAggregator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregationBuilders;
+import org.elasticsearch.search.aggregations.bucket.filter.FiltersAggregator;
+import org.elasticsearch.search.aggregations.bucket.filter.ParsedFilters;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Conditional(ElasticsearchCondition.class)
+@Component
+public class ElasticsearchDataAggregator implements DataAggregator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchDataAggregator.class);
+  @Autowired protected ObjectMapper objectMapper;
+  @Autowired private OperationReader operationReader;
+
+  @Override
+  public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
+      final List<BatchOperationEntity> batchEntities) {
+
+    final List<BatchOperationDto> resultDtos = new ArrayList<>(batchEntities.size());
+    if (batchEntities.isEmpty()) {
+      return resultDtos;
+    }
+
+    final Map<String, BatchOperationEntity> entityMap =
+        batchEntities.stream()
+            .collect(Collectors.toMap(BatchOperationEntity::getId, entity -> entity));
+    final List<String> idList = entityMap.keySet().stream().toList();
+
+    final AggregationBuilder metadataAggregation =
+        AggregationBuilders.filters(
+            OperationTemplate.METADATA_AGGREGATION,
+            new FiltersAggregator.KeyedFilter(
+                BatchOperationTemplate.FAILED_OPERATIONS_COUNT,
+                QueryBuilders.termQuery(OperationTemplate.STATE, OperationState.FAILED)),
+            new FiltersAggregator.KeyedFilter(
+                BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
+                QueryBuilders.termQuery(OperationTemplate.STATE, OperationState.COMPLETED)));
+
+    final Terms batchIdAggregation =
+        operationReader.getOperationsAggregatedByBatchOperationId(idList, metadataAggregation);
+    for (final Terms.Bucket bucket : batchIdAggregation.getBuckets()) {
+      final ParsedFilters aggregations =
+          bucket.getAggregations().get(OperationTemplate.METADATA_AGGREGATION);
+      final int failedCount =
+          (int)
+              aggregations
+                  .getBucketByKey(BatchOperationTemplate.FAILED_OPERATIONS_COUNT)
+                  .getDocCount();
+      final int completedCount =
+          (int)
+              aggregations
+                  .getBucketByKey(BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT)
+                  .getDocCount();
+      final String batchId = bucket.getKeyAsString();
+
+      final BatchOperationDto batchOperationDto =
+          BatchOperationDto.createFrom(entityMap.get(batchId), objectMapper)
+              .setFailedOperationsCount(failedCount)
+              .setCompletedOperationsCount(completedCount);
+      resultDtos.add(batchOperationDto);
+    }
+    return resultDtos;
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
@@ -31,9 +31,12 @@ import static org.opensearch.client.opensearch._types.SortOrder.Asc;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.entities.OperationEntity;
+import io.camunda.operate.entities.OperationState;
 import io.camunda.operate.entities.OperationType;
+import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.schema.templates.BatchOperationTemplate;
 import io.camunda.operate.schema.templates.OperationTemplate;
+import io.camunda.operate.store.opensearch.dsl.AggregationDSL;
 import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.rest.dto.DtoCreator;
@@ -42,10 +45,14 @@ import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import io.camunda.operate.webapp.security.UserService;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest.Builder;
+import org.opensearch.client.opensearch.core.SearchResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -212,7 +219,48 @@ public class OpensearchOperationReader extends OpensearchAbstractReader implemen
   @Override
   public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
       final List<BatchOperationEntity> batchEntities) {
-    return null; // TODO implement
+
+    final List<BatchOperationDto> resultDtos = new ArrayList<>(batchEntities.size());
+    for (final BatchOperationEntity batchEntity : batchEntities) {
+      final var searchRequestBuilder = getSearchRequestByIdWithMetadata(batchEntity.getId());
+      final Aggregate aggregate;
+      try {
+        final SearchResponse<OperationEntity> searchResponse =
+            richOpenSearchClient.doc().search(searchRequestBuilder, OperationEntity.class);
+        aggregate = searchResponse.aggregations().get(OperationTemplate.METADATA_AGGREGATION);
+
+        final Integer failedCount =
+            (int)
+                aggregate
+                    .filters()
+                    .buckets()
+                    .keyed()
+                    .get(BatchOperationTemplate.FAILED_OPERATIONS_COUNT)
+                    .docCount();
+        final Integer completedCount =
+            (int)
+                aggregate
+                    .filters()
+                    .buckets()
+                    .keyed()
+                    .get(BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT)
+                    .docCount();
+
+        final BatchOperationDto batchOperationDto =
+            BatchOperationDto.createFrom(batchEntity, objectMapper)
+                .setFailedOperationsCount(failedCount)
+                .setCompletedOperationsCount(completedCount);
+        resultDtos.add(batchOperationDto);
+      } catch (final OperateRuntimeException e) {
+        final String message =
+            String.format(
+                "Exception occurred, while searching for batch operation metadata.",
+                e.getMessage());
+        LOGGER.error(message, e);
+        throw new OperateRuntimeException(message, e);
+      }
+    }
+    return resultDtos;
   }
 
   @Override
@@ -233,5 +281,23 @@ public class OpensearchOperationReader extends OpensearchAbstractReader implemen
     final List<OperationEntity> operationEntities =
         richOpenSearchClient.doc().scrollValues(searchRequestBuilder, OperationEntity.class);
     return DtoCreator.create(operationEntities, OperationDto.class);
+  }
+
+  public Builder getSearchRequestByIdWithMetadata(final String batchOperationId) {
+    final Query failedOperationQuery = term(OperationTemplate.STATE, OperationState.FAILED.name());
+    final Query completedOperationQuery =
+        term(OperationTemplate.STATE, OperationState.COMPLETED.name());
+    final var searchRequestBuilder =
+        searchRequestBuilder(operationTemplate, ALL)
+            .query(term(BATCH_OPERATION_ID, batchOperationId))
+            .aggregations(
+                OperationTemplate.METADATA_AGGREGATION,
+                AggregationDSL.filtersAggregation(
+                        Map.of(
+                            BatchOperationTemplate.FAILED_OPERATIONS_COUNT, failedOperationQuery,
+                            BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
+                                completedOperationQuery))
+                    ._toAggregation());
+    return searchRequestBuilder;
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchOperationReader.java
@@ -38,6 +38,7 @@ import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.rest.dto.DtoCreator;
 import io.camunda.operate.webapp.rest.dto.OperationDto;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import io.camunda.operate.webapp.security.UserService;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
@@ -206,6 +207,12 @@ public class OpensearchOperationReader extends OpensearchAbstractReader implemen
     final List<OperationEntity> operationEntities =
         richOpenSearchClient.doc().scrollValues(searchRequestBuilder, OperationEntity.class);
     return DtoCreator.create(operationEntities, OperationDto.class);
+  }
+
+  @Override
+  public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
+      final List<BatchOperationEntity> batchEntities) {
+    return null; // TODO implement
   }
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregator.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.opensearch.transform;
+
+import static io.camunda.operate.schema.templates.OperationTemplate.BATCH_OPERATION_ID;
+import static io.camunda.operate.schema.templates.OperationTemplate.BATCH_OPERATION_ID_AGGREGATION;
+import static io.camunda.operate.store.opensearch.dsl.QueryDSL.stringTerms;
+import static io.camunda.operate.store.opensearch.dsl.QueryDSL.term;
+import static io.camunda.operate.store.opensearch.dsl.RequestDSL.QueryType.ALL;
+import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.entities.BatchOperationEntity;
+import io.camunda.operate.entities.OperationEntity;
+import io.camunda.operate.entities.OperationState;
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.OperationTemplate;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.store.opensearch.dsl.AggregationDSL;
+import io.camunda.operate.webapp.opensearch.reader.OpensearchOperationReader;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
+import io.camunda.operate.webapp.transform.DataAggregator;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchRequest.Builder;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Conditional(OpensearchCondition.class)
+@Component
+public class OpensearchDataAggregator implements DataAggregator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchDataAggregator.class);
+  @Autowired protected ObjectMapper objectMapper;
+  @Autowired protected RichOpenSearchClient richOpenSearchClient;
+  @Autowired private OpensearchOperationReader operationReader;
+  @Autowired private OperationTemplate operationTemplate;
+  @Autowired private BatchOperationTemplate batchOperationTemplate;
+
+  @Override
+  public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
+      final List<BatchOperationEntity> batchEntities) {
+
+    final List<BatchOperationDto> resultDtos = new ArrayList<>(batchEntities.size());
+    if (batchEntities.isEmpty()) {
+      return resultDtos;
+    }
+
+    final Map<String, BatchOperationEntity> entityMap =
+        batchEntities.stream()
+            .collect(Collectors.toMap(BatchOperationEntity::getId, entity -> entity));
+    final List<String> idList = entityMap.keySet().stream().toList();
+
+    final var searchRequestBuilder = getSearchRequestByIdWithMetadata(idList);
+    final StringTermsAggregate idAggregate;
+
+    try {
+      final SearchResponse<OperationEntity> searchResponse =
+          richOpenSearchClient.doc().search(searchRequestBuilder, OperationEntity.class);
+      idAggregate = searchResponse.aggregations().get(BATCH_OPERATION_ID_AGGREGATION).sterms();
+      for (final StringTermsBucket bucket : idAggregate.buckets().array()) {
+        final Aggregate metadataAggregate =
+            bucket.aggregations().get(OperationTemplate.METADATA_AGGREGATION);
+
+        final Integer failedCount =
+            (int)
+                metadataAggregate
+                    .filters()
+                    .buckets()
+                    .keyed()
+                    .get(BatchOperationTemplate.FAILED_OPERATIONS_COUNT)
+                    .docCount();
+        final Integer completedCount =
+            (int)
+                metadataAggregate
+                    .filters()
+                    .buckets()
+                    .keyed()
+                    .get(BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT)
+                    .docCount();
+
+        final BatchOperationDto batchOperationDto =
+            BatchOperationDto.createFrom(entityMap.get(bucket.key()), objectMapper)
+                .setFailedOperationsCount(failedCount)
+                .setCompletedOperationsCount(completedCount);
+        resultDtos.add(batchOperationDto);
+      }
+    } catch (final OperateRuntimeException e) {
+      final String message =
+          String.format(
+              "Exception occurred, while searching for batch operation metadata.", e.getMessage());
+      LOGGER.error(message, e);
+      throw new OperateRuntimeException(message, e);
+    }
+
+    return resultDtos;
+  }
+
+  public Builder getSearchRequestByIdWithMetadata(final List<String> batchOperationIds) {
+    final Query idsQuery = stringTerms(BATCH_OPERATION_ID, batchOperationIds);
+    final Query failedOperationQuery = term(OperationTemplate.STATE, OperationState.FAILED.name());
+    final Query completedOperationQuery =
+        term(OperationTemplate.STATE, OperationState.COMPLETED.name());
+    final var searchRequestBuilder =
+        searchRequestBuilder(operationTemplate, ALL)
+            .query(idsQuery)
+            .aggregations(
+                BATCH_OPERATION_ID_AGGREGATION,
+                AggregationDSL.withSubaggregations(
+                    AggregationDSL.termAggregation(BATCH_OPERATION_ID, batchOperationIds.size()),
+                    Map.of(
+                        OperationTemplate.METADATA_AGGREGATION,
+                        AggregationDSL.filtersAggregation(
+                                Map.of(
+                                    BatchOperationTemplate.FAILED_OPERATIONS_COUNT,
+                                    failedOperationQuery,
+                                    BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
+                                    completedOperationQuery))
+                            ._toAggregation())));
+    return searchRequestBuilder;
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/OperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/OperationReader.java
@@ -11,7 +11,6 @@ import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.entities.OperationEntity;
 import io.camunda.operate.entities.OperationType;
 import io.camunda.operate.webapp.rest.dto.OperationDto;
-import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import java.util.List;
 import java.util.Map;
 
@@ -32,9 +31,6 @@ public interface OperationReader {
   List<BatchOperationEntity> getBatchOperations(int pageSize);
 
   List<OperationDto> getOperationsByBatchOperationId(String batchOperationId);
-
-  public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
-      final List<BatchOperationEntity> batchEntities);
 
   List<OperationDto> getOperations(
       OperationType operationType, String processInstanceId, String scopeId, String variableName);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/OperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/OperationReader.java
@@ -11,6 +11,7 @@ import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.entities.OperationEntity;
 import io.camunda.operate.entities.OperationType;
 import io.camunda.operate.webapp.rest.dto.OperationDto;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import java.util.List;
 import java.util.Map;
 
@@ -31,6 +32,9 @@ public interface OperationReader {
   List<BatchOperationEntity> getBatchOperations(int pageSize);
 
   List<OperationDto> getOperationsByBatchOperationId(String batchOperationId);
+
+  public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
+      final List<BatchOperationEntity> batchEntities);
 
   List<OperationDto> getOperations(
       OperationType operationType, String processInstanceId, String scopeId, String variableName);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.webapp.InternalAPIErrorController;
 import io.camunda.operate.webapp.reader.BatchOperationReader;
+import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
@@ -33,6 +34,7 @@ public class BatchOperationRestService extends InternalAPIErrorController {
   public static final String BATCH_OPERATIONS_URL = "/api/batch-operations";
 
   @Autowired private BatchOperationReader batchOperationReader;
+  @Autowired private OperationReader operationReader;
 
   @Autowired private ObjectMapper objectMapper;
 
@@ -60,6 +62,6 @@ public class BatchOperationRestService extends InternalAPIErrorController {
 
     final List<BatchOperationEntity> batchOperations =
         batchOperationReader.getBatchOperations(batchOperationRequestDto);
-    return BatchOperationDto.createFrom(batchOperations, objectMapper);
+    return operationReader.enrichBatchEntitiesWithMetadata(batchOperations);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
@@ -39,7 +39,7 @@ public class BatchOperationRestService extends InternalAPIErrorController {
   @Operation(summary = "Query batch operations")
   @PostMapping
   public List<BatchOperationDto> queryBatchOperations(
-      @RequestBody BatchOperationRequestDto batchOperationRequestDto) {
+      @RequestBody final BatchOperationRequestDto batchOperationRequestDto) {
     if (batchOperationRequestDto.getPageSize() == null) {
       throw new InvalidRequestException("pageSize parameter must be provided.");
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
@@ -13,10 +13,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.webapp.InternalAPIErrorController;
 import io.camunda.operate.webapp.reader.BatchOperationReader;
-import io.camunda.operate.webapp.reader.OperationReader;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationRequestDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import io.camunda.operate.webapp.transform.DataAggregator;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
@@ -34,7 +34,7 @@ public class BatchOperationRestService extends InternalAPIErrorController {
   public static final String BATCH_OPERATIONS_URL = "/api/batch-operations";
 
   @Autowired private BatchOperationReader batchOperationReader;
-  @Autowired private OperationReader operationReader;
+  @Autowired private DataAggregator dataAggregator;
 
   @Autowired private ObjectMapper objectMapper;
 
@@ -62,6 +62,6 @@ public class BatchOperationRestService extends InternalAPIErrorController {
 
     final List<BatchOperationEntity> batchOperations =
         batchOperationReader.getBatchOperations(batchOperationRequestDto);
-    return operationReader.enrichBatchEntitiesWithMetadata(batchOperations);
+    return dataAggregator.enrichBatchEntitiesWithMetadata(batchOperations);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/BatchOperationDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/BatchOperationDto.java
@@ -36,7 +36,7 @@ public class BatchOperationDto {
   private SortValuesWrapper[] sortValues;
 
   public static BatchOperationDto createFrom(
-      final BatchOperationEntity batchOperationEntity, ObjectMapper objectMapper) {
+      final BatchOperationEntity batchOperationEntity, final ObjectMapper objectMapper) {
     return new BatchOperationDto()
         .setId(batchOperationEntity.getId())
         .setName(batchOperationEntity.getName())
@@ -52,7 +52,7 @@ public class BatchOperationDto {
   }
 
   public static List<BatchOperationDto> createFrom(
-      List<BatchOperationEntity> batchOperationEntities, ObjectMapper objectMapper) {
+      final List<BatchOperationEntity> batchOperationEntities, final ObjectMapper objectMapper) {
     if (batchOperationEntities == null) {
       return new ArrayList<>();
     }
@@ -66,7 +66,7 @@ public class BatchOperationDto {
     return name;
   }
 
-  public BatchOperationDto setName(String name) {
+  public BatchOperationDto setName(final String name) {
     this.name = name;
     return this;
   }
@@ -75,7 +75,7 @@ public class BatchOperationDto {
     return type;
   }
 
-  public BatchOperationDto setType(OperationTypeDto type) {
+  public BatchOperationDto setType(final OperationTypeDto type) {
     this.type = type;
     return this;
   }
@@ -84,7 +84,7 @@ public class BatchOperationDto {
     return startDate;
   }
 
-  public BatchOperationDto setStartDate(OffsetDateTime startDate) {
+  public BatchOperationDto setStartDate(final OffsetDateTime startDate) {
     this.startDate = startDate;
     return this;
   }
@@ -93,7 +93,7 @@ public class BatchOperationDto {
     return endDate;
   }
 
-  public BatchOperationDto setEndDate(OffsetDateTime endDate) {
+  public BatchOperationDto setEndDate(final OffsetDateTime endDate) {
     this.endDate = endDate;
     return this;
   }
@@ -102,7 +102,7 @@ public class BatchOperationDto {
     return instancesCount;
   }
 
-  public BatchOperationDto setInstancesCount(Integer instancesCount) {
+  public BatchOperationDto setInstancesCount(final Integer instancesCount) {
     this.instancesCount = instancesCount;
     return this;
   }
@@ -111,7 +111,7 @@ public class BatchOperationDto {
     return operationsTotalCount;
   }
 
-  public BatchOperationDto setOperationsTotalCount(Integer operationsTotalCount) {
+  public BatchOperationDto setOperationsTotalCount(final Integer operationsTotalCount) {
     this.operationsTotalCount = operationsTotalCount;
     return this;
   }
@@ -120,7 +120,7 @@ public class BatchOperationDto {
     return operationsFinishedCount;
   }
 
-  public BatchOperationDto setOperationsFinishedCount(Integer operationsFinishedCount) {
+  public BatchOperationDto setOperationsFinishedCount(final Integer operationsFinishedCount) {
     this.operationsFinishedCount = operationsFinishedCount;
     return this;
   }
@@ -129,7 +129,7 @@ public class BatchOperationDto {
     return id;
   }
 
-  public BatchOperationDto setId(String id) {
+  public BatchOperationDto setId(final String id) {
     this.id = id;
     return this;
   }
@@ -138,7 +138,7 @@ public class BatchOperationDto {
     return sortValues;
   }
 
-  public BatchOperationDto setSortValues(SortValuesWrapper[] sortValues) {
+  public BatchOperationDto setSortValues(final SortValuesWrapper[] sortValues) {
     this.sortValues = sortValues;
     return this;
   }
@@ -159,7 +159,7 @@ public class BatchOperationDto {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/BatchOperationDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/BatchOperationDto.java
@@ -28,6 +28,8 @@ public class BatchOperationDto {
   private Integer instancesCount = 0;
   private Integer operationsTotalCount = 0;
   private Integer operationsFinishedCount = 0;
+  private Integer failedOperationsCount = 0;
+  private Integer completedOperationsCount = 0;
 
   /**
    * Sort values, define the position of batch operation in the list and may be used to search for
@@ -125,6 +127,24 @@ public class BatchOperationDto {
     return this;
   }
 
+  public Integer getFailedOperationsCount() {
+    return failedOperationsCount;
+  }
+
+  public BatchOperationDto setFailedOperationsCount(final Integer failedOperationsCount) {
+    this.failedOperationsCount = failedOperationsCount;
+    return this;
+  }
+
+  public Integer getCompletedOperationsCount() {
+    return completedOperationsCount;
+  }
+
+  public BatchOperationDto setCompletedOperationsCount(final Integer completedOperationsCount) {
+    this.completedOperationsCount = completedOperationsCount;
+    return this;
+  }
+
   public String getId() {
     return id;
   }
@@ -197,6 +217,16 @@ public class BatchOperationDto {
     if (operationsFinishedCount != null
         ? !operationsFinishedCount.equals(that.operationsFinishedCount)
         : that.operationsFinishedCount != null) {
+      return false;
+    }
+    if (failedOperationsCount != null
+        ? !failedOperationsCount.equals(that.failedOperationsCount)
+        : that.failedOperationsCount != null) {
+      return false;
+    }
+    if (completedOperationsCount != null
+        ? !completedOperationsCount.equals(that.completedOperationsCount)
+        : that.completedOperationsCount != null) {
       return false;
     }
     // Probably incorrect - comparing Object[] arrays with Arrays.equals

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/BatchOperationDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/operation/BatchOperationDto.java
@@ -14,6 +14,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class BatchOperationDto {
@@ -174,6 +175,9 @@ public class BatchOperationDto {
     result = 31 * result + (operationsTotalCount != null ? operationsTotalCount.hashCode() : 0);
     result =
         31 * result + (operationsFinishedCount != null ? operationsFinishedCount.hashCode() : 0);
+    result =
+        31 * result + (completedOperationsCount != null ? completedOperationsCount.hashCode() : 0);
+    result = 31 * result + (failedOperationsCount != null ? failedOperationsCount.hashCode() : 0);
     result = 31 * result + Arrays.hashCode(sortValues);
     return result;
   }
@@ -189,44 +193,34 @@ public class BatchOperationDto {
 
     final BatchOperationDto that = (BatchOperationDto) o;
 
-    if (id != null ? !id.equals(that.id) : that.id != null) {
+    if (!Objects.equals(id, that.id)) {
       return false;
     }
-    if (name != null ? !name.equals(that.name) : that.name != null) {
+    if (!Objects.equals(name, that.name)) {
       return false;
     }
     if (type != that.type) {
       return false;
     }
-    if (startDate != null ? !startDate.equals(that.startDate) : that.startDate != null) {
+    if (!Objects.equals(startDate, that.startDate)) {
       return false;
     }
-    if (endDate != null ? !endDate.equals(that.endDate) : that.endDate != null) {
+    if (!Objects.equals(endDate, that.endDate)) {
       return false;
     }
-    if (instancesCount != null
-        ? !instancesCount.equals(that.instancesCount)
-        : that.instancesCount != null) {
+    if (!Objects.equals(instancesCount, that.instancesCount)) {
       return false;
     }
-    if (operationsTotalCount != null
-        ? !operationsTotalCount.equals(that.operationsTotalCount)
-        : that.operationsTotalCount != null) {
+    if (!Objects.equals(operationsTotalCount, that.operationsTotalCount)) {
       return false;
     }
-    if (operationsFinishedCount != null
-        ? !operationsFinishedCount.equals(that.operationsFinishedCount)
-        : that.operationsFinishedCount != null) {
+    if (!Objects.equals(operationsFinishedCount, that.operationsFinishedCount)) {
       return false;
     }
-    if (failedOperationsCount != null
-        ? !failedOperationsCount.equals(that.failedOperationsCount)
-        : that.failedOperationsCount != null) {
+    if (!Objects.equals(failedOperationsCount, that.failedOperationsCount)) {
       return false;
     }
-    if (completedOperationsCount != null
-        ? !completedOperationsCount.equals(that.completedOperationsCount)
-        : that.completedOperationsCount != null) {
+    if (!Objects.equals(completedOperationsCount, that.completedOperationsCount)) {
       return false;
     }
     // Probably incorrect - comparing Object[] arrays with Arrays.equals

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/transform/DataAggregator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/transform/DataAggregator.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.transform;
+
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+
+import io.camunda.operate.entities.BatchOperationEntity;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
+import java.util.List;
+
+public interface DataAggregator {
+  public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
+      final List<BatchOperationEntity> batchEntities);
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/transform/DataAggregator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/transform/DataAggregator.java
@@ -7,28 +7,40 @@
  */
 package io.camunda.operate.webapp.transform;
 
-/*
- * Copyright Camunda Services GmbH
- *
- * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
- * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
- *
- * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
- * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
- * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
- * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
- *
- * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
- *
- * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
- * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
- */
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.entities.BatchOperationEntity;
 import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
 
-public interface DataAggregator {
+public abstract class DataAggregator {
+
+  @Autowired protected ObjectMapper objectMapper;
+
+  public abstract Map<String, BatchOperationDto> requestAndAddMetadata(
+      Map<String, BatchOperationDto> resultDtos, List<String> ids);
+
   public List<BatchOperationDto> enrichBatchEntitiesWithMetadata(
-      final List<BatchOperationEntity> batchEntities);
+      final List<BatchOperationEntity> batchEntities) {
+
+    if (CollectionUtils.isEmpty(batchEntities)) {
+      return List.of();
+    }
+
+    /* using this map as starting point ensures that
+     * 1. BatchOperations that have no completed operations yet are also included in the end result
+     * 2. The sorting stays the same
+     */
+    final LinkedHashMap<String, BatchOperationDto> requestDtos =
+        new LinkedHashMap<>(batchEntities.size());
+    batchEntities.forEach(
+        entity -> {
+          requestDtos.put(entity.getId(), BatchOperationDto.createFrom(entity, objectMapper));
+        });
+    final List<String> idList = requestDtos.keySet().stream().toList();
+    return requestAndAddMetadata(requestDtos, idList).values().stream().toList();
+  }
 }


### PR DESCRIPTION
## Description
Added feature to return the failed and successfully completed count of operations for batch operations to display them in the UI.

## Notes for reviewer
I decided to fetch the additional data from the Operation index individually instead of for all currently active operations (as suggested in the issue), since the batch operations are loaded progressively while scrolling.
Performance could probably be improved by requesting information for all the operations that are being loaded in one scroll at once. I'd like to hear opinions on that (and on whether it should be done before we merge the feature or if we can improve that later).

## Related issues

closes #https://github.com/camunda/operate/issues/6294