### PR TITLE
fix: map OpenSearch port 9600 to 9601 (avoid conflict with actuator)

### DIFF
--- a/operate/docker-compose.opensearch-identity.yml
+++ b/operate/docker-compose.opensearch-identity.yml
@@ -22,7 +22,7 @@ services:
         hard: 65536
     ports:
       - "9200:9200"
-      - "9600:9600" # re
+      - "9601:9600" # re
   postgres:
     container_name: postgres
     image: postgres:16.3-alpine

--- a/operate/docker-compose.opensearch.yml
+++ b/operate/docker-compose.opensearch.yml
@@ -22,7 +22,7 @@ services:
         hard: 65536
     ports:
       - "9200:9200"
-      - "9600:9600" # required for Performance Analyzer
+      - "9601:9600" # required for Performance Analyzer
     volumes:
       - ./os-snapshots:/usr/local/os-snapshots
   zeebe-opensearch:


### PR DESCRIPTION
## Description

Map OpenSearch port `9600` to `9601` in `docker-compose.opensearch.yml` to avoid conflict with actuator endpoints

- OpenSearch port 9600 is used for performance analyzer and other plugins.

## Related issues

closes #
