### PR TITLE
fix: Opensearch metafield update methods

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/ImportStoreIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/ImportStoreIT.java
@@ -13,10 +13,12 @@ import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.Metrics;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
+import io.camunda.operate.connect.OpensearchConnector;
 import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
 import io.camunda.operate.schema.indices.ImportPositionIndex;
+import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
 import io.camunda.operate.schema.util.SchemaTestHelper;
 import io.camunda.operate.schema.util.TestTemplate;
 import io.camunda.operate.schema.util.elasticsearch.ElasticsearchSchemaTestHelper;
@@ -25,6 +27,7 @@ import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.store.elasticsearch.ElasticsearchImportStore;
 import io.camunda.operate.store.elasticsearch.ElasticsearchTaskStore;
 import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
+import io.camunda.operate.store.opensearch.OpensearchImportStore;
 import io.micrometer.core.instrument.MeterRegistry;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,12 +43,15 @@ import org.springframework.test.context.ContextConfiguration;
       TestTemplate.class,
       ElasticsearchSchemaManager.class,
       ElasticsearchImportStore.class,
+      OpensearchSchemaManager.class,
+      OpensearchImportStore.class,
       OpenSearchSchemaTestHelper.class,
       ElasticsearchSchemaTestHelper.class,
       DatabaseInfo.class,
       OperateProperties.class,
       RetryElasticsearchClient.class,
       ElasticsearchConnector.class,
+      OpensearchConnector.class,
       ElasticsearchTaskStore.class,
       JacksonConfig.class,
       OperateDateTimeFormatter.class,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ZeebeRecordTestUtil.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ZeebeRecordTestUtil.java
@@ -196,6 +196,7 @@ public abstract class ZeebeRecordTestUtil {
         .withName(var.getName())
         .withValue(var.getFullValue())
         .withProcessInstanceKey(var.getProcessInstanceKey())
+        .withBpmnProcessId(var.getBpmnProcessId())
         .withScopeKey(var.getScopeKey())
         .withTenantId(var.getTenantId());
     if (recordValueBuilderFunction != null) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/QueryDSL.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/dsl/QueryDSL.java
@@ -9,6 +9,7 @@ package io.camunda.operate.store.opensearch.dsl;
 
 import io.camunda.operate.tenant.TenantCheckApplierHolder;
 import io.camunda.operate.util.CollectionUtil;
+import jakarta.json.JsonValue;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -39,33 +40,33 @@ import org.opensearch.client.opensearch.core.search.SourceConfig;
 public interface QueryDSL {
   String DEFAULT_SCRIPT_LANG = "painless";
 
-  private static <A> List<A> nonNull(A[] items) {
+  private static <A> List<A> nonNull(final A[] items) {
     return nonNull(Arrays.asList(items));
   }
 
-  private static <A> List<A> nonNull(Collection<A> items) {
+  private static <A> List<A> nonNull(final Collection<A> items) {
     return items.stream().filter(Objects::nonNull).toList();
   }
 
-  private static Map<String, JsonData> jsonParams(Map<String, Object> params) {
+  private static Map<String, JsonData> jsonParams(final Map<String, Object> params) {
     return params.entrySet().stream()
         .collect(Collectors.toMap(Map.Entry::getKey, e -> json(e.getValue())));
   }
 
-  static Query and(Query... queries) {
+  static Query and(final Query... queries) {
     return BoolQuery.of(q -> q.must(nonNull(queries)))._toQuery();
   }
 
-  static Query and(List<Query> queries) {
+  static Query and(final List<Query> queries) {
     return BoolQuery.of(q -> q.must(nonNull(queries)))._toQuery();
   }
 
-  static Query withTenantCheck(Query query) {
+  static Query withTenantCheck(final Query query) {
     try {
       return TenantCheckApplierHolder.getOpenSearchTenantCheckApplier()
           .map(tenantCheckApplier -> tenantCheckApplier.apply(query))
           .orElse(query);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       /* In integration tests under some circumstances tenantCheckApplier.apply throws NPE due to some tricky bean wiring/mocking issues.
         E.g. only when all tests from io.camunda.operate.elasticsearch in operate-qa-it-tests are run then only all FlowNodeInstanceReaderIT tests fail,
         while running separately all tests from FlowNodeInstanceReaderIT passes successfully (i.e. doesn't reproduce when run separately from other IT tests).
@@ -75,67 +76,71 @@ public interface QueryDSL {
     }
   }
 
-  static Query constantScore(Query query) {
+  static Query constantScore(final Query query) {
     return ConstantScoreQuery.of(q -> q.filter(query))._toQuery();
   }
 
-  static Query exists(String field) {
+  static Query exists(final String field) {
     return ExistsQuery.of(q -> q.field(field))._toQuery();
   }
 
-  static <A> Query gt(String field, A gt) {
+  static <A> Query gt(final String field, final A gt) {
     return RangeQuery.of(q -> q.field(field).gt(json(gt)))._toQuery();
   }
 
-  static <A> Query gteLte(String field, A gte, A lte) {
+  static <A> Query gteLte(final String field, final A gte, final A lte) {
     return RangeQuery.of(q -> q.field(field).gte(json(gte)).lte(json(lte)))._toQuery();
   }
 
-  static <A> Query gtLte(String field, A gt, A lte) {
+  static <A> Query gtLte(final String field, final A gt, final A lte) {
     return RangeQuery.of(q -> q.field(field).gt(json(gt)).lte(json(lte)))._toQuery();
   }
 
-  static Query hasChildQuery(String type, Query query) {
+  static Query hasChildQuery(final String type, final Query query) {
     return HasChildQuery.of(q -> q.query(query).type(type).scoreMode(ChildScoreMode.None))
         ._toQuery();
   }
 
-  static Query ids(List<String> ids) {
+  static Query ids(final List<String> ids) {
     return IdsQuery.of(q -> q.values(nonNull(ids)))._toQuery();
   }
 
-  static Query ids(Collection<String> ids) {
+  static Query ids(final Collection<String> ids) {
     return IdsQuery.of(q -> q.values(ids.stream().toList()))._toQuery();
   }
 
-  static Query ids(String... ids) {
+  static Query ids(final String... ids) {
     return ids(List.of(ids));
   }
 
-  static <C extends Collection<Integer>> Query intTerms(String field, C values) {
+  static <C extends Collection<Integer>> Query intTerms(final String field, final C values) {
     return terms(field, values, FieldValue::of);
   }
 
-  static <A> JsonData json(A value) {
-    return JsonData.of(value);
+  static <A> JsonData json(final A value) {
+    return JsonData.of(value == null ? JsonValue.NULL : value);
   }
 
-  static <C extends Collection<Long>> Query longTerms(String field, C values) {
+  static <C extends Collection<Long>> Query longTerms(final String field, final C values) {
     return terms(field, values, FieldValue::of);
   }
 
-  static <A> Query terms(String field, Collection<A> values, Function<A, FieldValue> toFieldValue) {
+  static <A> Query terms(
+      final String field, final Collection<A> values, final Function<A, FieldValue> toFieldValue) {
     final List<FieldValue> fieldValues = values.stream().map(toFieldValue).toList();
     return TermsQuery.of(q -> q.field(field).terms(TermsQueryField.of(f -> f.value(fieldValues))))
         ._toQuery();
   }
 
-  static <A> Query lte(String field, A lte) {
+  static <A> Query lte(final String field, final A lte) {
     return RangeQuery.of(q -> q.field(field).lte(json(lte)))._toQuery();
   }
 
   static <A> Query match(
-      String field, A value, Operator operator, Function<A, FieldValue> toFieldValue) {
+      final String field,
+      final A value,
+      final Operator operator,
+      final Function<A, FieldValue> toFieldValue) {
     return new MatchQuery.Builder()
         .field(field)
         .query(toFieldValue.apply(value))
@@ -144,7 +149,7 @@ public interface QueryDSL {
         ._toQuery();
   }
 
-  static Query match(String field, String value, Operator operator) {
+  static Query match(final String field, final String value, final Operator operator) {
     return match(field, value, operator, FieldValue::of);
   }
 
@@ -156,15 +161,15 @@ public interface QueryDSL {
     return new MatchNoneQuery.Builder().build()._toQuery();
   }
 
-  static Query not(Query... queries) {
+  static Query not(final Query... queries) {
     return BoolQuery.of(q -> q.mustNot(nonNull(queries)))._toQuery();
   }
 
-  static Query or(Query... queries) {
+  static Query or(final Query... queries) {
     return BoolQuery.of(q -> q.should(nonNull(queries)))._toQuery();
   }
 
-  static Query prefix(String field, String value) {
+  static Query prefix(final String field, final String value) {
     return PrefixQuery.of(q -> q.field(field).value(value))._toQuery();
   }
 
@@ -172,83 +177,87 @@ public interface QueryDSL {
     return sortOrder == SortOrder.Asc ? SortOrder.Desc : SortOrder.Asc;
   }
 
-  static Script script(String script, Map<String, Object> params) {
+  static Script script(final String script, final Map<String, Object> params) {
     return new Script.Builder()
         .inline(b -> b.source(script).params(jsonParams(params)).lang(DEFAULT_SCRIPT_LANG))
         .build();
   }
 
-  static SortOptions sortOptions(String field, SortOrder sortOrder) {
+  static SortOptions sortOptions(final String field, final SortOrder sortOrder) {
     return SortOptions.of(so -> so.field(sf -> sf.field(field).order(sortOrder)));
   }
 
-  static SortOptions sortOptions(String field, SortOrder sortOrder, String missing) {
+  static SortOptions sortOptions(
+      final String field, final SortOrder sortOrder, final String missing) {
     return SortOptions.of(
         so ->
             so.field(sf -> sf.field(field).order(sortOrder).missing(m -> m.stringValue(missing))));
   }
 
-  static SourceConfig sourceInclude(String... fields) {
+  static SourceConfig sourceInclude(final String... fields) {
     if (CollectionUtil.isEmpty(fields)) {
       return sourceInclude(List.of());
     }
     return sourceInclude(List.of(fields));
   }
 
-  static SourceConfig sourceExclude(String... fields) {
+  static SourceConfig sourceExclude(final String... fields) {
     if (CollectionUtil.isEmpty(fields)) {
       return sourceExclude(List.of());
     }
     return sourceExclude(List.of(fields));
   }
 
-  static SourceConfig sourceIncludesExcludes(String[] includes, String[] excludes) {
+  static SourceConfig sourceIncludesExcludes(final String[] includes, final String[] excludes) {
     return sourceIncludesExcludes(
         includes == null ? List.of() : List.of(includes),
         excludes == null ? List.of() : List.of(excludes));
   }
 
-  static SourceConfig sourceExclude(List<String> fields) {
+  static SourceConfig sourceExclude(final List<String> fields) {
     return SourceConfig.of(s -> s.filter(f -> f.excludes(fields)));
   }
 
-  static SourceConfig sourceInclude(List<String> fields) {
+  static SourceConfig sourceInclude(final List<String> fields) {
     return SourceConfig.of(s -> s.filter(f -> f.includes(fields)));
   }
 
-  static SourceConfig sourceIncludesExcludes(List<String> includes, List<String> excludes) {
+  static SourceConfig sourceIncludesExcludes(
+      final List<String> includes, final List<String> excludes) {
     return SourceConfig.of(s -> s.filter(f -> f.includes(includes).excludes(excludes)));
   }
 
-  static <C extends Collection<String>> Query stringTerms(String field, C values) {
+  static <C extends Collection<String>> Query stringTerms(final String field, final C values) {
     return terms(field, values, FieldValue::of);
   }
 
-  static Query term(String field, Integer value) {
+  static Query term(final String field, final Integer value) {
     return term(field, value, FieldValue::of);
   }
 
-  static Query term(String field, Long value) {
+  static Query term(final String field, final Long value) {
     return term(field, value, FieldValue::of);
   }
 
-  static Query term(String field, String value) {
+  static Query term(final String field, final String value) {
     return term(field, value, FieldValue::of);
   }
 
-  static Query term(String field, boolean value) {
+  static Query term(final String field, final boolean value) {
     return term(field, value, FieldValue::of);
   }
 
-  static <A> Query term(String field, A value, Function<A, FieldValue> toFieldValue) {
+  static <A> Query term(
+      final String field, final A value, final Function<A, FieldValue> toFieldValue) {
     return TermQuery.of(q -> q.field(field).value(toFieldValue.apply(value)))._toQuery();
   }
 
-  static Query wildcardQuery(String field, String value) {
+  static Query wildcardQuery(final String field, final String value) {
     return WildcardQuery.of(q -> q.field(field).value(value))._toQuery();
   }
 
-  static Query matchDateQuery(final String name, final String dateAsString, String dateFormat) {
+  static Query matchDateQuery(
+      final String name, final String dateAsString, final String dateFormat) {
     // Used to match in different time ranges like hours, minutes etc
     // See:
     // https://www.elastic.co/guide/en/elasticsearch/reference/current/common-options.html#date-math


### PR DESCRIPTION
* implement Opensearch methods to check meta fields

closes #18452 in `main`

(This is the cherry-pick from https://github.com/camunda/zeebe/pull/18458 and https://github.com/camunda/zeebe/pull/18534)