### PR TITLE
[Backport stable/8.2] test: disable flake BackupUploadIT.shouldSaveBackupWithManyFiles

### DIFF
--- a/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
+++ b/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
@@ -26,6 +26,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -84,6 +85,7 @@ final class BackupUploadIT {
   }
 
   @Test
+  @Disabled("https://github.com/camunda/zeebe/issues/18177")
   void shouldSaveBackupWithManyFiles() throws IOException {
     // given
     // Default values for the configuration


### PR DESCRIPTION
# Description
Backport of #18205 to `stable/8.2`.

relates to #18177
original author: @megglos