### PR TITLE
ci: set correct reference to workflow

### DIFF
--- a/.github/workflows/operate-release-manual.yml
+++ b/.github/workflows/operate-release-manual.yml
@@ -58,7 +58,7 @@ on:
 jobs:
   release:
     name: "release manually v${{ inputs.releaseVersion }}"
-    uses: camunda/zeebe/.github/workflows/operate-release-reusable.yml@main
+    uses: camunda/zeebe/.github/workflows/operate-release-reusable.yml@stable/operate-8.5
     secrets: inherit
     with:
       branch: ${{ inputs.branch }}


### PR DESCRIPTION
## Description

As [discussed on slack ](https://camunda.slack.com/archives/C03NFMH4KC6/p1715169113080139?thread_ts=1715167286.162299&cid=C03NFMH4KC6)- the workflow has been removed from main, we need to reference the right workflow from the stable branch
