### PR TITLE
build: use default table as specified by the action

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -57,4 +57,3 @@ runs:
         user_reason: "${{ inputs.user_reason }}"
         user_description: "${{ inputs.user_description }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
-        big_query_table_name: "ci-30-162810:prod_ci_analytics.build_status_v2"

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -155,4 +155,3 @@ jobs:
         with:
           build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
           gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
-          big_query_table_name: "ci-30-162810:prod_ci_analytics.build_status_v2"

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -158,4 +158,3 @@ jobs:
         with:
           build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
           gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
-          big_query_table_name: "ci-30-162810:prod_ci_analytics.build_status_v2"


### PR DESCRIPTION
## Description

This PR defaults to the reusable action's table instead of explicitly specifying one, allowing for it to be swapped in one place only.

## Related issues

related to #18224
