### PR TITLE
ci: add zeebe java client to filter paths

### DIFF
--- a/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
+++ b/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
@@ -12,10 +12,13 @@ on:
       - '.github/actions/**'
       - '.github/workflows/spring-boot-starter-camunda-sdk-ci.yml'
       - 'spring-boot-starter-camunda-sdk/**'
+      - 'zeebe/client/java/**'
   pull_request:
     paths:
+      - '.github/actions/**'
       - '.github/workflows/spring-boot-starter-camunda-sdk-ci.yml'
       - 'spring-boot-starter-camunda-sdk/**'
+      - 'zeebe/client/java/**'
   merge_group: { }
   workflow_dispatch: { }
   workflow_call: { }


### PR DESCRIPTION
## Description

This PR add the zeebe java client path as filter paths. With this addition the Spring SDK CI runs also every time that something changes on the Java Client

## Related issues

related to #17767 
