### PR TITLE
Restore operate release workflows

### DIFF
--- a/.github/workflows/operate-release-manual.yml
+++ b/.github/workflows/operate-release-manual.yml
@@ -1,0 +1,70 @@
+# This GitHub Actions (GHA) workflow is used to manually trigger a release for `operate` application.
+#
+# It takes several inputs:
+# - 'branch': the branch from which to build the release.
+# - 'releaseVersion': the version number to apply to the release (in pom.xml and the Git tag).
+# - 'nextDevelopmentVersion': the version to use after the release.
+# - 'dryRun': if true, the release is built but no changes are made or artifacts (Docker, Maven) are pushed. Defaults to `true`.
+# - 'githubUploadRelease': if true, the release will be uploaded to GitHub. Defaults to `false`.
+# - 'isLatest': if true, the Docker image will be tagged with the 'latest' tag. Defaults to `false`.
+#
+# The workflow leverages a reusable workflow (./.github/workflows/operate-release-reusable.yml)
+# to perform the actual release process.
+#
+# It allows you to manually dispatch the workflow with custom input parameters to control the release process.
+# This can be done through GitHub's UI by navigating to the "Actions" tab of the `operate` repository, then clicking on the
+# "Run workflow" dropdown, selecting the workflow, filling in the input fields and clicking "Run workflow".
+#
+# Link to Release manual workflow: https://github.com/camunda/zeebe/actions/workflows/release-manual.yml
+
+name: Operate Release manual
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "The branch name to build release from."
+        type: string
+        required: true
+      releaseVersion:
+        description: "Version to release (applied to pom.xml and Git tag)."
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: "Next development version."
+        type: string
+        required: true
+      dryRun:
+        description: "Whether to perform a dry release, where no changes or artifacts(Docker, Maven) are pushed, defaults to `true`."
+        type: boolean
+        required: false
+        default: true
+      githubUploadRelease:
+        description: "Should upload the release to GitHub."
+        type: boolean
+        required: false
+        default: false
+      isLatest:
+        description: "Should tag the docker image with 'latest' tag."
+        type: boolean
+        required: false
+        default: false
+      fromCommit:
+        description: "Commit id which the changelog should be generated from."
+        type: string
+        required: true
+        default: ""
+
+jobs:
+  release:
+    name: "release manually v${{ inputs.releaseVersion }}"
+    uses: camunda/zeebe/.github/workflows/operate-release-reusable.yml@main
+    secrets: inherit
+    with:
+      branch: ${{ inputs.branch }}
+      releaseVersion: ${{ inputs.releaseVersion }}
+      nextDevelopmentVersion: ${{ inputs.nextDevelopmentVersion }}
+      dryRun: ${{ inputs.dryRun }}
+      githubUploadRelease: ${{ inputs.githubUploadRelease }}
+      isLatest: ${{ inputs.isLatest }}
+      fromCommit: ${{ inputs.fromCommit }}

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -1,0 +1,305 @@
+# This is a reusable GHA workflow for performing releases for `operate` application.
+#
+# It takes several inputs:
+# - 'branch': the branch from which to build the release.
+# - 'releaseVersion': the version number to apply to the release (in pom.xml and the Git tag).
+# - 'nextDevelopmentVersion': the version to use after the release.
+# - 'dryRun': if `true`, the release is built but no changes are made or artifacts (Docker, Maven) pushed. Defaults to `true`.
+# - 'githubUploadRelease': if `true`, the release will be uploaded to GitHub. Defaults to `false`.
+# - 'isLatest': if `true`, the Docker image will be tagged with the 'latest' tag. Defaults to `false`.
+#
+# The workflow does the following:
+# - Checks out the specified branch.
+# - Configures the GitHub user for Git operations.
+# - Imports necessary secrets from Vault.
+# - Configures Java and Maven for the build.
+# - Runs the Maven release process, including preparing and performing the release.
+#
+# - If specified, uploads the release to GitHub.
+# - If specified, uploads the Docker image to the Docker registry.
+# - If the release process fails, sends a notification to a (#operate-ci) Slack channel.
+
+name: Operate Release (reusable workflow)
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The branch name to build release from."
+        type: string
+        required: true
+      releaseVersion:
+        description: "Version to release (applied to pom.xml and Git tag)."
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: "Next development version."
+        type: string
+        required: true
+      dryRun:
+        description: "Whether to perform a dry release, where no changes or artifacts(Docker, Maven) are pushed, defaults to `true`."
+        type: boolean
+        required: false
+        default: true
+      githubUploadRelease:
+        description: "Should upload the release to GitHub."
+        type: boolean
+        required: false
+        default: false
+      isLatest:
+        description: "Should tag the docker image with 'latest' tag."
+        type: boolean
+        required: false
+        default: false
+      fromCommit:
+        description: "Commit id which the changelog should be generated from."
+        type: string
+        required: false
+        default: ""
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+env:
+  JAVA_VERSION: 21
+  LIMITS_CPU: 4
+  RELEASE_VERSION: ${{ inputs.releaseVersion }}
+  TAG_VERSION: operate-${{ inputs.releaseVersion }}
+  GITHUB_UPLOAD_RELEASE: ${{ inputs.githubUploadRelease }}
+  DRY_RUN: ${{ inputs.dryRun }}
+  CREATE_A_RELEASE: ${{ inputs.dryRun == false && inputs.fromCommit != '' }}
+
+jobs:
+  release:
+    name: "'${{ inputs.branch }}' branch"
+    runs-on: ubuntu-22.04
+    steps:
+      #########################################################################
+      # Setup: checkout branch
+      - name: "Checkout '${{ inputs.branch }}' branch"
+        uses: actions/checkout@v4
+        with:
+          ref: refs/heads/${{ inputs.branch }}
+          fetch-depth: 0  # fetches all history for all branches and tags
+
+      # Setup: configure GitHub user
+      - name: Configure GitHub user
+        run: |
+          git config --global user.email "ci@operate.camunda.cloud"
+          git config --global user.name "github-operate-app"
+
+      # Setup: import secrets from vault
+      - name: Import Secrets
+        id: secrets # important to refer to it in later steps
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          exportEnv: false # we rely on step outputs, no need for environment variables
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+            secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
+            secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
+            secret/data/products/operate/ci/github-actions OPERATE_CI_ALERT_WEBHOOK_URL;
+            secret/data/products/operate/release_process GITHUB_TOKEN;
+
+      # Setup: configure Java, Maven, settings.xml
+      - name: Setup Java ${{ env.JAVA_VERSION }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: "adopt"
+          java-version: ${{ env.JAVA_VERSION }}
+          cache: "maven"
+
+      - name: Setup Maven
+        uses: stCarolas/setup-maven@v4.5
+        with:
+          maven-version: 3.9.6
+
+      # Setup: Use CI Nexus as co-located pull-through cache for Maven artifacts via ~/.m2/settings.xml
+      - name: Create Maven settings.xml
+        uses: s4u/maven-settings-action@v3.0.0
+        with:
+          githubServer: false
+          servers: |
+            [{
+              "id": "camunda-nexus",
+              "username": "${{ steps.secrets.outputs.NEXUS_USR }}",
+              "password": "${{ steps.secrets.outputs.NEXUS_PSW }}"
+            }]
+          mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
+
+      #########################################################################
+      # Release: run Maven release
+      - name: Prepare Maven release
+        env:
+          NEXT_DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
+        run: |
+          mvn -f operate release:prepare -P -docker \
+          -DpushChanges=false \
+          -DskipTests=true -B -T$LIMITS_CPU --fail-at-end \
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+          -Dtag=$TAG_VERSION \
+          -DreleaseVersion=$RELEASE_VERSION \
+          -DdevelopmentVersion=$NEXT_DEVELOPMENT_VERSION \
+          -Darguments='-Dmaven.deploy.skip=$DRY_RUN -P -docker -DskipTests=true -DskipNexusStagingDeployMojo=$DRY_RUN -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f pom.xml'
+
+      # Pushing changes manually since maven-release-plugin fails in subfolders:
+      # https://issues.apache.org/jira/browse/MRELEASE-885
+      - name: Push Git changes
+        if: ${{ env.CREATE_A_RELEASE == 'true' }}
+        run: |
+          git push --tags
+          git push --all
+
+      - name: Perform Maven release
+        run: |
+          mvn -f operate release:perform -P -docker \
+          -DlocalCheckout=true \
+          -DskipTests=true -B -T$LIMITS_CPU --fail-at-end \
+          -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+          -Darguments='-Dmaven.deploy.skip=$DRY_RUN -P -docker -DskipTests=true -DskipNexusStagingDeployMojo=$DRY_RUN -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f pom.xml'
+
+      - name: Create a GitHub release
+        if: ${{ env.CREATE_A_RELEASE == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
+        uses: octokit/request-action@v2.3.0
+        with:
+          route: POST /repos/camunda/zeebe/releases
+          draft: true
+          name: ${{ env.TAG_VERSION }}
+          tag_name: ${{ env.TAG_VERSION }}
+          generate_release_notes: true
+          make_latest: \"false\"
+
+      # Easiest way to avoid race condition
+      - name: Wait for GitHub Release
+        run: sleep 10
+
+      # Upload: Upload to GitHub Release
+      - name: Upload to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ steps.secrets.outputs.GITHUB_TOKEN }}
+        run: |
+          ARTIFACT="camunda-operate"
+
+          cd operate/target/checkout/distro/target
+
+          # create checksums
+          sha1sum ${ARTIFACT}-${RELEASE_VERSION}.tar.gz > ${ARTIFACT}-${RELEASE_VERSION}.tar.gz.sha1sum
+          sha1sum ${ARTIFACT}-${RELEASE_VERSION}.zip > ${ARTIFACT}-${RELEASE_VERSION}.zip.sha1sum
+
+          # upload to github release
+          curl -sL https://github.com/github-release/github-release/releases/download/v0.10.0/linux-amd64-github-release.bz2 | bzip2 -fd - > github-release
+          chmod +x github-release
+
+          for f in ${ARTIFACT}-${RELEASE_VERSION}.{tar.gz,zip}{,.sha1sum}; do
+            if $DRY_RUN; then
+              echo "'${f}' file was created, skip upload in dryRun mode"
+            elif $GITHUB_UPLOAD_RELEASE; then
+              echo "Uploading '${f}' file to zeebe repo on GitHub"
+              ./github-release upload --user camunda --repo zeebe --tag "${TAG_VERSION}" --name "${f}" --file "${f}"
+            else
+              echo "'${f}' file was created, skip upload"
+            fi
+          done
+
+      # Upload: Upload Docker Image
+      - name: Upload Docker Image
+        env:
+          IMAGE_NAME: 'camunda/operate'
+          IMAGE_TAG: ${{ inputs.releaseVersion }}
+          IS_LATEST: ${{ inputs.isLatest }}
+          VERSION: ${{ inputs.releaseVersion }}
+          DOCKER_USERNAME: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
+          DOCKER_PASSWORD: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
+        run: |
+          echo "$DOCKER_PASSWORD" | docker login --username $DOCKER_USERNAME --password-stdin
+          docker buildx create --use
+
+          commit_hash=$(git rev-parse --verify HEAD)
+          date_time_stamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+
+          export VERSION=$VERSION
+          export DATE=$date_time_stamp
+          export REVISION=$commit_hash
+          export BASE_IMAGE=docker.io/library/alpine:3.19.1
+          sudo apt update
+          sudo apt install -y jq
+          sudo apt install -y bash
+
+          # Since docker buildx doesn't allow to use --load for a multi-platform build, we do it one at a time to be
+          # able to perform the checks before pushing
+          # First amd64
+          docker buildx build \
+            -f operate.Dockerfile \
+            -t $IMAGE_NAME:$IMAGE_TAG \
+            --build-arg VERSION=$VERSION \
+            --build-arg DATE=$date_time_stamp \
+            --build-arg REVISION=$commit_hash \
+            --platform linux/amd64 \
+            --provenance false \
+            --load \
+            .
+          export ARCHITECTURE=amd64
+          bash ./.ci/docker/test/verify.sh $IMAGE_NAME:$IMAGE_TAG
+
+          # Now arm64
+          docker buildx build \
+            -f operate.Dockerfile \
+            -t $IMAGE_NAME:$IMAGE_TAG \
+            --build-arg VERSION=$VERSION \
+            --build-arg DATE=$date_time_stamp \
+            --build-arg REVISION=$commit_hash \
+            --platform linux/arm64 \
+            --provenance false \
+            --load \
+            .
+          export ARCHITECTURE=arm64
+          bash ./.ci/docker/test/verify.sh $IMAGE_NAME:$IMAGE_TAG
+
+          if ${CREATE_A_RELEASE}; then
+            docker buildx build -f operate.Dockerfile . \
+            --platform linux/arm64,linux/amd64 \
+            --build-arg VERSION=$VERSION \
+            --build-arg REVISION=$commit_hash \
+            --build-arg DATE=$date_time_stamp \
+            --provenance false \
+            -t $IMAGE_NAME:$IMAGE_TAG \
+            --push
+
+            if ${IS_LATEST}; then
+              docker buildx build -f operate.Dockerfile . \
+              --platform linux/arm64,linux/amd64 \
+              --build-arg VERSION=$VERSION \
+              --build-arg REVISION=$commit_hash \
+              --build-arg DATE=$date_time_stamp \
+              --provenance false \
+              -t $IMAGE_NAME:latest \
+              --push
+            fi
+          fi
+
+      #########################################################################
+      # Notify: send Slack notification of release failure
+      - name: Send Slack notification on failure
+        if: failure()
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ steps.secrets.outputs.OPERATE_CI_ALERT_WEBHOOK_URL }}
+        with:
+          payload: |
+            {
+              "workflow_name": "${{ github.workflow }}",
+              "github_run_url": "https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}",
+              "dry_run": "${{ inputs.dryRun }}",
+              "release_version": "${{ inputs.releaseVersion }}",
+              "branch": "${{ inputs.branch }}"
+            }


### PR DESCRIPTION
## Description

We had to restore the operate release workflows, in order to trigger them from the Actions UI and (likely) also via the API. 

The latter needs to be still proven as we can see that some run has been actually be triggered, see https://github.com/camunda/zeebe/actions/workflows/operate-release-manual.yml but failed with:

```
[Invalid workflow file: .github/workflows/operate-release-manual.yml#L61](https://github.com/camunda/zeebe/actions/runs/9000805743/workflow)
error parsing called workflow ".github/workflows/operate-release-manual.yml" -> "camunda/zeebe/.github/workflows/operate-release-reusable.yml@main" : failed to fetch workflow: workflow was not found.
```

![2024-05-08_14-03](https://github.com/camunda/zeebe/assets/2758593/2b869411-77bb-48cc-8f27-439599a5919a)


Likely the API can also trigger workflows on branches. If this is the case we just need to fix the reference on a stable branch as done here https://github.com/camunda/zeebe/pull/18367

## Related issues

See related [thread](https://camunda.slack.com/archives/C03NFMH4KC6/p1715167286162299) 
