### PR TITLE
Add operation and applier for disabling exporter

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ClusterEndpoint.java
@@ -386,6 +386,7 @@ public class ClusterEndpoint {
               .operation(OperationEnum.BROKER_REMOVE)
               .brokerId(Integer.parseInt(memberRemoveOperation.memberId().id()))
               .brokers(List.of(Integer.parseInt(memberRemoveOperation.memberToRemove().id())));
+      default -> new Operation().operation(OperationEnum.UNKNOWN);
     };
   }
 
@@ -533,12 +534,15 @@ public class ClusterEndpoint {
                       partitionForceReconfigureOperation.members().stream()
                           .map(MemberId::id)
                           .map(Integer::parseInt)
-                          .collect(Collectors.toList()));
+                          .toList());
           case final MemberRemoveOperation memberRemoveOperation ->
               new TopologyChangeCompletedInner()
                   .operation(TopologyChangeCompletedInner.OperationEnum.BROKER_REMOVE)
                   .brokerId(Integer.parseInt(memberRemoveOperation.memberId().id()))
                   .brokers(List.of(Integer.parseInt(memberRemoveOperation.memberToRemove().id())));
+          default ->
+              new TopologyChangeCompletedInner()
+                  .operation(TopologyChangeCompletedInner.OperationEnum.UNKNOWN);
         };
 
     mappedOperation.completedAt(mapInstantToDateTime(operation.completedAt()));

--- a/dist/src/main/resources/api/cluster-api.yaml
+++ b/dist/src/main/resources/api/cluster-api.yaml
@@ -345,6 +345,7 @@ components:
             - PARTITION_RECONFIGURE_PRIORITY
             - PARTITION_FORCE_RECONFIGURE
             - BROKER_FORCE_REMOVE
+            - UNKNOWN
         brokerId:
           $ref: "#/components/schemas/BrokerId"
         partitionId:

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupProcessShutdownException;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthStatus;
@@ -365,5 +366,11 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
               });
         });
     return result;
+  }
+
+  @Override
+  public ActorFuture<Void> disableExporter(final int partitionId, final String exporterId) {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException("Not implemented"));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -68,6 +69,12 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
           // not the member that is leaving
           new MemberLeaveApplier(
               memberRemoveOperation.memberToRemove(), clusterMembershipChangeExecutor);
+      case final PartitionDisableExporterOperation disableExporterOperation ->
+          new PartitionDisableExporterApplier(
+              disableExporterOperation.partitionId(),
+              disableExporterOperation.memberId(),
+              disableExporterOperation.exporterId(),
+              partitionChangeExecutor);
       case null, default -> new FailingApplier(operation);
     };
   }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -36,4 +36,9 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
       final int partitionId, final Collection<MemberId> members) {
     return CompletableActorFuture.completed(null);
   }
+
+  @Override
+  public ActorFuture<Void> disableExporter(final int partitionId, final String exporterId) {
+    return CompletableActorFuture.completed(null);
+  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -59,4 +59,13 @@ public interface PartitionChangeExecutor {
    * @return a future that completes when the partition is reconfigured
    */
   ActorFuture<Void> forceReconfigure(final int partitionId, final Collection<MemberId> members);
+
+  /**
+   * Disables the exporter for the given partition.
+   *
+   * @param partitionId id of the partition
+   * @param exporterId id of the exporter to disable
+   * @return a future that completes when the exporter is disabled
+   */
+  ActorFuture<Void> disableExporter(final int partitionId, final String exporterId);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplier.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.function.UnaryOperator;
+
+final class PartitionDisableExporterApplier implements MemberOperationApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final String exporterId;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  public PartitionDisableExporterApplier(
+      final int partitionId,
+      final MemberId memberId,
+      final String exporterId,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.exporterId = exporterId;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public MemberId memberId() {
+    return memberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
+      final ClusterConfiguration currentClusterConfiguration) {
+
+    if (!currentClusterConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to disable exporter, but the member '%s' does not exist in the cluster",
+                  memberId)));
+    }
+
+    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    final var partitionExistsInLocalMember = member.hasPartition(partitionId);
+
+    if (!partitionExistsInLocalMember) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to disable exporter, but the member '%s' does not have the partition '%s'",
+                  memberId, partitionId)));
+    }
+
+    final var partitionHasExporter =
+        member.getPartition(partitionId).config().exporting().exporters().containsKey(exporterId);
+
+    if (!partitionHasExporter) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to disable exporter, but the partition '%s' does not have the exporter '%s'",
+                  partitionId, exporterId)));
+    }
+
+    // No need to change the state
+    return Either.right(memberstate -> memberstate);
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
+    final var result = new CompletableActorFuture<UnaryOperator<MemberState>>();
+
+    partitionChangeExecutor
+        .disableExporter(partitionId, exporterId)
+        .onComplete(
+            (nothing, error) -> {
+              if (error == null) {
+                result.complete(
+                    memberState ->
+                        memberState.updatePartition(
+                            partitionId,
+                            partition ->
+                                partition.updateConfig(
+                                    config -> disableExporter(config, exporterId))));
+              } else {
+                result.completeExceptionally(error);
+              }
+            });
+
+    return result;
+  }
+
+  private DynamicPartitionConfig disableExporter(
+      final DynamicPartitionConfig config, final String exporterId) {
+    return config.updateExporting(
+        exporting -> exporting.updateExporter(exporterId, new ExporterState(State.DISABLED)));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -370,6 +371,12 @@ public class ProtoBufSerializer
               Topology.MemberRemoveOperation.newBuilder()
                   .setMemberToRemove(memberRemoveOperation.memberToRemove().id())
                   .build());
+      case final PartitionDisableExporterOperation disableExporterOperation ->
+          builder.setPartitionDisableExporter(
+              Topology.PartitionDisableExporterOperation.newBuilder()
+                  .setPartitionId(disableExporterOperation.partitionId())
+                  .setExporterId(disableExporterOperation.exporterId())
+                  .build());
       default ->
           throw new IllegalArgumentException(
               "Unknown operation type: " + operation.getClass().getSimpleName());
@@ -455,6 +462,11 @@ public class ProtoBufSerializer
       return new MemberRemoveOperation(
           MemberId.from(topologyChangeOperation.getMemberId()),
           MemberId.from(topologyChangeOperation.getMemberRemove().getMemberToRemove()));
+    } else if (topologyChangeOperation.hasPartitionDisableExporter()) {
+      return new PartitionDisableExporterOperation(
+          MemberId.from(topologyChangeOperation.getMemberId()),
+          topologyChangeOperation.getPartitionDisableExporter().getPartitionId(),
+          topologyChangeOperation.getPartitionDisableExporter().getExporterId());
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -84,5 +84,15 @@ public sealed interface ClusterConfigurationChangeOperation {
     record PartitionForceReconfigureOperation(
         MemberId memberId, int partitionId, Collection<MemberId> members)
         implements PartitionChangeOperation {}
+
+    /**
+     * Operation to disable an exporter on a partition in the given member.
+     *
+     * @param memberId the member id of the member that will apply this operation
+     * @param partitionId id of the partition which disables the exporter
+     * @param exporterId id of the exporter to disable
+     */
+    record PartitionDisableExporterOperation(MemberId memberId, int partitionId, String exporterId)
+        implements PartitionChangeOperation {}
   }
 }

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -533,6 +533,11 @@
                 "id": 8,
                 "name": "memberRemove",
                 "type": "MemberRemoveOperation"
+              },
+              {
+                "id": 9,
+                "name": "partitionDisableExporter",
+                "type": "PartitionDisableExporterOperation"
               }
             ]
           },
@@ -604,6 +609,21 @@
                 "name": "members",
                 "type": "string",
                 "is_repeated": true
+              }
+            ]
+          },
+          {
+            "name": "PartitionDisableExporterOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitionId",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "exporterId",
+                "type": "string"
               }
             ]
           },

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -68,6 +68,7 @@ message TopologyChangeOperation {
     PartitionReconfigurePriorityOperation partitionReconfigurePriority = 6;
     PartitionForceReconfigureOperation partitionForceReconfigure = 7;
     MemberRemoveOperation memberRemove = 8;
+    PartitionDisableExporterOperation partitionDisableExporter = 9;
   }
 }
 
@@ -93,6 +94,11 @@ message PartitionReconfigurePriorityOperation {
 message PartitionForceReconfigureOperation {
   int32 partitionId = 1;
   repeated string members = 2;
+}
+
+message PartitionDisableExporterOperation {
+  int32 partitionId = 1;
+  string exporterId = 2;
 }
 
 message MemberJoinOperation {}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -52,6 +53,9 @@ final class ConfigurationChangeAppliersImplTest {
             PartitionReconfigurePriorityApplier.class),
         Arguments.of(
             new PartitionForceReconfigureOperation(localMemberId, 1, List.of()),
-            PartitionForceReconfigureApplier.class));
+            PartitionForceReconfigureApplier.class),
+        Arguments.of(
+            new PartitionDisableExporterOperation(localMemberId, 1, "expId"),
+            PartitionDisableExporterApplier.class));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+final class PartitionDisableExporterApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+
+  private final String exporterId = "exporterA";
+  private final int partitionId = 2;
+  private final MemberId localMemberId = MemberId.from("3");
+
+  private final PartitionDisableExporterApplier applier =
+      new PartitionDisableExporterApplier(
+          partitionId, localMemberId, exporterId, partitionChangeExecutor);
+
+  @Test
+  void shouldFailInitIfMemberDoesNotExist() {
+    // given
+    final var clusterConfiguration = ClusterConfiguration.init();
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("member '3' does not exist in the cluster");
+  }
+
+  @Test
+  void shouldFailInitIfPartitionDoesNotExist() {
+    // given
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the partition '2'");
+  }
+
+  @Test
+  void shouldFailInitIfExporterDoesNotExist() {
+    // given
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, DynamicPartitionConfig.init()))));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the exporter 'exporterA'");
+  }
+
+  @Test
+  void shouldNotChangeStateInInit() {
+    // given
+    final var configWithExporter =
+        new DynamicPartitionConfig(
+            new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, configWithExporter))));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final MemberState memberState = clusterConfiguration.getMember(localMemberId);
+    assertThat(result.get().apply(memberState)).isEqualTo(memberState);
+  }
+
+  @Test
+  void shouldFailFutureIfApplyFailed() {
+    // given
+    when(partitionChangeExecutor.disableExporter(partitionId, exporterId))
+        .thenReturn(
+            CompletableActorFuture.completedExceptionally(new RuntimeException("force fail")));
+
+    // when
+    final var result = applier.applyOperation();
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("force fail");
+  }
+
+  @Test
+  void shouldCompleteFutureAndUpdateStateIfApplySucceeds() {
+    // given
+    final var exporterState = new ExporterState(State.ENABLED);
+    final var exporterConfig = new ExportersConfig(Map.of(exporterId, exporterState));
+    final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
+    final var memberState =
+        MemberState.initializeAsActive(
+            Map.of(partitionId, PartitionState.active(1, partitionConfig)));
+
+    when(partitionChangeExecutor.disableExporter(partitionId, exporterId))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    // when
+    final var result = applier.applyOperation();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+
+    final var updatedState = result.join().apply(memberState);
+    assertThat(
+            updatedState
+                .getPartition(partitionId)
+                .config()
+                .exporting()
+                .exporters()
+                .get(exporterId)
+                .state())
+        .isEqualTo(State.DISABLED);
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -185,7 +186,8 @@ final class ProtoBufSerializerTest {
         topologyWithClusterChangePlan(),
         topologyWithCompletedClusterChangePlan(),
         topologyWithClusterChangePlanWithMemberOperations(),
-        topologyWithExporterState());
+        topologyWithExporterState(),
+        topologyWithExporterDisableOperation());
   }
 
   private static ClusterConfiguration topologyWithOneMemberNoPartitions() {
@@ -306,5 +308,11 @@ final class ProtoBufSerializerTest {
             m ->
                 m.addPartition(
                     1, new PartitionState(PartitionState.State.ACTIVE, 1, dynamicConfig)));
+  }
+
+  private static ClusterConfiguration topologyWithExporterDisableOperation() {
+    return topologyWithExporterState()
+        .startConfigurationChange(
+            List.of(new PartitionDisableExporterOperation(MemberId.from("1"), 1, "expA")));
   }
 }


### PR DESCRIPTION
## Description

This PR adds a new `PartitionDisabledExporterOperation` to the allowed list of configuration change operations. An operation applier is also added which can delegate the operation to the `PartitionManager` and updates the configuration after the exporter is disabled.  The operation will be applied by `ClusterConfigurationManager` similar to all other configuration change operation.

When a new operation is added, we also have to define it in the open-api spec for cluster endpoint. To simplify this, this PR also adds an `UNKNOWN` operation as a catch-all for all unimplemented operations. A proper response will be defined later when the gateway endpoint for disabling exporter will be added.

## Related issues

closes #18418 
