### PR TITLE
fix: retry SetVariable on for UNAVAILABLE and RESOURCE_EXHAUSTED

### DIFF
--- a/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
+++ b/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
@@ -31,10 +31,10 @@
         {"service": "gateway_protocol.Gateway", "method": "DeployResource"},
         {"service": "gateway_protocol.Gateway", "method": "ModifyProcessInstance"},
         {"service": "gateway_protocol.Gateway", "method": "PublishMessage"},
+        {"service": "gateway_protocol.Gateway", "method": "SetVariables"},
         {"service": "gateway_protocol.Gateway", "method": "ThrowError"},
         {"service": "gateway_protocol.Gateway", "method": "UpdateJobRetries"},
-        {"service": "gateway_protocol.Gateway", "method": "UpdateJobTimeout"},
-        {"service": "gateway_protocol.Gateway", "method": "SetVariables"}
+        {"service": "gateway_protocol.Gateway", "method": "UpdateJobTimeout"}
       ],
       "waitForReady": true,
       "retryPolicy": {

--- a/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
+++ b/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
@@ -9,7 +9,6 @@
         {"service": "gateway_protocol.Gateway", "method": "EvaluateDecision"},
         {"service": "gateway_protocol.Gateway", "method": "FailJob"},
         {"service": "gateway_protocol.Gateway", "method": "ResolveIncident"},
-        {"service": "gateway_protocol.Gateway", "method": "SetVariables"},
         {"service": "gateway_protocol.Gateway", "method": "StreamActivatedJobs"},
         {"service": "gateway_protocol.Gateway", "method": "Topology"},
         {"service": "gateway_protocol.Gateway", "method": "MigrateProcessInstance"}
@@ -34,7 +33,8 @@
         {"service": "gateway_protocol.Gateway", "method": "PublishMessage"},
         {"service": "gateway_protocol.Gateway", "method": "ThrowError"},
         {"service": "gateway_protocol.Gateway", "method": "UpdateJobRetries"},
-        {"service": "gateway_protocol.Gateway", "method": "UpdateJobTimeout"}
+        {"service": "gateway_protocol.Gateway", "method": "UpdateJobTimeout"},
+        {"service": "gateway_protocol.Gateway", "method": "SetVariables"}
       ],
       "waitForReady": true,
       "retryPolicy": {


### PR DESCRIPTION
## Description
SetVariable endpoint is making changes on the state of the process instance. Therefore, it is not idempotent. If we retry setting variables in different stages of process instance, it might provide different behaviour. Because of that we shouldn't retry SetVariables on timeouts (DEADLINE_EXCEEDED) where the processing of the engine can continue, so the process instance state changes. For UNAVAILABLE and RESOURCE_EXHAUSTED, the broker will not accept further commands, so that when we retry the SetVariables command, the process instance state will stay the same.

## Related issues

closes #15549 
