### PR TITLE
fix: update modify process instance behavior to give precedence to instance key when key and id are both specified

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandler.java
@@ -166,7 +166,11 @@ public class MoveTokenHandler {
     Integer newTokensCount = modification.getNewTokensCount();
 
     if (newTokensCount == null) {
-      if (modification.getFromFlowNodeId() != null) {
+      if (modification.getFromFlowNodeInstanceKey() != null) {
+        // If a flow node instance key was specified, assume that flow node is valid. Zeebe
+        // will correctly fail attempts to migrate off an invalid flow node
+        newTokensCount = 1;
+      } else if (modification.getFromFlowNodeId() != null) {
         newTokensCount =
             flowNodeInstanceReader
                 .getFlowNodeInstanceKeysByIdAndStates(
@@ -174,10 +178,6 @@ public class MoveTokenHandler {
                     modification.getFromFlowNodeId(),
                     List.of(FlowNodeState.ACTIVE))
                 .size();
-      } else if (modification.getFromFlowNodeInstanceKey() != null) {
-        // If a flow node instance key was specified, assume that flow node is valid. Zeebe
-        // will correctly fail attempts to migrate off an invalid flow node
-        newTokensCount = 1;
       } else {
         LOGGER.warn(
             "MOVE_TOKEN attempted with no flowNodeId, flowNodeInstanceKey, or newTokenCount specified");

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandlerTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/zeebe/operation/process/modify/MoveTokenHandlerTest.java
@@ -215,4 +215,28 @@ public class MoveTokenHandlerTest {
 
     verifyNoInteractions(mockFlowNodeInstanceReader);
   }
+
+  @Test
+  public void testMoveTokenWithIdAndInstanceKeySpecified() {
+    final Modification modification =
+        new Modification()
+            .setModification(Type.MOVE_TOKEN)
+            .setFromFlowNodeId("taskA")
+            .setFromFlowNodeInstanceKey("888")
+            .setToFlowNodeId("taskB");
+
+    final ModifyProcessInstanceCommandStep1.ModifyProcessInstanceCommandStep2 result =
+        moveTokenHandler.moveToken(mockZeebeCommand, 123L, modification);
+
+    assertThat(result).isNotNull();
+
+    assertThat(Mockito.mockingDetails(mockZeebeCommand).getInvocations()).hasSize(3);
+    verify(mockZeebeCommand, times(1)).activateElement("taskB");
+    verify(mockZeebeCommand, times(1)).terminateElement(888L);
+    verify((ModifyProcessInstanceCommandStep2) mockZeebeCommand, times(1)).and();
+
+    // Since an instance key was specified, reader should not be called during token count or
+    // cancelling existing tokens
+    verifyNoInteractions(mockFlowNodeInstanceReader);
+  }
 }


### PR DESCRIPTION
## Description

Fixes the logic in countNewTokens so that when both the flow node id and instance key are specified, the instance key is given precedence (we only modify one flow node instead of reading all the ones to modify)

## Related issues

closes #18162
