### PR TITLE
test: fix Operate test warnings

### DIFF
--- a/operate/client/src/App/Dashboard/PartiallyExpandableDataTable/index.tsx
+++ b/operate/client/src/App/Dashboard/PartiallyExpandableDataTable/index.tsx
@@ -65,10 +65,11 @@ const PartiallyExpandableDataTable: React.FC<Props> = ({
                   expandedContent !== undefined &&
                   React.isValidElement(expandedContent);
 
+                const {key, ...props} = getRowProps({row});
                 return (
                   <React.Fragment key={row.id}>
                     <TableExpandRow
-                      {...getRowProps({row})}
+                      {...props}
                       data-testid={`${dataTestId}-${index}`}
                       $isExpandable={isExpandable}
                     >

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/NewVariableModifications.test.tsx
@@ -29,8 +29,7 @@ import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/proces
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
 import {singleInstanceMetadata} from 'modules/mocks/metadata';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
-import {useEffect} from 'react';
-import {act} from 'react-dom/test-utils';
+import {useEffect, act} from 'react';
 import {Paths} from 'modules/Routes';
 
 const editNameFromTextfieldAndBlur = async (user: UserEvent, value: string) => {

--- a/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/VariablePanel/tests/index.test.tsx
@@ -37,8 +37,7 @@ import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockApplyOperation} from 'modules/mocks/api/processInstances/operations';
 import {mockGetOperation} from 'modules/mocks/api/getOperation';
 import * as operationApi from 'modules/api/getOperation';
-import {useEffect} from 'react';
-import {act} from 'react-dom/test-utils';
+import {useEffect, act} from 'react';
 import {Paths} from 'modules/Routes';
 import {notificationsStore} from 'modules/stores/notifications';
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/addVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/addVariable.test.tsx
@@ -19,7 +19,7 @@ import Variables from '../index';
 import {Wrapper, mockVariables} from './mocks';
 import {createInstance} from 'modules/testUtils';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 
 const instanceMock = createInstance({id: '1'});
 

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/editVariable.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/editVariable.test.tsx
@@ -21,7 +21,7 @@ import {createInstance, createVariable} from 'modules/testUtils';
 import {modificationsStore} from 'modules/stores/modifications';
 import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariables';
 import {mockFetchVariable} from 'modules/mocks/api/fetchVariable';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 import {notificationsStore} from 'modules/stores/notifications';
 
 jest.mock('modules/stores/notifications', () => ({

--- a/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/footer.test.tsx
+++ b/operate/client/src/App/ProcessInstance/BottomPanel/Variables/tests/footer.test.tsx
@@ -25,7 +25,7 @@ import {mockFetchVariables} from 'modules/mocks/api/processInstances/fetchVariab
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
 import {singleInstanceMetadata} from 'modules/mocks/metadata';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 
 const instanceMock = createInstance({id: '1'});
 

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/TimeStampLabel/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/Bar/TimeStampLabel/index.test.tsx
@@ -10,7 +10,7 @@ import {render, screen} from 'modules/testing-library';
 import {flowNodeTimeStampStore} from 'modules/stores/flowNodeTimeStamp';
 import {TimeStampLabel} from './index';
 import {MOCK_TIMESTAMP} from 'modules/utils/date/__mocks__/formatDate';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 
 describe('TimeStampLabel', () => {
   it('should hide/display time stamp on time stamp toggle', async () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationPlaceholders.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {createRef} from 'react';
+import {createRef, act} from 'react';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -32,7 +32,6 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetch
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
-import {act} from 'react-dom/test-utils';
 
 describe('FlowNodeInstancesTree - Modification placeholders', () => {
   beforeEach(async () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationsWithAncestorSelection.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/modificationsWithAncestorSelection.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {createRef} from 'react';
+import {createRef, act} from 'react';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {modificationsStore} from 'modules/stores/modifications';
@@ -26,7 +26,6 @@ import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetch
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
-import {act} from 'react-dom/test-utils';
 import {generateUniqueID} from 'modules/utils/generateUniqueID';
 
 describe('FlowNodeInstancesTree - modifications with ancestor selection', () => {

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/nestedSubprocess.test.tsx
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstancesTree/tests/nestedSubprocess.test.tsx
@@ -6,7 +6,7 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {createRef} from 'react';
+import {createRef, act} from 'react';
 import {render, screen, waitFor} from 'modules/testing-library';
 import {flowNodeInstanceStore} from 'modules/stores/flowNodeInstance';
 import {processInstanceDetailsStore} from 'modules/stores/processInstanceDetails';
@@ -24,7 +24,6 @@ import {generateUniqueID} from 'modules/utils/generateUniqueID';
 import {mockFetchProcessInstance} from 'modules/mocks/api/processInstances/fetchProcessInstance';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockFetchFlowNodeInstances} from 'modules/mocks/api/fetchFlowNodeInstances';
-import {act} from 'react-dom/test-utils';
 
 describe('FlowNodeInstancesTree - Nested Subprocesses', () => {
   beforeEach(async () => {

--- a/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/filtering.test.tsx
+++ b/operate/client/src/App/ProcessInstance/IncidentsWrapper/tests/filtering.test.tsx
@@ -11,7 +11,7 @@ import {IncidentsWrapper} from '../index';
 import {Wrapper, mockIncidents, mockResolvedIncidents} from './mocks';
 import {incidentsStore} from 'modules/stores/incidents';
 import {mockFetchProcessInstanceIncidents} from 'modules/mocks/api/processInstances/fetchProcessInstanceIncidents';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 
 describe('Filtering', () => {
   beforeEach(async () => {

--- a/operate/client/src/App/ProcessInstance/LastModification/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/LastModification/index.test.tsx
@@ -20,7 +20,7 @@ import {processInstanceDetailsDiagramStore} from 'modules/stores/processInstance
 import {processInstanceDetailsStatisticsStore} from 'modules/stores/processInstanceDetailsStatistics';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {open} from 'modules/mocks/diagrams';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 
 type Props = {
   children?: React.ReactNode;

--- a/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ModificationSummaryModal/index.test.tsx
@@ -18,8 +18,7 @@ import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/proces
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockModify} from 'modules/mocks/api/processInstances/modify';
 import {open} from 'modules/mocks/diagrams';
-import {useEffect} from 'react';
-import {act} from 'react-dom/test-utils';
+import {useEffect, act} from 'react';
 import {notificationsStore} from 'modules/stores/notifications';
 
 jest.mock('modules/stores/notifications', () => ({

--- a/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/ProcessInstanceHeader/index.test.tsx
@@ -43,8 +43,7 @@ import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {mockApplyOperation} from 'modules/mocks/api/processInstances/operations';
 import {mockGetOperation} from 'modules/mocks/api/getOperation';
 import * as operationApi from 'modules/api/getOperation';
-import {useEffect} from 'react';
-import {act} from 'react-dom/test-utils';
+import {useEffect, act} from 'react';
 import {Paths} from 'modules/Routes';
 import {notificationsStore} from 'modules/stores/notifications';
 

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/index.test.tsx
@@ -22,7 +22,7 @@ import {flowNodeMetaDataStore} from 'modules/stores/flowNodeMetaData';
 import {mockFetchFlowNodeMetadata} from 'modules/mocks/api/processInstances/fetchFlowNodeMetaData';
 import {incidentFlowNodeMetaData} from 'modules/mocks/metadata';
 import {open} from 'modules/mocks/diagrams';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 
 describe('Modification Dropdown', () => {
   beforeEach(() => {

--- a/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mutliScopes.test.tsx
+++ b/operate/client/src/App/ProcessInstance/TopPanel/ModificationDropdown/tests/mutliScopes.test.tsx
@@ -15,7 +15,7 @@ import {renderPopover} from './mocks';
 import {mockFetchProcessInstanceDetailStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstanceDetailStatistics';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
 import {IS_ADD_TOKEN_WITH_ANCESTOR_KEY_SUPPORTED} from 'modules/feature-flags';
-import {act} from 'react-dom/test-utils';
+import {act} from 'react';
 
 describe('Modification Dropdown - Multi Scopes', () => {
   beforeEach(() => {

--- a/operate/client/src/App/Processes/ListView/DiagramPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/DiagramPanel/index.test.tsx
@@ -26,8 +26,7 @@ import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetc
 import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
 import {mockFetchProcessInstancesStatistics} from 'modules/mocks/api/processInstances/fetchProcessInstancesStatistics';
 import {mockFetchProcessXML} from 'modules/mocks/api/processes/fetchProcessXML';
-import {useEffect} from 'react';
-import {act} from 'react-dom/test-utils';
+import {useEffect, act} from 'react';
 import {Paths} from 'modules/Routes';
 import {batchModificationStore} from 'modules/stores/batchModification';
 

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Header/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Header/index.test.tsx
@@ -9,8 +9,7 @@
 import {render, screen} from 'modules/testing-library';
 import {Header} from '.';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
-import {act} from 'react-dom/test-utils';
-import {useEffect} from 'react';
+import {useEffect, act} from 'react';
 import {MemoryRouter} from 'react-router-dom';
 import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
 import {groupedProcessesMock} from 'modules/testUtils';

--- a/operate/client/src/App/SessionWatcher.test.tsx
+++ b/operate/client/src/App/SessionWatcher.test.tsx
@@ -10,8 +10,7 @@ import {render, screen, waitFor} from 'modules/testing-library';
 import {authenticationStore} from 'modules/stores/authentication';
 import {Link, MemoryRouter} from 'react-router-dom';
 import {SessionWatcher} from './SessionWatcher';
-import {useEffect} from 'react';
-import {act} from 'react-dom/test-utils';
+import {useEffect, act} from 'react';
 import {Paths} from 'modules/Routes';
 import {notificationsStore} from 'modules/stores/notifications';
 

--- a/operate/client/src/modules/components/DataTable/index.tsx
+++ b/operate/client/src/modules/components/DataTable/index.tsx
@@ -103,10 +103,11 @@ const DataTable = React.forwardRef<HTMLDivElement, Props>(
                   {rows.map((row) => {
                     if (isExpandable) {
                       const expandedContent = expandedContents?.[row.id];
+                      const {key, ...props} = getRowProps({row});
                       return (
                         <React.Fragment key={row.id}>
                           <TableExpandRow
-                            {...getRowProps({row})}
+                            {...props}
                             title={expandableRowTitle}
                             id={`expanded-row-${row.id}`}
                           >
@@ -126,10 +127,12 @@ const DataTable = React.forwardRef<HTMLDivElement, Props>(
 
                     const isSelected = checkIsRowSelected?.(row.id) ?? false;
                     const isClickable = onRowClick !== undefined;
+                    const {key, ...props} = getRowProps({row});
 
                     return (
                       <TableRow
-                        {...getRowProps({row})}
+                        {...props}
+                        key={row.id}
                         onClick={() => {
                           onRowClick?.(row.id);
                         }}

--- a/operate/client/src/modules/components/SortableTable/index.tsx
+++ b/operate/client/src/modules/components/SortableTable/index.tsx
@@ -143,12 +143,15 @@ const SortableTable: React.FC<Props> = ({
                     />
                   )}
                   {headers.map((header) => {
+                    const {key, ...props} = getHeaderProps({
+                      header,
+                      isSortable: state === 'content',
+                    });
+
                     return (
                       <ColumnHeader
-                        {...getHeaderProps({
-                          header,
-                          isSortable: state === 'content',
-                        })}
+                        {...props}
+                        key={key}
                         label={header.header}
                         sortKey={header.sortKey ?? header.key}
                         isDefault={header.isDefault}
@@ -176,11 +179,14 @@ const SortableTable: React.FC<Props> = ({
                         return '';
                       };
 
+                      const {key, ...props} = getRowProps({row});
+
                       return (
                         <React.Fragment key={row.id}>
                           <TableExpandRow
                             className={expandRowStyleClasses()}
-                            {...getRowProps({row})}
+                            {...props}
+                            key={key}
                             isSelected={isSelected}
                             $isClickable={selectionType === 'row'}
                             aria-selected={isSelected}


### PR DESCRIPTION
## Description

### fix act warnings

`act` from `react-dom/test-utils` is deprecated which caused a lot of warnings in the tests. act` from `react` needs to be used instead. More context: https://react.dev/warnings/react-dom-test-utils

This PR updates all imports

### fix key spread warnings

Prevent "key" prop from being spread into JSX of DataTable components. This fixes the following warning (in tests and browser console):

`Warning: A props object containing a "key" prop is being spread into JSX`

