### PR TITLE
Send success message on release

### DIFF
--- a/.github/workflows/dispatch-release-8-6.yaml
+++ b/.github/workflows/dispatch-release-8-6.yaml
@@ -18,6 +18,33 @@ jobs:
       isLatest: ${{ github.event.client_payload.isLatest }}
       dryRun: ${{ github.event.client_payload.dryRun }}
       releaseBranch: ${{ github.event.client_payload.releaseBranch }}
+  notify-on-success:
+    name: Send slack notification on success
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    if: ${{ success() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK      
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

> [!Note]
>
> If accepted I will do this for the workflows as well.
> 

As the release is triggered async, we need to follow the progress of the release on GitHub. To make this easier, we send  a success notification to Slack (not only for failures).

This allows us to just follow the slack channel, and do other things in the meantime (and get notified). Furthermore, we can reference back to the success message if necessary.
