### PR TITLE
Generate changelog for patch releases

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -292,7 +292,7 @@ jobs:
             --label="version:$ZCL_TARGET_REV" \
             --org camunda --repo zeebe
 
-            # This command will print markdown code to the console. You will need to manually insert this output into the release draft.
+            # The following command will print the markdown code to sysout - we are storing this into our variable "changelog"
             changelog=$(./zcl generate \
             --token=${{ secrets.GITHUB_TOKEN }} \
             --label="version:$ZCL_TARGET_REV" \

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -299,7 +299,16 @@ jobs:
             --org camunda --repo zeebe)
           fi
 
-          echo "changelog=$changelog" >> $GITHUB_OUTPUT
+          # With multiline strings the output needs to be set differently.
+          #
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+          #
+          echo 'CHANGELOG<<EOF' >> $GITHUB_OUTPUT
+          echo $changelog >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
+
+          # To show the changelog also as step summary
+          echo "$changelog" >> $GITHUB_STEP_SUMMARY
       - name: Create Github release
         uses: ncipollo/release-action@v1
         if: ${{ inputs.dryRun == false }}

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -265,7 +265,8 @@ jobs:
 
           # Default changelog value
           changelog="Release ${{ inputs.releaseVersion }}"
-          # Right now we only support patch release for generating the change log
+
+          # Right now we only support patch releases for generating the changelog
           # as it is the easiest to automate and the most repetitive work to do on a release
           if [[ "$version" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
           then

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -276,9 +276,10 @@ jobs:
             # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type:
             #
             # PATCH: the tag for the previous patch version on the same minor branch. e.g. if you're releasing 1.2.3, then ZCL_FROM_REV=1.2.2.
-            # To find the previous patch version we extract the patch version and subsctract by one
-            patchVersion=$(echo ${{ inputs.releaseVersion }} | sed 's/8\.[1-9][0-9]\*\.//')
-            majorMinor=$(echo ${{ inputs.releaseVersion }} | sed 's/\.[1-9][0-9]\*$//')
+
+            # To find the previous patch version we extract the patch version and subtract by one
+            patchVersion=$(echo ${{ inputs.releaseVersion }} | sed 's/8\.[1-9][0-9]*\.//')
+            majorMinor=$(echo ${{ inputs.releaseVersion }} | sed 's/\.[1-9][0-9]*$//')
             ZCL_FROM_REV="$majorMinor".$(( patchVersion - 1 ))
             ZCL_TARGET_REV="${{ inputs.releaseVersion }}"
 

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -32,7 +32,7 @@ defaults:
 env:
   RELEASE_BRANCH: ${{ inputs.releaseBranch != '' && inputs.releaseBranch || format('release-{0}', inputs.releaseVersion) }}
   RELEASE_VERSION: ${{ inputs.releaseVersion }}
-
+  GH_TOKEN: ${{ github.token }} # needs to be available for the gh CLI tool
 jobs:
   release:
     name: Maven & Go Release

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -247,6 +247,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation
       - name: Install Zeebe changelog tool
         run: |
           wget https://github.com/zeebe-io/zeebe-changelog/releases/download/0.7.0/zeebe-changelog_0.7.0_Linux_i386.tar.gz

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -268,7 +268,7 @@ jobs:
 
           # Right now we only support patch releases for generating the changelog
           # as it is the easiest to automate and the most repetitive work to do on a release
-          if [[ "$version" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
+          if [[ "${{ inputs.releaseVersion }}" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
           then
             # Next, to add the release labels to release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
             #

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -270,7 +270,7 @@ jobs:
           # as it is the easiest to automate and the most repetitive work to do on a release
           if [[ "${{ inputs.releaseVersion }}" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
           then
-            # Next, to add the release labels to release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
+            # Next, add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
             #
             # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and 
             # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type:
@@ -282,7 +282,8 @@ jobs:
             ZCL_FROM_REV="$majorMinor".$(( patchVersion - 1 ))
             ZCL_TARGET_REV="${{ inputs.releaseVersion }}"
 
-            # This will add labels to the issues in GitHub. You can verify this step by looking at closed issues. They should now be tagged with the release.
+            # The following command will add labels to the issues on GitHub.
+            # You can verify this step by looking at closed issues. They should now be tagged with the release.
             ./zcl add-labels \
             --token=${{ secrets.GITHUB_TOKEN }} \
             --from=$ZCL_FROM_REV \

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -244,7 +244,7 @@ jobs:
           fi
           shopt -u nocasematch # reset it
           echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_BRANCH }}
       - name: Install Zeebe changelog tool

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -244,6 +244,50 @@ jobs:
           fi
           shopt -u nocasematch # reset it
           echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.RELEASE_BRANCH }}
+      - name: Install Zeebe changelog tool
+        run: |
+          wget https://github.com/zeebe-io/zeebe-changelog/releases/download/0.7.0/zeebe-changelog_0.7.0_Linux_i386.tar.gz
+          tar -xzvf zeebe-changelog_0.7.0_Linux_i386.tar.gz
+          chmod +x zcl
+      - name: Generate Changelog for patch release
+        id: gen-changelog
+        run: |
+          changelog="Release ${{ inputs.releaseVersion }}"
+          # Right now we only support patch release for generating the change log
+          # as it is the easiest to automate and the most repetitive work to do on a release
+          if [[ "$version" =~ ^8\.[1-9][0-9]*\.[1-9][0-9]*$ ]]
+          then
+            # Next, to add the release labels to release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
+            #
+            # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and 
+            # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type:
+            #
+            # PATCH: the tag for the previous patch version on the same minor branch. e.g. if you're releasing 1.2.3, then ZCL_FROM_REV=1.2.2.
+            # To find the previous patch version we extract the patch version and subsctract by one
+            patchVersion=$(echo ${{ inputs.releaseVersion }} | sed 's/8\.[1-9][0-9]\*\.//')
+            majorMinor=$(echo ${{ inputs.releaseVersion }} | sed 's/\.[1-9][0-9]\*$//')
+            ZCL_FROM_REV="$majorMinor".$(( patchVersion - 1 ))
+            ZCL_TARGET_REV="${{ inputs.releaseVersion }}"
+
+            # This will add labels to the issues in GitHub. You can verify this step by looking at closed issues. They should now be tagged with the release.
+            ./zcl add-labels \
+            --token=${{ secrets.GITHUB_TOKEN }} \
+            --from=$ZCL_FROM_REV \
+            --target=$ZCL_TARGET_REV \
+            --label="version:$ZCL_TARGET_REV" \
+            --org camunda --repo zeebe
+
+            # This command will print markdown code to the console. You will need to manually insert this output into the release draft.
+            changelog=$(./zcl generate \
+            --token=${{ secrets.GITHUB_TOKEN }} \
+            --label="version:$ZCL_TARGET_REV" \
+            --org camunda --repo zeebe)
+          fi
+
+          echo "changelog=$changelog" >> $GITHUB_OUTPUT
       - name: Create Github release
         uses: ncipollo/release-action@v1
         if: ${{ inputs.dryRun == false }}
@@ -252,9 +296,9 @@ jobs:
           artifacts: "*"
           artifactErrorsFailBuild: true
           draft: true
-          body: Release ${{ inputs.releaseVersion }}
+          body: ${{ steps.gen-changelog.outputs.changelog }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          prerelease: ${{ steps.pre-release.result }}
+          prerelease: ${{ steps.pre-release.outputs.result }}
           tag: ${{ inputs.releaseVersion }}
   docker:
     needs: release

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -256,6 +256,14 @@ jobs:
       - name: Generate Changelog for patch release
         id: gen-changelog
         run: |
+          # We set some bash properties to better fail/debug this script
+          #
+          # * https://www.gnu.org/software/bash/manual/html_node/The-Set-Builtin.html
+          # * https://explainshell.com/explain?cmd=set+-euox+pipefail
+          #
+          set -euox pipefail
+
+          # Default changelog value
           changelog="Release ${{ inputs.releaseVersion }}"
           # Right now we only support patch release for generating the change log
           # as it is the easiest to automate and the most repetitive work to do on a release

--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -250,8 +250,8 @@ jobs:
           fetch-depth: 0 # To fetch tags as well - necessary for the changelog generation
       - name: Install Zeebe changelog tool
         run: |
-          wget https://github.com/zeebe-io/zeebe-changelog/releases/download/0.7.0/zeebe-changelog_0.7.0_Linux_i386.tar.gz
-          tar -xzvf zeebe-changelog_0.7.0_Linux_i386.tar.gz
+          gh release download --repo zeebe-io/zeebe-changelog --pattern '*_Linux_i386.tar.gz'
+          tar -xzvf zeebe-changelog_*
           chmod +x zcl
       - name: Generate Changelog for patch release
         id: gen-changelog


### PR DESCRIPTION
## Description

> [!Note]
> 
> That is a proposal to extend our release workflow and add the changelog generation, 
> at least for the patch releases.
> 

This PR adds some more steps to the Github release job, to automate the changelog generation for patch releases, using the [zcl cli tool.](https://github.com/zeebe-io/zeebe-changelog)

Currently restricted to patch releases as it is the easiest to automate (less edge cases) and the most repetitive work to do on a release


## Related issues

See related thread https://camunda.slack.com/archives/C05DH1F5TAR/p1715098083616309
