### PR TITLE
test: fix app switcher tests

### DIFF
--- a/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
+++ b/operate/client/src/App/Layout/AppHeader/tests/appSwitcher.test.tsx
@@ -51,7 +51,7 @@ describe('App switcher', () => {
 
     await user.click(
       await screen.findByRole('button', {
-        name: /camunda apps/i,
+        name: /camunda components/i,
       }),
     );
 
@@ -109,7 +109,7 @@ describe('App switcher', () => {
 
     await user.click(
       await screen.findByRole('button', {
-        name: /camunda apps/i,
+        name: /camunda components/i,
       }),
     );
 


### PR DESCRIPTION
The button label changed from "camunda apps" to "camunda components".

## Description

Test were failing with:

```
Summary of all failing tests
FAIL src/App/Layout/AppHeader/tests/appSwitcher.test.tsx (14.332 s)
  ● App switcher › should render with correct links

    thrown: "Exceeded timeout of 7000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      27 |   });
      28 |
    > 29 |   it('should render with correct links', async () => {
         |   ^
      30 |     window.clientConfig = {
      31 |       isEnterprise: false,
      32 |       organizationId: 'some-organization-id',

      at src/App/Layout/AppHeader/tests/appSwitcher.test.tsx:29:3
      at Object.<anonymous> (src/App/Layout/AppHeader/tests/appSwitcher.test.tsx:24:1)

  ● App switcher › should not render links for CCSM

    thrown: "Exceeded timeout of 7000 ms for a test.
    Use jest.setTimeout(newTimeout) to increase the timeout value, if this is a long-running test."

      85 |   });
      86 |
    > 87 |   it('should not render links for CCSM', async () => {
         |   ^
      88 |     window.clientConfig = {
      89 |       isEnterprise: false,
      90 |       organizationId: null,

      at src/App/Layout/AppHeader/tests/appSwitcher.test.tsx:87:3
      at Object.<anonymous> (src/App/Layout/AppHeader/tests/appSwitcher.test.tsx:24:1)
```

## Related issues

closes #
