### PR TITLE
Add exporters to dynamic config

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionReconfigurePriorityApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionReconfigurePriorityApplier.java
@@ -90,7 +90,8 @@ public class PartitionReconfigurePriorityApplier implements MemberOperationAppli
                         memberState.updatePartition(
                             partitionId,
                             partitionState ->
-                                new PartitionState(partitionState.state(), newPriority)));
+                                new PartitionState(
+                                    partitionState.state(), newPriority, partitionState.config())));
               } else {
                 result.completeExceptionally(error);
               }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import java.util.function.UnaryOperator;
+
+public record DynamicPartitionConfig(ExportersConfig exporting) {
+  public static DynamicPartitionConfig init() {
+    return new DynamicPartitionConfig(ExportersConfig.empty());
+  }
+
+  public DynamicPartitionConfig updateExporter(final ExportersConfig exporter) {
+    return new DynamicPartitionConfig(exporter);
+  }
+
+  public DynamicPartitionConfig updateExporter(
+      final UnaryOperator<ExportersConfig> exporterUpdater) {
+    return new DynamicPartitionConfig(exporterUpdater.apply(exporting));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -9,8 +9,12 @@ package io.camunda.zeebe.dynamic.config.state;
 
 import java.util.function.UnaryOperator;
 
+/** Represents configuration of a partition that can be updated during runtime. */
 public record DynamicPartitionConfig(ExportersConfig exporting) {
+
   public static DynamicPartitionConfig init() {
+    // This is temporary until we have a way to initialize this during bootstrap or first update to
+    // the version that added this
     return new DynamicPartitionConfig(ExportersConfig.empty());
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -18,11 +18,11 @@ public record DynamicPartitionConfig(ExportersConfig exporting) {
     return new DynamicPartitionConfig(ExportersConfig.empty());
   }
 
-  public DynamicPartitionConfig updateExporter(final ExportersConfig exporter) {
+  public DynamicPartitionConfig updateExporting(final ExportersConfig exporter) {
     return new DynamicPartitionConfig(exporter);
   }
 
-  public DynamicPartitionConfig updateExporter(
+  public DynamicPartitionConfig updateExporting(
       final UnaryOperator<ExportersConfig> exporterUpdater) {
     return new DynamicPartitionConfig(exporterUpdater.apply(exporting));
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+public record ExporterState(final State state) {
+  public enum State {
+    ENABLED,
+    DISABLED
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
-public record ExporterState(final State state) {
+public record ExporterState(State state) {
   public enum State {
     ENABLED,
     DISABLED

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
@@ -7,6 +7,11 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+/**
+ * Represents the state of an exporter. The full configuration of this exporter must be provided as
+ * part of the application configuration. Here we only keep track of whether it is enabled or
+ * disabled. Sensitive information like access details must not be added here.
+ */
 public record ExporterState(State state) {
   public enum State {
     ENABLED,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+
+public record ExportersConfig(Map<String, ExporterState> exporters) {
+
+  public static ExportersConfig empty() {
+    return new ExportersConfig(Map.of());
+  }
+
+  public ExportersConfig updateExporter(
+      final String exporterName, final ExporterState exporterState) {
+    final var newExporters =
+        ImmutableMap.<String, ExporterState>builder()
+            .putAll(exporters)
+            .put(exporterName, exporterState)
+            .buildKeepingLast(); // choose last one if there are duplicate keys
+    return new ExportersConfig(newExporters);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExportersConfig.java
@@ -10,6 +10,11 @@ package io.camunda.zeebe.dynamic.config.state;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
+/**
+ * Represents configuration or state of exporting in a partition that can be updated during runtime.
+ *
+ * @param exporters the state of each exporter in this partition
+ */
 public record ExportersConfig(Map<String, ExporterState> exporters) {
 
   public static ExportersConfig empty() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
@@ -7,13 +7,15 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
-public record PartitionState(State state, int priority) {
+import java.util.function.UnaryOperator;
+
+public record PartitionState(State state, int priority, DynamicPartitionConfig config) {
   public static PartitionState active(final int priority) {
-    return new PartitionState(State.ACTIVE, priority);
+    return new PartitionState(State.ACTIVE, priority, DynamicPartitionConfig.init());
   }
 
   public static PartitionState joining(final int priority) {
-    return new PartitionState(State.JOINING, priority);
+    return new PartitionState(State.JOINING, priority, DynamicPartitionConfig.init());
   }
 
   public PartitionState toActive() {
@@ -21,11 +23,19 @@ public record PartitionState(State state, int priority) {
       throw new IllegalStateException(
           String.format("Cannot transition to ACTIVE when current state is %s", state));
     }
-    return new PartitionState(State.ACTIVE, priority);
+    return new PartitionState(State.ACTIVE, priority, config);
   }
 
   public PartitionState toLeaving() {
-    return new PartitionState(State.LEAVING, priority);
+    return new PartitionState(State.LEAVING, priority, config);
+  }
+
+  public PartitionState updateConfig(final DynamicPartitionConfig config) {
+    return new PartitionState(state, priority, config);
+  }
+
+  public PartitionState updateConfig(final UnaryOperator<DynamicPartitionConfig> configUpdater) {
+    return new PartitionState(state, priority, configUpdater.apply(config));
   }
 
   public enum State {

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -287,6 +287,22 @@
                 "integer": 4
               }
             ]
+          },
+          {
+            "name": "EnabledDisabledState",
+            "enum_fields": [
+              {
+                "name": "ENABLED_DISBALED_UNKNOWN"
+              },
+              {
+                "name": "ENABLED",
+                "integer": 1
+              },
+              {
+                "name": "DISABLED",
+                "integer": 2
+              }
+            ]
           }
         ],
         "messages": [
@@ -372,6 +388,44 @@
                 "id": 2,
                 "name": "priority",
                 "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "config",
+                "type": "PartitionConfig"
+              }
+            ]
+          },
+          {
+            "name": "PartitionConfig",
+            "fields": [
+              {
+                "id": 1,
+                "name": "exporting",
+                "type": "ExportersConfig"
+              }
+            ]
+          },
+          {
+            "name": "ExportersConfig",
+            "maps": [
+              {
+                "key_type": "string",
+                "field": {
+                  "id": 1,
+                  "name": "exporters",
+                  "type": "ExporterState"
+                }
+              }
+            ]
+          },
+          {
+            "name": "ExporterState",
+            "fields": [
+              {
+                "id": 1,
+                "name": "state",
+                "type": "EnabledDisabledState"
               }
             ]
           },

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -26,6 +26,19 @@ message MemberState {
 message PartitionState {
   State state = 1;
   int32 priority = 2;
+  PartitionConfig config = 3;
+}
+
+message PartitionConfig {
+  ExportersConfig exporting = 1;
+}
+
+message ExportersConfig{
+  map<string, ExporterState> exporters = 1;
+}
+
+message ExporterState {
+  EnabledDisabledState state = 1;
 }
 
 message ClusterChangePlan {
@@ -104,6 +117,12 @@ enum ChangeStatus {
   COMPLETED = 2;
   FAILED = 3;
   CANCELLED = 4;
+}
+
+enum EnabledDisabledState {
+  ENABLED_DISBALED_UNKNOWN = 0;
+  ENABLED = 1;
+  DISABLED = 2;
 }
 
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/MemberStateAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/MemberStateAssert.java
@@ -23,7 +23,8 @@ public final class MemberStateAssert extends AbstractAssert<MemberStateAssert, M
     return new MemberStateAssert(actual, MemberStateAssert.class);
   }
 
-  public MemberStateAssert hasPartitionWithState(final int partitionId, final State state) {
+  public MemberStateAssert hasPartitionWithState(
+      final int partitionId, final PartitionState.State state) {
     final Map<Integer, PartitionState> partitions = actual.partitions();
     Assertions.assertThat(partitions)
         .hasEntrySatisfying(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/MemberStateAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/MemberStateAssert.java
@@ -23,16 +23,31 @@ public final class MemberStateAssert extends AbstractAssert<MemberStateAssert, M
     return new MemberStateAssert(actual, MemberStateAssert.class);
   }
 
-  public MemberStateAssert hasPartitionWithState(
-      final int partitionId, final PartitionState state) {
+  public MemberStateAssert hasPartitionWithState(final int partitionId, final State state) {
     final Map<Integer, PartitionState> partitions = actual.partitions();
-    Assertions.assertThat(partitions).containsEntry(partitionId, state);
+    Assertions.assertThat(partitions)
+        .hasEntrySatisfying(
+            partitionId,
+            partitionState -> {
+              Assertions.assertThat(partitionState.state()).isEqualTo(state);
+            });
     return this;
   }
 
   public MemberStateAssert doesNotContainPartition(final int partitionId) {
     final Map<Integer, PartitionState> partitions = actual.partitions();
     Assertions.assertThat(partitions).doesNotContainKey(partitionId);
+    return this;
+  }
+
+  public MemberStateAssert hasPartitionWithPriority(final int partitionId, final int priority) {
+    final Map<Integer, PartitionState> partitions = actual.partitions();
+    Assertions.assertThat(partitions)
+        .hasEntrySatisfying(
+            partitionId,
+            partitionState -> {
+              Assertions.assertThat(partitionState.priority()).isEqualTo(priority);
+            });
     return this;
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
@@ -155,7 +155,8 @@ final class PartitionJoinApplierTest {
     ClusterConfigurationAssert.assertThatClusterTopology(resultingTopology)
         .hasMemberWithPartitions(1, Set.of(1))
         .member(localMemberId)
-        .hasPartitionWithState(1, new PartitionState(State.JOINING, 1));
+        .hasPartitionWithState(1, State.JOINING)
+        .hasPartitionWithPriority(1, 1);
   }
 
   @Test
@@ -182,7 +183,8 @@ final class PartitionJoinApplierTest {
     ClusterConfigurationAssert.assertThatClusterTopology(resultingTopology)
         .hasMemberWithPartitions(1, Set.of(1))
         .member(localMemberId)
-        .hasPartitionWithState(1, new PartitionState(State.ACTIVE, 1));
+        .hasPartitionWithState(1, State.ACTIVE)
+        .hasPartitionWithPriority(1, 1);
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionLeaveApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionLeaveApplierTest.java
@@ -85,7 +85,7 @@ final class PartitionLeaveApplierTest {
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(resultingTopology)
         .member(localMemberId)
-        .hasPartitionWithState(1, new PartitionState(State.LEAVING, 1));
+        .hasPartitionWithState(1, State.LEAVING);
   }
 
   @Test

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -38,15 +38,18 @@ class ClusterConfigurationTest {
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
         .hasMemberWithState(1, State.ACTIVE)
         .member(1)
-        .hasPartitionWithState(1, PartitionState.active(1));
+        .hasPartitionWithState(1, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(1, 1);
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
         .hasMemberWithState(2, State.ACTIVE)
         .member(2)
-        .hasPartitionWithState(2, PartitionState.active(1));
+        .hasPartitionWithState(2, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(2, 1);
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
         .hasMemberWithState(3, State.ACTIVE)
         .member(3)
-        .hasPartitionWithState(3, PartitionState.active(1));
+        .hasPartitionWithState(3, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(3, 1);
   }
 
   @Test
@@ -93,11 +96,13 @@ class ClusterConfigurationTest {
     ClusterConfigurationAssert.assertThatClusterTopology(mergedTopologyOne)
         .hasMemberWithState(1, State.ACTIVE)
         .member(1)
-        .hasPartitionWithState(1, PartitionState.active(1));
+        .hasPartitionWithState(1, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(1, 1);
     ClusterConfigurationAssert.assertThatClusterTopology(mergedTopologyOne)
         .hasMemberWithState(2, State.ACTIVE)
         .member(2)
-        .hasPartitionWithState(2, PartitionState.active(1));
+        .hasPartitionWithState(2, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(2, 1);
 
     assertThat(mergedTopologyTwo).isEqualTo(mergedTopologyOne);
   }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/TopologyUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/TopologyUtilTest.java
@@ -52,20 +52,26 @@ class TopologyUtilTest {
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
         .hasMemberWithState(0, State.ACTIVE)
         .member(0)
-        .hasPartitionWithState(1, PartitionState.active(1))
-        .hasPartitionWithState(2, PartitionState.active(3));
+        .hasPartitionWithState(1, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(1, 1)
+        .hasPartitionWithState(2, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(2, 3);
 
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
         .hasMemberWithState(1, State.ACTIVE)
         .member(1)
-        .hasPartitionWithState(1, PartitionState.active(2))
-        .hasPartitionWithState(2, PartitionState.active(2));
+        .hasPartitionWithState(1, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(1, 2)
+        .hasPartitionWithState(2, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(2, 2);
 
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
         .hasMemberWithState(2, State.ACTIVE)
         .member(2)
-        .hasPartitionWithState(1, PartitionState.active(3))
-        .hasPartitionWithState(2, PartitionState.active(1));
+        .hasPartitionWithState(1, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(1, 3)
+        .hasPartitionWithState(2, PartitionState.State.ACTIVE)
+        .hasPartitionWithPriority(2, 1);
   }
 
   @Test


### PR DESCRIPTION
## Description

Added a `DynamicPartitionConfig` to the `PartitionState`. Any configuration or state that can be changed dynamically can be added in this. Currently configuration of exporters is added. It keeps track of the state of each exporter configured in the broker.

These are also added to the protobuf definition. It is backward compatible as adding new fields does not break compatibility. What is challenging here is on how to inititialize it first time when upgrading to the new version that introduces this. This will addressed in #18034 

## Related issues

closes #18033 
