### PR TITLE
Schedule tasks by timestamp

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -115,7 +115,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
               final long scheduleFor = now + Math.max(dueDate - now, timerResolution);
               if (!(currentlyPlanned instanceof final Scheduled currentlyScheduled)
                   || (currentlyScheduled.scheduledFor() - scheduleFor > timerResolution)) {
-                final var task = scheduleService.runAt(scheduleFor, this::execute);
+                final var task = scheduleService.runAfter(scheduleFor, this::execute);
                 return Optional.of(new Scheduled(scheduleFor, task));
               }
               return Optional.empty();
@@ -131,9 +131,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   public void onRecovered(final ReadonlyStreamProcessorContext processingContext) {
     final var scheduleService = processingContext.getScheduleService();
     if (scheduleAsync) {
-      this.scheduleService = scheduleService::runAtAsync;
+      this.scheduleService = scheduleService::runAfterAsync;
     } else {
-      this.scheduleService = scheduleService::runAt;
+      this.scheduleService = scheduleService::runAfter;
     }
 
     shouldRescheduleChecker = true;
@@ -169,10 +169,11 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   interface ScheduleDelayed {
     /**
      * Implemented by either {@link
-     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAt(long, Task)} or {@link
-     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAtAsync(long, Task)}
+     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAfter(long, Task)} or
+     * {@link io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAfterAsync(long,
+     * Task)}
      */
-    ScheduledTask runAt(long timestamp, final Task task);
+    ScheduledTask runAfter(long timestamp, final Task task);
   }
 
   interface NextExecution {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/scheduled/DueDateChecker.java
@@ -115,7 +115,7 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
               final long scheduleFor = now + Math.max(dueDate - now, timerResolution);
               if (!(currentlyPlanned instanceof final Scheduled currentlyScheduled)
                   || (currentlyScheduled.scheduledFor() - scheduleFor > timerResolution)) {
-                final var task = scheduleService.runAfter(scheduleFor, this::execute);
+                final var task = scheduleService.runAt(scheduleFor, this::execute);
                 return Optional.of(new Scheduled(scheduleFor, task));
               }
               return Optional.empty();
@@ -131,9 +131,9 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   public void onRecovered(final ReadonlyStreamProcessorContext processingContext) {
     final var scheduleService = processingContext.getScheduleService();
     if (scheduleAsync) {
-      this.scheduleService = scheduleService::runAfterAsync;
+      this.scheduleService = scheduleService::runAtAsync;
     } else {
-      this.scheduleService = scheduleService::runAfter;
+      this.scheduleService = scheduleService::runAt;
     }
 
     shouldRescheduleChecker = true;
@@ -169,11 +169,10 @@ public final class DueDateChecker implements StreamProcessorLifecycleAware {
   interface ScheduleDelayed {
     /**
      * Implemented by either {@link
-     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAfter(long, Task)} or
-     * {@link io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAfterAsync(long,
-     * Task)}
+     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAt(long, Task)} or {@link
+     * io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService#runAtAsync(long, Task)}
      */
-    ScheduledTask runAfter(long timestamp, final Task task);
+    ScheduledTask runAt(long timestamp, final Task task);
   }
 
   interface NextExecution {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -8,7 +8,7 @@
 package io.camunda.zeebe.engine.processing.scheduled;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -20,7 +20,6 @@ import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService.ScheduledTask;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
-import java.time.Duration;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -34,10 +33,9 @@ public class DueDateCheckerTest {
     final var dueDateChecker = new DueDateChecker(timerResolution, false, (builder) -> 0L);
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
-
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -47,7 +45,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 1000); // in one second
 
     // then
-    verify(mockScheduleService).runDelayed(any(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
   }
 
   @Test
@@ -58,12 +56,11 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runDelayed(any(Duration.class), any(Task.class)))
-        .thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -73,7 +70,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 100); // in 100 millis
 
     // then
-    verify(mockScheduleService, times(2)).runDelayed(any(), any(Task.class));
+    verify(mockScheduleService, times(2)).runAt(anyLong(), any(Task.class));
     verify(mockScheduledTask).cancel();
   }
 
@@ -88,19 +85,18 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runDelayed(any(Duration.class), any(Task.class)))
-        .thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
     dueDateChecker.execute(mock(TaskResultBuilder.class));
 
     // then
-    verify(mockScheduleService).runDelayed(any(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
   }
 
   @Test
@@ -114,24 +110,23 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runDelayed(any(Duration.class), any(Task.class)))
-        .thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runDelayed(eq(Duration.ofMillis(timerResolution)), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     // expect that there is a next execution scheduled after execution
-    verify(mockScheduleService).runDelayed(any(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
     dueDateChecker.schedule(ActorClock.currentTimeMillis() + 100); // in one second
 
     // then
-    verify(mockScheduleService).runDelayed(any(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     verify(mockScheduledTask).cancel();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -35,7 +35,7 @@ public class DueDateCheckerTest {
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -45,7 +45,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 1000); // in one second
 
     // then
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
   }
 
   @Test
@@ -56,11 +56,11 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runAfter(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -70,7 +70,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 100); // in 100 millis
 
     // then
-    verify(mockScheduleService, times(2)).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService, times(2)).runAt(anyLong(), any(Task.class));
     verify(mockScheduledTask).cancel();
   }
 
@@ -85,18 +85,18 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runAfter(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
     dueDateChecker.execute(mock(TaskResultBuilder.class));
 
     // then
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
   }
 
   @Test
@@ -110,23 +110,23 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runAfter(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     // expect that there is a next execution scheduled after execution
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
     dueDateChecker.schedule(ActorClock.currentTimeMillis() + 100); // in one second
 
     // then
-    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
     verify(mockScheduledTask).cancel();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -35,7 +35,7 @@ public class DueDateCheckerTest {
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -45,7 +45,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 1000); // in one second
 
     // then
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
   }
 
   @Test
@@ -56,11 +56,11 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAfter(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     Mockito.clearInvocations(mockScheduleService);
 
@@ -70,7 +70,7 @@ public class DueDateCheckerTest {
     dueDateChecker.schedule(currentTimeMillis + 100); // in 100 millis
 
     // then
-    verify(mockScheduleService, times(2)).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService, times(2)).runAfter(anyLong(), any(Task.class));
     verify(mockScheduledTask).cancel();
   }
 
@@ -85,18 +85,18 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAfter(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
     dueDateChecker.execute(mock(TaskResultBuilder.class));
 
     // then
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
   }
 
   @Test
@@ -110,23 +110,23 @@ public class DueDateCheckerTest {
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
-    when(mockScheduleService.runAt(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
+    when(mockScheduleService.runAfter(anyLong(), any(Task.class))).thenReturn(mockScheduledTask);
 
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
     dueDateChecker.onRecovered(mockContext);
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     dueDateChecker.execute(mock(TaskResultBuilder.class));
     // expect that there is a next execution scheduled after execution
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
     Mockito.clearInvocations(mockScheduleService);
 
     // when
     dueDateChecker.schedule(ActorClock.currentTimeMillis() + 100); // in one second
 
     // then
-    verify(mockScheduleService).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService).runAfter(anyLong(), any(Task.class));
     verify(mockScheduledTask).cancel();
   }
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -110,8 +110,8 @@ public class ActorControl implements ConcurrencyControl {
    * @param runnable The runnable to run at (or after) the timestamp
    * @return A handle to the scheduled timer task
    */
-  public ScheduledTimer runAt(final long timestamp, final Runnable runnable) {
-    ensureCalledFromWithinActor("runAt(...)");
+  public ScheduledTimer runAfter(final long timestamp, final Runnable runnable) {
+    ensureCalledFromWithinActor("runAfter(...)");
     return scheduleTimerSubscription(runnable, job -> new StampedTimerSubscription(job, timestamp));
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -101,7 +101,7 @@ public class ActorControl implements ConcurrencyControl {
     job.onJobAddedToTask(task);
 
     final TimerSubscription timerSubscription =
-        new TimerSubscription(job, delay.toMillis(), TimeUnit.MILLISECONDS, isRecurring);
+        new DelayedTimerSubscription(job, delay.toMillis(), TimeUnit.MILLISECONDS, isRecurring);
     job.setSubscription(timerSubscription);
 
     timerSubscription.submit();

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -110,8 +110,8 @@ public class ActorControl implements ConcurrencyControl {
    * @param runnable The runnable to run at (or after) the timestamp
    * @return A handle to the scheduled timer task
    */
-  public ScheduledTimer runAfter(final long timestamp, final Runnable runnable) {
-    ensureCalledFromWithinActor("runAfter(...)");
+  public ScheduledTimer runAt(final long timestamp, final Runnable runnable) {
+    ensureCalledFromWithinActor("runAt(...)");
     return scheduleTimerSubscription(runnable, job -> new StampedTimerSubscription(job, timestamp));
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -91,7 +91,9 @@ public class ActorControl implements ConcurrencyControl {
    */
   public ScheduledTimer runAtFixedRate(final Duration delay, final Runnable runnable) {
     ensureCalledFromWithinActor("runAtFixedRate(...)");
-    return scheduleTimer(delay, true, runnable);
+    return scheduleTimerSubscription(
+        runnable,
+        job -> new DelayedTimerSubscription(job, delay.toMillis(), TimeUnit.MILLISECONDS, true));
   }
 
   /**
@@ -110,19 +112,6 @@ public class ActorControl implements ConcurrencyControl {
    */
   public ScheduledTimer runAt(final long timestamp, final Runnable runnable) {
     ensureCalledFromWithinActor("runAt(...)");
-    return scheduleTimer(timestamp, runnable);
-  }
-
-  private TimerSubscription scheduleTimer(
-      final Duration delay, final boolean isRecurring, final Runnable runnable) {
-    return scheduleTimerSubscription(
-        runnable,
-        job ->
-            new DelayedTimerSubscription(
-                job, delay.toMillis(), TimeUnit.MILLISECONDS, isRecurring));
-  }
-
-  private TimerSubscription scheduleTimer(final long timestamp, final Runnable runnable) {
     return scheduleTimerSubscription(runnable, job -> new StampedTimerSubscription(job, timestamp));
   }
 
@@ -216,7 +205,9 @@ public class ActorControl implements ConcurrencyControl {
   @Override
   public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
     ensureCalledFromWithinActor("runDelayed(...)");
-    return scheduleTimer(delay, false, runnable);
+    return scheduleTimerSubscription(
+        runnable,
+        job -> new DelayedTimerSubscription(job, delay.toMillis(), TimeUnit.MILLISECONDS, false));
   }
 
   /**

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -146,7 +146,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   }
 
   /** Must be called from this thread, schedules a job to be run later. */
-  public void scheduleTimer(final DelayedTimerSubscription timer) {
+  public void scheduleTimer(final TimerSubscription timer) {
     timerJobQueue.schedule(timer, clock);
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorThread.java
@@ -146,7 +146,7 @@ public class ActorThread extends Thread implements Consumer<Runnable> {
   }
 
   /** Must be called from this thread, schedules a job to be run later. */
-  public void scheduleTimer(final TimerSubscription timer) {
+  public void scheduleTimer(final DelayedTimerSubscription timer) {
     timerJobQueue.schedule(timer, clock);
   }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTimerQueue.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTimerQueue.java
@@ -48,9 +48,8 @@ public final class ActorTimerQueue extends DeadlineTimerWheel {
     } while (timersProcessed > 0);
   }
 
-  public void schedule(final DelayedTimerSubscription timer, final ActorClock now) {
-    final long deadline =
-        now.getTimeMillis() + timeUnit().convert(timer.getDeadline(), timer.getTimeUnit());
+  public void schedule(final TimerSubscription timer, final ActorClock now) {
+    final long deadline = timer.getDeadline(now);
 
     final long timerId = scheduleTimer(deadline);
     timer.setTimerId(timerId);

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTimerQueue.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorTimerQueue.java
@@ -48,7 +48,7 @@ public final class ActorTimerQueue extends DeadlineTimerWheel {
     } while (timersProcessed > 0);
   }
 
-  public void schedule(final TimerSubscription timer, final ActorClock now) {
+  public void schedule(final DelayedTimerSubscription timer, final ActorClock now) {
     final long deadline =
         now.getTimeMillis() + timeUnit().convert(timer.getDeadline(), timer.getTimeUnit());
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
@@ -17,7 +17,7 @@ public final class DelayedTimerSubscription implements TimerSubscription {
   private final ActorJob job;
   private final ActorTask task;
   private final TimeUnit timeUnit;
-  private final long deadline;
+  private final long delay;
   private final boolean isRecurring;
   private volatile boolean isDone = false;
   private volatile boolean isCanceled = false;
@@ -26,11 +26,11 @@ public final class DelayedTimerSubscription implements TimerSubscription {
   private long timerExpiredAt;
 
   public DelayedTimerSubscription(
-      final ActorJob job, final long deadline, final TimeUnit timeUnit, final boolean isRecurring) {
+      final ActorJob job, final long delay, final TimeUnit timeUnit, final boolean isRecurring) {
     this.job = job;
     task = job.getTask();
     this.timeUnit = timeUnit;
-    this.deadline = deadline;
+    this.delay = delay;
     this.isRecurring = isRecurring;
   }
 
@@ -90,11 +90,6 @@ public final class DelayedTimerSubscription implements TimerSubscription {
   }
 
   @Override
-  public long getDeadline() {
-    return deadline;
-  }
-
-  @Override
   public void onTimerExpired(final TimeUnit timeUnit, final long now) {
     if (!isCanceled) {
       isDone = true;
@@ -113,6 +108,11 @@ public final class DelayedTimerSubscription implements TimerSubscription {
     return timerExpiredAt;
   }
 
+  @Override
+  public long getDeadline() {
+    return delay;
+  }
+
   public TimeUnit getTimeUnit() {
     return timeUnit;
   }
@@ -122,8 +122,8 @@ public final class DelayedTimerSubscription implements TimerSubscription {
     return "TimerSubscription{"
         + "timerId="
         + timerId
-        + ", deadline="
-        + deadline
+        + ", delay="
+        + delay
         + ", timeUnit="
         + timeUnit
         + ", isRecurring="

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.scheduler;
 
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -90,6 +91,11 @@ public final class DelayedTimerSubscription implements TimerSubscription {
   }
 
   @Override
+  public long getDeadline(final ActorClock now) {
+    return now.getTimeMillis() + timeUnit.convert(delay, timeUnit);
+  }
+
+  @Override
   public void onTimerExpired(final TimeUnit timeUnit, final long now) {
     if (!isCanceled) {
       isDone = true;
@@ -106,11 +112,6 @@ public final class DelayedTimerSubscription implements TimerSubscription {
   @Override
   public long getTimerExpiredAt() {
     return timerExpiredAt;
-  }
-
-  @Override
-  public long getDeadline() {
-    return delay;
   }
 
   public TimeUnit getTimeUnit() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/DelayedTimerSubscription.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.scheduler;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A TimerSubscription based on a delay. Scheduling requires an external clock to determine the
+ * exact timestamp. This type of timer subscription can be triggered once, or recur until canceled.
+ */
+public final class DelayedTimerSubscription implements TimerSubscription {
+  private final ActorJob job;
+  private final ActorTask task;
+  private final TimeUnit timeUnit;
+  private final long deadline;
+  private final boolean isRecurring;
+  private volatile boolean isDone = false;
+  private volatile boolean isCanceled = false;
+  private long timerId = -1L;
+  private ActorThread thread;
+  private long timerExpiredAt;
+
+  public DelayedTimerSubscription(
+      final ActorJob job, final long deadline, final TimeUnit timeUnit, final boolean isRecurring) {
+    this.job = job;
+    task = job.getTask();
+    this.timeUnit = timeUnit;
+    this.deadline = deadline;
+    this.isRecurring = isRecurring;
+  }
+
+  @Override
+  public boolean poll() {
+    return isDone;
+  }
+
+  @Override
+  public ActorJob getJob() {
+    return job;
+  }
+
+  @Override
+  public boolean isRecurring() {
+    return isRecurring;
+  }
+
+  @Override
+  public void onJobCompleted() {
+
+    if (isRecurring && !isCanceled) {
+      isDone = false;
+      submit();
+    }
+  }
+
+  @Override
+  public void cancel() {
+    if (!isCanceled && (!isDone || isRecurring)) {
+      task.onSubscriptionCancelled(this);
+      isCanceled = true;
+      final ActorThread current = ActorThread.current();
+
+      if (current != thread) {
+        thread.submittedCallbacks.add(this);
+      } else {
+        run();
+      }
+    }
+  }
+
+  @Override
+  public long getTimerId() {
+    return timerId;
+  }
+
+  @Override
+  public void setTimerId(final long timerId) {
+    this.timerId = timerId;
+  }
+
+  @Override
+  public void submit() {
+    thread = ActorThread.current();
+    thread.scheduleTimer(this);
+  }
+
+  @Override
+  public long getDeadline() {
+    return deadline;
+  }
+
+  @Override
+  public void onTimerExpired(final TimeUnit timeUnit, final long now) {
+    if (!isCanceled) {
+      isDone = true;
+      timerExpiredAt = timeUnit.toNanos(now);
+      task.tryWakeup();
+    }
+  }
+
+  @Override
+  public void run() {
+    thread.removeTimer(this);
+  }
+
+  @Override
+  public long getTimerExpiredAt() {
+    return timerExpiredAt;
+  }
+
+  public TimeUnit getTimeUnit() {
+    return timeUnit;
+  }
+
+  @Override
+  public String toString() {
+    return "TimerSubscription{"
+        + "timerId="
+        + timerId
+        + ", deadline="
+        + deadline
+        + ", timeUnit="
+        + timeUnit
+        + ", isRecurring="
+        + isRecurring
+        + ", isDone="
+        + isDone
+        + ", isCanceled="
+        + isCanceled
+        + ", thread="
+        + thread
+        + '}';
+  }
+}

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/StampedTimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/StampedTimerSubscription.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.scheduler;
+
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.util.concurrent.TimeUnit;
+
+public final class StampedTimerSubscription implements TimerSubscription {
+  private final ActorJob job;
+  private final ActorTask task;
+  private final long deadline;
+  private volatile boolean isDone = false;
+  private volatile boolean isCanceled = false;
+  private long timerId = -1L;
+  private ActorThread thread;
+  private long timerExpiredAt;
+
+  public StampedTimerSubscription(final ActorJob job, final long timestamp) {
+    this.job = job;
+    task = job.getTask();
+    deadline = timestamp;
+  }
+
+  @Override
+  public boolean poll() {
+    return isDone;
+  }
+
+  @Override
+  public ActorJob getJob() {
+    return job;
+  }
+
+  @Override
+  public boolean isRecurring() {
+    return false;
+  }
+
+  @Override
+  public void onJobCompleted() {
+    // This timer can only trigger once, nothing to do
+  }
+
+  @Override
+  public void cancel() {
+    if (!isCanceled && !isDone) {
+      task.onSubscriptionCancelled(this);
+      isCanceled = true;
+      final ActorThread current = ActorThread.current();
+
+      if (current != thread) {
+        thread.submittedCallbacks.add(this);
+      } else {
+        run();
+      }
+    }
+  }
+
+  @Override
+  public long getTimerId() {
+    return timerId;
+  }
+
+  @Override
+  public void setTimerId(final long timerId) {
+    this.timerId = timerId;
+  }
+
+  @Override
+  public void submit() {
+    thread = ActorThread.current();
+    thread.scheduleTimer(this);
+  }
+
+  @Override
+  public long getDeadline(final ActorClock ignored) {
+    return deadline;
+  }
+
+  @Override
+  public void onTimerExpired(final TimeUnit timeUnit, final long now) {
+    if (!isCanceled) {
+      isDone = true;
+      timerExpiredAt = timeUnit.toNanos(now);
+      task.tryWakeup();
+    }
+  }
+
+  @Override
+  public void run() {
+    thread.removeTimer(this);
+  }
+
+  @Override
+  public long getTimerExpiredAt() {
+    return timerExpiredAt;
+  }
+
+  @Override
+  public String toString() {
+    return "TimerSubscription{"
+        + "timerId="
+        + timerId
+        + ", deadline="
+        + deadline
+        + ", isDone="
+        + isDone
+        + ", isCanceled="
+        + isCanceled
+        + ", thread="
+        + thread
+        + '}';
+  }
+}

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/TimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/TimerSubscription.java
@@ -9,121 +9,35 @@ package io.camunda.zeebe.scheduler;
 
 import java.util.concurrent.TimeUnit;
 
-public final class TimerSubscription implements ActorSubscription, ScheduledTimer, Runnable {
-  private final ActorJob job;
-  private final ActorTask task;
-  private final TimeUnit timeUnit;
-  private final long deadline;
-  private final boolean isRecurring;
-  private volatile boolean isDone = false;
-  private volatile boolean isCanceled = false;
-  private long timerId = -1L;
-  private ActorThread thread;
-  private long timerExpiredAt;
-
-  public TimerSubscription(
-      final ActorJob job, final long deadline, final TimeUnit timeUnit, final boolean isRecurring) {
-    this.job = job;
-    task = job.getTask();
-    this.timeUnit = timeUnit;
-    this.deadline = deadline;
-    this.isRecurring = isRecurring;
-  }
+public interface TimerSubscription extends ActorSubscription, ScheduledTimer, Runnable {
 
   @Override
-  public boolean poll() {
-    return isDone;
-  }
+  boolean poll();
 
   @Override
-  public ActorJob getJob() {
-    return job;
-  }
+  ActorJob getJob();
 
   @Override
-  public boolean isRecurring() {
-    return isRecurring;
-  }
+  boolean isRecurring();
 
   @Override
-  public void onJobCompleted() {
-
-    if (isRecurring && !isCanceled) {
-      isDone = false;
-      submit();
-    }
-  }
+  void onJobCompleted();
 
   @Override
-  public void cancel() {
-    if (!isCanceled && (!isDone || isRecurring)) {
-      task.onSubscriptionCancelled(this);
-      isCanceled = true;
-      final ActorThread current = ActorThread.current();
+  void cancel();
 
-      if (current != thread) {
-        thread.submittedCallbacks.add(this);
-      } else {
-        run();
-      }
-    }
-  }
+  long getTimerId();
 
-  public long getTimerId() {
-    return timerId;
-  }
+  void setTimerId(long timerId);
 
-  public void setTimerId(final long timerId) {
-    this.timerId = timerId;
-  }
+  void submit();
 
-  public void submit() {
-    thread = ActorThread.current();
-    thread.scheduleTimer(this);
-  }
+  long getDeadline();
 
-  public long getDeadline() {
-    return deadline;
-  }
-
-  public TimeUnit getTimeUnit() {
-    return timeUnit;
-  }
-
-  public void onTimerExpired(final TimeUnit timeUnit, final long now) {
-    if (!isCanceled) {
-      isDone = true;
-      timerExpiredAt = timeUnit.toNanos(now);
-      task.tryWakeup();
-    }
-  }
+  void onTimerExpired(TimeUnit timeUnit, long now);
 
   @Override
-  public void run() {
-    thread.removeTimer(this);
-  }
+  void run();
 
-  @Override
-  public String toString() {
-    return "TimerSubscription{"
-        + "timerId="
-        + timerId
-        + ", deadline="
-        + deadline
-        + ", timeUnit="
-        + timeUnit
-        + ", isRecurring="
-        + isRecurring
-        + ", isDone="
-        + isDone
-        + ", isCanceled="
-        + isCanceled
-        + ", thread="
-        + thread
-        + '}';
-  }
-
-  public long getTimerExpiredAt() {
-    return timerExpiredAt;
-  }
+  long getTimerExpiredAt();
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/TimerSubscription.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/TimerSubscription.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.scheduler;
 
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.util.concurrent.TimeUnit;
 
 public interface TimerSubscription extends ActorSubscription, ScheduledTimer, Runnable {
@@ -32,7 +33,7 @@ public interface TimerSubscription extends ActorSubscription, ScheduledTimer, Ru
 
   void submit();
 
-  long getDeadline();
+  long getDeadline(ActorClock now);
 
   void onTimerExpired(TimeUnit timeUnit, long now);
 

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
@@ -200,7 +200,7 @@ public final class TimedActionsTest {
           new Actor() {
             @Override
             protected void onActorStarted() {
-              actor.runAt(1000, action);
+              actor.runAfter(1000, action);
             }
           };
 
@@ -221,7 +221,7 @@ public final class TimedActionsTest {
           new Actor() {
             @Override
             protected void onActorStarted() {
-              actor.runAt(1000, action);
+              actor.runAfter(1000, action);
             }
           };
 
@@ -240,7 +240,7 @@ public final class TimedActionsTest {
     public void shouldCancelRunAt() {
       // given
       final Runnable action = mock(Runnable.class);
-      final TimerActor actor = new TimerActor(actorControl -> actorControl.runAt(1000, action));
+      final TimerActor actor = new TimerActor(actorControl -> actorControl.runAfter(1000, action));
 
       // when
       actorScheduler.setClockTime(100);
@@ -259,7 +259,7 @@ public final class TimedActionsTest {
     public void shouldCancelRunDelayedAfterExecution() {
       // given
       final Runnable action = mock(Runnable.class);
-      final var actor = new TimerActor(actorControl -> actorControl.runAt(1000, action));
+      final var actor = new TimerActor(actorControl -> actorControl.runAfter(1000, action));
 
       // when
       actorScheduler.setClockTime(100);

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
@@ -16,15 +16,16 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import java.time.Duration;
 import java.util.function.Function;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 public final class TimedActionsTest {
-  @Rule
-  public final ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+  @RegisterExtension
+  public final ControlledActorSchedulerExtension schedulerRule =
+      new ControlledActorSchedulerExtension();
 
   @Test
   public void shouldNotRunActionIfDeadlineNotReached() throws InterruptedException {
@@ -39,7 +40,7 @@ public final class TimedActionsTest {
         };
 
     // when
-    schedulerRule.getClock().setCurrentTime(100);
+    schedulerRule.setClockTime(100);
     schedulerRule.submitActor(actor);
     schedulerRule.workUntilDone();
 
@@ -60,10 +61,10 @@ public final class TimedActionsTest {
         };
 
     // when
-    schedulerRule.getClock().setCurrentTime(100);
+    schedulerRule.setClockTime(100);
     schedulerRule.submitActor(actor);
     schedulerRule.workUntilDone();
-    schedulerRule.getClock().addTime(Duration.ofMillis(10));
+    schedulerRule.updateClock(Duration.ofMillis(10));
     schedulerRule.workUntilDone();
 
     // then
@@ -83,19 +84,19 @@ public final class TimedActionsTest {
         };
 
     // when then
-    schedulerRule.getClock().setCurrentTime(100);
+    schedulerRule.setClockTime(100);
     schedulerRule.submitActor(actor);
     schedulerRule.workUntilDone();
 
-    schedulerRule.getClock().addTime(Duration.ofMillis(10));
+    schedulerRule.updateClock(Duration.ofMillis(10));
     schedulerRule.workUntilDone();
     verify(action, times(1)).run();
 
-    schedulerRule.getClock().addTime(Duration.ofMillis(10));
+    schedulerRule.updateClock(Duration.ofMillis(10));
     schedulerRule.workUntilDone();
     verify(action, times(2)).run();
 
-    schedulerRule.getClock().addTime(Duration.ofMillis(10));
+    schedulerRule.updateClock(Duration.ofMillis(10));
     schedulerRule.workUntilDone();
     verify(action, times(3)).run();
   }
@@ -108,12 +109,12 @@ public final class TimedActionsTest {
         new TimerActor(actorControl -> actorControl.schedule(Duration.ofMillis(10), action));
 
     // when
-    schedulerRule.getClock().setCurrentTime(100);
+    schedulerRule.setClockTime(100);
     schedulerRule.submitActor(actor);
     schedulerRule.workUntilDone();
     actor.cancelTimer();
     schedulerRule.workUntilDone();
-    schedulerRule.getClock().addTime(Duration.ofMillis(10));
+    schedulerRule.updateClock(Duration.ofMillis(10));
     schedulerRule.workUntilDone();
 
     // then
@@ -128,12 +129,12 @@ public final class TimedActionsTest {
         new TimerActor(actorControl -> actorControl.schedule(Duration.ofMillis(10), action));
 
     // when
-    schedulerRule.getClock().setCurrentTime(100);
+    schedulerRule.setClockTime(100);
     schedulerRule.submitActor(actor);
     schedulerRule.workUntilDone();
 
     // make timer run
-    schedulerRule.getClock().addTime(Duration.ofMillis(10));
+    schedulerRule.updateClock(Duration.ofMillis(10));
     schedulerRule.workUntilDone();
 
     // when
@@ -152,12 +153,12 @@ public final class TimedActionsTest {
         new TimerActor(actorControl -> actorControl.runAtFixedRate(Duration.ofMillis(10), action));
 
     // when
-    schedulerRule.getClock().setCurrentTime(100);
+    schedulerRule.setClockTime(100);
     schedulerRule.submitActor(actor);
     schedulerRule.workUntilDone();
     actor.cancelTimer();
     schedulerRule.workUntilDone();
-    schedulerRule.getClock().addTime(Duration.ofMillis(10));
+    schedulerRule.updateClock(Duration.ofMillis(10));
     schedulerRule.workUntilDone();
 
     // then

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
@@ -200,7 +200,7 @@ public final class TimedActionsTest {
           new Actor() {
             @Override
             protected void onActorStarted() {
-              actor.runAfter(1000, action);
+              actor.runAt(1000, action);
             }
           };
 
@@ -221,7 +221,7 @@ public final class TimedActionsTest {
           new Actor() {
             @Override
             protected void onActorStarted() {
-              actor.runAfter(1000, action);
+              actor.runAt(1000, action);
             }
           };
 
@@ -240,7 +240,7 @@ public final class TimedActionsTest {
     public void shouldCancelRunAt() {
       // given
       final Runnable action = mock(Runnable.class);
-      final TimerActor actor = new TimerActor(actorControl -> actorControl.runAfter(1000, action));
+      final TimerActor actor = new TimerActor(actorControl -> actorControl.runAt(1000, action));
 
       // when
       actorScheduler.setClockTime(100);
@@ -259,7 +259,7 @@ public final class TimedActionsTest {
     public void shouldCancelRunDelayedAfterExecution() {
       // given
       final Runnable action = mock(Runnable.class);
-      final var actor = new TimerActor(actorControl -> actorControl.runAfter(1000, action));
+      final var actor = new TimerActor(actorControl -> actorControl.runAt(1000, action));
 
       // when
       actorScheduler.setClockTime(100);

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/TimedActionsTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public final class TimedActionsTest {
   @RegisterExtension
-  public final ControlledActorSchedulerExtension schedulerRule =
+  public final ControlledActorSchedulerExtension actorScheduler =
       new ControlledActorSchedulerExtension();
 
   @Test
@@ -40,9 +40,9 @@ public final class TimedActionsTest {
         };
 
     // when
-    schedulerRule.setClockTime(100);
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
+    actorScheduler.setClockTime(100);
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
 
     // then
     verify(action, never()).run();
@@ -61,11 +61,11 @@ public final class TimedActionsTest {
         };
 
     // when
-    schedulerRule.setClockTime(100);
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
-    schedulerRule.updateClock(Duration.ofMillis(10));
-    schedulerRule.workUntilDone();
+    actorScheduler.setClockTime(100);
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofMillis(10));
+    actorScheduler.workUntilDone();
 
     // then
     verify(action, times(1)).run();
@@ -84,20 +84,20 @@ public final class TimedActionsTest {
         };
 
     // when then
-    schedulerRule.setClockTime(100);
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
+    actorScheduler.setClockTime(100);
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
 
-    schedulerRule.updateClock(Duration.ofMillis(10));
-    schedulerRule.workUntilDone();
+    actorScheduler.updateClock(Duration.ofMillis(10));
+    actorScheduler.workUntilDone();
     verify(action, times(1)).run();
 
-    schedulerRule.updateClock(Duration.ofMillis(10));
-    schedulerRule.workUntilDone();
+    actorScheduler.updateClock(Duration.ofMillis(10));
+    actorScheduler.workUntilDone();
     verify(action, times(2)).run();
 
-    schedulerRule.updateClock(Duration.ofMillis(10));
-    schedulerRule.workUntilDone();
+    actorScheduler.updateClock(Duration.ofMillis(10));
+    actorScheduler.workUntilDone();
     verify(action, times(3)).run();
   }
 
@@ -109,13 +109,13 @@ public final class TimedActionsTest {
         new TimerActor(actorControl -> actorControl.schedule(Duration.ofMillis(10), action));
 
     // when
-    schedulerRule.setClockTime(100);
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
+    actorScheduler.setClockTime(100);
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
     actor.cancelTimer();
-    schedulerRule.workUntilDone();
-    schedulerRule.updateClock(Duration.ofMillis(10));
-    schedulerRule.workUntilDone();
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofMillis(10));
+    actorScheduler.workUntilDone();
 
     // then
     verify(action, times(0)).run();
@@ -129,17 +129,17 @@ public final class TimedActionsTest {
         new TimerActor(actorControl -> actorControl.schedule(Duration.ofMillis(10), action));
 
     // when
-    schedulerRule.setClockTime(100);
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
+    actorScheduler.setClockTime(100);
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
 
     // make timer run
-    schedulerRule.updateClock(Duration.ofMillis(10));
-    schedulerRule.workUntilDone();
+    actorScheduler.updateClock(Duration.ofMillis(10));
+    actorScheduler.workUntilDone();
 
     // when
     actor.cancelTimer();
-    schedulerRule.workUntilDone();
+    actorScheduler.workUntilDone();
 
     // then
     // no exception has been thrown
@@ -153,13 +153,13 @@ public final class TimedActionsTest {
         new TimerActor(actorControl -> actorControl.runAtFixedRate(Duration.ofMillis(10), action));
 
     // when
-    schedulerRule.setClockTime(100);
-    schedulerRule.submitActor(actor);
-    schedulerRule.workUntilDone();
+    actorScheduler.setClockTime(100);
+    actorScheduler.submitActor(actor);
+    actorScheduler.workUntilDone();
     actor.cancelTimer();
-    schedulerRule.workUntilDone();
-    schedulerRule.updateClock(Duration.ofMillis(10));
-    schedulerRule.workUntilDone();
+    actorScheduler.workUntilDone();
+    actorScheduler.updateClock(Duration.ofMillis(10));
+    actorScheduler.workUntilDone();
 
     // then
     verify(action, times(0)).run();

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
@@ -82,6 +82,10 @@ public class ControlledActorSchedulerExtension implements BeforeEachCallback, Af
     clock.addTime(duration);
   }
 
+  public void setClockTime(final long currentTime) {
+    clock.setCurrentTime(currentTime);
+  }
+
   static final class ControlledActorThreadFactory implements ActorThreadFactory {
     private ControlledActorThread controlledThread;
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -60,5 +60,5 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * @implNote If the delay is short, cancellation via {@link ScheduledTask} may happen after
    *     execution and have no effect.
    */
-  ScheduledTask runAtAsync(final long timestamp, final Task task);
+  ScheduledTask runAfterAsync(final long timestamp, final Task task);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -60,5 +60,5 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    * @implNote If the delay is short, cancellation via {@link ScheduledTask} may happen after
    *     execution and have no effect.
    */
-  ScheduledTask runAfterAsync(final long timestamp, final Task task);
+  ScheduledTask runAtAsync(final long timestamp, final Task task);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/ProcessingScheduleService.java
@@ -44,4 +44,21 @@ public interface ProcessingScheduleService extends SimpleProcessingScheduleServi
    *     execution and have no effect.
    */
   ScheduledTask runDelayedAsync(final Duration delay, final Task task);
+
+  /**
+   * Schedule a task to execute at or after a specific timestamp. The task is executed after the
+   * timestamp is passed. No guarantee is provided that the task is run exactly at the timestamp,
+   * but we guarantee that it is not executed before.
+   *
+   * <p>The execution of the scheduled task is running asynchronously/concurrently to task scheduled
+   * through non-async methods. While other, non-async methods guarantee the execution order of
+   * scheduled tasks and always execute scheduled tasks on the same thread, this method does not
+   * guarantee this.
+   *
+   * @param timestamp Unix epoch timestamp in milliseconds
+   * @param task The task to execute at or after the timestamp
+   * @implNote If the delay is short, cancellation via {@link ScheduledTask} may happen after
+   *     execution and have no effect.
+   */
+  ScheduledTask runAtAsync(final long timestamp, final Task task);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
@@ -33,7 +33,7 @@ public interface SimpleProcessingScheduleService {
    * @implNote Can be silently ignored if the scheduling service is not ready.
    * @return A representation of the scheduled task.
    */
-  ScheduledTask runAfter(long timestamp, Task task);
+  ScheduledTask runAt(long timestamp, Task task);
 
   /**
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
@@ -33,7 +33,7 @@ public interface SimpleProcessingScheduleService {
    * @implNote Can be silently ignored if the scheduling service is not ready.
    * @return A representation of the scheduled task.
    */
-  ScheduledTask runAt(long timestamp, Task task);
+  ScheduledTask runAfter(long timestamp, Task task);
 
   /**
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
@@ -28,6 +28,14 @@ public interface SimpleProcessingScheduleService {
   ScheduledTask runDelayed(Duration delay, Task task);
 
   /**
+   * Schedules the task to run at or after the given timestamp.
+   *
+   * @implNote Can be silently ignored if the scheduling service is not ready.
+   * @return A representation of the scheduled task.
+   */
+  ScheduledTask runAt(long timestamp, Task task);
+
+  /**
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
    * the task is executed, it is rescheduled with the same delay again.
    *

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -54,12 +54,12 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public ScheduledTask runAfterAsync(final long timestamp, final Task task) {
+  public ScheduledTask runAtAsync(final long timestamp, final Task task) {
     final var futureScheduledTask = concurrencyControl.<ScheduledTask>createFuture();
     concurrencyControl.run(
         () -> {
           // we must run in different actor in order to schedule task
-          final var scheduledTask = asyncActorService.runAfter(timestamp, task);
+          final var scheduledTask = asyncActorService.runAt(timestamp, task);
           futureScheduledTask.complete(scheduledTask);
         });
     return new AsyncScheduledTask(futureScheduledTask);
@@ -91,11 +91,11 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public ScheduledTask runAfter(final long timestamp, final Task task) {
+  public ScheduledTask runAt(final long timestamp, final Task task) {
     if (alwaysAsync) {
-      return runAfterAsync(timestamp, task);
+      return runAtAsync(timestamp, task);
     } else {
-      return processorActorService.runAfter(timestamp, task);
+      return processorActorService.runAt(timestamp, task);
     }
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -54,12 +54,12 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public ScheduledTask runAtAsync(final long timestamp, final Task task) {
+  public ScheduledTask runAfterAsync(final long timestamp, final Task task) {
     final var futureScheduledTask = concurrencyControl.<ScheduledTask>createFuture();
     concurrencyControl.run(
         () -> {
           // we must run in different actor in order to schedule task
-          final var scheduledTask = asyncActorService.runAt(timestamp, task);
+          final var scheduledTask = asyncActorService.runAfter(timestamp, task);
           futureScheduledTask.complete(scheduledTask);
         });
     return new AsyncScheduledTask(futureScheduledTask);
@@ -91,11 +91,11 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
-  public ScheduledTask runAt(final long timestamp, final Task task) {
+  public ScheduledTask runAfter(final long timestamp, final Task task) {
     if (alwaysAsync) {
-      return runAtAsync(timestamp, task);
+      return runAfterAsync(timestamp, task);
     } else {
-      return processorActorService.runAt(timestamp, task);
+      return processorActorService.runAfter(timestamp, task);
     }
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ExtendedProcessingScheduleServiceImpl.java
@@ -54,6 +54,18 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
   }
 
   @Override
+  public ScheduledTask runAtAsync(final long timestamp, final Task task) {
+    final var futureScheduledTask = concurrencyControl.<ScheduledTask>createFuture();
+    concurrencyControl.run(
+        () -> {
+          // we must run in different actor in order to schedule task
+          final var scheduledTask = asyncActorService.runAt(timestamp, task);
+          futureScheduledTask.complete(scheduledTask);
+        });
+    return new AsyncScheduledTask(futureScheduledTask);
+  }
+
+  @Override
   public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
     if (alwaysAsync) {
       final var futureScheduledTask = concurrencyControl.<ScheduledTask>createFuture();
@@ -75,6 +87,15 @@ public class ExtendedProcessingScheduleServiceImpl implements ProcessingSchedule
       return runDelayedAsync(delay, task);
     } else {
       return processorActorService.runDelayed(delay, task);
+    }
+  }
+
+  @Override
+  public ScheduledTask runAt(final long timestamp, final Task task) {
+    if (alwaysAsync) {
+      return runAtAsync(timestamp, task);
+    } else {
+      return processorActorService.runAt(timestamp, task);
     }
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -67,12 +67,12 @@ public class ProcessingScheduleServiceImpl
   }
 
   @Override
-  public ScheduledTask runAfter(final long timestamp, final Task task) {
+  public ScheduledTask runAt(final long timestamp, final Task task) {
     if (actorControl == null) {
       LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
-    final var scheduledTimer = actorControl.runAfter(timestamp, toRunnable(task));
+    final var scheduledTimer = actorControl.runAt(timestamp, toRunnable(task));
     return scheduledTimer::cancel;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -67,6 +67,16 @@ public class ProcessingScheduleServiceImpl
   }
 
   @Override
+  public ScheduledTask runAt(final long timestamp, final Task task) {
+    if (actorControl == null) {
+      LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
+      return NOOP_SCHEDULED_TASK;
+    }
+    final var scheduledTimer = actorControl.runAt(timestamp, toRunnable(task));
+    return scheduledTimer::cancel;
+  }
+
+  @Override
   public void runAtFixedRate(final Duration delay, final Task task) {
     runDelayed(
         delay,

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -54,7 +54,7 @@ public class ProcessingScheduleServiceImpl
   @Override
   public ScheduledTask runDelayed(final Duration delay, final Runnable followUpTask) {
     if (actorControl == null) {
-      LOG.debug("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
+      LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
     final var scheduledTimer = actorControl.schedule(delay, followUpTask);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -67,12 +67,12 @@ public class ProcessingScheduleServiceImpl
   }
 
   @Override
-  public ScheduledTask runAt(final long timestamp, final Task task) {
+  public ScheduledTask runAfter(final long timestamp, final Task task) {
     if (actorControl == null) {
       LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
-    final var scheduledTimer = actorControl.runAt(timestamp, toRunnable(task));
+    final var scheduledTimer = actorControl.runAfter(timestamp, toRunnable(task));
     return scheduledTimer::cancel;
   }
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -443,9 +443,9 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
-    public ScheduledTask runAt(final long timestamp, final Task task) {
+    public ScheduledTask runAfter(final long timestamp, final Task task) {
       final var futureScheduledTask =
-          actor.call(() -> processingScheduleService.runAt(timestamp, task));
+          actor.call(() -> processingScheduleService.runAfter(timestamp, task));
       return () ->
           actor.run(
               () ->
@@ -535,7 +535,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAt(90, mockedTask);
+      scheduleService.runAfter(90, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -548,7 +548,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAt(100, mockedTask);
+      scheduleService.runAfter(100, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -562,8 +562,8 @@ class ProcessingScheduleServiceTest {
       final var mockedTask2 = spy(new DummyTask());
 
       // when
-      scheduleService.runAt(100, mockedTask);
-      scheduleService.runAt(90, mockedTask2);
+      scheduleService.runAfter(100, mockedTask);
+      scheduleService.runAfter(90, mockedTask2);
       actorScheduler.workUntilDone();
 
       // then
@@ -580,7 +580,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAt(100, mockedTask);
+      scheduleService.runAfter(100, mockedTask);
       // The task will be resubmitted infinitely. So workUntilDone will never return.
       actorScheduler.resume();
 
@@ -595,7 +595,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAt(100, mockedTask);
+      scheduleService.runAfter(100, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -609,7 +609,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAt(100, mockedTask);
+      scheduleService.runAfter(100, mockedTask);
       // The task will be resubmitted infinitely. So workUntilDone will never return.
       actorScheduler.resume();
       verify(mockedTask, never()).execute(any());
@@ -632,7 +632,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      notOpenScheduleService.runAt(100, mockedTask);
+      notOpenScheduleService.runAfter(100, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -644,7 +644,7 @@ class ProcessingScheduleServiceTest {
       // given
 
       // when
-      scheduleService.runAt(
+      scheduleService.runAfter(
           100,
           (builder) -> {
             builder.appendCommandRecord(1, ACTIVATE_ELEMENT, Records.processInstance(1));

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -442,6 +442,22 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
+    public ScheduledTask runAt(final long timestamp, final Task task) {
+      final var futureScheduledTask =
+          actor.call(() -> processingScheduleService.runAt(timestamp, task));
+      return () ->
+          actor.run(
+              () ->
+                  actor.runOnCompletion(
+                      futureScheduledTask,
+                      (scheduledTask, throwable) -> {
+                        if (scheduledTask != null) {
+                          scheduledTask.cancel();
+                        }
+                      }));
+    }
+
+    @Override
     public void runAtFixedRate(final Duration delay, final Task task) {
       actor.submit(() -> processingScheduleService.runAtFixedRate(delay, task));
     }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -517,6 +518,146 @@ class ProcessingScheduleServiceTest {
 
       entries.addAll(appendEntries);
       return Either.right((long) entries.size());
+    }
+  }
+
+  @Nested
+  class RunAtTests {
+
+    @BeforeEach
+    void before() {
+      actorScheduler.setClockTime(100);
+    }
+
+    @Test
+    void shouldNotExecuteScheduledTaskBeforeTimestamp() {
+      // given
+      final var mockedTask = spy(new DummyTask());
+
+      // when
+      scheduleService.runAt(90, mockedTask);
+      actorScheduler.workUntilDone();
+
+      // then
+      verify(mockedTask).execute(any());
+    }
+
+    @Test
+    void shouldExecuteScheduledTaskAtTimestamp() {
+      // given
+      final var mockedTask = spy(new DummyTask());
+
+      // when
+      scheduleService.runAt(100, mockedTask);
+      actorScheduler.workUntilDone();
+
+      // then
+      verify(mockedTask).execute(any());
+    }
+
+    @Test
+    void shouldExecuteScheduledTaskInOrderOfTimestamp() {
+      // given
+      final var mockedTask = spy(new DummyTask());
+      final var mockedTask2 = spy(new DummyTask());
+
+      // when
+      scheduleService.runAt(100, mockedTask);
+      scheduleService.runAt(90, mockedTask2);
+      actorScheduler.workUntilDone();
+
+      // then
+      final var inOrder = inOrder(mockedTask2, mockedTask);
+      inOrder.verify(mockedTask).execute(any());
+      inOrder.verify(mockedTask2).execute(any());
+      inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void shouldNotExecuteScheduledTaskIfNotInProcessingPhase() {
+      // given
+      lifecycleSupplier.currentPhase = Phase.INITIAL;
+      final var mockedTask = spy(new DummyTask());
+
+      // when
+      scheduleService.runAt(100, mockedTask);
+      // The task will be resubmitted infinitely. So workUntilDone will never return.
+      actorScheduler.resume();
+
+      // then
+      verify(mockedTask, never()).execute(any());
+    }
+
+    @Test
+    void shouldNotExecuteScheduledTaskIfAborted() {
+      // given
+      lifecycleSupplier.isAborted = true;
+      final var mockedTask = spy(new DummyTask());
+
+      // when
+      scheduleService.runAt(100, mockedTask);
+      actorScheduler.workUntilDone();
+
+      // then
+      verify(mockedTask, never()).execute(any());
+    }
+
+    @Test
+    void shouldExecuteScheduledTaskInProcessing() {
+      // given
+      lifecycleSupplier.currentPhase = Phase.PAUSED;
+      final var mockedTask = spy(new DummyTask());
+
+      // when
+      scheduleService.runAt(100, mockedTask);
+      // The task will be resubmitted infinitely. So workUntilDone will never return.
+      actorScheduler.resume();
+      verify(mockedTask, never()).execute(any());
+      lifecycleSupplier.currentPhase = Phase.PROCESSING;
+
+      // then
+      verify(mockedTask, timeout(2_000)).execute(any());
+    }
+
+    @Test
+    void shouldNotExecuteTasksWhenScheduledOnClosedActor() {
+      // given
+      lifecycleSupplier.currentPhase = Phase.PAUSED;
+      final var notOpenScheduleService =
+          new ProcessingScheduleServiceImpl(
+              lifecycleSupplier,
+              lifecycleSupplier,
+              writerAsyncSupplier,
+              new NoopScheduledCommandCache());
+      final var mockedTask = spy(new DummyTask());
+
+      // when
+      notOpenScheduleService.runAt(100, mockedTask);
+      actorScheduler.workUntilDone();
+
+      // then
+      verify(mockedTask, never()).execute(any());
+    }
+
+    @Test
+    void shouldWriteRecordAfterTaskWasExecuted() {
+      // given
+
+      // when
+      scheduleService.runAt(
+          100,
+          (builder) -> {
+            builder.appendCommandRecord(1, ACTIVATE_ELEMENT, Records.processInstance(1));
+            return builder.build();
+          });
+      actorScheduler.workUntilDone();
+
+      // then
+
+      assertThat(writerAsyncSupplier.writer.entries)
+          .describedAs("Record is written to the log stream")
+          .map(LogAppendEntry::key)
+          .containsExactly(1L);
     }
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -443,9 +443,9 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
-    public ScheduledTask runAfter(final long timestamp, final Task task) {
+    public ScheduledTask runAt(final long timestamp, final Task task) {
       final var futureScheduledTask =
-          actor.call(() -> processingScheduleService.runAfter(timestamp, task));
+          actor.call(() -> processingScheduleService.runAt(timestamp, task));
       return () ->
           actor.run(
               () ->
@@ -535,7 +535,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAfter(90, mockedTask);
+      scheduleService.runAt(90, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -548,7 +548,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAfter(100, mockedTask);
+      scheduleService.runAt(100, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -562,8 +562,8 @@ class ProcessingScheduleServiceTest {
       final var mockedTask2 = spy(new DummyTask());
 
       // when
-      scheduleService.runAfter(100, mockedTask);
-      scheduleService.runAfter(90, mockedTask2);
+      scheduleService.runAt(100, mockedTask);
+      scheduleService.runAt(90, mockedTask2);
       actorScheduler.workUntilDone();
 
       // then
@@ -580,7 +580,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAfter(100, mockedTask);
+      scheduleService.runAt(100, mockedTask);
       // The task will be resubmitted infinitely. So workUntilDone will never return.
       actorScheduler.resume();
 
@@ -595,7 +595,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAfter(100, mockedTask);
+      scheduleService.runAt(100, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -609,7 +609,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      scheduleService.runAfter(100, mockedTask);
+      scheduleService.runAt(100, mockedTask);
       // The task will be resubmitted infinitely. So workUntilDone will never return.
       actorScheduler.resume();
       verify(mockedTask, never()).execute(any());
@@ -632,7 +632,7 @@ class ProcessingScheduleServiceTest {
       final var mockedTask = spy(new DummyTask());
 
       // when
-      notOpenScheduleService.runAfter(100, mockedTask);
+      notOpenScheduleService.runAt(100, mockedTask);
       actorScheduler.workUntilDone();
 
       // then
@@ -644,7 +644,7 @@ class ProcessingScheduleServiceTest {
       // given
 
       // when
-      scheduleService.runAfter(
+      scheduleService.runAt(
           100,
           (builder) -> {
             builder.appendCommandRecord(1, ACTIVATE_ELEMENT, Records.processInstance(1));


### PR DESCRIPTION
## Description

Unflake tests that rely on time travel to trigger timers.

This was unstable because the due date checker was scheduled with a delay, which is used to determine an actual deadline later during the actor's scheduling of the TimerSubscription. The instability arose because the task can be scheduled async, which means that the deadline was calculated async as well, so it could happen that the deadline was determined after the test had already traveled through time.

This problem is resolved by introducing a new `runAt` method, which allows scheduling a task at a specific timestamp. When the async scheduling is postponed until after the time traveling, the task will trigger immediately if the timestamp is now in the past.

This changes the following modules:
- `schedule` introduces a new `runAt` method that can schedule Timer tasks (TimerSubscription) by timestamp
- `stream-platform` introduces a new `runAt` method for the engine to schedule tasks at a timestamp that can produce processing results
- `engine` uses the new `runAt` method to (re)schedule the DueDateChecker

## Related issues

closes #17254 
closes #10169
closes #18462