### PR TITLE
Remove unreachable code

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporter.java
@@ -106,11 +106,6 @@ public class MetricsExporter implements Exporter {
 
   @Override
   public void export(final Record<?> record) {
-    if (record.getRecordType() != RecordType.EVENT) {
-      controller.updateLastExportedRecordPosition(record.getPosition());
-      return;
-    }
-
     final var partitionId = record.getPartitionId();
     final var recordKey = record.getKey();
 


### PR DESCRIPTION
## Description

Removes an unnecessary condition to exit early if the record is not event. This is unnecessary because we're already applying a record filter for the exporter which only accepts events.

## Related issues

closes #9760 
