### PR TITLE
Observe status of Zeebe CI jobs

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -53,7 +53,7 @@ runs:
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name }}"
-        build_status: "${{ inputs.build_status || (contains(steps.*.outcome, 'failure') && 'failure' || 'success') }}"
+        build_status: "${{ inputs.build_status }}"
         user_reason: "${{ inputs.user_reason }}"
         user_description: "${{ inputs.user_description }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -1,0 +1,60 @@
+# This action expects the code to have been checked out beforehand, e.g. via actions/checkout@v4
+#
+# This action expects certain secrets to be provided:
+#   - VAULT_ADDR
+#   - VAULT_ROLE_ID
+#   - VAULT_SECRET_ID
+---
+name: Observe Build Status
+description: Records the build status remotely for analytic purposes
+
+inputs:
+  build_status:
+    description: 'The status of the job, one of: success, failure, aborted, cancelled'
+    required: true
+  user_reason:
+    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
+    required: false
+  user_description:
+    description: 'Optional string (200 chars max) the user can submit to indicate the reason why a build has ended with a certain build status.'
+    required: false
+  job_name:
+    description: 'Optional string, the job whose status is being observed; defaults to $GITHUB_JOB when omitted'
+    required: false
+  secret_vault_address:
+    description: 'Secret vault url'
+    required: false
+  secret_vault_roleId:
+    description: 'Secret vault roleId'
+    required: false
+  secret_vault_secretId:
+    description: 'Secret vault ID'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      if: |
+        inputs.secret_vault_address != ''
+        && inputs.secret_vault_roleId != ''
+        && inputs.secret_vault_secretId != ''
+      with:
+        url: ${{ inputs.secret_vault_address }}
+        method: approle
+        roleId: ${{ inputs.secret_vault_roleId }}
+        secretId: ${{ inputs.secret_vault_secretId }}
+        exportEnv: false # we rely on step outputs, no need for environment variables
+        secrets: |
+          secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
+    - uses: camunda/infra-global-github-actions/submit-build-status@main
+      if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
+      with:
+        job_name_override: "${{ inputs.job_name }}"
+        build_status: "${{ inputs.build_status || (contains(steps.*.outcome, 'failure') && 'failure' || 'success') }}"
+        user_reason: "${{ inputs.user_reason }}"
+        user_description: "${{ inputs.user_description }}"
+        gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+        big_query_table_name: "ci-30-162810:prod_ci_analytics.build_status_v2"

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -153,9 +153,11 @@ jobs:
           name: "[IT] ${{ matrix.name }}"
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
           job_name: "integration-tests/${{ matrix.group }}"
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -209,8 +211,10 @@ jobs:
           name: "unit tests"
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -275,9 +279,11 @@ jobs:
           name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
           job_name: "smoke-tests/${{ matrix.os }}"
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -322,8 +328,10 @@ jobs:
           name: Property Tests
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -381,8 +389,10 @@ jobs:
           name: Performance Tests
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -412,8 +422,10 @@ jobs:
         run: go test -mod=vendor -v ./...
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -439,8 +451,10 @@ jobs:
           working-directory: clients/go
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -468,8 +482,10 @@ jobs:
           base-ref:  origin/${{ env.GO_CLIENT_BASE_REF }}
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -488,8 +504,10 @@ jobs:
       - run: ./mvnw -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -547,8 +565,10 @@ jobs:
           platforms: ${{ env.DOCKER_PLATFORMS }}
       - name: Observe build status
         if: always()
+        continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -151,6 +151,14 @@ jobs:
         if: ${{ failure() || cancelled() }}
         with:
           name: "[IT] ${{ matrix.name }}"
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests/${{ matrix.group }}"
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   unit-tests:
     name: Unit tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
@@ -199,6 +207,13 @@ jobs:
         if: ${{ failure() || cancelled() }}
         with:
           name: "unit tests"
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
     timeout-minutes: 20
@@ -258,6 +273,14 @@ jobs:
         if: ${{ failure() || cancelled() }}
         with:
           name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "smoke-tests/${{ matrix.os }}"
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   property-tests:
     name: Property Tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
@@ -297,6 +320,13 @@ jobs:
         if: ${{ failure() || cancelled() }}
         with:
           name: Property Tests
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   performance-tests:
     name: Performance Tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
@@ -349,6 +379,13 @@ jobs:
         if: ${{ failure() || cancelled() }}
         with:
           name: Performance Tests
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   go-client:
     name: Go client tests
     runs-on: ubuntu-latest
@@ -373,6 +410,13 @@ jobs:
       - name: Run Go tests
         working-directory: clients/go
         run: go test -mod=vendor -v ./...
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   go-lint:
     name: Go linting
     runs-on: ubuntu-latest
@@ -393,6 +437,13 @@ jobs:
           skip-pkg-cache: true
           skip-build-cache: true
           working-directory: clients/go
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   go-apidiff:
     name: Go Backward Compatibility
     runs-on: ubuntu-latest
@@ -415,6 +466,13 @@ jobs:
       - uses: joelanford/go-apidiff@main
         with:
           base-ref:  origin/${{ env.GO_CLIENT_BASE_REF }}
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   java-checks:
     name: Java checks
     runs-on: ubuntu-latest
@@ -428,6 +486,13 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: ./mvnw -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   docker-checks:
     name: Docker checks
     runs-on: ubuntu-latest
@@ -480,6 +545,14 @@ jobs:
           revision: ${{ github.sha }}
           version: ${{ steps.build-zeebe-docker.outputs.version }}
           platforms: ${{ env.DOCKER_PLATFORMS }}
+      - name: Observe build status
+        if: always()
+        uses: ./.github/actions/observe-build-status
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!


### PR DESCRIPTION
## Description

This PR observes the result of each Zeebe CI job, and submits its result via the [submit-build-status](https://github.com/camunda/infra-global-github-actions/tree/main/submit-build-status) action. That way, we can aggregate statistics about the pass/fail status of our CI runs at the job level, and use analytics on the BigQuery table to visualize its health.

As a first step, we only collect pass/fail for each job, and make no distinction of failure causes. This will be done in a second PR.

Right now, we observe the status for all jobs required by `test-summary`:

- integration-tests
  - Matrix branches use the job name with the `matrix.group` param, e.g. `integration-tests/qa-update`, `integration-tests/qa-integration`, etc.
- unit-tests
- smoke-tests
  - Matrix branches use the job name with the `matrix.os` param, e.g. `smoke-tests/macos`, `smoke-tests/windows`, etc.
- property-tests
- performance-tests
- go-client
- java-checks
- go-lint
- go-apidiff
- docker-checks

## Related issues

closes #18268
