### PR TITLE
POC: Timers of banned instances are forever re-triggered

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -80,7 +80,10 @@ public final class EngineProcessors {
     final var config = typedRecordProcessorContext.getConfig();
 
     final DueDateTimerChecker timerChecker =
-        new DueDateTimerChecker(scheduledTaskStateFactory.get().getTimerState(), featureFlags);
+        new DueDateTimerChecker(
+            scheduledTaskStateFactory.get().getTimerState(),
+            featureFlags,
+            processingState.getBannedInstanceState());
 
     final var jobMetrics = new JobMetrics(partitionId);
     final var processEngineMetrics = new ProcessEngineMetrics(processingState.getPartitionId());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/BannedInstanceState.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.state.immutable;
 
+import io.camunda.zeebe.protocol.record.value.ProcessInstanceRelated;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import java.util.List;
@@ -14,6 +15,8 @@ import java.util.List;
 public interface BannedInstanceState extends StreamProcessorLifecycleAware {
 
   boolean isBanned(final TypedRecord record);
+
+  boolean isBanned(final ProcessInstanceRelated record);
 
   /** Returns a list of keys of all banned process instances */
   List<Long> getBannedProcessInstanceKeys();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/TimerInstanceState.java
@@ -12,6 +12,8 @@ import java.util.function.Consumer;
 
 public interface TimerInstanceState {
 
+  void remove(TimerInstance timer);
+
   /**
    * Finds timers with due date before {@code timestamp}, and presents them to the {@code consumer}
    *

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
@@ -13,6 +13,4 @@ import io.camunda.zeebe.engine.state.instance.TimerInstance;
 public interface MutableTimerInstanceState extends TimerInstanceState {
 
   void store(TimerInstance timer);
-
-  void remove(TimerInstance timer);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/processing/DbBannedInstanceState.java
@@ -95,6 +95,15 @@ public final class DbBannedInstanceState implements MutableBannedInstanceState {
   }
 
   @Override
+  public boolean isBanned(final ProcessInstanceRelated value) {
+    final long processInstanceKey = value.getProcessInstanceKey();
+    if (processInstanceKey >= 0) {
+      return isBanned(processInstanceKey);
+    }
+    return false;
+  }
+
+  @Override
   public boolean tryToBanInstance(
       final TypedRecord<?> typedRecord, final Consumer<Long> onBanningInstance) {
     final Intent intent = typedRecord.getIntent();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -91,7 +91,8 @@ public final class TestEngine {
   }
 
   public ProcessInstanceClient createProcessInstanceClient() {
-    return new ProcessInstanceClient(streamProcessingComposite);
+    return new ProcessInstanceClient(
+        streamProcessingComposite, streamProcessingComposite.getEventWriter());
   }
 
   public static TestEngine createSinglePartitionEngine(final TestContext testContext) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
@@ -61,7 +61,8 @@ class DueDateTimerCheckerTest {
           new TestTimerInstanceStateThatSimulatesAnEndlessListOfDueTimers(
               mockTimer, testActorClock);
 
-      final var sut = new TriggerTimersSideEffect(testTimerInstanceState, testActorClock, true);
+      final var sut =
+          new TriggerTimersSideEffect(testTimerInstanceState, testActorClock, null, true);
 
       // when
       sut.apply(mockTaskResultBuilder);
@@ -103,7 +104,8 @@ class DueDateTimerCheckerTest {
           new TestTimerInstanceStateThatSimulatesAnEndlessListOfDueTimers(
               mockTimer, testActorClock);
 
-      final var sut = new TriggerTimersSideEffect(testTimerInstanceState, testActorClock, true);
+      final var sut =
+          new TriggerTimersSideEffect(testTimerInstanceState, testActorClock, null, true);
 
       // when
       sut.apply(mockTaskResultBuilder);
@@ -218,6 +220,10 @@ class DueDateTimerCheckerTest {
         final TimerInstance timer, final TestActorClock testActorClock) {
       this.timer = timer;
       this.testActorClock = testActorClock;
+    }
+
+    @Override
+    public void remove(final TimerInstance timer) { // do nothing
     }
 
     @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -268,7 +268,7 @@ public final class EngineRule extends ExternalResource {
   }
 
   public ProcessInstanceClient processInstance() {
-    return new ProcessInstanceClient(environmentRule);
+    return new ProcessInstanceClient(environmentRule, environmentRule.getEventWriter());
   }
 
   public DecisionEvaluationClient decision() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -59,6 +59,10 @@ public class StreamProcessingComposite implements CommandWriter {
     return streams.newLogStreamWriter(logName);
   }
 
+  public LogStreamWriter getEventWriter() {
+    return streams.newLogStreamWriter(getLogName(partitionId));
+  }
+
   public StreamProcessor startTypedStreamProcessor(
       final StreamProcessorTestFactory factory,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -166,6 +166,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
     return streams.getMockedResponseWriter();
   }
 
+  public LogStreamWriter getEventWriter() {
+    return streams.newLogStreamWriter(getLogName(startPartitionId));
+  }
+
   public ControlledActorClock getClock() {
     return clock;
   }

--- a/zeebe/engine/src/test/resources/processes/straight_test.bpmn
+++ b/zeebe/engine/src/test/resources/processes/straight_test.bpmn
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0" camunda:diagramRelationId="eb53fcb1-5305-43cf-8c22-9b5c514460cf">
+  <bpmn:process id="GamedayProcess" name="test_process_id" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Send Email newsletter">
+      <bpmn:outgoing>Flow_0yg4sg4</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0yg4sg4" sourceRef="StartEvent_1" targetRef="Event_02vb3b2" />
+    <bpmn:intermediateCatchEvent id="Event_02vb3b2" name="16 o&#39;clock">
+      <bpmn:incoming>Flow_0yg4sg4</bpmn:incoming>
+      <bpmn:incoming>Flow_1dr09o3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0bbnbt4</bpmn:outgoing>
+      <bpmn:timerEventDefinition id="TimerEventDefinition_1mcgxr7">
+        <bpmn:timeDuration xsi:type="bpmn:tFormalExpression">="PT2S"</bpmn:timeDuration>
+      </bpmn:timerEventDefinition>
+    </bpmn:intermediateCatchEvent>
+    <bpmn:sequenceFlow id="Flow_1537k1v" sourceRef="Gateway_1knikyw" targetRef="Activity_1r2d7uw" />
+    <bpmn:endEvent id="Event_1rb64gr">
+      <bpmn:incoming>Flow_1jfq4dj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:parallelGateway id="Gateway_1knikyw">
+      <bpmn:incoming>Flow_0bbnbt4</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dr09o3</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1537k1v</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:sequenceFlow id="Flow_1jfq4dj" sourceRef="Activity_1r2d7uw" targetRef="Event_1rb64gr" />
+    <bpmn:serviceTask id="Activity_1r2d7uw" name="Send Email">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="sendNewsletter" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1537k1v</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jfq4dj</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1dr09o3" name="Next Day again" sourceRef="Gateway_1knikyw" targetRef="Event_02vb3b2" />
+    <bpmn:sequenceFlow id="Flow_0bbnbt4" sourceRef="Event_02vb3b2" targetRef="Gateway_1knikyw" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="GamedayProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="141" y="166" width="57" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_121xx9h_di" bpmnElement="Event_02vb3b2">
+        <dc:Bounds x="252" y="120" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="255" y="93" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1rb64gr_di" bpmnElement="Event_1rb64gr">
+        <dc:Bounds x="572" y="120" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0i1s8cx_di" bpmnElement="Gateway_1knikyw">
+        <dc:Bounds x="335" y="113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16cmsco_di" bpmnElement="Activity_1r2d7uw">
+        <dc:Bounds x="420" y="98" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0yg4sg4_di" bpmnElement="Flow_0yg4sg4">
+        <di:waypoint x="188" y="138" />
+        <di:waypoint x="252" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1537k1v_di" bpmnElement="Flow_1537k1v">
+        <di:waypoint x="385" y="138" />
+        <di:waypoint x="420" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jfq4dj_di" bpmnElement="Flow_1jfq4dj">
+        <di:waypoint x="520" y="138" />
+        <di:waypoint x="572" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dr09o3_di" bpmnElement="Flow_1dr09o3">
+        <di:waypoint x="360" y="163" />
+        <di:waypoint x="360" y="210" />
+        <di:waypoint x="270" y="210" />
+        <di:waypoint x="270" y="156" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="277" y="192" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bbnbt4_di" bpmnElement="Flow_0bbnbt4">
+        <di:waypoint x="288" y="138" />
+        <di:waypoint x="335" y="138" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>


### PR DESCRIPTION
## Description

Created a PR to show the second solution option mentioned in the issue https://github.com/camunda/zeebe/issues/14213#issuecomment-2115344104.

The solution simply passes the BannedInstanceState object to `DueDateTimerChecker`. Then while visiting timers which have due date expired, the visitor checks if the process instance of the timer is banned or not. If banned, the timer is removed from the state.

The solution is straightforward but not performant as it requires a database call for each timer visited. We can improve this by adding a cache to banned instance state.

## Related issues

#14213 
