### PR TITLE
Migrate active call activity

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.processinstance;
 
-import static io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditionChecker.*;
+import static io.camunda.zeebe.engine.processing.processinstance.ProcessInstanceMigrationPreconditions.*;
 import static io.camunda.zeebe.engine.state.immutable.IncidentState.MISSING_INCIDENT;
 
 import io.camunda.zeebe.engine.Loggers;
@@ -373,7 +373,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     final boolean existSubscriptionForMessageName =
         processMessageSubscriptionState.existSubscriptionForElementInstance(
             elementInstance.getKey(), messageName, tenantId);
-    ProcessInstanceMigrationPreconditionChecker.requireNoSubscriptionForMessage(
+    ProcessInstanceMigrationPreconditions.requireNoSubscriptionForMessage(
         existSubscriptionForMessageName, elementInstance, messageName, targetCatchEventId);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -38,7 +38,8 @@ public final class ProcessInstanceMigrationPreconditions {
           BpmnElementType.PROCESS,
           BpmnElementType.SERVICE_TASK,
           BpmnElementType.USER_TASK,
-          BpmnElementType.SUB_PROCESS);
+          BpmnElementType.SUB_PROCESS,
+          BpmnElementType.CALL_ACTIVITY);
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -31,7 +31,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.agrona.DirectBuffer;
 
-public final class ProcessInstanceMigrationPreconditionChecker {
+public final class ProcessInstanceMigrationPreconditions {
 
   private static final EnumSet<BpmnElementType> SUPPORTED_ELEMENT_TYPES =
       EnumSet.of(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
@@ -99,7 +99,7 @@ public class MigrateCallActivityTest {
   }
 
   @Test
-  public void shouldContinueFlowAfterMigratingParentProcessInstance() {
+  public void shouldAllowToContinueFlowAfterMigratingParentProcessInstance() {
     // given
     final String processId = helper.getBpmnProcessId() + "_source";
     final String childProcessId = helper.getBpmnProcessId() + "_child";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
@@ -94,4 +94,78 @@ public class MigrateCallActivityTest {
         .describedAs("Expect that version number did not change")
         .hasVersion(1);
   }
+
+  @Test
+  public void shouldContinueFlowAfterMigratingParentProcessInstance() {
+    // given
+    final String processId = helper.getBpmnProcessId() + "_source";
+    final String childProcessId = helper.getBpmnProcessId() + "_child";
+    final String targetProcessId = helper.getBpmnProcessId() + "_target";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("start")
+                    .callActivity("A", c -> c.zeebeProcessId(childProcessId))
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("start")
+                    .callActivity("B", c -> c.zeebeProcessId(childProcessId))
+                    .userTask("C")
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(childProcessId)
+                    .startEvent("start")
+                    .userTask("task", AbstractUserTaskBuilder::zeebeUserTask)
+                    .endEvent("end")
+                    .done())
+            .deploy();
+    final long parentProcessInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var childUserTask =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withParentProcessInstanceKey(parentProcessInstanceKey)
+            .withElementType(BpmnElementType.USER_TASK)
+            .withElementId("task")
+            .getFirst();
+    final var childProcessInstanceKey = childUserTask.getValue().getProcessInstanceKey();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(parentProcessInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    ENGINE.userTask().ofInstance(childProcessInstanceKey).complete();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_COMPLETED)
+                .withProcessInstanceKey(childProcessInstanceKey)
+                .withElementType(BpmnElementType.PROCESS)
+                .getFirst())
+        .describedAs("Expect that the child process instance completed")
+        .isNotNull();
+
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(parentProcessInstanceKey)
+                .withElementType(BpmnElementType.USER_TASK)
+                .withElementId("C")
+                .getFirst())
+        .describedAs(
+            "Expect that the parent process instance continues in the target process after migrating")
+        .isNotNull();
+  }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateCallActivityTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractUserTaskBuilder;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateCallActivityTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateCallActivity() {
+    // given
+    final String processId = helper.getBpmnProcessId() + "_source";
+    final String childProcessId = helper.getBpmnProcessId() + "_child";
+    final String targetProcessId = helper.getBpmnProcessId() + "_target";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("start")
+                    .callActivity("A", c -> c.zeebeProcessId(childProcessId))
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("start")
+                    .callActivity("B", c -> c.zeebeProcessId(childProcessId))
+                    .userTask("C")
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(childProcessId)
+                    .startEvent("start")
+                    .userTask("task")
+                    .endEvent("end")
+                    .done())
+            .deploy();
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementId("A")
+        .withElementType(BpmnElementType.CALL_ACTIVITY)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.CALL_ACTIVITY)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that process definition key is changed")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that bpmn process id and element id changed")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("B")
+        .describedAs("Expect that version number did not change")
+        .hasVersion(1);
+  }
+}


### PR DESCRIPTION
## Description

This allows the migration of a process instance with an active call activity. Like migrating other active elements, this requires mapping instructions for the active call activity elements.

Migration of the child process instance is out of scope.

The migration of the call activity instance is achieved in the same way as any other element instance using the `PROCESS_INSTANCE:ELEMENT_MIGRATED` event.

Tests are added to ensure the functioning of the call activity instance after migration. We don't have to adjust the child process instance's properties on migrating the parent instance / call activity (see https://github.com/camunda/zeebe/issues/15921#issuecomment-2098524784 for details).

## Related issues

closes #15921
