### PR TITLE
fix: add leading slash to opensearch endpoints

### DIFF
--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -219,7 +219,7 @@ public class OpensearchClient implements AutoCloseable {
   Optional<GetIndexStateManagementPolicyResponse> getIndexStateManagementPolicy() {
     try {
       final var request =
-          new Request("GET", "_plugins/_ism/policies/" + configuration.retention.getPolicyName());
+          new Request("GET", "/_plugins/_ism/policies/" + configuration.retention.getPolicyName());
       return Optional.of(sendRequest(request, GetIndexStateManagementPolicyResponse.class));
     } catch (final IOException e) {
       return Optional.empty();
@@ -240,7 +240,7 @@ public class OpensearchClient implements AutoCloseable {
     try {
       final var request =
           new Request(
-              "DELETE", "_plugins/_ism/policies/" + configuration.retention.getPolicyName());
+              "DELETE", "/_plugins/_ism/policies/" + configuration.retention.getPolicyName());
 
       final var response = sendRequest(request, DeleteStateManagementPolicyResponse.class);
       return response.result().equals(DeleteStateManagementPolicyResponse.DELETED);
@@ -252,7 +252,7 @@ public class OpensearchClient implements AutoCloseable {
   private boolean putIndexStateManagementPolicy(final Map<String, String> queryParameters) {
     try {
       final var request =
-          new Request("PUT", "_plugins/_ism/policies/" + configuration.retention.getPolicyName());
+          new Request("PUT", "/_plugins/_ism/policies/" + configuration.retention.getPolicyName());
 
       queryParameters.forEach(request::addParameter);
 
@@ -269,7 +269,7 @@ public class OpensearchClient implements AutoCloseable {
   public boolean bulkAddISMPolicyToAllZeebeIndices() {
     try {
       final var request =
-          new Request("POST", "_plugins/_ism/add/" + configuration.index.prefix + "*");
+          new Request("POST", "/_plugins/_ism/add/" + configuration.index.prefix + "*");
       final var requestEntity = new AddPolicyRequest(configuration.retention.getPolicyName());
       request.setJsonEntity(MAPPER.writeValueAsString(requestEntity));
       final var response = sendRequest(request, IndexPolicyResponse.class);
@@ -282,7 +282,7 @@ public class OpensearchClient implements AutoCloseable {
   public boolean bulkRemoveISMPolicyToAllZeebeIndices() {
     try {
       final var request =
-          new Request("POST", "_plugins/_ism/remove/" + configuration.index.prefix + "*");
+          new Request("POST", "/_plugins/_ism/remove/" + configuration.index.prefix + "*");
       final var response = sendRequest(request, IndexPolicyResponse.class);
       return !response.failures();
     } catch (final IOException e) {


### PR DESCRIPTION
## Description

While the bare opensearch service allows a missing leading slash, the AWS service or it's ingress doesn't, returning a 400.

As I don't see an easy way to cover this in our ITs we may consider following up with a nightly IT on prepared AWS Opensearch instance see https://github.com/camunda/zeebe/issues/18252 .

## Related issues

closes #18251 
