### PR TITLE
feat: supply partition count depending on running modules

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -115,6 +115,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>operate-webapp</artifactId>
       <exclusions>
         <exclusion>

--- a/dist/src/main/java/io/camunda/operate/OperateModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/operate/OperateModuleConfiguration.java
@@ -45,11 +45,16 @@ public class OperateModuleConfiguration {
 
   // if present, then it will ensure
   // that the broker is started first
-  @Autowired(required = false)
-  private Broker broker;
+  private final Broker broker;
 
   // if present, then it will ensure
   // that the gateway is started first
-  @Autowired(required = false)
-  private Gateway gateway;
+  private final Gateway gateway;
+
+  public OperateModuleConfiguration(
+      @Autowired(required = false) final Broker broker,
+      @Autowired(required = false) Gateway gateway) {
+    this.broker = broker;
+    this.gateway = gateway;
+  }
 }

--- a/dist/src/main/java/io/camunda/operate/OperatePartitionSupplierConfiguration.java
+++ b/dist/src/main/java/io/camunda/operate/OperatePartitionSupplierConfiguration.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate;
+
+import io.camunda.operate.util.Either;
+import io.camunda.operate.zeebe.PartitionSupplier;
+import io.camunda.operate.zeebe.StandalonePartitionSupplier;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.gateway.Gateway;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+public class OperatePartitionSupplierConfiguration {
+
+  private final Broker broker;
+  private final Gateway gateway;
+  private final ZeebeClient zeebeClient;
+
+  public OperatePartitionSupplierConfiguration(
+      @Autowired(required = false) final Broker broker,
+      @Autowired(required = false) Gateway gateway,
+      @Autowired ZeebeClient zeebeClient) {
+    this.broker = broker;
+    this.gateway = gateway;
+    this.zeebeClient = zeebeClient;
+  }
+
+  @Bean
+  public PartitionSupplier operatePartitionSupplier() {
+    if (broker != null) {
+      final var brokerConfiguration = broker.getConfig();
+      return new BrokerConfigurationPartitionSupplier(brokerConfiguration);
+    } else if (gateway != null) {
+      final var brokerClient = gateway.getBrokerClient();
+      return new BrokerClientPartitionSupplier(brokerClient);
+    } else {
+      // default use Standalone Partition Holder by using the Zeebe Client
+      return new StandalonePartitionSupplier(zeebeClient);
+    }
+  }
+
+  private static final class BrokerConfigurationPartitionSupplier implements PartitionSupplier {
+
+    private final BrokerCfg configuration;
+
+    private BrokerConfigurationPartitionSupplier(final BrokerCfg configuration) {
+      this.configuration = configuration;
+    }
+
+    @Override
+    public Either<Exception, Integer> getPartitionsCount() {
+      final var clusterConfiguration = configuration.getCluster();
+      final var partitionsCount = clusterConfiguration.getPartitionsCount();
+      return Either.right(partitionsCount);
+    }
+  }
+
+  private static final class BrokerClientPartitionSupplier implements PartitionSupplier {
+
+    private final BrokerClient brokerClient;
+
+    private BrokerClientPartitionSupplier(final BrokerClient brokerClient) {
+      this.brokerClient = brokerClient;
+    }
+
+    @Override
+    public Either<Exception, Integer> getPartitionsCount() {
+      final var topologyManager = brokerClient.getTopologyManager();
+      final var topology = topologyManager.getTopology();
+      return Either.right(topology.getPartitionsCount());
+    }
+  }
+}

--- a/operate/common/src/main/java/io/camunda/operate/zeebe/PartitionSupplier.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/PartitionSupplier.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebe;
+
+import io.camunda.operate.util.Either;
+
+public interface PartitionSupplier {
+
+  public Either<Exception, Integer> getPartitionsCount();
+}

--- a/operate/common/src/main/java/io/camunda/operate/zeebe/StandalonePartitionSupplier.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/StandalonePartitionSupplier.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebe;
+
+import io.camunda.operate.util.Either;
+import io.camunda.zeebe.client.ZeebeClient;
+
+public class StandalonePartitionSupplier implements PartitionSupplier {
+
+  private final ZeebeClient zeebeClient;
+
+  public StandalonePartitionSupplier(final ZeebeClient zeebeClient) {
+    this.zeebeClient = zeebeClient;
+  }
+
+  @Override
+  public Either<Exception, Integer> getPartitionsCount() {
+    try {
+      final var topology = zeebeClient.newTopologyRequest().send().join();
+      final var partitionCount = topology.getPartitionsCount();
+      return Either.right(partitionCount);
+    } catch (Exception t) {
+      return Either.left(t);
+    }
+  }
+}

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/OperateZeebeAbstractIT.java
@@ -31,6 +31,7 @@ import io.camunda.operate.webapp.rest.dto.operation.CreateBatchOperationRequestD
 import io.camunda.operate.webapp.rest.dto.operation.CreateOperationRequestDto;
 import io.camunda.operate.webapp.zeebe.operation.OperationExecutor;
 import io.camunda.operate.zeebe.PartitionHolder;
+import io.camunda.operate.zeebe.StandalonePartitionSupplier;
 import io.camunda.operate.zeebeimport.ImportPositionHolder;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -214,7 +215,8 @@ public abstract class OperateZeebeAbstractIT extends OperateAbstractIT {
     importPositionHolder.cancelScheduledImportPositionUpdateTask().join();
     importPositionHolder.clearCache();
     importPositionHolder.scheduleImportPositionUpdateTask();
-    partitionHolder.setZeebeClient(getClient());
+    final var partitionSupplier = new StandalonePartitionSupplier(getClient());
+    partitionHolder.setPartitionSupplier(partitionSupplier);
   }
 
   @After

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateZeebeSearchAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateZeebeSearchAbstractIT.java
@@ -21,6 +21,7 @@ import io.camunda.operate.webapp.security.Permission;
 import io.camunda.operate.webapp.security.UserService;
 import io.camunda.operate.webapp.security.tenant.TenantService;
 import io.camunda.operate.zeebe.PartitionHolder;
+import io.camunda.operate.zeebe.StandalonePartitionSupplier;
 import io.camunda.operate.zeebeimport.ImportPositionHolder;
 import io.camunda.zeebe.client.ZeebeClient;
 import java.util.List;
@@ -101,7 +102,9 @@ public class OperateZeebeSearchAbstractIT {
     importPositionHolder.cancelScheduledImportPositionUpdateTask().join();
     importPositionHolder.clearCache();
     importPositionHolder.scheduleImportPositionUpdateTask();
-    partitionHolder.setZeebeClient(zeebeClient);
+
+    final var partitionSupplier = new StandalonePartitionSupplier(zeebeClient);
+    partitionHolder.setPartitionSupplier(partitionSupplier);
 
     // Allows time for everything to settle and indices to show up
     zeebeStabilityDelay();


### PR DESCRIPTION
## Description

The Single Application only gets ready, when all components (Broker, Operate including importer and archiver) are started. To start the importer and archiver, Operate needs the partitions count. So far, it uses the Zeebe Client to execute a topology request which effectively calls the Single Application itself. However, the service might not be available when deploying a Single Application on Kubernetes. Hence, the request will fail. That way, the Single Application pod never gets ready.

To avoid such a situation, a partition supplier is implemented that supplies the partition count depending on the context:
* If the Operate and the Broker profiles are set, then the partition count is retrieved from the broker configuration.
* If the Operate and the Gateway profiles are set, then the partition count is retrieved by using the broker client that used by the Gateway to join the cluster of brokers.
* If only Operate is set, then the partitions count is retrieved as always by using the Zeebe client.

## Related issues

closes #
