### PR TITLE
fix: do not retry create instance on closed connection

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
@@ -64,4 +64,11 @@ public class MessagingException extends IOException {
       super(message);
     }
   }
+
+  /** Exception indicating a connection was closed unexpectedly. */
+  public static class ConnectionClosed extends MessagingException {
+    public ConnectionClosed(final String message) {
+      super(message);
+    }
+  }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
@@ -19,7 +19,6 @@ package io.atomix.cluster.messaging.impl;
 import com.google.common.collect.Maps;
 import io.atomix.cluster.messaging.MessagingException;
 import io.camunda.zeebe.util.StringUtil;
-import java.net.ConnectException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -73,7 +72,8 @@ abstract class AbstractClientConnection implements ClientConnection {
     if (closed.compareAndSet(false, true)) {
       for (final CompletableFuture<byte[]> responseFuture : responseFutures.values()) {
         responseFuture.completeExceptionally(
-            new ConnectException(String.format("Connection %s was closed", this)));
+            new MessagingException.ConnectionClosed(
+                String.format("Connection %s was closed", this)));
       }
     }
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -768,7 +768,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
             onClose -> {
               if (!future.isDone()) {
                 future.completeExceptionally(
-                    new ConnectException(
+                    new MessagingException.ConnectionClosed(
                         String.format(
                             "Channel %s for address %s was closed unexpectedly before the request was handled",
                             channel, address)));

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
@@ -18,10 +18,10 @@ package io.atomix.cluster.messaging.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import java.net.ConnectException;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -74,7 +74,7 @@ final class NettyMessagingServiceTlsTest {
         .failsWithin(Duration.ofSeconds(10))
         .withThrowableOfType(ExecutionException.class)
         .havingRootCause()
-        .isInstanceOf(ConnectException.class);
+        .isInstanceOf(MessagingException.ConnectionClosed.class);
   }
 
   @Test
@@ -100,7 +100,7 @@ final class NettyMessagingServiceTlsTest {
         .failsWithin(Duration.ofSeconds(2))
         .withThrowableOfType(ExecutionException.class)
         .havingRootCause()
-        .isInstanceOf(ConnectException.class);
+        .isInstanceOf(MessagingException.ConnectionClosed.class);
   }
 
   private NettyMessagingService createInsecureMessagingService() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/RemoteClientConnectionTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/RemoteClientConnectionTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.netty.channel.Channel;
@@ -19,6 +20,8 @@ import io.netty.channel.ChannelFuture;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -120,6 +123,25 @@ public class RemoteClientConnectionTest {
     assertThat(simpleMetrics.messageCount.size()).isZero();
   }
 
+  @Test
+  public void shouldReceiveConnectionClosedExceptionForResponseOnClientClose() {
+    // given
+    final var responseFuture =
+        remoteClientConnection.sendAndReceive(
+            new ProtocolRequest(1, new Address("", 12345), "subj", "payload".getBytes()));
+
+    // when
+    remoteClientConnection.close();
+
+    // then
+    assertThat(responseFuture)
+        .failsWithin(100, TimeUnit.MILLISECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(MessagingException.ConnectionClosed.class)
+        .withMessageContaining("Connection")
+        .withMessageContaining("was closed");
+  }
+
   private static final class SimpleMessagingMetrics implements MessagingMetrics {
 
     private static final String LABEL_FORMAT = "%s-%s";
@@ -148,10 +170,6 @@ public class RemoteClientConnectionTest {
       final String key = computeKey(to, name);
       final Integer integer = messageCount.computeIfAbsent(key, s -> 0);
       messageCount.put(key, integer + 1);
-    }
-
-    String computeKey(final String to, final String name) {
-      return String.format(LABEL_FORMAT, to, name);
     }
 
     @Override
@@ -185,6 +203,10 @@ public class RemoteClientConnectionTest {
       final String key = computeKey(address, topic);
       final Integer integer = inFlightRequestCount.computeIfAbsent(key, k -> 0);
       inFlightRequestCount.put(key, integer - 1);
+    }
+
+    String computeKey(final String to, final String name) {
+      return String.format(LABEL_FORMAT, to, name);
     }
   }
 }


### PR DESCRIPTION
## Description

This replaces `ConnectionException` throws in cases where a connection was actually established previously with a more appropriate `MessagingException.ConnectionClosed`, as `ConnectionException` is only supposed to be used in cases where a connection couldn't get established at all, see https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/java/net/ConnectException.html.

## Related issues

closes #17333 
