### PR TITLE
[Backport release] Allow all semantic versions

### DIFF
--- a/zeebe/atomix/utils/pom.xml
+++ b/zeebe/atomix/utils/pom.xml
@@ -77,5 +77,11 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/zeebe/atomix/utils/src/main/java/io/atomix/utils/Version.java
+++ b/zeebe/atomix/utils/src/main/java/io/atomix/utils/Version.java
@@ -16,29 +16,33 @@
  */
 package io.atomix.utils;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static java.lang.Integer.parseInt;
-
-import com.google.common.collect.ComparisonChain;
-import java.util.Arrays;
+import io.camunda.zeebe.util.SemanticVersion;
 import java.util.Objects;
 
-/** Atomix software version. */
+/**
+ * Atomix software version.
+ *
+ * <p>NOTE: eventually we should stop using this and use {@link SemanticVersion} directly instead.
+ */
 public final class Version implements Comparable<Version> {
 
   private final int major;
   private final int minor;
   private final int patch;
   private final String build;
+  private final String metadata;
 
-  private Version(final int major, final int minor, final int patch, final String build) {
-    checkArgument(major >= 0, "major version must be >= 0");
-    checkArgument(minor >= 0, "minor version must be >= 0");
-    checkArgument(patch >= 0, "patch version must be >= 0");
+  private Version(
+      final int major,
+      final int minor,
+      final int patch,
+      final String build,
+      final String metadata) {
     this.major = major;
     this.minor = minor;
     this.patch = patch;
-    this.build = Build.from(build).toString();
+    this.build = build;
+    this.metadata = metadata;
   }
 
   public int major() {
@@ -53,6 +57,14 @@ public final class Version implements Comparable<Version> {
     return patch;
   }
 
+  public String preRelease() {
+    return build;
+  }
+
+  public String buildMetadata() {
+    return metadata;
+  }
+
   /**
    * Returns a new version from the given version string.
    *
@@ -61,46 +73,25 @@ public final class Version implements Comparable<Version> {
    * @throws IllegalArgumentException if the version string is invalid
    */
   public static Version from(final String version) {
-    final String[] fields = version.split("[.-]", 4);
-    checkArgument(fields.length >= 3, String.format("version number is invalid :%s", version));
+    final SemanticVersion semanticVersion =
+        SemanticVersion.parse(version)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Expected to parse valid semantic version, but got [%s]"
+                            .formatted(version)));
+
     return new Version(
-        parseInt(fields[0]),
-        parseInt(fields[1]),
-        parseInt(fields[2]),
-        fields.length == 4 ? fields[3] : null);
-  }
-
-  /**
-   * Returns a new version from the given parts.
-   *
-   * @param major the major version number
-   * @param minor the minor version number
-   * @param patch the patch version number
-   * @param build the build version number
-   * @return the version object
-   */
-  public static Version from(
-      final int major, final int minor, final int patch, final String build) {
-    return new Version(major, minor, patch, build);
-  }
-
-  /**
-   * Returns the build version number.
-   *
-   * @return the build version number
-   */
-  public String build() {
-    return build;
+        semanticVersion.major(),
+        semanticVersion.minor(),
+        semanticVersion.patch(),
+        semanticVersion.preRelease(),
+        semanticVersion.buildMetadata());
   }
 
   @Override
   public int compareTo(final Version that) {
-    return ComparisonChain.start()
-        .compare(major, that.major)
-        .compare(minor, that.minor)
-        .compare(patch, that.patch)
-        .compare(Build.from(build), Build.from(that.build))
-        .result();
+    return toSemanticVersion().compareTo(that.toSemanticVersion());
   }
 
   @Override
@@ -123,134 +114,10 @@ public final class Version implements Comparable<Version> {
 
   @Override
   public String toString() {
-    final StringBuilder builder =
-        new StringBuilder().append(major).append('.').append(minor).append('.').append(patch);
-    final String build = Build.from(this.build).toString();
-    if (build != null) {
-      builder.append('-').append(build);
-    }
-    return builder.toString();
+    return toSemanticVersion().toString();
   }
 
-  /** Build version. */
-  private static final class Build implements Comparable<Build> {
-
-    private final Type type;
-    private final String version;
-    private final int[] versionIdentifiers;
-
-    private Build(final Type type, final int version) {
-      this(type, String.valueOf(version), new int[] {version});
-    }
-
-    private Build(final Type type, final String version, final int[] versionIdentifiers) {
-      this.type = type;
-      this.version = version;
-      this.versionIdentifiers = versionIdentifiers;
-    }
-
-    /**
-     * Creates a new build version from the given string.
-     *
-     * @param build the build version string
-     * @return the build version
-     * @throws IllegalArgumentException if the build version string is invalid
-     */
-    public static Build from(final String build) {
-      if (build == null) {
-        return new Build(Type.FINAL, 0);
-      } else if (build.equalsIgnoreCase(Type.SNAPSHOT.name())) {
-        return new Build(Type.SNAPSHOT, 0);
-      }
-
-      for (final Type type : Type.values()) {
-        if (type.name != null
-            && build.length() >= type.name.length()
-            && build.substring(0, type.name.length()).equalsIgnoreCase(type.name)) {
-          try {
-            final String preReleaseVersion = build.substring(type.name.length());
-            final String[] preReleaseSplitVersion = preReleaseVersion.split("[.]");
-            final int[] preReleaseVersionIdentifiers = new int[preReleaseSplitVersion.length];
-            for (int i = 0; i < preReleaseVersionIdentifiers.length; i++) {
-              preReleaseVersionIdentifiers[i] = parseInt(preReleaseSplitVersion[i]);
-            }
-            return new Build(type, preReleaseVersion, preReleaseVersionIdentifiers);
-          } catch (final NumberFormatException e) {
-            throw new IllegalArgumentException(build + " is not a valid build version string");
-          }
-        }
-      }
-      throw new IllegalArgumentException(build + " is not a valid build version string");
-    }
-
-    @Override
-    public int compareTo(final Build that) {
-      ComparisonChain comparisonChain =
-          ComparisonChain.start().compare(type.ordinal(), that.type.ordinal());
-
-      int[] left = versionIdentifiers;
-      int[] right = that.versionIdentifiers;
-      // growing either of the arrays results in new elements defaulting to `0`,
-      // thus allowing a comparison
-      if (left.length < right.length) {
-        left = Arrays.copyOf(left, right.length);
-      } else if (left.length > right.length) {
-        right = Arrays.copyOf(right, left.length);
-      }
-
-      for (int i = 0; i < left.length; i++) {
-        comparisonChain = comparisonChain.compare(left[i], right[i]);
-      }
-      return comparisonChain.result();
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(type, version);
-    }
-
-    @Override
-    public boolean equals(final Object object) {
-      if (!(object instanceof Build)) {
-        return false;
-      }
-      final Build that = (Build) object;
-      return Objects.equals(type, that.type) && Objects.equals(version, that.version);
-    }
-
-    @Override
-    public String toString() {
-      return type.format(version);
-    }
-
-    /** Build type. */
-    private enum Type {
-      SNAPSHOT("snapshot"),
-      ALPHA("alpha"),
-      BETA("beta"),
-      RC("rc"),
-      FINAL(null);
-
-      private final String name;
-
-      Type(final String name) {
-        this.name = name;
-      }
-
-      String format(final String version) {
-        if (name == null) {
-          return null;
-        } else if ("snapshot".equals(name)) {
-          return "SNAPSHOT";
-        } else {
-          return String.format("%s%s", name, version);
-        }
-      }
-
-      @Override
-      public String toString() {
-        return name;
-      }
-    }
+  private SemanticVersion toSemanticVersion() {
+    return new SemanticVersion(major, minor, patch, build, null);
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/VersionTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/VersionTest.java
@@ -16,9 +16,8 @@
  */
 package io.atomix.utils;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.Test;
 
@@ -26,53 +25,43 @@ import org.junit.Test;
 public class VersionTest {
   @Test
   public void testVersionComparison() {
-    assertTrue(Version.from("1.0.0").compareTo(Version.from("2.0.0")) < 0);
-    assertTrue(Version.from("2.0.0").compareTo(Version.from("1.0.0")) > 0);
-    assertTrue(Version.from("1.0.0").compareTo(Version.from("0.1.0")) > 0);
-    assertTrue(Version.from("0.1.0").compareTo(Version.from("1.0.0")) < 0);
-    assertTrue(Version.from("0.1.0").compareTo(Version.from("0.1.1")) < 0);
-    assertTrue(Version.from("1.0.0").compareTo(Version.from("0.0.1")) > 0);
-    assertTrue(Version.from("1.1.1").compareTo(Version.from("1.0.3")) > 0);
-    assertTrue(Version.from("1.0.0").compareTo(Version.from("1.0.0-beta1")) > 0);
-    assertTrue(Version.from("1.0.0-rc2").compareTo(Version.from("1.0.0-rc1")) > 0);
-    assertTrue(Version.from("1.0.0-rc2.1").compareTo(Version.from("1.0.0-rc2")) > 0);
-    assertTrue(Version.from("1.0.0-rc2.1.1").compareTo(Version.from("1.0.0-rc2.1")) > 0);
-    assertTrue(Version.from("1.0.0-rc2").compareTo(Version.from("1.0.0-rc2.1")) < 0);
-    assertTrue(Version.from("1.0.0-rc1").compareTo(Version.from("1.0.0-beta1")) > 0);
-    assertTrue(Version.from("2.0.0-beta1").compareTo(Version.from("1.0.0")) > 0);
-    assertTrue(Version.from("1.0.0-alpha1").compareTo(Version.from("1.0.0-SNAPSHOT")) > 0);
+    assertThat(Version.from("1.0.0")).isLessThan(Version.from("2.0.0"));
+    assertThat(Version.from("2.0.0")).isGreaterThan(Version.from("1.0.0"));
+    assertThat(Version.from("1.0.0")).isGreaterThan(Version.from("0.1.0"));
+    assertThat(Version.from("0.1.0"))
+        .isLessThan(Version.from("1.0.0"))
+        .isLessThan(Version.from("0.1.1"));
+    assertThat(Version.from("1.0.0")).isGreaterThan(Version.from("0.0.1"));
+    assertThat(Version.from("1.1.1")).isGreaterThan(Version.from("1.0.3"));
+    assertThat(Version.from("1.0.0")).isGreaterThan(Version.from("1.0.0-beta1"));
+    assertThat(Version.from("1.0.0-rc2")).isGreaterThan(Version.from("1.0.0-rc1"));
+    assertThat(Version.from("1.0.0-rc2.1")).isGreaterThan(Version.from("1.0.0-rc2"));
+    assertThat(Version.from("1.0.0-rc2.1.1")).isGreaterThan(Version.from("1.0.0-rc2.1"));
+    assertThat(Version.from("1.0.0-rc2")).isLessThan(Version.from("1.0.0-rc2.1"));
+    assertThat(Version.from("1.0.0-rc1")).isGreaterThan(Version.from("1.0.0-beta1"));
+    assertThat(Version.from("2.0.0-beta1")).isGreaterThan(Version.from("1.0.0"));
+    assertThat(Version.from("1.0.0-alpha1")).isGreaterThan(Version.from("1.0.0-SNAPSHOT"));
+    assertThat(Version.from("1.0.0-alpha1-rc1")).isLessThan(Version.from("1.0.0-alpha1-rc2"));
   }
 
   @Test
   public void testVersionToString() {
-    assertEquals("1.0.0", Version.from("1.0.0").toString());
-    assertEquals("1.0.0-alpha1", Version.from("1.0.0-alpha1").toString());
-    assertEquals("1.0.0-beta1", Version.from("1.0.0-beta1").toString());
-    assertEquals("1.0.0-rc1", Version.from("1.0.0-rc1").toString());
-    assertEquals("1.0.0-rc1.2", Version.from("1.0.0-rc1.2").toString());
-    assertEquals("1.0.0-SNAPSHOT", Version.from("1.0.0-SNAPSHOT").toString());
+    assertThat(Version.from("1.0.0")).hasToString("1.0.0");
+    assertThat(Version.from("1.0.0-alpha1")).hasToString("1.0.0-alpha1");
+    assertThat(Version.from("1.0.0-beta1")).hasToString("1.0.0-beta1");
+    assertThat(Version.from("1.0.0-rc1")).hasToString("1.0.0-rc1");
+    assertThat(Version.from("1.0.0-rc1.2")).hasToString("1.0.0-rc1.2");
+    assertThat(Version.from("1.0.0-SNAPSHOT")).hasToString("1.0.0-SNAPSHOT");
   }
 
   @Test
   public void testInvalidVersions() {
-    assertIllegalArgument(() -> Version.from("1"));
-    assertIllegalArgument(() -> Version.from("1.0"));
-    assertIllegalArgument(() -> Version.from("1.0-beta1"));
-    assertIllegalArgument(() -> Version.from("1.0.0-beta1XYZ"));
-    assertIllegalArgument(() -> Version.from("1.0.0.0"));
-    assertIllegalArgument(() -> Version.from("1.0.0.0-beta1"));
-    assertIllegalArgument(() -> Version.from("1.0.0-not1"));
-    assertIllegalArgument(() -> Version.from("1.0.0-alpha"));
-    assertIllegalArgument(() -> Version.from("1.0.0-beta"));
-    assertIllegalArgument(() -> Version.from("1.0.0-rc"));
-  }
-
-  private void assertIllegalArgument(final Runnable callback) {
-    try {
-      callback.run();
-      fail();
-    } catch (final IllegalArgumentException e) {
-      // expected
-    }
+    assertThatThrownBy(() -> Version.from("1")).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Version.from("1.0")).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Version.from("1.0-beta1"))
+        .isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Version.from("1.0.0.0")).isInstanceOf(IllegalArgumentException.class);
+    assertThatThrownBy(() -> Version.from("1.0.0.0-beta1"))
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/zeebe/atomix/utils/src/test/java/io/atomix/utils/VersionTest.java
+++ b/zeebe/atomix/utils/src/test/java/io/atomix/utils/VersionTest.java
@@ -23,6 +23,23 @@ import org.junit.Test;
 
 /** Version test. */
 public class VersionTest {
+
+  @Test
+  public void shouldAllowAlphaReleaseCandidates() {
+    // given
+    final var version = "8.6.0-alpha1-rc1";
+
+    // when
+    final Version from = Version.from(version);
+
+    // then
+    assertThat(from.major()).isEqualTo(8);
+    assertThat(from.minor()).isEqualTo(6);
+    assertThat(from.patch()).isEqualTo(0);
+    assertThat(from.preRelease()).isEqualTo("alpha1-rc1");
+    assertThat(from.buildMetadata()).isNull();
+  }
+
   @Test
   public void testVersionComparison() {
     assertThat(Version.from("1.0.0")).isLessThan(Version.from("2.0.0"));


### PR DESCRIPTION
## Description

Simple cherry-pick of #18220 

> Description
Modifies the Atomix utili

> ty Version to use the more complete SemanticVersion utility from Zeebe. This fully complies with the semantic version spec, and is much more lenient about adding build-metadata and so on.
> 
> At the same time, we preserve the check on start up that the version is parse-able at all, to avoid issues where we would run with un-parseable versions and potentially use a snapshot which could cause inconsistencies.
> 

## Related issues

Backport https://github.com/camunda/zeebe/pull/18220


> Related issues
> related to https://camunda.slack.com/archives/C03NFMH4KC6/p1714730721838389
