### PR TITLE
Feat: schedule Long-Running-Migrating-Benchmark to run every monday

### DIFF
--- a/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
+++ b/.github/workflows/zeebe-update-long-running-migrating-benchmark.yaml
@@ -1,8 +1,8 @@
 name: Zeebe Long Running Migrating Benchmark
 on:
   workflow_dispatch:
-  release:
-    types: [published]
+  schedule:
+    - cron: "0 0 * * 1" # every Monday at 00:00
 
 jobs:
   fetch-release:


### PR DESCRIPTION
## Description

This PR schedules the Zeebe-Long-Running-Migrating-Benchmark to run every Monday at midnight.
 
## Related issues

closes https://github.com/camunda/zeebe/issues/17362
