### PR TITLE
fix: Missing Zeebe user task migration doc URL in REST API error message

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistDocumentationProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistDocumentationProperties.java
@@ -9,13 +9,14 @@ package io.camunda.tasklist.property;
 
 public class TasklistDocumentationProperties {
 
-  private String apiMigrationDocsUrl;
+  private String apiMigrationDocsUrl =
+      "https://docs.camunda.io/docs/apis-tools/tasklist-api-rest/migrate-to-zeebe-user-tasks/";
 
   public String getApiMigrationDocsUrl() {
     return apiMigrationDocsUrl;
   }
 
-  public void setApiMigrationDocsUrl(String apiMigrationDocsUrl) {
+  public void setApiMigrationDocsUrl(final String apiMigrationDocsUrl) {
     this.apiMigrationDocsUrl = apiMigrationDocsUrl;
   }
 }

--- a/tasklist/config/application.yml
+++ b/tasklist/config/application.yml
@@ -9,5 +9,3 @@ camunda.tasklist:
     clusterName: elasticsearch
     url: http://localhost:9200
     prefix: zeebe-record
-  documentation:
-    apiMigrationDocsUrl: https://docs.camunda.io/docs/apis-tools/tasklist-api-rest/tasklist-api-rest-overview/ #TODO update this URL


### PR DESCRIPTION
## Description

## Related issues

closes #18663
To be backported to 8.5