### PR TITLE
refactor: modularize operate-data-generator module

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -126,6 +126,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>operate-data-generator</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>tasklist-webapp</artifactId>
       <exclusions>
         <exclusion>
@@ -541,6 +546,7 @@
             <dependency>io.camunda:identity-spring-boot-autoconfigure</dependency>
 
             <dependency>io.camunda:operate-webapp</dependency>
+            <dependency>io.camunda:operate-data-generator</dependency>
             <dependency>io.camunda:tasklist-webapp</dependency>
 
             <!-- Used to parse PKCS1 certificates -->

--- a/operate/data-generator/src/main/java/io/camunda/operate/DataGeneratorModuleConfiguration.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/DataGeneratorModuleConfiguration.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@ComponentScan(
+    basePackages = "io.camunda.operate.data",
+    nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
+@Profile({"dev-data", "usertest-data"})
+public class DataGeneratorModuleConfiguration {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(DataGeneratorModuleConfiguration.class);
+
+  @PostConstruct
+  public void logModule() {
+    LOGGER.info("Starting module: data generator");
+  }
+}

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -15,6 +15,7 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.ZeebeStore;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.worker.JobWorker;
+import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
 import java.time.Duration;
 import java.util.concurrent.Executors;
@@ -24,7 +25,9 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.DependsOn;
 
+@DependsOn("schemaStartup")
 public abstract class AbstractDataGenerator implements DataGenerator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataGenerator.class);
@@ -34,6 +37,21 @@ public abstract class AbstractDataGenerator implements DataGenerator {
   protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3);
   private boolean shutdown = false;
   @Autowired private ZeebeStore zeebeStore;
+
+  @PostConstruct
+  private void startDataGenerator() {
+    startGeneratingData();
+  }
+
+  protected void startGeneratingData() {
+    LOGGER.debug("INIT: Generate demo data...");
+    try {
+      createZeebeDataAsync(false);
+    } catch (Exception ex) {
+      LOGGER.debug("Demo data could not be generated. Cause: {}", ex.getMessage());
+      LOGGER.error("Error occurred when generating demo data.", ex);
+    }
+  }
 
   @PreDestroy
   public void shutdown() {

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/DataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/DataGenerator.java
@@ -9,7 +9,5 @@ package io.camunda.operate.data;
 
 public interface DataGenerator {
 
-  DataGenerator DO_NOTHING = (boolean manuallyCalled) -> {};
-
   void createZeebeDataAsync(boolean manuallyCalled);
 }

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/develop/DevelopDataGenerator.java
@@ -17,7 +17,6 @@ import io.camunda.operate.util.ZeebeTestUtil;
 import io.camunda.operate.util.rest.StatefulRestTemplate;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.worker.JobWorker;
-import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -51,9 +50,9 @@ public class DevelopDataGenerator extends UserTestDataGenerator {
   @Autowired private BiFunction<String, Integer, StatefulRestTemplate> statefulRestTemplateFactory;
   private StatefulRestTemplate restTemplate;
 
-  @PostConstruct
-  private void initRestTemplate() {
+  protected void startGeneratingData() {
     restTemplate = statefulRestTemplateFactory.apply(OPERATE_HOST, OPERATE_PORT);
+    super.startGeneratingData();
   }
 
   @Override

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/TestApplication.java
@@ -8,11 +8,8 @@
 package io.camunda.operate.util;
 
 import io.camunda.operate.Application;
-import io.camunda.operate.data.DataGenerator;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -31,11 +28,5 @@ public class TestApplication {
 
   public static void main(String[] args) throws Exception {
     SpringApplication.run(TestApplication.class, args);
-  }
-
-  @Bean(name = "dataGenerator")
-  @ConditionalOnMissingBean
-  public DataGenerator stubDataGenerator() {
-    return DataGenerator.DO_NOTHING;
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/apps/modules/ModulesTestApplication.java
@@ -8,12 +8,9 @@
 package io.camunda.operate.util.apps.modules;
 
 import io.camunda.operate.Application;
-import io.camunda.operate.data.DataGenerator;
 import io.camunda.operate.util.TestApplication;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -31,6 +28,9 @@ import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGe
       @ComponentScan.Filter(
           type = FilterType.REGEX,
           pattern = "io\\.camunda\\.operate\\.archiver\\..*"),
+      @ComponentScan.Filter(
+          type = FilterType.REGEX,
+          pattern = "io\\.camunda\\.operate\\.data\\..*"),
       @ComponentScan.Filter(type = FilterType.REGEX, pattern = "io\\.camunda\\.operate\\.it\\..*"),
       @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = TestApplication.class),
       @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, value = Application.class)
@@ -40,11 +40,5 @@ public class ModulesTestApplication {
 
   public static void main(String[] args) throws Exception {
     SpringApplication.run(ModulesTestApplication.class, args);
-  }
-
-  @Bean(name = "dataGenerator")
-  @ConditionalOnMissingBean
-  public DataGenerator stubDataGenerator() {
-    return DataGenerator.DO_NOTHING;
   }
 }

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -23,11 +23,6 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>operate-data-generator</artifactId>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>operate-importer</artifactId>
       <scope>runtime</scope>
     </dependency>
@@ -397,7 +392,6 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <usedDependencies>
-            <dependency>io.camunda:operate-data-generator</dependency>
             <dependency>io.camunda:operate-importer</dependency>
             <dependency>io.camunda:operate-archiver</dependency>
             <dependency>io.camunda:operate-webjar</dependency>

--- a/operate/webapp/src/main/java/io/camunda/operate/Application.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/Application.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.operate;
 
-import io.camunda.operate.data.DataGenerator;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -16,10 +15,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.event.ApplicationFailedEvent;
 import org.springframework.context.ApplicationListener;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
@@ -37,7 +34,8 @@ import org.springframework.core.env.ConfigurableEnvironment;
           pattern = "io\\.camunda\\.operate\\.webapp\\..*"),
       @ComponentScan.Filter(
           type = FilterType.REGEX,
-          pattern = "io\\.camunda\\.operate\\.archiver\\..*")
+          pattern = "io\\.camunda\\.operate\\.archiver\\..*"),
+      @ComponentScan.Filter(type = FilterType.REGEX, pattern = "io\\.camunda\\.operate\\.data\\..*")
     },
     // use fully qualified names as bean name, as we have classes with same names for different
     // versions of importer
@@ -125,13 +123,6 @@ public class Application {
 
         // add custom check to standard readiness check
         "management.endpoint.health.group.readiness.include", "readinessState,indicesCheck");
-  }
-
-  @Bean(name = "dataGenerator")
-  @ConditionalOnMissingBean
-  public DataGenerator stubDataGenerator() {
-    LOGGER.debug("Create Data generator stub");
-    return DataGenerator.DO_NOTHING;
   }
 
   public static class ApplicationErrorListener

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/StartupBean.java
@@ -10,7 +10,6 @@ package io.camunda.operate.webapp;
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
-import io.camunda.operate.data.DataGenerator;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.security.auth.OperateUserDetailsService;
 import io.camunda.operate.webapp.zeebe.operation.OperationExecutor;
@@ -43,8 +42,6 @@ public class StartupBean {
   @Autowired(required = false)
   private OperateUserDetailsService operateUserDetailsService;
 
-  @Autowired private DataGenerator dataGenerator;
-
   @Autowired private OperateProperties operateProperties;
 
   @Autowired private OperationExecutor operationExecutor;
@@ -56,13 +53,7 @@ public class StartupBean {
           "INIT: Create users in {} if not exists ...", DatabaseInfo.getCurrent().getCode());
       operateUserDetailsService.initializeUsers();
     }
-    LOGGER.debug("INIT: Generate demo data...");
-    try {
-      dataGenerator.createZeebeDataAsync(false);
-    } catch (Exception ex) {
-      LOGGER.debug("Demo data could not be generated. Cause: {}", ex.getMessage());
-      LOGGER.error("Error occurred when generating demo data.", ex);
-    }
+
     LOGGER.info("INIT: Start operation executor...");
     operationExecutor.startExecuting();
     LOGGER.info("INIT: DONE");


### PR DESCRIPTION
## Description

This PR removes the need to have a "do nothing" data generator bean by modularizing the data-generator module in the same way as done for other modules.

## Related issues

related #17579 
