### PR TITLE
test: fix e2e tests

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -3,30 +3,30 @@ name: Operate E2E Tests
 on:
   push:
     branches:
-      - 'main'
-      - 'stable/**'
-      - 'release/**'
+      - "main"
+      - "stable/**"
+      - "release/**"
     paths:
-      - '.ci/**'
-      - '.github/actions/**'
-      - '.github/workflows/operate-*'
-      - 'bom/*'
-      - 'distro/**'
-      - 'operate.Dockerfile'
-      - 'operate/**'
-      - 'parent/*'
-      - 'pom.xml'
+      - ".ci/**"
+      - ".github/actions/**"
+      - ".github/workflows/operate-*"
+      - "bom/*"
+      - "distro/**"
+      - "operate.Dockerfile"
+      - "operate/**"
+      - "parent/*"
+      - "pom.xml"
   pull_request:
     paths:
-      - '.ci/**'
-      - '.github/actions/**'
-      - '.github/workflows/operate-*'
-      - 'bom/*'
-      - 'distro/**'
-      - 'operate.Dockerfile'
-      - 'operate/**'
-      - 'parent/*'
-      - 'pom.xml'
+      - ".ci/**"
+      - ".github/actions/**"
+      - ".github/workflows/operate-*"
+      - "bom/*"
+      - "distro/**"
+      - "operate.Dockerfile"
+      - "operate/**"
+      - "parent/*"
+      - "pom.xml"
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).
 # If a new commits occurs, the current run will be canceled to save costs.
@@ -117,7 +117,9 @@ jobs:
       - name: Build backend
         run: mvn clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Operate
-        run: mvn -q -B spring-boot:start -pl dist -Dspring-boot.run.fork=true -Dspring-boot.run.main-class=io.camunda.operate.StandaloneOperate -DCAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED=false
+        run: mvn -q -B spring-boot:start -pl dist -Dspring-boot.run.fork=true -Dspring-boot.run.main-class=io.camunda.operate.StandaloneOperate
+        env:
+          CAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED: false
       - name: Run tests
         working-directory: ./operate/client
         run: yarn run test:e2e:ci

--- a/operate/Makefile
+++ b/operate/Makefile
@@ -83,4 +83,5 @@ start-e2e:
 	CAMUNDA_OPERATE_ELASTICSEARCH_INDEXPREFIX=e2eoperate \
 	CAMUNDA_OPERATE_IMPORTER_READERBACKOFF=0 \
 	CAMUNDA_OPERATE_IMPORTER_SCHEDULERBACKOFF=0 \
+	CAMUNDA_OPERATE_CSRF_PREVENTION_ENABLED=false \
 	mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.operate.StandaloneOperate" -Dserver.port=8081

--- a/operate/client/e2e-playwright/pages/Processes/Processes.ts
+++ b/operate/client/e2e-playwright/pages/Processes/Processes.ts
@@ -11,6 +11,7 @@ import {convertToQueryString} from '../../utils/convertToQueryString';
 import {Paths} from 'modules/Routes';
 import {DeleteResourceModal} from '../components/DeleteResourceModal';
 import MigrationModal from '../components/MigrationModal';
+import MoveModificationModal from '../components/MoveModificationModal';
 import {Diagram} from '../components/Diagram';
 
 type OptionalFilter =
@@ -27,6 +28,7 @@ export class Processes {
   private page: Page;
   readonly deleteResourceModal: InstanceType<typeof DeleteResourceModal>;
   readonly migrationModal: InstanceType<typeof MigrationModal>;
+  readonly moveModificationModal: InstanceType<typeof MoveModificationModal>;
   readonly diagram: InstanceType<typeof Diagram>;
   readonly activeCheckbox: Locator;
   readonly incidentsCheckbox: Locator;
@@ -57,6 +59,7 @@ export class Processes {
       name: /Delete Process Definition/i,
     });
     this.migrationModal = new MigrationModal(page);
+    this.moveModificationModal = new MoveModificationModal(page);
     this.diagram = new Diagram(page);
     this.activeCheckbox = page.getByRole('checkbox', {name: 'Active'});
     this.incidentsCheckbox = page.getByRole('checkbox', {name: 'Incidents'});
@@ -122,11 +125,11 @@ export class Processes {
     });
 
     this.migrateButton = this.processInstancesTable.getByRole('button', {
-      name: 'Migrate',
+      name: /^migrate$/i,
     });
 
     this.moveButton = this.processInstancesTable.getByRole('button', {
-      name: 'Move',
+      name: /^move$/i,
     });
   }
 

--- a/operate/client/e2e-playwright/pages/components/MoveModificationModal.ts
+++ b/operate/client/e2e-playwright/pages/components/MoveModificationModal.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {Locator, Page} from '@playwright/test';
+
+class MoveModificationModal {
+  private readonly modal: Locator;
+  readonly confirmButton: Locator;
+
+  constructor(page: Page) {
+    this.modal = page.getByRole('dialog', {
+      name: /process instance batch move mode/i,
+    });
+
+    this.confirmButton = this.modal.locator(
+      page.getByRole('button', {name: /continue/i}),
+    );
+  }
+}
+
+export default MoveModificationModal;

--- a/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
+++ b/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
@@ -75,7 +75,7 @@ test.describe('Process Instance Batch Modification', () => {
     await processesPage.moveButton.click();
 
     // Confirm move modification modal
-    await page.getByRole('button', {name: 'Continue'}).click();
+    await processesPage.moveModificationModal.confirmButton.click();
 
     // Select target flow node
     await processesPage.diagram.clickFlowNode('Ship Articles');
@@ -124,6 +124,8 @@ test.describe('Process Instance Batch Modification', () => {
       })
       .click();
 
+    await commonPage.collapseOperationsPanel();
+
     await processesPage.selectProcess('Order process');
     await processesPage.selectVersion(initialData.version.toString());
 
@@ -170,7 +172,7 @@ test.describe('Process Instance Batch Modification', () => {
     await processesPage.moveButton.click();
 
     // Confirm move modification modal
-    await page.getByRole('button', {name: 'Continue'}).click();
+    await processesPage.moveModificationModal.confirmButton.click();
 
     // Select target flow node
     await processesPage.diagram.clickFlowNode('Ship Articles');

--- a/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
+++ b/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
@@ -42,21 +42,19 @@ test.beforeAll(async ({request}) => {
 
 test.describe('Process Instance Batch Modification', () => {
   test('Move Operation', async ({processesPage, commonPage, page}) => {
-    await processesPage.navigateToProcesses({
-      searchParams: {active: 'true'},
-    });
-
     const processInstanceKeys = initialData.processInstances
       .map((instance) => instance.processInstanceKey)
       .join(',');
 
-    await processesPage.selectProcess('Order process');
-    await processesPage.selectVersion(initialData.version.toString());
-    await processesPage.selectFlowNode('Check payment');
-
-    // Filter by all process instances which have been created in setup
-    await processesPage.displayOptionalFilter('Process Instance Key(s)');
-    await processesPage.processInstanceKeysFilter.fill(processInstanceKeys);
+    await processesPage.navigateToProcesses({
+      searchParams: {
+        active: 'true',
+        ids: processInstanceKeys,
+        process: initialData.bpmnProcessId,
+        version: initialData.version.toString(),
+        flowNodeId: 'checkPayment',
+      },
+    });
 
     await expect(
       processesPage.processInstancesTable.getByText(

--- a/operate/client/e2e-playwright/tests/processInstancesFilters.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstancesFilters.spec.ts
@@ -206,7 +206,7 @@ test.describe('Process Instances Filters', () => {
     ).not.toBeVisible();
 
     // switch to multiple mode and add multiple variables
-    await page.getByRole('switch', {name: /multiple/i}).click({force: true});
+    await page.getByLabel(/multiple/i).click({force: true});
     await processesPage.variableNameFilter.fill('filtersTest');
     await processesPage.variableValueFilter.fill('123, 456');
 

--- a/operate/client/playwright.config.ts
+++ b/operate/client/playwright.config.ts
@@ -60,6 +60,7 @@ const config: PlaywrightTestConfig = {
     baseURL: `http://localhost:${getPort()}`,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
 };
 


### PR DESCRIPTION
## Description

This fixes several issues on the Operate e2e tests:

- add env var to disable CSRF in e2e tests (locally and CI)
- fix timing issue in batch modification e2e test caused by using the filters panel
- enable playwright video for failing test cases, because this turned out pretty helpful for debugging
- improve move modification modal button selector, which was flaky before