### PR TITLE
fix: Fix scrolling on Chrome

### DIFF
--- a/tasklist/client/e2e/tests/task-panel.spec.ts
+++ b/tasklist/client/e2e/tests/task-panel.spec.ts
@@ -111,8 +111,8 @@ test.describe('task panel page', () => {
     await expect(page.getByText(/some text/)).not.toHaveCount(50);
   });
 
-  test.skip('scrolling', async ({page, taskPanelPage}) => {
-    test.setTimeout(40000);
+  test('scrolling', async ({page, taskPanelPage}) => {
+    test.slow();
 
     await expect(page.getByText('usertask_for_scrolling_1')).toHaveCount(1);
     await expect(page.getByText('usertask_for_scrolling_2')).toHaveCount(49);

--- a/tasklist/client/src/Tasks/AvailableTasks/index.tsx
+++ b/tasklist/client/src/Tasks/AvailableTasks/index.tsx
@@ -60,10 +60,11 @@ const AvailableTasks: React.FC<Props> = ({
                 const target = event.target as HTMLDivElement;
 
                 if (
-                  target.scrollHeight -
-                    target.clientHeight -
-                    target.scrollTop <=
-                  0
+                  Math.floor(
+                    target.scrollHeight -
+                      target.clientHeight -
+                      target.scrollTop,
+                  ) <= 0
                 ) {
                   await onScrollDown();
                 } else if (target.scrollTop === 0) {


### PR DESCRIPTION
## Description

Scrolling on Chrome was broken because the height difference was `0.5`, which must have come from the changes we made on the task cards
