### PR TITLE
fix: use timeout check for decide to have INCOMPLETE backup

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/BackupProperties.java
@@ -11,12 +11,22 @@ public class BackupProperties {
 
   private String repositoryName;
 
+  private Long incompleteCheckTimeoutInSeconds = 5 /* minutes */ * 60L;
+
   public String getRepositoryName() {
     return repositoryName;
   }
 
-  public BackupProperties setRepositoryName(String repositoryName) {
+  public BackupProperties setRepositoryName(final String repositoryName) {
     this.repositoryName = repositoryName;
     return this;
+  }
+
+  public Long getIncompleteCheckTimeoutInSeconds() {
+    return incompleteCheckTimeoutInSeconds;
+  }
+
+  public void setIncompleteCheckTimeoutInSeconds(final Long incompleteCheckTimeoutInSeconds) {
+    this.incompleteCheckTimeoutInSeconds = incompleteCheckTimeoutInSeconds;
   }
 }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/BackupControllerIT.java
@@ -529,10 +529,11 @@ public class BackupControllerIT {
   @Test
   public void shouldReturnIncompleteState() throws IOException {
     final Long backupId = 2L;
-    // we have only 2 out of 3 snapshots
+    // we have only 2 out of 3 snapshots + timeout
     final SnapshotInfo snapshotInfo1 =
         createSnapshotInfoMock(
             "snapshotName1", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
+    when(snapshotInfo1.startTime()).thenReturn(0L);
     final SnapshotInfo snapshotInfo2 =
         createSnapshotInfoMock(
             "snapshotName2", UUID.randomUUID().toString(), SnapshotState.SUCCESS);
@@ -711,17 +712,19 @@ public class BackupControllerIT {
             new Metadata().setBackupId(backupId1).setVersion("8.8.8").setPartNo(2).setPartCount(2),
             UUID.randomUUID().toString(),
             SnapshotState.SUCCESS);
-    // we have only 2 out of 3 snapshots -> INCOMPLETE
+    // we have only 2 out of 3 snapshots + TIMEOUT -> INCOMPLETE
     final SnapshotInfo snapshotInfo21 =
         createSnapshotInfoMock(
             new Metadata().setBackupId(backupId2).setVersion("8.8.8").setPartNo(1).setPartCount(3),
             UUID.randomUUID().toString(),
             SnapshotState.SUCCESS);
+    when(snapshotInfo21.startTime()).thenReturn(0L);
     final SnapshotInfo snapshotInfo22 =
         createSnapshotInfoMock(
             new Metadata().setBackupId(backupId2).setVersion("8.8.8").setPartNo(2).setPartCount(3),
             UUID.randomUUID().toString(),
             SnapshotState.SUCCESS);
+    when(snapshotInfo22.startTime()).thenReturn(0L);
     // IN_PROGRESS
     final SnapshotInfo snapshotInfo31 =
         createSnapshotInfoMock(
@@ -820,7 +823,7 @@ public class BackupControllerIT {
   }
 
   private void assertBackupDetails(
-      List<SnapshotInfo> snapshotInfos, GetBackupStateResponseDto backupState) {
+      final List<SnapshotInfo> snapshotInfos, final GetBackupStateResponseDto backupState) {
     assertThat(backupState.getDetails()).hasSize(snapshotInfos.size());
     assertThat(backupState.getDetails())
         .extracting(GetBackupStateResponseDetailDto::getSnapshotName)
@@ -836,27 +839,32 @@ public class BackupControllerIT {
             snapshotInfos.stream().map(si -> si.startTime()).toArray(Long[]::new));
   }
 
-  private SnapshotInfo createSnapshotInfoMock(String name, String uuid, SnapshotState state) {
+  private SnapshotInfo createSnapshotInfoMock(
+      final String name, final String uuid, final SnapshotState state) {
     return createSnapshotInfoMock(null, name, uuid, state, null);
   }
 
-  private SnapshotInfo createSnapshotInfoMock(Metadata metadata, String uuid, SnapshotState state) {
+  private SnapshotInfo createSnapshotInfoMock(
+      final Metadata metadata, final String uuid, final SnapshotState state) {
     return createSnapshotInfoMock(metadata, null, uuid, state, null);
   }
 
   @NotNull
   private SnapshotInfo createSnapshotInfoMock(
-      String name, String uuid, SnapshotState state, List<SnapshotShardFailure> failures) {
+      final String name,
+      final String uuid,
+      final SnapshotState state,
+      final List<SnapshotShardFailure> failures) {
     return createSnapshotInfoMock(null, name, uuid, state, failures);
   }
 
   @NotNull
   private SnapshotInfo createSnapshotInfoMock(
-      Metadata metadata,
-      String name,
-      String uuid,
-      SnapshotState state,
-      List<SnapshotShardFailure> failures) {
+      final Metadata metadata,
+      final String name,
+      final String uuid,
+      final SnapshotState state,
+      final List<SnapshotShardFailure> failures) {
     final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class);
     if (metadata != null) {
       when(snapshotInfo.snapshotId())

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
@@ -9,8 +9,6 @@ package io.camunda.operate.webapp.backup;
 
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDto;
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,14 +31,13 @@ public interface BackupRepository {
       BackupService.SnapshotRequest snapshotRequest, Runnable onSuccess, Runnable onFailure);
 
   default boolean isIncompleteCheckTimedOut(
-      final OperateProperties operateProperties, final long startTimeInMilliseconds) {
+      final OperateProperties operateProperties,
+      final long startTimeInMilliseconds,
+      final long endTimeInMilliseconds) {
     try {
       final long timeOutInSeconds =
           operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds();
-      return Instant.now()
-          .isAfter(
-              Instant.ofEpochMilli(startTimeInMilliseconds)
-                  .plus(timeOutInSeconds, ChronoUnit.SECONDS));
+      return (endTimeInMilliseconds - startTimeInMilliseconds) > timeOutInSeconds;
     } catch (final Exception e) {
       LOGGER.warn(
           "Couldn't check incomplete timeout for backup. Return incomplete check is timed out", e);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/backup/BackupRepository.java
@@ -9,6 +9,7 @@ package io.camunda.operate.webapp.backup;
 
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.webapp.management.dto.GetBackupStateResponseDto;
+import java.time.Instant;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,6 +36,12 @@ public interface BackupRepository {
       final long startTimeInMilliseconds,
       final long endTimeInMilliseconds) {
     try {
+      final var now = Instant.now().toEpochMilli();
+      final var timeout = operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds();
+      // if is no end time available we just check start time with now
+      if (now - startTimeInMilliseconds > timeout && endTimeInMilliseconds <= 0) {
+        return true;
+      }
       final long timeOutInSeconds =
           operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds();
       return (endTimeInMilliseconds - startTimeInMilliseconds) > timeOutInSeconds;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -335,7 +335,9 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       response.setState(BackupStateDto.IN_PROGRESS);
     } else if (snapshots.size() < expectedSnapshotsCount) {
       if (isIncompleteCheckTimedOut(
-          operateProperties, startTimeInMilliseconds, endTimeInMilliseconds)) {
+          operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds(),
+          startTimeInMilliseconds,
+          endTimeInMilliseconds)) {
         response.setState(BackupStateDto.INCOMPLETE);
       } else {
         response.setState(BackupStateDto.IN_PROGRESS);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
@@ -365,7 +365,9 @@ public class OpensearchBackupRepository implements BackupRepository {
       return BackupStateDto.IN_PROGRESS;
     } else if (snapshots.size() < expectedSnapshotsCount) {
       if (isIncompleteCheckTimedOut(
-          operateProperties, startTimeInMilliseconds, endTimeInMilliseconds)) {
+          operateProperties.getBackup().getIncompleteCheckTimeoutInSeconds(),
+          startTimeInMilliseconds,
+          endTimeInMilliseconds)) {
         return BackupStateDto.INCOMPLETE;
       } else {
         return BackupStateDto.IN_PROGRESS;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepository.java
@@ -352,6 +352,8 @@ public class OpensearchBackupRepository implements BackupRepository {
       final List<OpenSearchSnapshotInfo> snapshots, final Integer expectedSnapshotsCount) {
     final var firstSnapshot = snapshots.get(0);
     final var startTimeInMilliseconds = firstSnapshot.getStartTimeInMillis();
+    final var lastSnapshot = snapshots.get(snapshots.size() - 1);
+    final var endTimeInMilliseconds = lastSnapshot.getStartTimeInMillis();
     if (snapshots.size() == expectedSnapshotsCount
         && snapshots.stream().map(OpenSearchSnapshotInfo::getState).allMatch(SUCCESS::equals)) {
       return BackupStateDto.COMPLETED;
@@ -362,7 +364,8 @@ public class OpensearchBackupRepository implements BackupRepository {
     } else if (snapshots.stream().map(OpenSearchSnapshotInfo::getState).anyMatch(STARTED::equals)) {
       return BackupStateDto.IN_PROGRESS;
     } else if (snapshots.size() < expectedSnapshotsCount) {
-      if (isIncompleteCheckTimedOut(operateProperties, startTimeInMilliseconds)) {
+      if (isIncompleteCheckTimedOut(
+          operateProperties, startTimeInMilliseconds, endTimeInMilliseconds)) {
         return BackupStateDto.INCOMPLETE;
       } else {
         return BackupStateDto.IN_PROGRESS;

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -81,17 +81,24 @@ class ElasticsearchBackupRepositoryTest {
     final var snapshotClient = mock(SnapshotClient.class);
     final var firstSnapshotInfo = mock(SnapshotInfo.class);
     final var snapshotResponse = mock(GetSnapshotsResponse.class);
+    final var lastSnapshotInfo = mock(SnapshotInfo.class);
 
     // Set up Snapshot client
     when(esClient.snapshot()).thenReturn(snapshotClient);
-    // Set up Snapshot details
+    // Set up first Snapshot details
     when(firstSnapshotInfo.userMetadata())
         .thenReturn(objectMapper.convertValue(new Metadata().setPartCount(3), Map.class));
     when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
     when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(firstSnapshotInfo.startTime()).thenReturn(23L);
+
+    // Set up last Snapshot details
+    when(lastSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(lastSnapshotInfo.endTime()).thenReturn(23L + 6 * 60);
+    when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
 
     // Set up Snapshot response
-    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo));
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo, lastSnapshotInfo));
     when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
 
     // Test

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -93,7 +93,7 @@ class ElasticsearchBackupRepositoryTest {
 
     // Set up last Snapshot details
     when(lastSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
-    when(lastSnapshotInfo.endTime()).thenReturn(23L + 6 * 60);
+    when(lastSnapshotInfo.endTime()).thenReturn(23L + 6 * 60 * 1_000);
     when(lastSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
 
     // Set up Snapshot response

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepositoryTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.elasticsearch.backup;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.webapp.backup.Metadata;
+import io.camunda.operate.webapp.management.dto.BackupStateDto;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.SnapshotClient;
+import org.elasticsearch.snapshots.SnapshotId;
+import org.elasticsearch.snapshots.SnapshotInfo;
+import org.elasticsearch.snapshots.SnapshotState;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ElasticsearchBackupRepositoryTest {
+
+  @Mock RestHighLevelClient esClient;
+
+  OperateProperties operateProperties = new OperateProperties();
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  ElasticsearchBackupRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new ElasticsearchBackupRepository(esClient, objectMapper, operateProperties);
+  }
+
+  @Test
+  void shouldCreate() {
+    assertThat(repository).isNotNull();
+  }
+
+  @Test
+  void shouldReturnBackupStateCompleted() throws IOException {
+    final var snapshotClient = mock(SnapshotClient.class);
+    final var firstSnapshotInfo = mock(SnapshotInfo.class);
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+
+    // Set up Snapshot client
+    when(esClient.snapshot()).thenReturn(snapshotClient);
+    // Set up Snapshot details
+    when(firstSnapshotInfo.userMetadata())
+        .thenReturn(objectMapper.convertValue(new Metadata().setPartCount(1), Map.class));
+    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+
+    // Set up Snapshot response
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo));
+    when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
+
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.COMPLETED);
+  }
+
+  @Test
+  void shouldReturnBackupStateIncomplete() throws IOException {
+    final var snapshotClient = mock(SnapshotClient.class);
+    final var firstSnapshotInfo = mock(SnapshotInfo.class);
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+
+    // Set up Snapshot client
+    when(esClient.snapshot()).thenReturn(snapshotClient);
+    // Set up Snapshot details
+    when(firstSnapshotInfo.userMetadata())
+        .thenReturn(objectMapper.convertValue(new Metadata().setPartCount(3), Map.class));
+    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+
+    // Set up Snapshot response
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo));
+    when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
+
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.INCOMPLETE);
+  }
+
+  @Test
+  void shouldReturnBackupStateProgress() throws IOException {
+    final var snapshotClient = mock(SnapshotClient.class);
+    final var firstSnapshotInfo = mock(SnapshotInfo.class);
+    final var snapshotResponse = mock(GetSnapshotsResponse.class);
+
+    // Set up Snapshot client
+    when(esClient.snapshot()).thenReturn(snapshotClient);
+    // Set up Snapshot details
+    when(firstSnapshotInfo.userMetadata())
+        .thenReturn(objectMapper.convertValue(new Metadata().setPartCount(3), Map.class));
+    when(firstSnapshotInfo.snapshotId()).thenReturn(new SnapshotId("snapshot-name", "uuid"));
+    when(firstSnapshotInfo.state()).thenReturn(SnapshotState.SUCCESS);
+    when(firstSnapshotInfo.startTime()).thenReturn(Instant.now().toEpochMilli());
+
+    // Set up Snapshot response
+    when(snapshotResponse.getSnapshots()).thenReturn(List.of(firstSnapshotInfo));
+    when(snapshotClient.get(any(), any())).thenReturn(snapshotResponse);
+
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -285,9 +285,15 @@ class OpensearchBackupRepositoryTest {
         new OpenSearchSnapshotInfo()
             .setUuid("uuid")
             .setState(SnapshotState.SUCCESS)
-            .setStartTimeInMillis(0L);
+            .setStartTimeInMillis(17L);
+    final var lastSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(17L + 6 * 60);
     when(openSearchSnapshotOperations.get(any()))
-        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+        .thenReturn(
+            new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo, lastSnapshotInfo)));
     // Test
     final var backupState = repository.getBackupState("repository-name", 5L);
     assertThat(backupState.getState()).isEqualTo(BackupStateDto.INCOMPLETE);

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -197,9 +197,9 @@ class OpensearchBackupRepositoryTest {
 
   @Test
   void getBackupState() {
+    when(operateProperties.getBackup()).thenReturn(new BackupProperties());
     mockSynchronSnapshotOperations();
     mockObjectMapperForMetadata(new Metadata().setPartCount(3));
-
     when(openSearchSnapshotOperations.get(any()))
         .thenReturn(
             new OpenSearchGetSnapshotResponse(
@@ -212,7 +212,7 @@ class OpensearchBackupRepositoryTest {
     final var response = repository.getBackupState("repo", 5L);
 
     assertThat(response).isNotNull();
-    assertThat(response.getState()).isEqualTo(BackupStateDto.INCOMPLETE);
+    assertThat(response.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
     assertThat(response.getBackupId()).isEqualTo(5L);
     final var snapshotDetails = response.getDetails();
     assertThat(snapshotDetails).hasSize(1);
@@ -290,7 +290,7 @@ class OpensearchBackupRepositoryTest {
         new OpenSearchSnapshotInfo()
             .setUuid("uuid")
             .setState(SnapshotState.SUCCESS)
-            .setStartTimeInMillis(17L + 6 * 60);
+            .setStartTimeInMillis(17L + 6 * 60 * 1_000);
     when(openSearchSnapshotOperations.get(any()))
         .thenReturn(
             new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo, lastSnapshotInfo)));

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.BackupProperties;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.opensearch.client.async.OpenSearchAsyncSnapshotOperations;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchSnapshotOperations;
@@ -28,7 +29,9 @@ import io.camunda.operate.webapp.backup.BackupService;
 import io.camunda.operate.webapp.backup.Metadata;
 import io.camunda.operate.webapp.management.dto.BackupStateDto;
 import io.camunda.operate.webapp.rest.exception.InvalidRequestException;
+import java.io.IOException;
 import java.net.SocketTimeoutException;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -271,5 +274,93 @@ class OpensearchBackupRepositoryTest {
             () -> repository.validateNoDuplicateBackupId("repo", 42L));
     assertThat(exception.getMessage())
         .isEqualTo("A backup with ID [42] already exists. Found snapshots: [test]");
+  }
+
+  @Test
+  void shouldReturnBackupStateIncomplete() throws IOException {
+    when(operateProperties.getBackup()).thenReturn(new BackupProperties());
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(3));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(0L);
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.INCOMPLETE);
+  }
+
+  @Test
+  void shouldReturnBackupStateInProgress() throws IOException {
+    when(operateProperties.getBackup()).thenReturn(new BackupProperties());
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(3));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.IN_PROGRESS);
+  }
+
+  @Test
+  void shouldReturnBackupStateFailedWhenSnapshotIsPartialCompleted() throws IOException {
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(1));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.PARTIAL)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.FAILED);
+  }
+
+  @Test
+  void shouldReturnBackupStateFailedCompleted() throws IOException {
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(2));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    final var lastSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.SUCCESS)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(
+            new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo, lastSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.COMPLETED);
+  }
+
+  @Test
+  void shouldReturnBackupStateFailedWhenSnapshotIsFailed() throws IOException {
+    mockSynchronSnapshotOperations();
+    mockObjectMapperForMetadata(new Metadata().setPartCount(1));
+    final var firstSnapshotInfo =
+        new OpenSearchSnapshotInfo()
+            .setUuid("uuid")
+            .setState(SnapshotState.FAILED)
+            .setStartTimeInMillis(Instant.now().toEpochMilli());
+    when(openSearchSnapshotOperations.get(any()))
+        .thenReturn(new OpenSearchGetSnapshotResponse(List.of(firstSnapshotInfo)));
+    // Test
+    final var backupState = repository.getBackupState("repository-name", 5L);
+    assertThat(backupState.getState()).isEqualTo(BackupStateDto.FAILED);
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/backup/OpensearchBackupRepositoryTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.opensearch.client.async.OpenSearchAsyncSnapshotOperations;
 import io.camunda.operate.store.opensearch.client.sync.OpenSearchSnapshotOperations;
 import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
@@ -53,11 +54,14 @@ class OpensearchBackupRepositoryTest {
 
   @Mock private ObjectMapper objectMapper;
 
+  @Mock private OperateProperties operateProperties;
+
   private OpensearchBackupRepository repository;
 
   @BeforeEach
   public void setUp() {
-    repository = new OpensearchBackupRepository(richOpenSearchClient, objectMapper);
+    repository =
+        new OpensearchBackupRepository(richOpenSearchClient, objectMapper, operateProperties);
   }
 
   private void mockAsynchronSnapshotOperations() {


### PR DESCRIPTION
## Description

* Add timeout check for decision if the backup is `INCOMPLETE` or still `IN_PROGRESS`
* if not all expected snapshots are existing, endpoint `/actuator/backups` returns 
   * `IN_PROGRESS` before the timeout
   * `INCOMPLETE` after the timeout
* Add configuration `CAMUNDA_OPERATE_BACKUP_INCOMPLETE_CHECK_TIMEOUT_IN_SECONDS` with default value of 5 minutes 
* Add Unit tests for implementations of `BackupRepository`

## Related issues

closes https://github.com/camunda/operate/issues/5191
