### PR TITLE
test: update test to use correct management ports

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsMockedZeebeImportIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/metric/ImporterMetricsMockedZeebeImportIT.java
@@ -13,6 +13,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.operate.metric.ImporterMetricsZeebeImportIT.ManagementPropertyRemoval;
 import io.camunda.operate.util.MetricAssert;
 import io.camunda.operate.util.OperateZeebeAbstractIT;
 import io.camunda.operate.util.TestImportListener;
@@ -28,7 +29,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.ContextConfiguration;
 
+@ContextConfiguration(initializers = ManagementPropertyRemoval.class)
 public class ImporterMetricsMockedZeebeImportIT extends OperateZeebeAbstractIT {
 
   @Autowired private ZeebeImporter zeebeImporter;


### PR DESCRIPTION
## Description

Fix the operate nightly run of importer tests, broken example: https://github.com/camunda/zeebe/actions/runs/8964266108

This updates the failing test to not use the reconfigured management ports

## Related issues

closes #
