### PR TITLE
fix: return resource_exhausted when sequencer buffer is full

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -134,7 +134,11 @@ public final class ErrorResponseWriter implements BufferWriter {
                           + " but the writer is closed. Most likely, this node is not the"
                           + " leader for this partition.")
                       .formatted(partitionId));
-      case FULL -> raiseInternalError("because the writer is full.", partitionId);
+      case FULL ->
+          resourceExhausted(
+              String.format(
+                  "Failed to write client request to partition '%d', because the writer buffer is full.",
+                  partitionId));
       case INVALID_ARGUMENT -> raiseInternalError("due to invalid entry.", partitionId);
     };
   }


### PR DESCRIPTION
## Description

This PR doesn't fix the root cause where the writer buffer is full. But just map the error to `RESOURCE_EXHAUSTED` so that user's can know the request can be retried. 

## Related issues

closes #13018 
