### PR TITLE
test: fail fast when broker closing is stuck

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
@@ -152,7 +153,14 @@ public final class TestCluster implements CloseableSilently {
         nodes().values().stream()
             .map(node -> CompletableFuture.runAsync(node::stop))
             .toArray(CompletableFuture[]::new);
-    CompletableFuture.allOf(stopped).join();
+
+    try {
+      CompletableFuture.allOf(stopped).get(2, TimeUnit.MINUTES);
+    } catch (final Exception e) {
+      LOGGER.error("Failed to shutdown cluster", e);
+      throw new RuntimeException(e);
+    }
+
     return this;
   }
 


### PR DESCRIPTION
## Description

When broker close is stuck due to any reason, the test is stuck and waits until the gh job times out which is configured to be around 20 minutes. This is unnecessary and makes it difficult to investigate the root cause for the failing test. To improve this situation, we add a timeout for cluster shutdown in tests. 

This does not fix, but improves the situation in #18190. Instead of waiting for the gh job to timeout, the test will fail early. 
