### PR TITLE
[Backport stable/8.2] fix: do not retry create instance on closed connection

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/MessagingException.java
@@ -31,7 +31,7 @@ public class MessagingException extends IOException {
 
   /** Exception indicating no remote registered remote handler. */
   public static class NoRemoteHandler extends MessagingException {
-    public NoRemoteHandler(String subject) {
+    public NoRemoteHandler(final String subject) {
       super(
           String.format(
               "No remote message handler registered for this message, subject %s", subject));
@@ -40,7 +40,7 @@ public class MessagingException extends IOException {
 
   /** Exception indicating handler failure. */
   public static class RemoteHandlerFailure extends MessagingException {
-    public RemoteHandlerFailure(String message) {
+    public RemoteHandlerFailure(final String message) {
       super(String.format("Remote handler failed to handle message, cause: %s", message));
     }
   }
@@ -51,6 +51,13 @@ public class MessagingException extends IOException {
   public static class ProtocolException extends MessagingException {
     public ProtocolException() {
       super("Failed to process message due to invalid message structure");
+    }
+  }
+
+  /** Exception indicating a connection was closed unexpectedly. */
+  public static class ConnectionClosed extends MessagingException {
+    public ConnectionClosed(final String message) {
+      super(message);
     }
   }
 }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/AbstractClientConnection.java
@@ -19,7 +19,6 @@ package io.atomix.cluster.messaging.impl;
 import com.google.common.collect.Maps;
 import io.atomix.cluster.messaging.MessagingException;
 import io.camunda.zeebe.util.StringUtil;
-import java.net.ConnectException;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -73,7 +72,8 @@ abstract class AbstractClientConnection implements ClientConnection {
     if (closed.compareAndSet(false, true)) {
       for (final CompletableFuture<byte[]> responseFuture : responseFutures.values()) {
         responseFuture.completeExceptionally(
-            new ConnectException(String.format("Connection %s was closed", this)));
+            new MessagingException.ConnectionClosed(
+                String.format("Connection %s was closed", this)));
       }
     }
   }

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -749,7 +749,7 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .addListener(
             onClose ->
                 future.completeExceptionally(
-                    new ConnectException(
+                    new MessagingException.ConnectionClosed(
                         String.format(
                             "Channel %s for address %s was closed unexpectedly before the request was handled",
                             channel, address))));

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/NettyMessagingServiceTlsTest.java
@@ -18,10 +18,10 @@ package io.atomix.cluster.messaging.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.atomix.cluster.messaging.MessagingConfig;
+import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.netty.handler.ssl.util.SelfSignedCertificate;
-import java.net.ConnectException;
 import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
@@ -74,7 +74,7 @@ final class NettyMessagingServiceTlsTest {
         .failsWithin(Duration.ofSeconds(10))
         .withThrowableOfType(ExecutionException.class)
         .havingRootCause()
-        .isInstanceOf(ConnectException.class);
+        .isInstanceOf(MessagingException.ConnectionClosed.class);
   }
 
   @Test
@@ -100,7 +100,7 @@ final class NettyMessagingServiceTlsTest {
         .failsWithin(Duration.ofSeconds(2))
         .withThrowableOfType(ExecutionException.class)
         .havingRootCause()
-        .isInstanceOf(ConnectException.class);
+        .isInstanceOf(MessagingException.ConnectionClosed.class);
   }
 
   private NettyMessagingService createInsecureMessagingService() {

--- a/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/RemoteClientConnectionTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/cluster/messaging/impl/RemoteClientConnectionTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.atomix.cluster.messaging.MessagingException;
 import io.atomix.utils.net.Address;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.netty.channel.Channel;
@@ -19,6 +20,8 @@ import io.netty.channel.ChannelFuture;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -120,6 +123,25 @@ public class RemoteClientConnectionTest {
     assertThat(simpleMetrics.messageCount.size()).isZero();
   }
 
+  @Test
+  public void shouldReceiveConnectionClosedExceptionForResponseOnClientClose() {
+    // given
+    final var responseFuture =
+        remoteClientConnection.sendAndReceive(
+            new ProtocolRequest(1, new Address("", 12345), "subj", "payload".getBytes()));
+
+    // when
+    remoteClientConnection.close();
+
+    // then
+    assertThat(responseFuture)
+        .failsWithin(100, TimeUnit.MILLISECONDS)
+        .withThrowableOfType(ExecutionException.class)
+        .withCauseInstanceOf(MessagingException.ConnectionClosed.class)
+        .withMessageContaining("Connection")
+        .withMessageContaining("was closed");
+  }
+
   private static final class SimpleMessagingMetrics implements MessagingMetrics {
 
     private static final String LABEL_FORMAT = "%s-%s";
@@ -148,10 +170,6 @@ public class RemoteClientConnectionTest {
       final String key = computeKey(to, name);
       final Integer integer = messageCount.computeIfAbsent(key, s -> 0);
       messageCount.put(key, integer + 1);
-    }
-
-    String computeKey(final String to, final String name) {
-      return String.format(LABEL_FORMAT, to, name);
     }
 
     @Override
@@ -185,6 +203,10 @@ public class RemoteClientConnectionTest {
       final String key = computeKey(address, topic);
       final Integer integer = inFlightRequestCount.computeIfAbsent(key, k -> 0);
       inFlightRequestCount.put(key, integer - 1);
+    }
+
+    String computeKey(final String to, final String name) {
+      return String.format(LABEL_FORMAT, to, name);
     }
   }
 }


### PR DESCRIPTION
# Description
Manual backport of #18264 to `stable/8.2`.

There were conflicts in [MessagingException.java](https://github.com/camunda/zeebe/pull/18286/files#diff-cfd7f2bc0198b1461470a353efa3fbebce2cec3c7ca71c96513eefc316b61245) which contains one subtype less than on all newer branches.

relates to #17333
original author: @megglos