### PR TITLE
Allow ExporterDirector to disable a configured exporter

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -216,6 +216,11 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
           // miss to export the record to any of the exporters whose index has changed.
           recordExporter.resetExporterIndex();
           LOG.debug("Exporter '{}' is disabled.", exporterId);
+
+          if (containers.isEmpty()) {
+            LOG.info("No exporters are enabled. Closing the exporter director '{}'.", name);
+            actor.close();
+          }
         });
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import io.camunda.zeebe.logstreams.log.LoggedEvent;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.stream.impl.records.RecordValues;
+import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
+import java.util.List;
+
+class RecordExporter {
+
+  private final RecordValues recordValues = new RecordValues();
+  private final RecordMetadata rawMetadata = new RecordMetadata();
+  private final List<ExporterContainer> containers;
+  private final TypedRecordImpl typedEvent;
+  private final ExporterMetrics exporterMetrics;
+
+  private boolean shouldExport;
+  private int exporterIndex;
+
+  RecordExporter(
+      final ExporterMetrics exporterMetrics,
+      final List<ExporterContainer> containers,
+      final int partitionId) {
+    this.containers = containers;
+    typedEvent = new TypedRecordImpl(partitionId);
+    this.exporterMetrics = exporterMetrics;
+  }
+
+  void wrap(final LoggedEvent rawEvent) {
+    rawEvent.readMetadata(rawMetadata);
+
+    final UnifiedRecordValue recordValue =
+        recordValues.readRecordValue(rawEvent, rawMetadata.getValueType());
+
+    shouldExport = recordValue != null;
+    if (shouldExport) {
+      typedEvent.wrap(rawEvent, rawMetadata, recordValue);
+      exporterIndex = 0;
+    }
+  }
+
+  boolean export() {
+    if (!shouldExport) {
+      return true;
+    }
+
+    final int exportersCount = containers.size();
+
+    // current error handling strategy is simply to repeat forever until the record can be
+    // successfully exported.
+    while (exporterIndex < exportersCount) {
+      final ExporterContainer container = containers.get(exporterIndex);
+
+      if (container.exportRecord(rawMetadata, typedEvent)) {
+        exporterIndex++;
+        exporterMetrics.setLastExportedPosition(container.getId(), typedEvent.getPosition());
+      } else {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  TypedRecordImpl getTypedEvent() {
+    return typedEvent;
+  }
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.records.TypedRecordImpl;
 import java.util.List;
 
-class RecordExporter {
+final class RecordExporter {
 
   private final RecordValues recordValues = new RecordValues();
   private final RecordMetadata rawMetadata = new RecordMetadata();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
@@ -73,4 +73,8 @@ class RecordExporter {
   TypedRecordImpl getTypedEvent() {
     return typedEvent;
   }
+
+  public void resetExporterIndex() {
+    exporterIndex = 0;
+  }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableDisableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableDisableTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.util.ControlledTestExporter;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.awaitility.Awaitility;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ExporterEnableDisableTest {
+  private static final String EXPORTER_ID_1 = "exporter-1";
+  private static final String EXPORTER_ID_2 = "exporter-2";
+
+  @Rule public final ExporterRule rule = ExporterRule.activeExporter();
+  private final Map<String, ControlledTestExporter> exporters = new HashMap<>();
+  private final List<ExporterDescriptor> exporterDescriptors = new ArrayList<>();
+
+  @Before
+  public void init() {
+    exporters.clear();
+    exporterDescriptors.clear();
+
+    createExporter(EXPORTER_ID_1, Collections.singletonMap("x", 1));
+    createExporter(EXPORTER_ID_2, Collections.singletonMap("y", 2));
+  }
+
+  private void createExporter(final String exporterId, final Map<String, Object> arguments) {
+    final ControlledTestExporter exporter = spy(new ControlledTestExporter());
+    exporter.shouldAutoUpdatePosition(true);
+
+    final ExporterDescriptor descriptor =
+        spy(new ExporterDescriptor(exporterId, exporter.getClass(), arguments));
+    doAnswer(c -> exporter).when(descriptor).newInstance();
+
+    exporters.put(exporterId, exporter);
+    exporterDescriptors.add(descriptor);
+  }
+
+  @Test
+  public void shouldDisableExporter() {
+    // given
+    rule.startExporterDirector(exporterDescriptors);
+    rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+
+    // when
+    rule.getDirector().disableExporter(EXPORTER_ID_1).join();
+
+    rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    final long expectedLastExportedPosition =
+        rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+
+    // then
+
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(exporters.get(EXPORTER_ID_2).getExportedRecords()).hasSize(3));
+
+    assertThat(rule.getDirector().getLowestPosition().join())
+        .describedAs("The lowest position should be updated when one exporter is disabled")
+        .isEqualTo(expectedLastExportedPosition);
+
+    assertThat(exporters.get(EXPORTER_ID_1).getExportedRecords())
+        .describedAs("Should not export to exporter-1 after disabling")
+        .hasSizeLessThanOrEqualTo(1);
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableDisableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableDisableTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.util.ControlledTestExporter;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -86,6 +87,40 @@ public class ExporterEnableDisableTest {
     assertThat(exporters.get(EXPORTER_ID_1).getExportedRecords())
         .describedAs("Should not export to exporter-1 after disabling")
         .hasSizeLessThanOrEqualTo(1);
+  }
+
+  @Test
+  public void shouldSucceedWhenDisablingAlreadyDisabledExporter() {
+    // given
+    rule.startExporterDirector(exporterDescriptors);
+    rule.getDirector().disableExporter(EXPORTER_ID_1).join();
+
+    // when - then
+    assertThat(rule.getDirector().disableExporter(EXPORTER_ID_1))
+        .succeedsWithin(Duration.ofMillis(100));
+  }
+
+  @Test
+  public void shouldSucceedWhenDisablingNonExistingExporter() {
+    // given
+    rule.startExporterDirector(exporterDescriptors);
+
+    // when - then
+    assertThat(rule.getDirector().disableExporter("non-existing-exporter"))
+        .succeedsWithin(Duration.ofMillis(100));
+  }
+
+  @Test
+  public void shouldSucceedDisablingWhenActorIsAlreadyClosed() {
+    // give
+    rule.startExporterDirector(exporterDescriptors);
+
+    // when
+    rule.getDirector().close();
+
+    // then
+    assertThat(rule.getDirector().disableExporter(EXPORTER_ID_1))
+        .succeedsWithin(Duration.ofMillis(100));
   }
 
   @Test


### PR DESCRIPTION
## Description

`ExporterDirector` exposes a method to disable an exporter by its id. When the exporter is disabled, it's container is closed and it's state is removed from the database.  No records will be exported to this exporter anymore. The logs can be compacted after the records are exported to the remaining exporters.

When there are no more exporters configured, `ExporterDirector` will be closed. This is the same behavior during startup.

After restart or a role-change, we expect that the `ExporterDirector` is given only the enabled exporters. So it doesn't persist this information anywhere. This case will be fully handled by the partition manager and transition steps. 

## Related issues

closes #18356 
