### PR TITLE
refactor: removed redundancy for opensearch docker-compose startup

### DIFF
--- a/operate/Makefile
+++ b/operate/Makefile
@@ -8,7 +8,7 @@ env-up:
 	   mvn clean install -DskipTests -DskipChecks -f ../dist/pom.xml exec:java -Dexec.mainClass="io.camunda.application.StandaloneOperate" -Dspring.profiles.active=dev,dev-data,auth
 
 env-os-up:
-	docker-compose -f docker-compose.yml up -d opensearch zeebe-opensearch \
+	docker-compose -f docker-compose.opensearch.yml up -d opensearch zeebe-opensearch \
 	&& mvn install -DskipTests=true -Dskip.fe.build=false -DskipChecks \
 	&& CAMUNDA_OPERATE_TASKLIST_URL=http://localhost:8081 \
 	&& CAMUNDA_OPERATE_DATABASE=opensearch \

--- a/operate/docker-compose.yml
+++ b/operate/docker-compose.yml
@@ -29,39 +29,6 @@ services:
     links:
       - elasticsearch
 
-  opensearch:
-    image: opensearchproject/opensearch:2.14.0
-    depends_on:
-      - opensearch-init
-    container_name: opensearch
-    environment:
-      - node.name=opensearch
-      - discovery.seed_hosts=opensearch
-      - plugins.security.disabled=true
-      - cluster.initial_cluster_manager_nodes=opensearch
-      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
-      - "OPENSEARCH_JAVA_OPTS=-Xms1G -Xmx1G" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
-      - path.repo=/usr/local/os-snapshots
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
-      nofile:
-        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
-        hard: 65536
-    ports:
-      - "9200:9200"
-      - "9600:9600" # required for Performance Analyzer
-    volumes:
-      - ./os-snapshots:/usr/local/os-snapshots
-
-  opensearch-init:
-    image: bash
-    privileged: true
-    user: root
-    command: ["sysctl", "-w", "vm.max_map_count=262144"]
-
   zeebe:
     container_name: zeebe
     image: camunda/zeebe:SNAPSHOT
@@ -77,22 +44,6 @@ services:
     restart: always
     volumes:
       - ./config/zeebe.cfg.yaml:/usr/local/zeebe/config/application.yaml
-
-  zeebe-opensearch:
-    container_name: zeebe-opensearch
-    image: camunda/zeebe:SNAPSHOT
-    environment:
-      - "JAVA_TOOL_OPTIONS=-Xms512m -Xmx512m"
-      - ZEEBE_HOST=${ZEEBE_HOST:-}
-      - ZEEBE_BROKER_CLUSTER_PARTITIONS_COUNT=4
-      - ZEEBE_BROKER_EXPORTERS_OPENSEARCH_ARGS_INDEX_DEPLOYMENT=false
-      #- "JAVA_OPTS=-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
-    ports:
-      - 26500:26500
-      - 8000:8000
-    restart: always
-    volumes:
-      - ./config/zeebe-opensearch.cfg.yaml:/usr/local/zeebe/config/application.yaml
 
   zeebe-e2e:
     container_name: zeebe-e2e


### PR DESCRIPTION
## Description
Removed redundant docker-compose configurations for opensearch, as done for 8.5 in https://github.com/camunda/zeebe/pull/18547

## Related issues

closes #