### PR TITLE
refactor: track in-flight entries for flow control

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderRole.java
@@ -737,6 +737,8 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
   private void replicate(final IndexedRaftLogEntry indexed, final AppendListener appendListener) {
     raft.checkThread();
     final var appendEntriesFuture = appender.appendEntries(indexed.index());
+    final var committedPosition =
+        indexed.isApplicationEntry() ? indexed.getApplicationEntry().highestPosition() : -1;
 
     if (indexed.isApplicationEntry()) {
       // We have some services which are waiting for the application records, especially position
@@ -744,7 +746,6 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
       // passing the complete object (IndexedRaftLogEntry) threw the listeners and
       // keep them in heap until they are committed. This had the risk of going out of OOM
       // if records can't be committed, see https://github.com/camunda/zeebe/issues/14275
-      final var committedPosition = indexed.getApplicationEntry().highestPosition();
       appendEntriesFuture.whenCompleteAsync(
           (commitIndex, commitError) -> {
             if (isRunning() && commitError == null) {
@@ -764,7 +765,7 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
           // up to date with the latest entries, so it can handle configuration and initial
           // entries properly on fail over
           if (commitError == null) {
-            appendListener.onCommit(commitIndex);
+            appendListener.onCommit(commitIndex, committedPosition);
           } else {
             appendListener.onCommitError(commitIndex, commitError);
             // replicating the entry will be retried on the next append request

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/zeebe/ZeebeLogAppender.java
@@ -25,7 +25,7 @@ import java.nio.ByteBuffer;
 /**
  * A log appender provides a central entry point to append to the local Raft log such that it is
  * automatically replicated and eventually committed, and the ability for callers to be notified of
- * various events, e.g. {@link AppendListener#onCommit(long)}.
+ * various events, e.g. {@link AppendListener#onCommit(long, long)}.
  */
 @FunctionalInterface
 public interface ZeebeLogAppender {
@@ -89,7 +89,7 @@ public interface ZeebeLogAppender {
      *
      * @param index the index of the entry that was committed
      */
-    default void onCommit(final long index) {}
+    default void onCommit(final long index, final long highestPosition) {}
 
     /**
      * Called when an error occurred while replicating or committing an entry, typically when if an

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -674,7 +674,7 @@ public final class ControllableRaftContexts {
     }
 
     @Override
-    public void onCommit(final long index) {
+    public void onCommit(final long index, final long highestPosition) {
       if (committedIndexToChecksumMap.containsKey(index)
           && pendingWriteToBeCommitted.containsKey(index)
           && !pendingWriteToBeCommitted.get(index).equals(committedIndexToChecksumMap.get(index))) {
@@ -688,7 +688,7 @@ public final class ControllableRaftContexts {
         dataloss = true;
       }
       committedIndexToChecksumMap.put(index, pendingWriteToBeCommitted.remove(index));
-      delegate.onCommit(index);
+      delegate.onCommit(index, highestPosition);
     }
 
     @Override

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -672,7 +672,7 @@ public final class RaftRule extends ExternalResource {
     }
 
     @Override
-    public void onCommit(final long index) {
+    public void onCommit(final long index, final long highestPosition) {
       commitFuture.complete(index);
     }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -596,7 +596,7 @@ public class RaftTest extends ConcurrentTestCase {
     }
 
     @Override
-    public void onCommit(final long index) {
+    public void onCommit(final long index, final long highestPosition) {
       commitFuture.complete(index);
     }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ReconfigurationTest.java
@@ -187,7 +187,7 @@ final class ReconfigurationTest {
     }
 
     @Override
-    public void onCommit(final long index) {
+    public void onCommit(final long index, final long highestPosition) {
       commit.complete(index);
     }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/TestAppender.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/zeebe/util/TestAppender.java
@@ -46,7 +46,7 @@ public class TestAppender implements AppendListener {
   }
 
   @Override
-  public void onCommit(final long index) {
+  public void onCommit(final long index, final long highestPosition) {
     committed.offer(index);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixAppendListenerAdapter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/logstreams/AtomixAppendListenerAdapter.java
@@ -20,11 +20,13 @@ public final class AtomixAppendListenerAdapter implements AppendListener {
 
   @Override
   public void onWrite(final IndexedRaftLogEntry indexed) {
-    delegate.onWrite(indexed.index());
+    delegate.onWrite(
+        indexed.index(),
+        indexed.isApplicationEntry() ? indexed.getApplicationEntry().highestPosition() : -1);
   }
 
   @Override
-  public void onCommit(final long index) {
-    delegate.onCommit(index);
+  public void onCommit(final long index, final long highestPosition) {
+    delegate.onCommit(index, highestPosition);
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -146,7 +146,7 @@ final class CommandApiRequestHandler
 
     if (logStreamWriter.canWriteEvents(1, appendEntry.getLength())) {
       return logStreamWriter
-          .tryWrite(WriteContext.userCommand(), appendEntry)
+          .tryWrite(WriteContext.userCommand(metadata.getIntent()), appendEntry)
           .map(ignore -> true)
           .mapLeft(error -> errorWriter.mapWriteError(partitionId, error));
     } else {

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/logstreams/AtomixLogStorageReaderTest.java
@@ -175,7 +175,7 @@ final class AtomixLogStorageReaderTest {
       final var indexed = log.append(new RaftLogEntry(1, entry));
       appendListener.onWrite(indexed);
       log.setCommitIndex(indexed.index());
-      appendListener.onCommit(indexed.index());
+      appendListener.onCommit(indexed.index(), entry.highestPosition());
     }
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -71,7 +71,7 @@ public final class FlowControl implements AppendListener {
 
   @Override
   public void onCommit(final long index, final long highestPosition) {
-    inFlightEntries.get(highestPosition).onCommit();
+    inFlightEntries.remove(highestPosition).onCommit();
   }
 
   public sealed interface Rejection {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -38,10 +38,10 @@ public final class FlowControl {
   /**
    * Tries to acquire a free in-flight spot, applying backpressure as needed.
    *
-   * @return An Optional containing a {@link InFlightAppend} if append was accepted, an empty
+   * @return An Optional containing a {@link InFlightEntry} if append was accepted, an empty
    *     Optional otherwise.
    */
-  public Either<Rejection, InFlightAppend> tryAcquire(final WriteContext context) {
+  public Either<Rejection, InFlightEntry> tryAcquire(final WriteContext context) {
     final var appendListener = appendLimiter.acquire(null).orElse(null);
     if (appendListener == null) {
       metrics.increaseDeferredAppends();
@@ -49,7 +49,7 @@ public final class FlowControl {
       return Either.left(new AppendLimitExhausted());
     }
 
-    return Either.right(new InFlightAppend(appendListener, metrics));
+    return Either.right(new InFlightEntry(appendListener, metrics));
   }
 
   public sealed interface Rejection {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -14,16 +14,20 @@ import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection.AppendLimitExhausted;
 import io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata;
 import io.camunda.zeebe.logstreams.log.WriteContext;
+import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
+import java.util.concurrent.ConcurrentSkipListMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public final class FlowControl {
+public final class FlowControl implements AppendListener {
   private static final Logger LOG = LoggerFactory.getLogger(FlowControl.class);
 
   private final Limiter<Void> appendLimiter;
   private final LogStreamMetrics metrics;
+  private final ConcurrentSkipListMap<Long, InFlightEntry> inFlightEntries =
+      new ConcurrentSkipListMap<>();
 
   public FlowControl(final LogStreamMetrics metrics) {
     this(metrics, VegasLimit.newDefault());
@@ -53,6 +57,21 @@ public final class FlowControl {
     }
 
     return Either.right(new InFlightEntry(batchMetadata, appendListener, metrics));
+  }
+
+  public void onAppend(final InFlightEntry inFlightEntry, final long highestPosition) {
+    inFlightEntries.put(highestPosition, inFlightEntry);
+    inFlightEntry.onAppend(highestPosition);
+  }
+
+  @Override
+  public void onWrite(final long index, final long highestPosition) {
+    inFlightEntries.get(highestPosition).onWrite();
+  }
+
+  @Override
+  public void onCommit(final long index, final long highestPosition) {
+    inFlightEntries.get(highestPosition).onCommit();
   }
 
   public sealed interface Rejection {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -13,10 +13,12 @@ import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
 import io.prometheus.client.Histogram;
 
 /**
- * Represents an in-flight append. Updates metrics and backpressure limits after being {@link
- * InFlightAppend#start(long) started} and handles callbacks from the log storage.
+ * Represents an in-flight entry and its lifecycle from being written, committed, processed and
+ * finally exported. Updates metrics and backpressure limits after being {@link
+ * InFlightEntry#start(long) started} and handles callbacks from the log storage and other
+ * components involved.
  */
-public final class InFlightAppend implements AppendListener {
+public final class InFlightEntry implements AppendListener {
 
   private final Limiter.Listener limiter;
   private final LogStreamMetrics metrics;
@@ -24,7 +26,7 @@ public final class InFlightAppend implements AppendListener {
   private Histogram.Timer commitTimer;
   private long position;
 
-  public InFlightAppend(final Limiter.Listener limiter, final LogStreamMetrics metrics) {
+  public InFlightEntry(final Limiter.Listener limiter, final LogStreamMetrics metrics) {
     this.limiter = limiter;
     this.metrics = metrics;
   }
@@ -45,7 +47,7 @@ public final class InFlightAppend implements AppendListener {
     limiter.onSuccess();
   }
 
-  public InFlightAppend start(final long position) {
+  public InFlightEntry start(final long position) {
     this.position = position;
     writeTimer = metrics.startWriteTimer();
     commitTimer = metrics.startCommitTimer();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -39,7 +39,7 @@ public final class InFlightEntry implements AppendListener {
   }
 
   @Override
-  public void onWrite(final long index) {
+  public void onWrite(final long index, final long highestPosition) {
     writeTimer.close();
     entryMetadata.forEach(
         metadata ->
@@ -49,7 +49,7 @@ public final class InFlightEntry implements AppendListener {
   }
 
   @Override
-  public void onCommit(final long index) {
+  public void onCommit(final long index, final long highestPosition) {
     metrics.decreaseInflight();
     metrics.setLastCommittedPosition(position);
     if (commitTimer != null) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -39,7 +39,7 @@ public final class InFlightEntry implements AppendListener {
   }
 
   @Override
-  public void onWrite(final long address) {
+  public void onWrite(final long index) {
     writeTimer.close();
     entryMetadata.forEach(
         metadata ->
@@ -49,7 +49,7 @@ public final class InFlightEntry implements AppendListener {
   }
 
   @Override
-  public void onCommit(final long address) {
+  public void onCommit(final long index) {
     metrics.decreaseInflight();
     metrics.setLastCommittedPosition(position);
     if (commitTimer != null) {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadata.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogAppendEntryMetadata.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.log;
+
+import io.camunda.zeebe.logstreams.log.LogAppendEntry;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import java.util.ArrayList;
+import java.util.List;
+
+public record LogAppendEntryMetadata(RecordType recordType, ValueType valueType, Intent intent) {
+  LogAppendEntryMetadata(final LogAppendEntry entry) {
+    this(
+        entry.recordMetadata().getRecordType(),
+        entry.recordMetadata().getValueType(),
+        entry.recordMetadata().getIntent());
+  }
+
+  public static List<LogAppendEntryMetadata> copyMetadata(final List<LogAppendEntry> entries) {
+    final var metricsMetadata = new ArrayList<LogAppendEntryMetadata>(entries.size());
+    for (final LogAppendEntry entry : entries) {
+      metricsMetadata.add(new LogAppendEntryMetadata(entry));
+    }
+
+    return metricsMetadata;
+  }
+}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -212,7 +212,6 @@ public final class LogStreamImpl extends Actor
         getWriteBuffersInitialPosition(),
         maxFragmentSize,
         new SequencerMetrics(partitionId),
-        logStreamMetrics,
         new FlowControl(logStreamMetrics, appendLimit));
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -7,24 +7,19 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
+import static io.camunda.zeebe.logstreams.impl.log.LogAppendEntryMetadata.copyMetadata;
 import static io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor.FRAME_ALIGNMENT;
 import static io.camunda.zeebe.logstreams.impl.serializer.SequencedBatchSerializer.calculateBatchLength;
 import static io.camunda.zeebe.scheduler.clock.ActorClock.currentTimeMillis;
 
-import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
 import io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
-import io.camunda.zeebe.logstreams.storage.LogStorage.AppendListener;
-import io.camunda.zeebe.protocol.record.RecordType;
-import io.camunda.zeebe.protocol.record.ValueType;
-import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.util.Either;
 import java.io.Closeable;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
@@ -45,7 +40,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
   private final ReentrantLock lock = new ReentrantLock();
   private final LogStorage logStorage;
   private final SequencerMetrics sequencerMetrics;
-  private final LogStreamMetrics logStreamMetrics;
   private final FlowControl flowControl;
 
   Sequencer(
@@ -53,7 +47,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
       final long initialPosition,
       final int maxFragmentSize,
       final SequencerMetrics sequencerMetrics,
-      final LogStreamMetrics logStreamMetrics,
       final FlowControl flowControl) {
     this.logStorage = logStorage;
     LOG.trace("Starting new sequencer at position {}", initialPosition);
@@ -61,8 +54,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
     this.maxFragmentSize = maxFragmentSize;
     this.sequencerMetrics =
         Objects.requireNonNull(sequencerMetrics, "must specify sequencer metrics");
-    this.logStreamMetrics =
-        Objects.requireNonNull(logStreamMetrics, "must specify appender metrics");
     this.flowControl = flowControl;
   }
 
@@ -95,7 +86,7 @@ final class Sequencer implements LogStreamWriter, Closeable {
         return Either.left(WriteFailure.INVALID_ARGUMENT);
       }
     }
-    final var permit = flowControl.tryAcquire(context);
+    final var permit = flowControl.tryAcquire(context, copyMetadata(appendEntries));
     if (permit.isLeft()) {
       return Either.left(WriteFailure.FULL);
     }
@@ -104,11 +95,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
     final int batchSize = appendEntries.size();
     final int batchLength = calculateBatchLength(appendEntries);
 
-    // extract only the required metadata for metrics from the batch to avoid capturing the whole
-    // batch and holding onto its memory longer than necessary.
-    final var metadata = copyMetricsMetadata(appendEntries);
-    final var appendListener =
-        new InstrumentedAppendListener(inflightAppend, metadata, logStreamMetrics);
     lock.lock();
     try {
       final var currentPosition = position;
@@ -117,7 +103,7 @@ final class Sequencer implements LogStreamWriter, Closeable {
           new SequencedBatch(
               currentTimeMillis(), currentPosition, sourcePosition, appendEntries, batchLength);
       inflightAppend.start(highestPosition);
-      logStorage.append(currentPosition, highestPosition, sequencedBatch, appendListener);
+      logStorage.append(currentPosition, highestPosition, sequencedBatch, inflightAppend);
       position = currentPosition + batchSize;
       return Either.right(highestPosition);
     } finally {
@@ -142,45 +128,5 @@ final class Sequencer implements LogStreamWriter, Closeable {
         && entry.recordValue().getLength() > 0
         && entry.recordMetadata() != null
         && entry.recordMetadata().getLength() > 0;
-  }
-
-  private static List<LogAppendEntryMetadata> copyMetricsMetadata(
-      final List<LogAppendEntry> entries) {
-    final var metricsMetadata = new ArrayList<LogAppendEntryMetadata>(entries.size());
-    for (final LogAppendEntry entry : entries) {
-      metricsMetadata.add(new LogAppendEntryMetadata(entry));
-    }
-
-    return metricsMetadata;
-  }
-
-  private record InstrumentedAppendListener(
-      AppendListener delegate, List<LogAppendEntryMetadata> batchMetadata, LogStreamMetrics metrics)
-      implements AppendListener {
-
-    @Override
-    public void onWrite(final long address) {
-      delegate.onWrite(address);
-      batchMetadata.forEach(this::recordAppendedEntry);
-    }
-
-    @Override
-    public void onCommit(final long address) {
-      delegate.onCommit(address);
-    }
-
-    private void recordAppendedEntry(final LogAppendEntryMetadata metadata) {
-      metrics.recordAppendedEntry(
-          1, metadata.recordType(), metadata.valueType(), metadata.intent());
-    }
-  }
-
-  private record LogAppendEntryMetadata(RecordType recordType, ValueType valueType, Intent intent) {
-    private LogAppendEntryMetadata(final LogAppendEntry entry) {
-      this(
-          entry.recordMetadata().getRecordType(),
-          entry.recordMetadata().getValueType(),
-          entry.recordMetadata().getIntent());
-    }
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/WriteContext.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/WriteContext.java
@@ -7,9 +7,11 @@
  */
 package io.camunda.zeebe.logstreams.log;
 
+import io.camunda.zeebe.protocol.record.intent.Intent;
+
 public sealed interface WriteContext {
-  static WriteContext userCommand() {
-    return UserCommand.INSTANCE;
+  static WriteContext userCommand(final Intent intent) {
+    return new UserCommand(intent);
   }
 
   static WriteContext processingResult() {
@@ -28,9 +30,7 @@ public sealed interface WriteContext {
     return Internal.INSTANCE;
   }
 
-  final class UserCommand implements WriteContext {
-    private static final UserCommand INSTANCE = new UserCommand();
-  }
+  record UserCommand(Intent intent) implements WriteContext {}
 
   final class ProcessingResult implements WriteContext {
     private static final ProcessingResult INSTANCE = new ProcessingResult();

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -103,14 +103,14 @@ public interface LogStorage {
      *
      * @param index the index of the written entry
      */
-    default void onWrite(final long index) {}
+    default void onWrite(final long index, final long highestPosition) {}
 
     /**
      * Called when the entry has been successfully committed.
      *
      * @param index the index of the committed entry
      */
-    default void onCommit(final long index) {}
+    default void onCommit(final long index, final long highestPosition) {}
   }
 
   /**

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/storage/LogStorage.java
@@ -101,16 +101,16 @@ public interface LogStorage {
     /**
      * Called when the entry has been successfully written to the local storage.
      *
-     * @param address the address of the written entry
+     * @param index the index of the written entry
      */
-    default void onWrite(final long address) {}
+    default void onWrite(final long index) {}
 
     /**
      * Called when the entry has been successfully committed.
      *
-     * @param address the address of the committed entry
+     * @param index the index of the committed entry
      */
-    default void onCommit(final long address) {}
+    default void onCommit(final long index) {}
   }
 
   /**

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -49,7 +49,7 @@ final class FlowControlTest {
         inFlight.push(result.get());
       }
     } while (!rejecting);
-    inFlight.forEach(append -> append.onCommit(1));
+    inFlight.forEach(append -> append.onCommit(1, -1));
 
     // then
     Awaitility.await("Eventually accepts appends again")

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -39,7 +39,7 @@ final class FlowControlTest {
     final var flow = new FlowControl(logStreamMetrics);
     // when
     boolean rejecting = false;
-    final var inFlight = new LinkedList<InFlightAppend>();
+    final var inFlight = new LinkedList<InFlightEntry>();
     do {
       final var result = flow.tryAcquire(WriteContext.internal());
       if (result.isLeft()) {

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.log.WriteContext;
 import java.time.Duration;
 import java.util.LinkedList;
+import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
@@ -29,7 +30,7 @@ final class FlowControlTest {
     Awaitility.await("Rejects new appends")
         .pollInSameThread()
         .pollInterval(Duration.ZERO)
-        .until(() -> flow.tryAcquire(WriteContext.internal()).isLeft());
+        .until(() -> flow.tryAcquire(WriteContext.internal(), List.of()).isLeft());
   }
 
   @Test
@@ -41,7 +42,7 @@ final class FlowControlTest {
     boolean rejecting = false;
     final var inFlight = new LinkedList<InFlightEntry>();
     do {
-      final var result = flow.tryAcquire(WriteContext.internal());
+      final var result = flow.tryAcquire(WriteContext.internal(), List.of());
       if (result.isLeft()) {
         rejecting = true;
       } else {
@@ -52,6 +53,6 @@ final class FlowControlTest {
 
     // then
     Awaitility.await("Eventually accepts appends again")
-        .until(() -> flow.tryAcquire(WriteContext.internal()).isRight());
+        .until(() -> flow.tryAcquire(WriteContext.internal(), List.of()).isRight());
   }
 }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControlTest.java
@@ -49,7 +49,7 @@ final class FlowControlTest {
         inFlight.push(result.get());
       }
     } while (!rejecting);
-    inFlight.forEach(append -> append.onCommit(1, -1));
+    inFlight.forEach(InFlightEntry::onCommit);
 
     // then
     Awaitility.await("Eventually accepts appends again")

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -63,7 +63,6 @@ final class LogStorageAppenderTest {
             INITIAL_POSITION,
             4 * 1024 * 1024,
             new SequencerMetrics(PARTITION_ID),
-            logStreamMetrics,
             new FlowControl(logStreamMetrics));
     reader = new LogStreamReaderImpl(logStorage.newReader());
   }

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -45,7 +45,6 @@ final class SequencerTest {
             initialPosition,
             16,
             new SequencerMetrics(1),
-            logStreamMetrics,
             new FlowControl(logStreamMetrics));
 
     // when
@@ -67,7 +66,6 @@ final class SequencerTest {
             initialPosition,
             16,
             new SequencerMetrics(1),
-            logStreamMetrics,
             new FlowControl(logStreamMetrics));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
@@ -88,12 +86,7 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage,
-            1,
-            16,
-            new SequencerMetrics(1),
-            logStreamMetrics,
-            new FlowControl(logStreamMetrics));
+            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
     final var entry = TestEntry.ofDefaults();
 
     // when
@@ -110,12 +103,7 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage,
-            1,
-            16,
-            new SequencerMetrics(1),
-            logStreamMetrics,
-            new FlowControl(logStreamMetrics));
+            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
 
@@ -133,12 +121,7 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage,
-            1,
-            16,
-            new SequencerMetrics(1),
-            logStreamMetrics,
-            new FlowControl(logStreamMetrics));
+            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
     final var entry = TestEntry.ofDefaults();
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();
 
@@ -160,12 +143,7 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage,
-            1,
-            16,
-            new SequencerMetrics(1),
-            logStreamMetrics,
-            new FlowControl(logStreamMetrics));
+            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
     final var entry = TestEntry.ofDefaults();
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();
 
@@ -192,12 +170,7 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage,
-            1,
-            16,
-            new SequencerMetrics(1),
-            logStreamMetrics,
-            new FlowControl(logStreamMetrics));
+            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();
@@ -219,12 +192,7 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage,
-            1,
-            16,
-            new SequencerMetrics(1),
-            logStreamMetrics,
-            new FlowControl(logStreamMetrics));
+            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -265,7 +265,7 @@ final class SequencerTest {
         Assertions.assertThat(lowestPosition).isEqualTo(position + 1);
       }
       position = highestPosition;
-      listener.onCommit(position);
+      listener.onCommit(position, highestPosition);
     }
 
     @Override

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/ListLogStorage.java
@@ -72,12 +72,12 @@ public class ListLogStorage implements LogStorage {
     final var index = currentIndex.getAndIncrement();
     entries.put(index, entry);
     positionIndexMapping.put(lowestPosition, index);
-    listener.onWrite(index);
+    listener.onWrite(index, highestPosition);
 
     if (positionListener != null) {
       positionListener.accept(highestPosition);
     }
-    listener.onCommit(index);
+    listener.onCommit(index, highestPosition);
     commitListeners.forEach(CommitListener::onCommit);
   }
 


### PR DESCRIPTION
## Description

Preparation for handling user command flow control here too. Unlike flow control for appends, we can't pass around a listener and instead have to keep a map of positions to listeners. 

## Related issues

relates to https://github.com/camunda/zeebe/issues/18120
