### PR TITLE
ci: build Tasklist and Operate frontends in distribution module

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -173,15 +173,18 @@ jobs:
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory
           export ZBCTL_ROOT_DIR=${PWD}
 
-          # -DskipQaBuild=true -P-autoFormat
+          # -DskipQaBuild=true -P-autoFormat,buildDistFrontend,skipFrontendBuild
           #   In order to disable QA/IT and the auto formatting during the release.
           #   It is unnecessary to release integration tests, and we don't want to run the auto-formatting unnecessarily.
+          #   Building Operate and Tasklist frontend packages does not work in concurrent mode:
+          #   - It is necessary to build the frontend packages in a single place, from dist module, using buildDistFrontend profile
+          #   - It is necessary to skip frontend build in the respective Operate and Tasklist client modules using skipFrontendBuild profile
           ./mvnw release:perform -B \
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.dryRun }} \
             -DskipQaBuild=true \
-            -P-autoFormat \
-            -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
+            -P-autoFormat,buildDistFrontend,skipFrontendBuild \
+            -Darguments='-T0.5C -P-autoFormat,buildDistFrontend,skipFrontendBuild -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 
           # switch to the directory to which maven checks out the release tag
           # see https://maven.apache.org/maven-release/maven-release-plugin/perform-mojo.html#workingDirectory

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -615,4 +615,105 @@
       </plugin>
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>buildDistFrontend</id>
+      <build>
+        <resources>
+          <resource>
+            <targetPath>${project.build.outputDirectory}/META-INF/resources/operate</targetPath>
+            <directory>${maven.multiModuleProjectDirectory}/operate/client/build</directory>
+          </resource>
+          <resource>
+            <targetPath>${project.build.outputDirectory}/META-INF/resources/tasklist</targetPath>
+            <directory>${maven.multiModuleProjectDirectory}/tasklist/client/build</directory>
+          </resource>
+        </resources>
+        <plugins>
+          <plugin>
+            <groupId>com.github.eirslett</groupId>
+            <artifactId>frontend-maven-plugin</artifactId>
+            <configuration>
+              <installDirectory>target</installDirectory>
+            </configuration>
+            <executions>
+              <execution>
+                <id>install node and yarn</id>
+                <goals>
+                  <goal>install-node-and-yarn</goal>
+                </goals>
+                <configuration>
+                  <nodeVersion>${version.node}</nodeVersion>
+                  <yarnVersion>${version.yarn}</yarnVersion>
+                </configuration>
+              </execution>
+              <execution>
+                <id>operate update package.json version</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>version --new-version=${project.version} --no-git-tag-version</arguments>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}/operate/client</workingDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>operate yarn install</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <failOnError>false</failOnError>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}/operate/client</workingDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>operate yarn build</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <failOnError>false</failOnError>
+                  <arguments>build</arguments>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}/operate/client</workingDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>tasklist update package.json version</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <arguments>version --new-version=${project.version} --no-git-tag-version</arguments>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}/tasklist/client</workingDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>tasklist yarn install</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <failOnError>false</failOnError>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}/tasklist/client</workingDirectory>
+                </configuration>
+              </execution>
+              <execution>
+                <id>tasklist yarn build</id>
+                <goals>
+                  <goal>yarn</goal>
+                </goals>
+                <configuration>
+                  <failOnError>false</failOnError>
+                  <arguments>build</arguments>
+                  <workingDirectory>${maven.multiModuleProjectDirectory}/tasklist/client</workingDirectory>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>


### PR DESCRIPTION
## Description
This is to fix the issues found when running `release:perform` with concurrency, yarn install mvn plugin could not be run at the same time for Operate and Tasklist, thus we had to disable the concurrency for the releasing (which makes it taking ~6 minutes longer)

In this pull request, `frontend-maven-plugin` executions are run by `dist` module to ensure that they are not run in parallel, it also allows that `install-node-and-yarn` goal is excuted only once.
A new profile `buildDistFrontend` was created to be used for mvn `release:perform` along with `skipFrontendBuild` that skips the same plugin executions in client submodules in Tasklist and Operate
The plugin is kept though in client modules, to allow developers to start the applications using webapp only (without building and running the single JAR) 

Dry-run for this branch https://github.com/camunda/zeebe/actions/runs/9075444643

## Related issues

closes #