### PR TITLE
ci: add Renovate configuration validator

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,9 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
-
   "commitMessagePrefix": "deps:",
   "baseBranches": [
     "/^stable\\/8\\..*/",
@@ -107,11 +106,11 @@
       "groupName": "definitelyTyped"
     },
     {
-      "extends": "monorepo:react",
+      "extends": ["monorepo:react"],
       "groupName": "react monorepo"
     },
     {
-      "extends": "monorepo:react-router",
+      "extends": ["monorepo:react-router"],
       "groupName": "react-router monorepo"
     },
     {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:base"
   ],
+
   "commitMessagePrefix": "deps:",
   "baseBranches": [
     "/^stable\\/8\\..*/",

--- a/.github/workflows/renovatelint.yml
+++ b/.github/workflows/renovatelint.yml
@@ -1,0 +1,18 @@
+---
+name: Renovate lint
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/renovatelint.yml'
+      - '**/renovate.json'
+      - '**/renovate.json5'
+
+jobs:
+  renovate-config-validator:
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/renovatebot/renovate
+      options: --user root
+    steps:
+      - uses: actions/checkout@v4
+      - run: renovate-config-validator --strict


### PR DESCRIPTION
## Description

This PR makes the Renovate configuration validator run whenever the Renovate configuration is adjusted: This helps catching errors, outdated options and typos in the Renovate configuration and is generally a best practice (know it from the Infra team): https://docs.renovatebot.com/config-validation/

This PR also fixes the outdated Renovate configuration options to make the linter happy, one change needed is e.g. https://github.com/renovatebot/renovate/issues/23326