### PR TITLE
ci: specify on release dispatch

### DIFF
--- a/.github/workflows/dispatch-release-8-6.yaml
+++ b/.github/workflows/dispatch-release-8-6.yaml
@@ -17,6 +17,7 @@ jobs:
       nextDevelopmentVersion: ${{ github.event.client_payload.nextDevelopmentVersion }}
       isLatest: ${{ github.event.client_payload.isLatest }}
       dryRun: ${{ github.event.client_payload.dryRun }}
+      releaseBranch: ${{ github.event.client_payload.releaseBranch }}
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Separating the release version and release branch and expecting as input, allows to create release candidates, as this is normally done from an release branch that has not the same name as the release version.

For example: branch = 'release-8.6.0-alpha1' and version = 'release-8.6.0-alpha1-rc1'


Related change on the process models https://github.com/zeebe-io/zeebe-engineering-processes/pull/385

