### PR TITLE
[Backport release-8.6.0-alpha1] fix: disable spring.mvc.problemdetails.enabled for Tasklist

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/Application.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/Application.java
@@ -69,6 +69,9 @@ public class Application {
     // Must be removed with the single application.
     System.setProperty("spring.web.resources.add-mappings", "true");
     System.setProperty("spring.banner.location", "classpath:/tasklist-banner.txt");
+    // We need to disable this property in Tasklist (enabled in dist/application.properties),
+    // otherwise ForwardErrorController does not get invoked
+    System.setProperty("spring.mvc.problemdetails.enabled", "false");
     final SpringApplication springApplication = new SpringApplication(Application.class);
     // add "tasklist" profile, so that application-tasklist.yml gets loaded. This is a way to not
     // load other components' 'application-{component}.yml'


### PR DESCRIPTION
# Description
Backport of #18326 to `release-8.6.0-alpha1`.

relates to 
original author: @houssain-barouni