### PR TITLE
Initialize exporter state in dynamic config during cluster bootstrap

### DIFF
--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerTopologyManagerTest.java
@@ -17,6 +17,7 @@ import io.atomix.cluster.MemberConfig;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.broker.client.impl.BrokerTopologyManagerImpl;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
@@ -435,11 +436,19 @@ final class BrokerTopologyManagerTest {
             .addMember(
                 MemberId.from("1"),
                 MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(2))))
+                    Map.of(
+                        1,
+                        PartitionState.active(1, DynamicPartitionConfig.init()),
+                        2,
+                        PartitionState.active(2, DynamicPartitionConfig.init()))))
             .addMember(
                 MemberId.from("2"),
                 MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(1))));
+                    Map.of(
+                        1,
+                        PartitionState.active(2, DynamicPartitionConfig.init()),
+                        2,
+                        PartitionState.active(1, DynamicPartitionConfig.init()))));
     topologyManager.onClusterConfigurationUpdated(clusterTopologyWithTwoBrokers);
     actorSchedulerRule.workUntilDone();
 
@@ -457,11 +466,19 @@ final class BrokerTopologyManagerTest {
             .addMember(
                 MemberId.from("1"),
                 MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(2))))
+                    Map.of(
+                        1,
+                        PartitionState.active(1, DynamicPartitionConfig.init()),
+                        2,
+                        PartitionState.active(2, DynamicPartitionConfig.init()))))
             .addMember(
                 MemberId.from("2"),
                 MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(2), 2, PartitionState.active(1))));
+                    Map.of(
+                        1,
+                        PartitionState.active(2, DynamicPartitionConfig.init()),
+                        2,
+                        PartitionState.active(1, DynamicPartitionConfig.init()))));
     topologyManager.onClusterConfigurationUpdated(clusterTopologyWithTwoBrokers);
     actorSchedulerRule.workUntilDone();
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
@@ -122,10 +122,7 @@ public class DynamicClusterTopologyService implements ClusterTopologyService {
         brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
 
     final var staticConfiguration =
-        PartitionDistributionResolver.getStaticConfiguration(
-            brokerConfiguration.getCluster(),
-            brokerConfiguration.getExperimental().getPartitioning(),
-            localMember);
+        StaticConfigurationGenerator.getStaticConfiguration(brokerConfiguration, localMember);
 
     return clusterConfigurationManagerService.start(
         brokerStartupContext.getActorSchedulingService(), staticConfiguration);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/DynamicClusterTopologyService.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentC
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManagerService;
 import io.camunda.zeebe.dynamic.config.changes.PartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
-import io.camunda.zeebe.dynamic.config.util.TopologyUtil;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
@@ -74,7 +74,7 @@ public class DynamicClusterTopologyService implements ClusterTopologyService {
                         try {
                           partitionDistribution =
                               new PartitionDistribution(
-                                  TopologyUtil.getPartitionDistributionFrom(
+                                  ConfigurationUtil.getPartitionDistributionFrom(
                                       topology, PartitionManagerImpl.GROUP_NAME));
                           started.complete(null);
                         } catch (final Exception topologyConversionFailed) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticClusterTopologyService.java
@@ -41,10 +41,7 @@ public class StaticClusterTopologyService implements ClusterTopologyService {
           brokerStartupContext.getClusterServices().getMembershipService().getLocalMember().id();
 
       final var staticConfiguration =
-          PartitionDistributionResolver.getStaticConfiguration(
-              brokerConfiguration.getCluster(),
-              brokerConfiguration.getExperimental().getPartitioning(),
-              localMember);
+          StaticConfigurationGenerator.getStaticConfiguration(brokerConfiguration, localMember);
 
       partitionDistribution =
           new PartitionDistribution(staticConfiguration.generatePartitionDistribution());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGeneratorTest.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionMetadata;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.broker.system.configuration.ClusterCfg;
 import io.camunda.zeebe.broker.system.configuration.PartitioningCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
@@ -22,7 +23,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
-class StaticPartitionDistributionResolverTest {
+class StaticConfigurationGeneratorTest {
 
   @Test
   void shouldGenerateRoundRobinDistribution() {
@@ -48,11 +49,14 @@ class StaticPartitionDistributionResolverTest {
     clusterCfg.setClusterSize(6);
     clusterCfg.setPartitionsCount(6);
     clusterCfg.setReplicationFactor(3);
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.setCluster(clusterCfg);
+    brokerCfg.getExperimental().setPartitioning(partitioningCfg);
+    brokerCfg.setExporters(Map.of());
 
     // when
     final var partitionDistribution =
-        PartitionDistributionResolver.getStaticConfiguration(
-                clusterCfg, partitioningCfg, MemberId.from("1"))
+        StaticConfigurationGenerator.getStaticConfiguration(brokerCfg, MemberId.from("1"))
             .generatePartitionDistribution();
 
     // then
@@ -112,11 +116,13 @@ fixed:
     clusterCfg.setClusterSize(3);
     clusterCfg.setPartitionsCount(3);
     clusterCfg.setReplicationFactor(3);
+    final BrokerCfg brokerCfg = new BrokerCfg();
+    brokerCfg.setCluster(clusterCfg);
+    brokerCfg.getExperimental().setPartitioning(partitioningCfg);
 
     // when
     final var partitionDistribution =
-        PartitionDistributionResolver.getStaticConfiguration(
-                clusterCfg, partitioningCfg, MemberId.from("1"))
+        StaticConfigurationGenerator.getStaticConfiguration(brokerCfg, MemberId.from("1"))
             .generatePartitionDistribution();
 
     // then

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -21,12 +21,12 @@ public record StaticConfiguration(
     Set<MemberId> clusterMembers,
     MemberId localMemberId,
     List<PartitionId> partitionIds,
-    int replicationFactor) {
+    int replicationFactor,
+    DynamicPartitionConfig partitionConfig) {
 
   public ClusterConfiguration generateTopology() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
-    return ConfigurationUtil.getClusterConfigFrom(
-        partitionDistribution, DynamicPartitionConfig.init());
+    return ConfigurationUtil.getClusterConfigFrom(partitionDistribution, partitionConfig);
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -11,7 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.util.TopologyUtil;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.List;
 import java.util.Set;
 
@@ -24,7 +24,7 @@ public record StaticConfiguration(
 
   public ClusterConfiguration generateTopology() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
-    return TopologyUtil.getClusterTopologyFrom(partitionDistribution);
+    return ConfigurationUtil.getClusterConfigFrom(partitionDistribution);
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import java.util.List;
 import java.util.Set;
@@ -24,7 +25,8 @@ public record StaticConfiguration(
 
   public ClusterConfiguration generateTopology() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
-    return ConfigurationUtil.getClusterConfigFrom(partitionDistribution);
+    return ConfigurationUtil.getClusterConfigFrom(
+        partitionDistribution, DynamicPartitionConfig.init());
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformer.java
@@ -18,8 +18,8 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
-import io.camunda.zeebe.dynamic.config.util.TopologyUtil;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +64,8 @@ public class PartitionReassignRequestTransformer implements ConfigurationChangeR
           final ClusterConfiguration currentTopology, final Set<MemberId> brokers) {
     final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
 
-    final var oldDistribution = TopologyUtil.getPartitionDistributionFrom(currentTopology, "temp");
+    final var oldDistribution =
+        ConfigurationUtil.getPartitionDistributionFrom(currentTopology, "temp");
     final int replicationFactor = getReplicationFactor(currentTopology);
 
     if (replicationFactor <= 0) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplier.java
@@ -130,8 +130,14 @@ final class PartitionJoinApplier implements MemberOperationApplier {
 
   private DynamicPartitionConfig getPartitionConfig(
       final ClusterConfiguration currentClusterConfiguration) {
-    // TODO: Init partitionConfig from other partitions
-    return DynamicPartitionConfig.init();
+    // Find configuration from any other member that has the same partition. We can assume that
+    // configuration is not being changed at the same time as scaling operations
+    return currentClusterConfiguration.members().values().stream()
+        .filter(m -> m.hasPartition(partitionId))
+        .map(m -> m.partitions().get(partitionId))
+        .findAny()
+        .orElseThrow() // We are certain that there is another member with the same partition
+        .config();
   }
 
   private HashMap<MemberId, Integer> collectPriorityByMembers(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/PartitionState.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.dynamic.config.state;
 import java.util.function.UnaryOperator;
 
 public record PartitionState(State state, int priority, DynamicPartitionConfig config) {
-  public static PartitionState active(final int priority) {
-    return new PartitionState(State.ACTIVE, priority, DynamicPartitionConfig.init());
+  public static PartitionState active(
+      final int priority, final DynamicPartitionConfig partitionConfig) {
+    return new PartitionState(State.ACTIVE, priority, partitionConfig);
   }
 
-  public static PartitionState joining(final int priority) {
-    return new PartitionState(State.JOINING, priority, DynamicPartitionConfig.init());
+  public static PartitionState joining(
+      final int priority, final DynamicPartitionConfig partitionConfig) {
+    return new PartitionState(State.JOINING, priority, partitionConfig);
   }
 
   public PartitionState toActive() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -21,11 +21,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-public final class TopologyUtil {
+public final class ConfigurationUtil {
 
-  private TopologyUtil() {}
+  private ConfigurationUtil() {}
 
-  public static ClusterConfiguration getClusterTopologyFrom(
+  public static ClusterConfiguration getClusterConfigFrom(
       final Set<PartitionMetadata> partitionDistribution) {
     final var partitionStatesByMember = new HashMap<MemberId, Map<Integer, PartitionState>>();
     for (final var partitionMetadata : partitionDistribution) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.atomix.primitive.partition.PartitionMetadata;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
@@ -26,7 +27,8 @@ public final class ConfigurationUtil {
   private ConfigurationUtil() {}
 
   public static ClusterConfiguration getClusterConfigFrom(
-      final Set<PartitionMetadata> partitionDistribution) {
+      final Set<PartitionMetadata> partitionDistribution,
+      final DynamicPartitionConfig partitionConfig) {
     final var partitionStatesByMember = new HashMap<MemberId, Map<Integer, PartitionState>>();
     for (final var partitionMetadata : partitionDistribution) {
       final var partitionId = partitionMetadata.id().id();
@@ -34,7 +36,7 @@ public final class ConfigurationUtil {
         final var memberPriority = partitionMetadata.getPriority(member);
         partitionStatesByMember
             .computeIfAbsent(member, k -> new HashMap<>())
-            .put(partitionId, PartitionState.active(memberPriority));
+            .put(partitionId, PartitionState.active(memberPriority, partitionConfig));
       }
     }
     final var memberStates = new HashMap<MemberId, MemberState>();

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -210,7 +210,8 @@ final class ClusterConfigurationInitializerTest {
             Set.of(member),
             member,
             List.of(partitionId),
-            1));
+            1,
+            DynamicPartitionConfig.init()));
   }
 
   private static final class TestClusterConfigurationNotifier

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticIni
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.SyncInitializer;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -52,7 +53,8 @@ final class ClusterConfigurationInitializerTest {
       ClusterConfiguration.init()
           .addMember(
               MemberId.from("10"),
-              MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+              MemberState.initializeAsActive(
+                  Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()))));
 
   private PersistedClusterConfiguration persistedClusterConfiguration;
   private Path topologyFile;

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.dynamic.config.changes.NoopPartitionChangeExecutor;
 import io.camunda.zeebe.dynamic.config.gossip.ClusterConfigurationGossiperConfig;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -301,7 +302,8 @@ class ClusterConfigurationManagementIntegrationTest {
                   clusterMembers,
                   cluster.getMembershipService().getLocalMember().id(),
                   List.of(),
-                  3));
+                  3,
+                  DynamicPartitionConfig.init()));
       startFuture.onComplete(
           (ignore, error) -> {
             if (error == null) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/MemberStateAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/MemberStateAssert.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.util.Map;
+import java.util.function.Consumer;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.Assertions;
 
@@ -25,13 +26,9 @@ public final class MemberStateAssert extends AbstractAssert<MemberStateAssert, M
 
   public MemberStateAssert hasPartitionWithState(
       final int partitionId, final PartitionState.State state) {
-    final Map<Integer, PartitionState> partitions = actual.partitions();
-    Assertions.assertThat(partitions)
-        .hasEntrySatisfying(
-            partitionId,
-            partitionState -> {
-              Assertions.assertThat(partitionState.state()).isEqualTo(state);
-            });
+    hasPartitionSatisfying(
+        partitionId,
+        partitionState -> Assertions.assertThat(partitionState.state()).isEqualTo(state));
     return this;
   }
 
@@ -42,13 +39,16 @@ public final class MemberStateAssert extends AbstractAssert<MemberStateAssert, M
   }
 
   public MemberStateAssert hasPartitionWithPriority(final int partitionId, final int priority) {
+    hasPartitionSatisfying(
+        partitionId,
+        partitionState -> Assertions.assertThat(partitionState.priority()).isEqualTo(priority));
+    return this;
+  }
+
+  public MemberStateAssert hasPartitionSatisfying(
+      final int partitionId, final Consumer<PartitionState> partitionStateCondition) {
     final Map<Integer, PartitionState> partitions = actual.partitions();
-    Assertions.assertThat(partitions)
-        .hasEntrySatisfying(
-            partitionId,
-            partitionState -> {
-              Assertions.assertThat(partitionState.priority()).isEqualTo(priority);
-            });
+    Assertions.assertThat(partitions).hasEntrySatisfying(partitionId, partitionStateCondition);
     return this;
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionStateAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PartitionStateAssert.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+public final class PartitionStateAssert
+    extends AbstractAssert<PartitionStateAssert, PartitionState> {
+
+  private PartitionStateAssert(final PartitionState partitionState, final Class<?> selfType) {
+    super(partitionState, selfType);
+  }
+
+  public static PartitionStateAssert assertThat(final PartitionState actual) {
+    return new PartitionStateAssert(actual, PartitionStateAssert.class);
+  }
+
+  public PartitionStateAssert hasState(final PartitionState.State state) {
+    Assertions.assertThat(actual.state()).isEqualTo(state);
+    return this;
+  }
+
+  public PartitionStateAssert hasPriority(final int priority) {
+    Assertions.assertThat(actual.priority()).isEqualTo(priority);
+    return this;
+  }
+
+  public PartitionStateAssert hasConfig(final DynamicPartitionConfig config) {
+    Assertions.assertThat(actual.config()).isEqualTo(config);
+    return this;
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationTest.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration.MissingHead
 import io.camunda.zeebe.dynamic.config.PersistedClusterConfiguration.UnexpectedVersion;
 import io.camunda.zeebe.dynamic.config.serializer.ProtoBufSerializer;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.io.IOException;
@@ -23,6 +24,8 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 final class PersistedClusterConfigurationTest {
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
   @Test
   void shouldDetectFileWithMoreDataThanExpected() throws IOException {
     // given
@@ -104,12 +107,14 @@ final class PersistedClusterConfigurationTest {
         ClusterConfiguration.init()
             .addMember(
                 MemberId.from("1"),
-                MemberState.initializeAsActive(Map.of(1, PartitionState.active(2))));
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(2, partitionConfig))));
     final var changedTopology =
         ClusterConfiguration.init()
             .addMember(
                 MemberId.from("1"),
-                MemberState.initializeAsActive(Map.of(1, PartitionState.active(3))));
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(3, partitionConfig))));
 
     persistedClusterTopology.update(initialTopology);
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
@@ -55,6 +56,8 @@ final class ClusterConfigurationManagementApiTest {
   private final MemberId id3 = MemberId.from("3");
   private final ClusterConfiguration initialTopology =
       ClusterConfiguration.init().addMember(id0, MemberState.initializeAsActive(Map.of()));
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @BeforeEach
   void setup() {
@@ -188,7 +191,11 @@ final class ClusterConfigurationManagementApiTest {
             .addMember(
                 id1,
                 MemberState.initializeAsActive(
-                    Map.of(1, PartitionState.active(1), 2, PartitionState.active(1))))
+                    Map.of(
+                        1,
+                        PartitionState.active(1, partitionConfig),
+                        2,
+                        PartitionState.active(1, partitionConfig))))
             .addMember(id2, MemberState.initializeAsActive(Map.of()));
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -208,8 +215,8 @@ final class ClusterConfigurationManagementApiTest {
         new ClusterConfigurationManagementRequest.ScaleRequest(Set.of(id0, id1), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1)));
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -232,8 +239,8 @@ final class ClusterConfigurationManagementApiTest {
             Set.of(id0, id1), Optional.of(2), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1)));
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -257,8 +264,8 @@ final class ClusterConfigurationManagementApiTest {
             Set.of(id0, id1), Optional.of(0), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1)));
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -281,11 +288,11 @@ final class ClusterConfigurationManagementApiTest {
             Set.of(id0, id1), Optional.of(1), false);
     final ClusterConfiguration currentTopology =
         initialTopology
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(2)))
-            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1)))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(1)))
-            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(2)));
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
 
     recordingCoordinator.setCurrentTopology(currentTopology);
 
@@ -312,10 +319,10 @@ final class ClusterConfigurationManagementApiTest {
             .addMember(id1, MemberState.initializeAsActive(Map.of()))
             .addMember(id2, MemberState.initializeAsActive(Map.of()))
             .addMember(id3, MemberState.initializeAsActive(Map.of()))
-            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1)))
-            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2)))
-            .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1)))
-            .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2)));
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+            .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+            .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
     recordingCoordinator.setCurrentTopology(currentTopology);
 
     // when

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ForceScaleDownRequestTransformerTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestFailedExce
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -28,16 +29,18 @@ class ForceScaleDownRequestTransformerTest {
   private final MemberId id2 = MemberId.from("2");
   private final MemberId id3 = MemberId.from("3");
 
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
   private final ClusterConfiguration currentTopology =
       ClusterConfiguration.init()
           .addMember(id0, MemberState.initializeAsActive(Map.of()))
           .addMember(id1, MemberState.initializeAsActive(Map.of()))
           .addMember(id2, MemberState.initializeAsActive(Map.of()))
           .addMember(id3, MemberState.initializeAsActive(Map.of()))
-          .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1)))
-          .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2)))
-          .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1)))
-          .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2)));
+          .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
+          .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, partitionConfig)))
+          .updateMember(id2, m -> m.addPartition(2, PartitionState.active(1, partitionConfig)))
+          .updateMember(id3, m -> m.addPartition(2, PartitionState.active(2, partitionConfig)));
 
   @Test
   void shouldGenerateForceConfigureOperations() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
@@ -14,8 +14,8 @@ import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
-import io.camunda.zeebe.dynamic.config.util.TopologyUtil;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Map;
@@ -99,7 +99,7 @@ class PartitionReassignRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
-    var oldClusterTopology = TopologyUtil.getClusterTopologyFrom(oldDistribution);
+    var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(
@@ -150,7 +150,7 @@ class PartitionReassignRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 oldReplicationFactor);
-    var oldClusterTopology = TopologyUtil.getClusterTopologyFrom(oldDistribution);
+    var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(
@@ -173,7 +173,7 @@ class PartitionReassignRequestTransformerTest {
     final ClusterConfiguration newTopology =
         TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
     // then
-    final var newDistribution = TopologyUtil.getPartitionDistributionFrom(newTopology, "temp");
+    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
     assertThat(newDistribution).isEqualTo(expectedNewDistribution);
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
@@ -31,6 +32,8 @@ import net.jqwik.api.ShrinkingMode;
 import net.jqwik.api.constraints.IntRange;
 
 class PartitionReassignRequestTransformerTest {
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @Property(tries = 10)
   void shouldReassignPartitionsWithReplicationFactor1(
@@ -99,7 +102,8 @@ class PartitionReassignRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
-    var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
+    var oldClusterTopology =
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(
@@ -150,7 +154,8 @@ class PartitionReassignRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 oldReplicationFactor);
-    var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
+    var oldClusterTopology =
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -26,6 +27,9 @@ import net.jqwik.api.ShrinkingMode;
 import net.jqwik.api.constraints.IntRange;
 
 class ScaleRequestTransformerTest {
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
+
   @Property(tries = 10)
   void shouldScaleAndReassignWithReplicationFactor1(
       @ForAll @IntRange(min = 1, max = 100) final int partitionCount,
@@ -82,7 +86,8 @@ class ScaleRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
-    final var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
+    final var oldClusterTopology =
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
 
     //  when
     final var operationsEither =
@@ -115,7 +120,8 @@ class ScaleRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
-    final var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
+    final var oldClusterTopology =
+        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
 
     // when
     final var operations =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -12,8 +12,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.partition.PartitionId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.util.ConfigurationUtil;
 import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
-import io.camunda.zeebe.dynamic.config.util.TopologyUtil;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.List;
 import java.util.Set;
@@ -82,7 +82,7 @@ class ScaleRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
-    final var oldClusterTopology = TopologyUtil.getClusterTopologyFrom(oldDistribution);
+    final var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
 
     //  when
     final var operationsEither =
@@ -115,7 +115,7 @@ class ScaleRequestTransformerTest {
                 getClusterMembers(oldClusterSize),
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
-    final var oldClusterTopology = TopologyUtil.getClusterTopologyFrom(oldDistribution);
+    final var oldClusterTopology = ConfigurationUtil.getClusterConfigFrom(oldDistribution);
 
     // when
     final var operations =
@@ -128,7 +128,7 @@ class ScaleRequestTransformerTest {
         TestTopologyChangeSimulator.apply(oldClusterTopology, operations);
 
     // then
-    final var newDistribution = TopologyUtil.getPartitionDistributionFrom(newTopology, "temp");
+    final var newDistribution = ConfigurationUtil.getPartitionDistributionFrom(newTopology, "temp");
     assertThat(newDistribution).isEqualTo(expectedNewDistribution);
     assertThat(newTopology.members().keySet())
         .containsExactlyInAnyOrderElementsOf(getClusterMembers(newClusterSize));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeCoordinatorImplTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
@@ -47,6 +48,8 @@ final class ConfigurationChangeCoordinatorImplTest {
   private final ClusterConfiguration initialTopology =
       ClusterConfiguration.init()
           .addMember(MemberId.from("0"), MemberState.initializeAsActive(Map.of()));
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @Test
   void shouldFailOnInvalidChanges() {
@@ -79,9 +82,13 @@ final class ConfigurationChangeCoordinatorImplTest {
     clusterTopologyManager.setClusterTopology(
         initialTopology
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
-            .updateMember(MemberId.from("1"), m -> m.addPartition(1, PartitionState.active(1)))
+            .updateMember(
+                MemberId.from("1"),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
             .addMember(MemberId.from("2"), MemberState.initializeAsActive(Map.of()))
-            .updateMember(MemberId.from("2"), m -> m.addPartition(1, PartitionState.active(1))));
+            .updateMember(
+                MemberId.from("2"),
+                m -> m.addPartition(1, PartitionState.active(1, partitionConfig))));
 
     // when
 
@@ -129,7 +136,8 @@ final class ConfigurationChangeCoordinatorImplTest {
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
             .addMember(
                 MemberId.from("2"),
-                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))));
     clusterTopologyManager.setClusterTopology(topology);
 
     final List<ClusterConfigurationChangeOperation> operations =
@@ -153,7 +161,8 @@ final class ConfigurationChangeCoordinatorImplTest {
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
             .addMember(
                 MemberId.from("2"),
-                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))));
     clusterTopologyManager.setClusterTopology(topology);
 
     final List<ClusterConfigurationChangeOperation> operations =
@@ -197,7 +206,8 @@ final class ConfigurationChangeCoordinatorImplTest {
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
             .addMember(
                 MemberId.from("2"),
-                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))));
     clusterTopologyManager.setClusterTopology(topology);
 
     final List<ClusterConfigurationChangeOperation> operations =
@@ -232,7 +242,8 @@ final class ConfigurationChangeCoordinatorImplTest {
             .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
             .addMember(
                 MemberId.from("2"),
-                MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))));
     clusterTopologyManager.setClusterTopology(topology);
 
     final List<ClusterConfigurationChangeOperation> operations =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/MemberLeaveApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/MemberLeaveApplierTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.changes;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
@@ -47,7 +48,8 @@ final class MemberLeaveApplierTest {
         ClusterConfiguration.init()
             .addMember(
                 memberId,
-                MemberState.initializeAsActive(Map.of()).addPartition(1, PartitionState.active(1)));
+                MemberState.initializeAsActive(Map.of())
+                    .addPartition(1, PartitionState.active(1, DynamicPartitionConfig.init())));
 
     // when
     final var result = memberLeaveApplier.init(clusterConfigurationWithMember);

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionForceReconfigureApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionForceReconfigureApplierTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationAssert;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
@@ -31,12 +32,16 @@ final class PartitionForceReconfigureApplierTest {
       mock(PartitionChangeExecutor.class);
   private final MemberId localMemberId = MemberId.from("1");
   private final MemberId otherMember = MemberId.from("2");
+
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
   private final ClusterConfiguration validTopology =
       ClusterConfiguration.init()
           .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
-          .updateMember(localMemberId, m -> m.addPartition(1, PartitionState.active(1)))
+          .updateMember(
+              localMemberId, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)))
           .addMember(otherMember, MemberState.initializeAsActive(Map.of()))
-          .updateMember(otherMember, m -> m.addPartition(1, PartitionState.active(1)));
+          .updateMember(
+              otherMember, m -> m.addPartition(1, PartitionState.active(1, partitionConfig)));
 
   @Test
   void shouldRejectIfLocalMemberNotPartOfNewConfiguration() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionReconfigurePriorityApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionReconfigurePriorityApplierTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -28,6 +29,7 @@ class PartitionReconfigurePriorityApplierTest {
 
   private static final PartitionChangeExecutor FAILING_EXECUTOR =
       mock(PartitionChangeExecutor.class);
+  private final DynamicPartitionConfig partitionConfig = DynamicPartitionConfig.init();
 
   @BeforeAll
   static void init() {
@@ -46,7 +48,9 @@ class PartitionReconfigurePriorityApplierTest {
     final ClusterConfiguration clusterConfigurationWithMember =
         ClusterConfiguration.init()
             .addMember(
-                memberId, MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+                memberId,
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, partitionConfig))));
 
     // when
     final var result = partitionReconfigurePriorityApplier.init(clusterConfigurationWithMember);
@@ -69,7 +73,8 @@ class PartitionReconfigurePriorityApplierTest {
         ClusterConfiguration.init()
             .addMember(
                 memberId,
-                MemberState.initializeAsActive(Map.of(partitionId, PartitionState.joining(1))));
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.joining(1, partitionConfig))));
 
     // when
     final var result = partitionReconfigurePriorityApplier.init(clusterConfigurationWithMember);
@@ -92,7 +97,8 @@ class PartitionReconfigurePriorityApplierTest {
         ClusterConfiguration.init()
             .addMember(
                 memberId,
-                MemberState.initializeAsActive(Map.of(partitionId, PartitionState.active(1))));
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, partitionConfig))));
 
     // when
     final var result = partitionReconfigurePriorityApplier.init(initialClusterConfiguration);
@@ -115,7 +121,8 @@ class PartitionReconfigurePriorityApplierTest {
         ClusterConfiguration.init()
             .addMember(
                 memberId,
-                MemberState.initializeAsActive(Map.of(partitionId, PartitionState.active(1))));
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, partitionConfig))));
 
     // when
     final var newMemberState =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 final class ProtoBufSerializerTest {
 
-  final ProtoBufSerializer protoBufSerializer = new ProtoBufSerializer();
+  private final ProtoBufSerializer protoBufSerializer = new ProtoBufSerializer();
 
   @ParameterizedTest
   @MethodSource("provideClusterTopologies")
@@ -212,21 +212,24 @@ final class ProtoBufSerializerTest {
     return ClusterConfiguration.init()
         .addMember(
             MemberId.from("0"),
-            MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))));
+            MemberState.initializeAsActive(
+                Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()))));
   }
 
   private static ClusterConfiguration topologyWithOneMemberOneLeavingPartition() {
     return ClusterConfiguration.init()
         .addMember(
             MemberId.from("0"),
-            MemberState.initializeAsActive(Map.of(1, PartitionState.active(1).toLeaving())));
+            MemberState.initializeAsActive(
+                Map.of(1, PartitionState.active(1, DynamicPartitionConfig.init()).toLeaving())));
   }
 
   private static ClusterConfiguration topologyWithOneMemberOneJoiningPartition() {
     return ClusterConfiguration.init()
         .addMember(
             MemberId.from("0"),
-            MemberState.initializeAsActive(Map.of(1, PartitionState.joining(1))));
+            MemberState.initializeAsActive(
+                Map.of(1, PartitionState.joining(1, DynamicPartitionConfig.init()))));
   }
 
   private static ClusterConfiguration topologyWithOneMemberTwoPartitions() {
@@ -234,7 +237,11 @@ final class ProtoBufSerializerTest {
         .addMember(
             MemberId.from("0"),
             MemberState.initializeAsActive(
-                Map.of(1, PartitionState.active(1), 2, PartitionState.active(2).toLeaving())));
+                Map.of(
+                    1,
+                    PartitionState.active(1, DynamicPartitionConfig.init()),
+                    2,
+                    PartitionState.active(2, DynamicPartitionConfig.init()).toLeaving())));
   }
 
   private static ClusterConfiguration topologyWithTwoMembers() {
@@ -242,7 +249,11 @@ final class ProtoBufSerializerTest {
         .addMember(
             MemberId.from("0"),
             MemberState.initializeAsActive(
-                Map.of(1, PartitionState.joining(1), 2, PartitionState.active(2))))
+                Map.of(
+                    1,
+                    PartitionState.joining(1, DynamicPartitionConfig.init()),
+                    2,
+                    PartitionState.active(2, DynamicPartitionConfig.init()))))
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()).toLeaving());
   }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -22,17 +22,26 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class ClusterConfigurationTest {
+
+  private final DynamicPartitionConfig emptyPartitionConfig = DynamicPartitionConfig.init();
+
   @Test
   void canInitializeClusterWithPreExistingMembers() {
     // when
     final var topology =
         ClusterConfiguration.init()
             .addMember(
-                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))))
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, emptyPartitionConfig))))
             .addMember(
-                member(2), MemberState.initializeAsActive(Map.of(2, PartitionState.active(1))))
+                member(2),
+                MemberState.initializeAsActive(
+                    Map.of(2, PartitionState.active(1, emptyPartitionConfig))))
             .addMember(
-                member(3), MemberState.initializeAsActive(Map.of(3, PartitionState.active(1))));
+                member(3),
+                MemberState.initializeAsActive(
+                    Map.of(3, PartitionState.active(1, emptyPartitionConfig))));
 
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
@@ -58,11 +67,17 @@ class ClusterConfigurationTest {
     final var topology =
         ClusterConfiguration.init()
             .addMember(
-                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))))
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, emptyPartitionConfig))))
             .addMember(
-                member(2), MemberState.initializeAsActive(Map.of(1, PartitionState.active(2))))
+                member(2),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(2, emptyPartitionConfig))))
             .addMember(
-                member(3), MemberState.initializeAsActive(Map.of(1, PartitionState.active(3))));
+                member(3),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(3, emptyPartitionConfig))));
 
     // then
     assertThat(topology.clusterSize()).isEqualTo(3);
@@ -76,9 +91,13 @@ class ClusterConfigurationTest {
     final var topology =
         ClusterConfiguration.init()
             .addMember(
-                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.joining(1))))
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.joining(1, emptyPartitionConfig))))
             .addMember(
-                member(2), MemberState.initializeAsActive(Map.of(2, PartitionState.joining(1))));
+                member(2),
+                MemberState.initializeAsActive(
+                    Map.of(2, PartitionState.joining(1, emptyPartitionConfig))));
 
     // update topology in one member
     final var topologyInMemberOne =
@@ -113,9 +132,13 @@ class ClusterConfigurationTest {
     final var initialTopology =
         ClusterConfiguration.init()
             .addMember(
-                member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1))))
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, emptyPartitionConfig))))
             .addMember(
-                member(2), MemberState.initializeAsActive(Map.of(2, PartitionState.active(1))));
+                member(2),
+                MemberState.initializeAsActive(
+                    Map.of(2, PartitionState.active(1, emptyPartitionConfig))));
 
     var topologyOnAnotherMember = ClusterConfiguration.init().merge(initialTopology);
 
@@ -212,13 +235,19 @@ class ClusterConfigurationTest {
     // when
     final var finalTopology =
         initialTopology.advanceConfigurationChange(
-            t -> t.updateMember(member(1), m -> m.addPartition(1, PartitionState.active(1))));
+            t ->
+                t.updateMember(
+                    member(1),
+                    m -> m.addPartition(1, PartitionState.active(1, emptyPartitionConfig))));
 
     // then
     final var expected =
         new ClusterConfiguration(
             2,
-            Map.of(member(1), MemberState.initializeAsActive(Map.of(1, PartitionState.active(1)))),
+            Map.of(
+                member(1),
+                MemberState.initializeAsActive(
+                    Map.of(1, PartitionState.active(1, emptyPartitionConfig)))),
             Optional.of(
                 new CompletedChange(changeId, Status.COMPLETED, Instant.now(), Instant.now())),
             Optional.empty());

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -21,7 +21,7 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
-class TopologyUtilTest {
+class ConfigurationUtilTest {
 
   private static final String GROUP_NAME = "test";
 
@@ -46,7 +46,7 @@ class TopologyUtilTest {
     final var partitionDistribution = Set.of(partitionTwo, partitionOne);
 
     // when
-    final var topology = TopologyUtil.getClusterTopologyFrom(partitionDistribution);
+    final var topology = ConfigurationUtil.getClusterConfigFrom(partitionDistribution);
 
     // then
     ClusterConfigurationAssert.assertThatClusterTopology(topology)
@@ -123,7 +123,7 @@ class TopologyUtilTest {
 
     // when
     final var partitionDistribution =
-        TopologyUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
+        ConfigurationUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
 
     // then
     assertThat(partitionDistribution).containsExactlyInAnyOrderElementsOf(expected);
@@ -164,7 +164,7 @@ class TopologyUtilTest {
 
     // when
     final var partitionDistribution =
-        TopologyUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
+        ConfigurationUtil.getPartitionDistributionFrom(topology, GROUP_NAME);
 
     // then
     assertThat(partitionDistribution).containsExactlyInAnyOrderElementsOf(expected);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
-import io.camunda.zeebe.broker.partitioning.topology.PartitionDistributionResolver;
+import io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
 import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
 import io.camunda.zeebe.util.FileUtil;
@@ -103,10 +103,7 @@ public class RestoreManager {
     final var localMember = MemberId.from(String.valueOf(localBrokerId));
     final var clusterTopology =
         new PartitionDistribution(
-            PartitionDistributionResolver.getStaticConfiguration(
-                    configuration.getCluster(),
-                    configuration.getExperimental().getPartitioning(),
-                    localMember)
+            StaticConfigurationGenerator.getStaticConfiguration(configuration, localMember)
                 .generatePartitionDistribution());
     final var raftPartitionFactory = new RaftPartitionFactory(configuration);
 


### PR DESCRIPTION
## Description

Initialize state of all configured exporters as enabled during the cluster bootstrap. During the cluster bootstrap, `StaticConfiguration` is used to generated the `ClusterConfiguration` which now also included the initial partition config. Note that this PR does not address the upgrade from previous version. This will be handled in another issue.

We also have to initialize it during a partition-join operation. When a partition is newly added to a broker, it's config is initialized from any of the other broker that has the same partition. 

## Related issues

closes #18034 
