### PR TITLE
Coordinator can process request to disable exporter 

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -44,6 +45,9 @@ public interface ClusterConfigurationManagementApi {
    */
   ActorFuture<ClusterConfigurationChangeResponse> forceScaleDown(
       ScaleRequest forceScaleDownRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
+      ExporterDisableRequest exporterDisableRequest);
 
   ActorFuture<ClusterConfiguration> cancelTopologyChange(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -42,6 +42,9 @@ public sealed interface ClusterConfigurationManagementRequest {
     }
   }
 
+  record ExporterDisableRequest(String exporterId, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
   record CancelChangeRequest(long changeId) implements ClusterConfigurationManagementRequest {
 
     @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -111,6 +112,17 @@ public final class ClusterConfigurationManagementRequestSender {
         serializer::encodeScaleRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getNextCoordinator(forceScaleDownRequest.members()),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      disableExporter(final ExporterDisableRequest exporterDisableRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.DISABLE_EXPORTER.topic(),
+        exporterDisableRequest,
+        serializer::encodeExporterDisableRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.api;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -124,6 +125,14 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         forceScaleDownRequest.dryRun(),
         new ForceScaleDownRequestTransformer(forceScaleDownRequest.members(), localMemberId));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
+      final ExporterDisableRequest exporterDisableRequest) {
+    return handleRequest(
+        exporterDisableRequest.dryRun(),
+        new ExporterDisableRequestTransformer(exporterDisableRequest.exporterId()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -44,6 +44,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerGetTopologyQueryHandler();
     registerTopologyCancelHandler();
     registerForceScaleDownHandler();
+    registerDisableExporterHandler();
   }
 
   @Override
@@ -141,6 +142,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
             mapClusterTopologyResponse(
                 clusterConfigurationManagementApi.cancelTopologyChange(request)),
         this::encodeClusterTopologyResponse);
+  }
+
+  private void registerDisableExporterHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.DISABLE_EXPORTER.topic(),
+        serializer::decodeExporterDisableRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.disableExporter(request)),
+        this::encodeResponse);
   }
 
   private CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>> mapResponse(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -16,7 +16,8 @@ public enum ClusterConfigurationRequestTopics {
   SCALE_MEMBERS("topology-member-scale"),
   QUERY_TOPOLOGY("topology-query"),
   CANCEL_CHANGE("topology-change-cancel"),
-  FORCE_SCALE_DOWN("topology-force-scale-down");
+  FORCE_SCALE_DOWN("topology-force-scale-down"),
+  DISABLE_EXPORTER("topology-exporter-disable");
   private final String topic;
 
   ClusterConfigurationRequestTopics(final String topic) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ExporterDisableRequestTransformer implements ConfigurationChangeRequest {
+
+  private final String exporterId;
+
+  public ExporterDisableRequestTransformer(final String exporterId) {
+
+    this.exporterId = exporterId;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+    for (final var member : clusterConfiguration.members().entrySet()) {
+      final var memberId = member.getKey();
+      for (final var partitions : member.getValue().partitions().entrySet()) {
+        final var partitionId = partitions.getKey();
+        operations.add(new PartitionDisableExporterOperation(memberId, partitionId, exporterId));
+      }
+    }
+    return Either.right(operations);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -32,6 +32,9 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeCancelChangeRequest(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);
 
+  byte[] encodeExporterDisableRequest(
+      ClusterConfigurationManagementRequest.ExporterDisableRequest exporterDisableRequest);
+
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
 
@@ -51,6 +54,9 @@ public interface ClusterConfigurationRequestsSerializer {
 
   ClusterConfigurationManagementRequest.CancelChangeRequest decodeCancelChangeRequest(
       byte[] encodedState);
+
+  ClusterConfigurationManagementRequest.ExporterDisableRequest decodeExporterDisableRequest(
+      byte[] encodedRequest);
 
   byte[] encodeResponse(ClusterConfigurationChangeResponse response);
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -13,6 +13,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -554,6 +555,15 @@ public class ProtoBufSerializer
   }
 
   @Override
+  public byte[] encodeExporterDisableRequest(final ExporterDisableRequest exporterDisableRequest) {
+    return Requests.ExporterDisableRequest.newBuilder()
+        .setExporterId(exporterDisableRequest.exporterId())
+        .setDryRun(exporterDisableRequest.dryRun())
+        .build()
+        .toByteArray();
+  }
+
+  @Override
   public AddMembersRequest decodeAddMembersRequest(final byte[] encodedState) {
     try {
       final var addMemberRequest = Requests.AddMembersRequest.parseFrom(encodedState);
@@ -645,6 +655,17 @@ public class ProtoBufSerializer
     try {
       final var cancelChangeRequest = Requests.CancelTopologyChangeRequest.parseFrom(encodedState);
       return new CancelChangeRequest(cancelChangeRequest.getChangeId());
+    } catch (final InvalidProtocolBufferException e) {
+      throw new DecodingFailed(e);
+    }
+  }
+
+  @Override
+  public ExporterDisableRequest decodeExporterDisableRequest(final byte[] encodedRequest) {
+    try {
+      final var exporterDisableRequest = Requests.ExporterDisableRequest.parseFrom(encodedRequest);
+      return new ExporterDisableRequest(
+          exporterDisableRequest.getExporterId(), exporterDisableRequest.getDryRun());
     } catch (final InvalidProtocolBufferException e) {
       throw new DecodingFailed(e);
     }

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -141,6 +141,21 @@
             ]
           },
           {
+            "name": "ExporterDisableRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "exporterId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
             "name": "CancelTopologyChangeRequest",
             "fields": [
               {

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -40,6 +40,11 @@ message ReassignAllPartitionsRequest {
   bool dryRun = 2;
 }
 
+message ExporterDisableRequest {
+  string exporterId = 1;
+  bool dryRun = 2;
+}
+
 message CancelTopologyChangeRequest {
   int64 changeId = 1;
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class ExporterDisableRequestTransformerTest {
+
+  final String exporterId = "exporterA";
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final DynamicPartitionConfig config =
+      new DynamicPartitionConfig(
+          new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
+
+  @Test
+  void shouldGenerateOperationForAllPartitionsAndMembers() {
+    // given
+    final var transformer = new ExporterDisableRequestTransformer(exporterId);
+
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, config)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, config)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, config)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, config)));
+
+    // when
+    final var result = transformer.operations(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactlyInAnyOrder(
+            new PartitionDisableExporterOperation(id0, 1, exporterId),
+            new PartitionDisableExporterOperation(id0, 2, exporterId),
+            new PartitionDisableExporterOperation(id1, 2, exporterId),
+            new PartitionDisableExporterOperation(id1, 1, exporterId));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -12,6 +12,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -145,6 +146,20 @@ final class ProtoBufSerializerTest {
     // then
     final var decodedRequest = protoBufSerializer.decodeLeavePartitionRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(leavePartitionRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeExporterDisableRequest() {
+    // given
+    final var exporterDisableRequest = new ExporterDisableRequest("expId", false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeExporterDisableRequest(exporterDisableRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeExporterDisableRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(exporterDisableRequest);
   }
 
   @Test


### PR DESCRIPTION
## Description

A coordinator broker (which is usually the broker with the lowest id in the cluster) can accept a request to disable an exporter. When the request is received, it is translated to a sequence of operations which is then added to the cluster change plan, similar to how other topology change requests like scaling are handled.

This PR 
1. Defines the proto message for the request
2. Implements the request logic in the receiving broker.
3. Implements the sender that can send the request to the coordinator.

## Related issues

closes #18420 
