### PR TITLE
fix: fix shouldEnableStreamingWithProperty fails to run locally

### DIFF
--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1.JobWorkerBuilder
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeClientImpl;
 import io.camunda.zeebe.client.impl.util.Environment;
+import io.camunda.zeebe.client.impl.util.EnvironmentRule;
 import io.camunda.zeebe.client.impl.util.ExecutorResource;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
@@ -68,6 +69,7 @@ public final class JobWorkerImplTest {
   private static final Duration SLOW_POLL_THRESHOLD = Duration.ofMillis(SLOW_POLL_DELAY_IN_MS / 2);
 
   @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  @Rule public final EnvironmentRule environmentRule = new EnvironmentRule();
 
   private MockedGateway gateway;
   private ZeebeClient client;


### PR DESCRIPTION
## Description

It was due to `JobWorkerImplTest.workerBuilderShouldOverrideEnvVariables` modifying the Environment:https://github.com/camunda/zeebe/blob/e7dcdf283d0511ab0cbff755b06e6d2bc330b3e6/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerImplTest.java#L179-L181

We have an `EnvironmentRule` rule class to clean up the environment before and after each test:
https://github.com/camunda/zeebe/blob/e7dcdf283d0511ab0cbff755b06e6d2bc330b3e6/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/impl/util/EnvironmentRule.java#L21-L34

Adding this to `JobWorkerImplTest` class should resolve the issue.

closes #17910
