### PR TITLE
fix: OpenSearch docker requires OPENSEARCH_INITIAL_ADMIN_PASSWORD

### DIFF
--- a/tasklist/config/docker-compose.identity.yml
+++ b/tasklist/config/docker-compose.identity.yml
@@ -43,6 +43,7 @@ services:
       - plugins.security.disabled=true
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
     ulimits:
       memlock:
         soft: -1

--- a/tasklist/docker-compose.yml
+++ b/tasklist/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - plugins.security.disabled=true
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms1024m -Xmx1024m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=yourStrongPassword123!
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
## Description
To fix Opensearch IT tests

## Related issues

closes #
