### PR TITLE
fix: input the token independent of response code

### DIFF
--- a/tasklist/client/src/modules/request.ts
+++ b/tasklist/client/src/modules/request.ts
@@ -50,12 +50,13 @@ async function request(
 
     if (response.ok) {
       authenticationStore.activateSession();
-      const tokenFromResponse = response.headers.get('X-CSRF-TOKEN');
+    }
 
-      // If the token is found in the response headers, use it
-      if (tokenFromResponse) {
-        sessionStorage.setItem('X-CSRF-TOKEN', tokenFromResponse);
-      }
+    const tokenFromResponse = response.headers.get('X-CSRF-TOKEN');
+
+    // If the token is found in the response headers, use it
+    if (tokenFromResponse) {
+      sessionStorage.setItem('X-CSRF-TOKEN', tokenFromResponse);
     }
 
     if (!skipSessionCheck && response.status === 401) {


### PR DESCRIPTION
## Description

inputing Csrf tokens independent of the response codes
so in case a prioblem of any specific endpoint, we wont have a problem with 403 errors, once token is always updated

