### PR TITLE
ci: add generous timeout to tasklist build to avoid stalling

### DIFF
--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -39,6 +39,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch


### PR DESCRIPTION
## Description

As [reported on Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1714744418471709) the build job of Tasklist merge CI is prone to stalling (for unknown reasons). A quick fix even before those reasons are found is to apply a general best practice: `timeout-minutes` as done e.g. in similar https://github.com/camunda/zeebe/blob/c8as-add-timeout/.github/workflows/operate-ci-build-reusable.yml#L42

I choose 20 minutes since [history shows](https://github.com/camunda/zeebe/actions/workflows/tasklist-merge-ci.yml?query=is%3Asuccess) that the job is normally finished in 6-9 minutes.

## Related issues

https://camunda.slack.com/archives/C071KP5BTHB/p1714744418471709