### PR TITLE
fix: configure management security filter chain

### DIFF
--- a/dist/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
+++ b/dist/src/main/resources/META-INF/spring/org.springframework.boot.actuate.autoconfigure.web.ManagementContextConfiguration.imports
@@ -1,2 +1,1 @@
 io.camunda.zeebe.broker.health.BrokerHealthRoutes
-io.camunda.zeebe.shared.security.SecurityConfiguration.ManagementSecurityConfiguration

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/GatewayHealthProbeIntegrationTest.java
@@ -206,4 +206,60 @@ public class GatewayHealthProbeIntegrationTest {
       }
     }
   }
+
+  @Nested
+  final class WithAuthenticationIdentityTest {
+    @TestZeebe(awaitReady = false, awaitCompleteTopology = false) // since there's no broker
+    private final TestStandaloneGateway gateway =
+        new TestStandaloneGateway().withAdditionalProfile("identity-auth");
+
+    @Test
+    void shouldReportReadinessUpWithoutAuthentication() {
+      // given
+      final var gatewayServerSpec =
+          new RequestSpecBuilder()
+              .setContentType(ContentType.JSON)
+              .setBaseUri(gateway.actuatorUri())
+              .addFilter(new ResponseLoggingFilter())
+              .addFilter(new RequestLoggingFilter())
+              .build();
+
+      // when - then
+      // most of the readiness probes use a delayed health indicator which is scheduled at a fixed
+      // rate of 5 seconds, so it may take up to that and a bit more in the worst case once the
+      // gateway finds the broker
+      try {
+        Awaitility.await("wait until status turns UP")
+            .atMost(Duration.ofSeconds(10))
+            .pollInterval(Duration.ofMillis(100))
+            .untilAsserted(
+                () ->
+                    given()
+                        .spec(gatewayServerSpec)
+                        .when()
+                        .get(PATH_READINESS_PROBE)
+                        .then()
+                        .statusCode(200));
+      } catch (final ConditionTimeoutException e) {
+        // it can happen that a single request takes too long and causes awaitility to timeout,
+        // in which case we want to try a second time to run the request without timeout
+        given().spec(gatewayServerSpec).when().get(PATH_READINESS_PROBE).then().statusCode(200);
+      }
+    }
+
+    @Test
+    void shouldReturnNotFoundWhenCallingNoneExistingEndpoint() {
+      // given
+      final var gatewayServerSpec =
+          new RequestSpecBuilder()
+              .setContentType(ContentType.JSON)
+              .setBaseUri(gateway.monitoringUri())
+              .addFilter(new ResponseLoggingFilter())
+              .addFilter(new RequestLoggingFilter())
+              .build();
+
+      // when - then
+      given().spec(gatewayServerSpec).when().get(PATH_TO_HEALTH_PROBE).then().statusCode(404);
+    }
+  }
 }


### PR DESCRIPTION
## Description

This PR ensures that all actuator endpoints are accessible and do not return the status code 401. The same applies to the `BrokerHealthRoutes` (`ready`, `startup`, and `health`). Therefore, it defines a security filter chain `managementSecurity` only applied when one of the defined `requestMatchers` matches. If none of the `requestMatchers` match, then the default `restGatewaySecurity` security filter chain is applied, requiring proper authentication.


## Related issues

closes #18568 
