### PR TITLE
feat: clients can provide a reference to a command that can be observed in the resulting event

### DIFF
--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/RecordImpl.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/RecordImpl.java
@@ -38,6 +38,7 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
   private T value;
 
   private Map<String, Object> authorizations;
+  private long operationReference;
 
   public RecordImpl() {}
 
@@ -92,13 +93,22 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
   }
 
   @Override
-  public ValueType getValueType() {
-    return valueType;
+  public Map<String, Object> getAuthorizations() {
+    return authorizations;
+  }
+
+  public void setAuthorizations(final Map<String, Object> authorizations) {
+    this.authorizations = authorizations;
   }
 
   @Override
-  public Map<String, Object> getAuthorizations() {
-    return authorizations;
+  public int getRecordVersion() {
+    return recordVersion;
+  }
+
+  @Override
+  public ValueType getValueType() {
+    return valueType;
   }
 
   @Override
@@ -106,70 +116,71 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
     return value;
   }
 
-  public void setValue(T value) {
+  public void setValue(final T value) {
     this.value = value;
   }
 
-  public void setRejectionReason(String rejectionReason) {
-    this.rejectionReason = rejectionReason;
+  @Override
+  public long getOperationReference() {
+    return operationReference;
+  }
+
+  public void setOperationReference(final long operationReference) {
+    this.operationReference = operationReference;
+  }
+
+  public void setValueType(final ValueType valueType) {
+    this.valueType = valueType;
+  }
+
+  public RecordImpl<T> setRecordVersion(final int recordVersion) {
+    this.recordVersion = recordVersion;
+    return this;
   }
 
   public void setBrokerVersion(final String brokerVersion) {
     this.brokerVersion = brokerVersion;
   }
 
-  public void setRejectionType(RejectionType rejectionType) {
+  public void setRejectionReason(final String rejectionReason) {
+    this.rejectionReason = rejectionReason;
+  }
+
+  public void setRejectionType(final RejectionType rejectionType) {
     this.rejectionType = rejectionType;
   }
 
-  public void setRecordType(RecordType recordType) {
+  public void setRecordType(final RecordType recordType) {
     this.recordType = recordType;
   }
 
-  public void setPartitionId(int partitionId) {
+  public void setPartitionId(final int partitionId) {
     this.partitionId = partitionId;
   }
 
-  public void setIntent(Intent intent) {
+  public void setIntent(final Intent intent) {
     this.intent = intent;
   }
 
-  public void setTimestamp(long timestamp) {
+  public void setTimestamp(final long timestamp) {
     this.timestamp = timestamp;
   }
 
-  public void setKey(long key) {
+  public void setKey(final long key) {
     this.key = key;
   }
 
-  public void setSourceRecordPosition(long sourceRecordPosition) {
+  public void setSourceRecordPosition(final long sourceRecordPosition) {
     this.sourceRecordPosition = sourceRecordPosition;
   }
 
-  public void setPosition(long position) {
+  public void setPosition(final long position) {
     this.position = position;
-  }
-
-  public void setValueType(ValueType valueType) {
-    this.valueType = valueType;
-  }
-
-  public void setAuthorizations(Map<String, Object> authorizations) {
-    this.authorizations = authorizations;
   }
 
   @Override
   public Record<T> clone() {
     throw new UnsupportedOperationException("Clone not implemented");
-  }
-
-  public int getRecordVersion() {
-    return recordVersion;
-  }
-
-  public RecordImpl<T> setRecordVersion(int recordVersion) {
-    this.recordVersion = recordVersion;
-    return this;
   }
 
   @Override
@@ -203,6 +214,8 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
         + (authorizations == null ? "null" : String.format("[size='%d']", authorizations.size()))
         + ", value="
         + value
+        + ", operationReference="
+        + operationReference
         + '}';
   }
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/RecordImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/RecordImpl.java
@@ -38,6 +38,7 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
   private T value;
 
   private Map<String, Object> authorizations;
+  private long operationReference;
 
   public RecordImpl() {}
 
@@ -117,6 +118,15 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
 
   public void setValue(final T value) {
     this.value = value;
+  }
+
+  @Override
+  public long getOperationReference() {
+    return operationReference;
+  }
+
+  public void setOperationReference(final long operationReference) {
+    this.operationReference = operationReference;
   }
 
   public void setValueType(final ValueType valueType) {
@@ -204,6 +214,8 @@ public class RecordImpl<T extends RecordValue> implements Record<T> {
         + (authorizations == null ? "null" : String.format("[size='%d']", authorizations.size()))
         + ", value="
         + value
+        + ", operationReference="
+        + operationReference
         + '}';
   }
 

--- a/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
+++ b/zeebe/backup/src/main/java/io/camunda/zeebe/backup/processing/CheckpointCreateProcessor.java
@@ -90,7 +90,8 @@ public final class CheckpointCreateProcessor {
             .recordType(RecordType.EVENT)
             .intent(resultIntent)
             .rejectionType(RejectionType.NULL_VAL)
-            .rejectionReason(""));
+            .rejectionReason("")
+            .operationReference(command.getOperationReference()));
 
     if (command.hasRequestMetadata()) {
       resultBuilder.withResponse(

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockTypedCheckpointRecord.java
@@ -84,6 +84,11 @@ record MockTypedCheckpointRecord(
   }
 
   @Override
+  public long getOperationReference() {
+    return -1;
+  }
+
+  @Override
   public long getKey() {
     return 0;
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/dto/BrokerExecuteCommand.java
@@ -132,4 +132,12 @@ public abstract class BrokerExecuteCommand<T> extends BrokerRequest<T> {
   protected boolean isRejection() {
     return response.getRecordType() == RecordType.COMMAND_REJECTION;
   }
+
+  public long getOperationReference() {
+    return request.getOperationReference();
+  }
+
+  public void setOperationReference(final long operationReference) {
+    request.setOperationReference(operationReference);
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandler.java
@@ -74,6 +74,7 @@ final class CommandApiRequestHandler
     final var valueType = command.valueType();
     final var intent = Intent.fromProtocolValue(valueType, command.intent());
     final var value = reader.value();
+    final long operationReference = command.operationReference();
     final var metadata = reader.metadata();
 
     metadata.requestId(requestId);
@@ -81,6 +82,7 @@ final class CommandApiRequestHandler
     metadata.recordType(RecordType.COMMAND);
     metadata.intent(intent);
     metadata.valueType(valueType);
+    metadata.operationReference(operationReference);
 
     if (logStreamWriter == null) {
       errorWriter.partitionLeaderMismatch(partitionId);

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CancelProcessInstanceCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CancelProcessInstanceCommandStep1.java
@@ -18,7 +18,8 @@ package io.camunda.zeebe.client.api.command;
 import io.camunda.zeebe.client.api.response.CancelProcessInstanceResponse;
 
 public interface CancelProcessInstanceCommandStep1
-    extends FinalCommandStep<CancelProcessInstanceResponse> {
+    extends CommandWithOperationReferenceStep<CancelProcessInstanceCommandStep1>,
+        FinalCommandStep<CancelProcessInstanceResponse> {
   // the place for new optional parameters
 
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
@@ -18,6 +18,11 @@ package io.camunda.zeebe.client.api.command;
 public interface CommandWithOperationReferenceStep<T> {
 
   /**
+   * Set the Operation Reference.
+   *
+   * <p>This is a key chosen by the user and will be part of all records resulted from this
+   * operation
+   *
    * @param operationReference a reference key chosen by the user and will be part of all records
    *     resulted from this operation
    * @return the builder for this command with the operation reference specified

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
@@ -15,8 +15,13 @@
  */
 package io.camunda.zeebe.client.api.command;
 
-import io.camunda.zeebe.client.api.response.DeleteResourceResponse;
+public interface CommandWithOperationReferenceStep<T> {
 
-public interface DeleteResourceCommandStep1
-    extends CommandWithOperationReferenceStep<DeleteResourceCommandStep1>,
-        FinalCommandStep<DeleteResourceResponse> {}
+  /**
+   * @param operationReference a reference key sent from the client to correlate the operation with
+   *     its result records
+   * @return the builder for this command with the tenant specified
+   * @since 8.6
+   */
+  T operationReference(long operationReference);
+}

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CommandWithOperationReferenceStep.java
@@ -18,9 +18,9 @@ package io.camunda.zeebe.client.api.command;
 public interface CommandWithOperationReferenceStep<T> {
 
   /**
-   * @param operationReference a reference key sent from the client to correlate the operation with
-   *     its result records
-   * @return the builder for this command with the tenant specified
+   * @param operationReference a reference key chosen by the user and will be part of all records
+   *     resulted from this operation
+   * @return the builder for this command with the operation reference specified
    * @since 8.6
    */
   T operationReference(long operationReference);

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrateProcessInstanceCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/MigrateProcessInstanceCommandStep1.java
@@ -66,7 +66,9 @@ public interface MigrateProcessInstanceCommandStep1 {
   }
 
   interface MigrateProcessInstanceCommandFinalStep
-      extends MigrateProcessInstanceCommandStep2, FinalCommandStep<MigrateProcessInstanceResponse> {
+      extends MigrateProcessInstanceCommandStep2,
+          CommandWithOperationReferenceStep<MigrateProcessInstanceCommandFinalStep>,
+          FinalCommandStep<MigrateProcessInstanceResponse> {
 
     /**
      * Add a {@link

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ModifyProcessInstanceCommandStep1.java
@@ -57,7 +57,8 @@ public interface ModifyProcessInstanceCommandStep1 {
   ModifyProcessInstanceCommandStep2 terminateElement(final long elementInstanceKey);
 
   interface ModifyProcessInstanceCommandStep2
-      extends FinalCommandStep<ModifyProcessInstanceResponse> {
+      extends CommandWithOperationReferenceStep<ModifyProcessInstanceCommandStep2>,
+          FinalCommandStep<ModifyProcessInstanceResponse> {
     /**
      * Acts as a boundary between the different activate and terminate instructions. Use this if you
      * want to activate or terminate another element. Otherwise, {@link #send()} the command.

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ResolveIncidentCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ResolveIncidentCommandStep1.java
@@ -17,6 +17,8 @@ package io.camunda.zeebe.client.api.command;
 
 import io.camunda.zeebe.client.api.response.ResolveIncidentResponse;
 
-public interface ResolveIncidentCommandStep1 extends FinalCommandStep<ResolveIncidentResponse> {
+public interface ResolveIncidentCommandStep1
+    extends CommandWithOperationReferenceStep<ResolveIncidentCommandStep1>,
+        FinalCommandStep<ResolveIncidentResponse> {
   // the place for new optional parameters
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/SetVariablesCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/SetVariablesCommandStep1.java
@@ -56,7 +56,9 @@ public interface SetVariablesCommandStep1 {
    */
   SetVariablesCommandStep2 variables(Object variables);
 
-  interface SetVariablesCommandStep2 extends FinalCommandStep<SetVariablesResponse> {
+  interface SetVariablesCommandStep2
+      extends CommandWithOperationReferenceStep<SetVariablesCommandStep2>,
+          FinalCommandStep<SetVariablesResponse> {
     // the place for new optional parameters
 
     /**

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateRetriesJobCommandStep1.java
@@ -30,7 +30,9 @@ public interface UpdateRetriesJobCommandStep1 {
    */
   UpdateRetriesJobCommandStep2 retries(int retries);
 
-  interface UpdateRetriesJobCommandStep2 extends FinalCommandStep<UpdateRetriesJobResponse> {
+  interface UpdateRetriesJobCommandStep2
+      extends CommandWithOperationReferenceStep<UpdateRetriesJobCommandStep2>,
+          FinalCommandStep<UpdateRetriesJobResponse> {
     // the place for new optional parameters
   }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateTimeoutJobCommandStep1.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/api/command/UpdateTimeoutJobCommandStep1.java
@@ -44,7 +44,9 @@ public interface UpdateTimeoutJobCommandStep1 {
    */
   UpdateTimeoutJobCommandStep2 timeout(Duration timeout);
 
-  interface UpdateTimeoutJobCommandStep2 extends FinalCommandStep<UpdateTimeoutJobResponse> {
+  interface UpdateTimeoutJobCommandStep2
+      extends CommandWithOperationReferenceStep<UpdateTimeoutJobCommandStep2>,
+          FinalCommandStep<UpdateTimeoutJobResponse> {
     // the place for new optional parameters
   }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CancelProcessInstanceCommandImpl.java
@@ -80,4 +80,10 @@ public final class CancelProcessInstanceCommandImpl implements CancelProcessInst
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .cancelProcessInstance(request, future);
   }
+
+  @Override
+  public CancelProcessInstanceCommandStep1 operationReference(final long operationReference) {
+    builder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeleteResourceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/DeleteResourceCommandImpl.java
@@ -77,4 +77,10 @@ public class DeleteResourceCommandImpl implements DeleteResourceCommandStep1 {
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .deleteResource(request, streamObserver);
   }
+
+  @Override
+  public DeleteResourceCommandStep1 operationReference(final long operationReference) {
+    requestBuilder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateRetriesCommandImpl.java
@@ -87,4 +87,10 @@ public final class JobUpdateRetriesCommandImpl
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .updateJobRetries(request, streamObserver);
   }
+
+  @Override
+  public UpdateRetriesJobCommandStep2 operationReference(final long operationReference) {
+    builder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateTimeoutCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/JobUpdateTimeoutCommandImpl.java
@@ -93,4 +93,10 @@ public class JobUpdateTimeoutCommandImpl
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .updateJobTimeout(request, streamObserver);
   }
+
+  @Override
+  public UpdateTimeoutJobCommandStep2 operationReference(final long operationReference) {
+    builder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/MigrateProcessInstanceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/MigrateProcessInstanceCommandImpl.java
@@ -133,4 +133,10 @@ public final class MigrateProcessInstanceCommandImpl
         .setTargetElementId(targetElementId)
         .build();
   }
+
+  @Override
+  public MigrateProcessInstanceCommandFinalStep operationReference(final long operationReference) {
+    requestBuilder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ModifyProcessInstanceCommandImpl.java
@@ -235,4 +235,10 @@ public final class ModifyProcessInstanceCommandImpl
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .modifyProcessInstance(request, streamObserver);
   }
+
+  @Override
+  public ModifyProcessInstanceCommandStep2 operationReference(final long operationReference) {
+    requestBuilder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ResolveIncidentCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ResolveIncidentCommandImpl.java
@@ -78,4 +78,10 @@ public final class ResolveIncidentCommandImpl implements ResolveIncidentCommandS
         .withDeadlineAfter(requestTimeout.toMillis(), TimeUnit.MILLISECONDS)
         .resolveIncident(request, streamObserver);
   }
+
+  @Override
+  public ResolveIncidentCommandStep1 operationReference(final long operationReference) {
+    builder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/SetVariablesCommandImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/SetVariablesCommandImpl.java
@@ -120,4 +120,10 @@ public final class SetVariablesCommandImpl
     builder.setVariables(jsonDocument);
     return this;
   }
+
+  @Override
+  public SetVariablesCommandStep2 operationReference(final long operationReference) {
+    builder.setOperationReference(operationReference);
+    return this;
+  }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentRecordWrapper.java
@@ -96,6 +96,11 @@ final class IncidentRecordWrapper implements TypedRecord<ProcessInstanceRecord> 
   }
 
   @Override
+  public long getOperationReference() {
+    return 0;
+  }
+
+  @Override
   public Record<ProcessInstanceRecord> copyOf() {
     return this;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedRejectionWriter.java
@@ -33,7 +33,8 @@ final class ResultBuilderBackedRejectionWriter extends AbstractResultBuilderBack
             .recordType(RecordType.COMMAND_REJECTION)
             .intent(command.getIntent())
             .rejectionType(rejectionType)
-            .rejectionReason(reason);
+            .rejectionReason(reason)
+            .operationReference(command.getOperationReference());
     resultBuilder().appendRecord(command.getKey(), command.getValue(), metadata);
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/MockTypedRecord.java
@@ -130,6 +130,11 @@ public final class MockTypedRecord<T extends UnifiedRecordValue> implements Type
   }
 
   @Override
+  public long getOperationReference() {
+    return metadata.getOperationReference();
+  }
+
+  @Override
   public Record<T> copyOf() {
     throw new UnsupportedOperationException("not yet implemented");
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-template.json
@@ -50,6 +50,9 @@
         },
         "sequence": {
           "type": "long"
+        },
+        "operationReference": {
+          "type": "long"
         }
       }
     }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-template.json
@@ -50,6 +50,9 @@
         },
         "sequence": {
           "type": "long"
+        },
+        "operationReference": {
+          "type": "long"
         }
       }
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -121,12 +121,22 @@ public final class RequestMapper extends RequestUtil {
 
   public static BrokerUpdateJobRetriesRequest toUpdateJobRetriesRequest(
       final UpdateJobRetriesRequest grpcRequest) {
-    return new BrokerUpdateJobRetriesRequest(grpcRequest.getJobKey(), grpcRequest.getRetries());
+    final var brokerRequest =
+        new BrokerUpdateJobRetriesRequest(grpcRequest.getJobKey(), grpcRequest.getRetries());
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+    return brokerRequest;
   }
 
   public static BrokerUpdateJobTimeoutRequest toUpdateJobTimeoutRequest(
       final UpdateJobTimeoutRequest grpcRequest) {
-    return new BrokerUpdateJobTimeoutRequest(grpcRequest.getJobKey(), grpcRequest.getTimeout());
+    final var brokerRequest =
+        new BrokerUpdateJobTimeoutRequest(grpcRequest.getJobKey(), grpcRequest.getTimeout());
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+    return brokerRequest;
   }
 
   public static BrokerFailJobRequest toFailJobRequest(final FailJobRequest grpcRequest) {
@@ -150,8 +160,7 @@ public final class RequestMapper extends RequestUtil {
 
   public static BrokerCreateProcessInstanceRequest toCreateProcessInstanceRequest(
       final CreateProcessInstanceRequest grpcRequest) {
-    final BrokerCreateProcessInstanceRequest brokerRequest =
-        new BrokerCreateProcessInstanceRequest();
+    final var brokerRequest = new BrokerCreateProcessInstanceRequest();
 
     brokerRequest
         .setBpmnProcessId(grpcRequest.getBpmnProcessId())
@@ -161,16 +170,19 @@ public final class RequestMapper extends RequestUtil {
         .setVariables(ensureJsonSet(grpcRequest.getVariables()))
         .setStartInstructions(grpcRequest.getStartInstructionsList());
 
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+
     return brokerRequest;
   }
 
   public static BrokerCreateProcessInstanceWithResultRequest
       toCreateProcessInstanceWithResultRequest(
           final CreateProcessInstanceWithResultRequest grpcRequest) {
-    final BrokerCreateProcessInstanceWithResultRequest brokerRequest =
-        new BrokerCreateProcessInstanceWithResultRequest();
+    final var brokerRequest = new BrokerCreateProcessInstanceWithResultRequest();
 
-    final CreateProcessInstanceRequest request = grpcRequest.getRequest();
+    final var request = grpcRequest.getRequest();
     brokerRequest
         .setBpmnProcessId(request.getBpmnProcessId())
         .setKey(request.getProcessDefinitionKey())
@@ -180,6 +192,9 @@ public final class RequestMapper extends RequestUtil {
         .setStartInstructions(request.getStartInstructionsList())
         .setFetchVariables(grpcRequest.getFetchVariablesList());
 
+    if (request.hasOperationReference()) {
+      brokerRequest.setOperationReference(request.getOperationReference());
+    }
     return brokerRequest;
   }
 
@@ -198,21 +213,27 @@ public final class RequestMapper extends RequestUtil {
 
   public static BrokerCancelProcessInstanceRequest toCancelProcessInstanceRequest(
       final CancelProcessInstanceRequest grpcRequest) {
-    final BrokerCancelProcessInstanceRequest brokerRequest =
-        new BrokerCancelProcessInstanceRequest();
-
+    final var brokerRequest = new BrokerCancelProcessInstanceRequest();
     brokerRequest.setProcessInstanceKey(grpcRequest.getProcessInstanceKey());
+
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
 
     return brokerRequest;
   }
 
   public static BrokerSetVariablesRequest toSetVariablesRequest(
       final SetVariablesRequest grpcRequest) {
-    final BrokerSetVariablesRequest brokerRequest = new BrokerSetVariablesRequest();
+    final var brokerRequest = new BrokerSetVariablesRequest();
 
     brokerRequest.setElementInstanceKey(grpcRequest.getElementInstanceKey());
     brokerRequest.setVariables(ensureJsonSet(grpcRequest.getVariables()));
     brokerRequest.setLocal(grpcRequest.getLocal());
+
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
 
     return brokerRequest;
   }
@@ -233,29 +254,53 @@ public final class RequestMapper extends RequestUtil {
 
   public static BrokerResolveIncidentRequest toResolveIncidentRequest(
       final ResolveIncidentRequest grpcRequest) {
-    return new BrokerResolveIncidentRequest(grpcRequest.getIncidentKey());
+    final var brokerRequest = new BrokerResolveIncidentRequest(grpcRequest.getIncidentKey());
+
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+
+    return brokerRequest;
   }
 
   public static BrokerModifyProcessInstanceRequest toModifyProcessInstanceRequest(
       final ModifyProcessInstanceRequest grpcRequest) {
-    return new BrokerModifyProcessInstanceRequest()
-        .setProcessInstanceKey(grpcRequest.getProcessInstanceKey())
-        .addActivateInstructions(grpcRequest.getActivateInstructionsList())
-        .addTerminateInstructions(grpcRequest.getTerminateInstructionsList());
+    final var brokerRequest =
+        new BrokerModifyProcessInstanceRequest()
+            .setProcessInstanceKey(grpcRequest.getProcessInstanceKey())
+            .addActivateInstructions(grpcRequest.getActivateInstructionsList())
+            .addTerminateInstructions(grpcRequest.getTerminateInstructionsList());
+
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+    return brokerRequest;
   }
 
   public static BrokerMigrateProcessInstanceRequest toMigrateProcessInstanceRequest(
       final MigrateProcessInstanceRequest grpcRequest) {
-    return new BrokerMigrateProcessInstanceRequest()
-        .setProcessInstanceKey(grpcRequest.getProcessInstanceKey())
-        .setTargetProcessDefinitionKey(
-            grpcRequest.getMigrationPlan().getTargetProcessDefinitionKey())
-        .addMappingInstructions(grpcRequest.getMigrationPlan().getMappingInstructionsList());
+    final var brokerRequest =
+        new BrokerMigrateProcessInstanceRequest()
+            .setProcessInstanceKey(grpcRequest.getProcessInstanceKey())
+            .setTargetProcessDefinitionKey(
+                grpcRequest.getMigrationPlan().getTargetProcessDefinitionKey())
+            .addMappingInstructions(grpcRequest.getMigrationPlan().getMappingInstructionsList());
+
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+    return brokerRequest;
   }
 
   public static BrokerDeleteResourceRequest toDeleteResourceRequest(
       final DeleteResourceRequest grpcRequest) {
-    return new BrokerDeleteResourceRequest().setResourceKey(grpcRequest.getResourceKey());
+    final var brokerRequest =
+        new BrokerDeleteResourceRequest().setResourceKey(grpcRequest.getResourceKey());
+
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+    return brokerRequest;
   }
 
   public static BrokerBroadcastSignalRequest toBroadcastSignalRequest(

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -90,7 +90,7 @@ message CancelProcessInstanceRequest {
   // CreateProcessInstanceResponse)
   int64 processInstanceKey = 1;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 2;
+  optional uint64 operationReference = 2;
 }
 
 message CancelProcessInstanceResponse {
@@ -128,7 +128,7 @@ message CreateProcessInstanceRequest {
   string tenantId = 6;
 
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 7;
+  optional uint64 operationReference = 7;
 }
 
 message ProcessInstanceCreationStartInstruction {
@@ -487,7 +487,7 @@ message ResolveIncidentRequest {
   // the unique ID of the incident to resolve
   int64 incidentKey = 1;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 2;
+  optional uint64 operationReference = 2;
 }
 
 message ResolveIncidentResponse {
@@ -551,7 +551,7 @@ message UpdateJobRetriesRequest {
   // the new amount of retries for the job; must be positive
   int32 retries = 2;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 3;
+  optional uint64 operationReference = 3;
 }
 
 message UpdateJobRetriesResponse {
@@ -563,7 +563,7 @@ message UpdateJobTimeoutRequest {
   // the duration of the new timeout in ms, starting from the current moment
   int64 timeout = 2;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 3;
+  optional uint64 operationReference = 3;
 }
 
 message UpdateJobTimeoutResponse {
@@ -586,7 +586,7 @@ message SetVariablesRequest {
   // then scope 1 would be `{ "foo": 5 }`, and scope 2 would be `{ "bar" : 1 }`.
   bool local = 3;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 4;
+  optional uint64 operationReference = 4;
 }
 
 message SetVariablesResponse {
@@ -603,7 +603,7 @@ message ModifyProcessInstanceRequest {
   // instructions describing which elements should be terminated
   repeated TerminateInstruction terminateInstructions = 3;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 4;
+  optional uint64 operationReference = 4;
 
   message ActivateInstruction {
     // the id of the element that should be activated
@@ -644,7 +644,7 @@ message MigrateProcessInstanceRequest {
   // the migration plan that defines target process and element mappings
   MigrationPlan migrationPlan = 2;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 3;
+  optional uint64 operationReference = 3;
 
   message MigrationPlan {
     // the key of process definition to migrate the process instance to
@@ -670,7 +670,7 @@ message DeleteResourceRequest {
   // of a process definition, the key of a decision requirements definition or the key of a form.
   int64 resourceKey = 1;
   // a reference key chosen by the user and will be part of all records resulted from this operation
-  optional int64 operationReference = 2;
+  optional uint64 operationReference = 2;
 }
 
 message DeleteResourceResponse {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -89,8 +89,7 @@ message CancelProcessInstanceRequest {
   // the process instance key (as, for example, obtained from
   // CreateProcessInstanceResponse)
   int64 processInstanceKey = 1;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 2;
 }
 
@@ -128,8 +127,7 @@ message CreateProcessInstanceRequest {
   // the tenant id of the process definition
   string tenantId = 6;
 
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 7;
 }
 
@@ -488,8 +486,7 @@ message PublishMessageResponse {
 message ResolveIncidentRequest {
   // the unique ID of the incident to resolve
   int64 incidentKey = 1;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 2;
 }
 
@@ -553,8 +550,7 @@ message UpdateJobRetriesRequest {
   int64 jobKey = 1;
   // the new amount of retries for the job; must be positive
   int32 retries = 2;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 3;
 }
 
@@ -566,8 +562,7 @@ message UpdateJobTimeoutRequest {
   int64 jobKey = 1;
   // the duration of the new timeout in ms, starting from the current moment
   int64 timeout = 2;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 3;
 }
 
@@ -590,8 +585,7 @@ message SetVariablesRequest {
   // be unchanged, and scope 2 will now be `{ "bar" : 1, "foo" 5 }`. if local was false, however,
   // then scope 1 would be `{ "foo": 5 }`, and scope 2 would be `{ "bar" : 1 }`.
   bool local = 3;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 4;
 }
 
@@ -608,8 +602,7 @@ message ModifyProcessInstanceRequest {
   repeated ActivateInstruction activateInstructions = 2;
   // instructions describing which elements should be terminated
   repeated TerminateInstruction terminateInstructions = 3;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 4;
 
   message ActivateInstruction {
@@ -650,8 +643,7 @@ message MigrateProcessInstanceRequest {
   int64 processInstanceKey = 1;
   // the migration plan that defines target process and element mappings
   MigrationPlan migrationPlan = 2;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 3;
 
   message MigrationPlan {
@@ -677,8 +669,7 @@ message DeleteResourceRequest {
   // The key of the resource that should be deleted. This can either be the key
   // of a process definition, the key of a decision requirements definition or the key of a form.
   int64 resourceKey = 1;
-  // a reference key sent from the client to correlate an operation with its
-  // result records
+  // a reference key chosen by the user and will be part of all records resulted from this operation
   optional int64 operationReference = 2;
 }
 

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -89,6 +89,9 @@ message CancelProcessInstanceRequest {
   // the process instance key (as, for example, obtained from
   // CreateProcessInstanceResponse)
   int64 processInstanceKey = 1;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 2;
 }
 
 message CancelProcessInstanceResponse {
@@ -124,6 +127,10 @@ message CreateProcessInstanceRequest {
   repeated ProcessInstanceCreationStartInstruction startInstructions = 5;
   // the tenant id of the process definition
   string tenantId = 6;
+
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 7;
 }
 
 message ProcessInstanceCreationStartInstruction {
@@ -481,6 +488,9 @@ message PublishMessageResponse {
 message ResolveIncidentRequest {
   // the unique ID of the incident to resolve
   int64 incidentKey = 1;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 2;
 }
 
 message ResolveIncidentResponse {
@@ -543,6 +553,9 @@ message UpdateJobRetriesRequest {
   int64 jobKey = 1;
   // the new amount of retries for the job; must be positive
   int32 retries = 2;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 3;
 }
 
 message UpdateJobRetriesResponse {
@@ -553,6 +566,9 @@ message UpdateJobTimeoutRequest {
   int64 jobKey = 1;
   // the duration of the new timeout in ms, starting from the current moment
   int64 timeout = 2;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 3;
 }
 
 message UpdateJobTimeoutResponse {
@@ -574,6 +590,9 @@ message SetVariablesRequest {
   // be unchanged, and scope 2 will now be `{ "bar" : 1, "foo" 5 }`. if local was false, however,
   // then scope 1 would be `{ "foo": 5 }`, and scope 2 would be `{ "bar" : 1 }`.
   bool local = 3;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 4;
 }
 
 message SetVariablesResponse {
@@ -589,6 +608,9 @@ message ModifyProcessInstanceRequest {
   repeated ActivateInstruction activateInstructions = 2;
   // instructions describing which elements should be terminated
   repeated TerminateInstruction terminateInstructions = 3;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 4;
 
   message ActivateInstruction {
     // the id of the element that should be activated
@@ -628,6 +650,9 @@ message MigrateProcessInstanceRequest {
   int64 processInstanceKey = 1;
   // the migration plan that defines target process and element mappings
   MigrationPlan migrationPlan = 2;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 3;
 
   message MigrationPlan {
     // the key of process definition to migrate the process instance to
@@ -652,6 +677,9 @@ message DeleteResourceRequest {
   // The key of the resource that should be deleted. This can either be the key
   // of a process definition, the key of a decision requirements definition or the key of a form.
   int64 resourceKey = 1;
+  // a reference key sent from the client to correlate an operation with its
+  // result records
+  optional int64 operationReference = 2;
 }
 
 message DeleteResourceResponse {

--- a/zeebe/gateway-protocol/src/main/proto/proto.lock
+++ b/zeebe/gateway-protocol/src/main/proto/proto.lock
@@ -205,6 +205,11 @@
                 "id": 1,
                 "name": "processInstanceKey",
                 "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "operationReference",
+                "type": "int64"
               }
             ]
           },
@@ -262,6 +267,11 @@
                 "id": 6,
                 "name": "tenantId",
                 "type": "string"
+              },
+              {
+                "id": 7,
+                "name": "operationReference",
+                "type": "int64"
               }
             ]
           },
@@ -955,6 +965,11 @@
                 "id": 1,
                 "name": "incidentKey",
                 "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "operationReference",
+                "type": "int64"
               }
             ]
           },
@@ -1058,6 +1073,11 @@
                 "id": 2,
                 "name": "retries",
                 "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "operationReference",
+                "type": "int64"
               }
             ]
           },
@@ -1075,6 +1095,11 @@
               {
                 "id": 2,
                 "name": "timeout",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "operationReference",
                 "type": "int64"
               }
             ]
@@ -1099,6 +1124,11 @@
                 "id": 3,
                 "name": "local",
                 "type": "bool"
+              },
+              {
+                "id": 4,
+                "name": "operationReference",
+                "type": "int64"
               }
             ]
           },
@@ -1131,6 +1161,11 @@
                 "name": "terminateInstructions",
                 "type": "TerminateInstruction",
                 "is_repeated": true
+              },
+              {
+                "id": 4,
+                "name": "operationReference",
+                "type": "int64"
               }
             ],
             "messages": [
@@ -1197,6 +1232,11 @@
                 "id": 2,
                 "name": "migrationPlan",
                 "type": "MigrationPlan"
+              },
+              {
+                "id": 3,
+                "name": "operationReference",
+                "type": "int64"
               }
             ],
             "messages": [
@@ -1242,6 +1282,11 @@
               {
                 "id": 1,
                 "name": "resourceKey",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "operationReference",
                 "type": "int64"
               }
             ]

--- a/zeebe/gateway-protocol/src/main/proto/proto.lock
+++ b/zeebe/gateway-protocol/src/main/proto/proto.lock
@@ -209,7 +209,7 @@
               {
                 "id": 2,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ]
           },
@@ -271,7 +271,7 @@
               {
                 "id": 7,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ]
           },
@@ -969,7 +969,7 @@
               {
                 "id": 2,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ]
           },
@@ -1077,7 +1077,7 @@
               {
                 "id": 3,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ]
           },
@@ -1100,7 +1100,7 @@
               {
                 "id": 3,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ]
           },
@@ -1128,7 +1128,7 @@
               {
                 "id": 4,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ]
           },
@@ -1165,7 +1165,7 @@
               {
                 "id": 4,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ],
             "messages": [
@@ -1236,7 +1236,7 @@
               {
                 "id": 3,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ],
             "messages": [
@@ -1287,7 +1287,7 @@
               {
                 "id": 2,
                 "name": "operationReference",
-                "type": "int64"
+                "type": "uint64"
               }
             ]
           },

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/encoding/ExecuteCommandRequest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.protocol.impl.encoding;
 
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.keyNullValue;
+import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.operationReferenceNullValue;
 import static io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.partitionIdNullValue;
 
 import io.camunda.zeebe.protocol.Protocol;
@@ -33,6 +34,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   private final DirectBuffer value = new UnsafeBuffer(0, 0);
   private int partitionId;
   private long key;
+  private long operationReference;
   private ValueType valueType;
   private Intent intent;
   private final AuthInfo authorization = new AuthInfo();
@@ -44,6 +46,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
   public ExecuteCommandRequest reset() {
     partitionId = partitionIdNullValue();
     key = keyNullValue();
+    operationReference = operationReferenceNullValue();
     valueType = ValueType.NULL_VAL;
     intent = Intent.UNKNOWN;
     value.wrap(0, 0);
@@ -69,6 +72,15 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
     this.key = key;
     partitionId = Protocol.decodePartitionId(key);
 
+    return this;
+  }
+
+  public long getOperationReference() {
+    return operationReference;
+  }
+
+  public ExecuteCommandRequest setOperationReference(final long operationReference) {
+    this.operationReference = operationReference;
     return this;
   }
 
@@ -128,6 +140,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
 
     partitionId = bodyDecoder.partitionId();
     key = bodyDecoder.key();
+    operationReference = bodyDecoder.operationReference();
     valueType = bodyDecoder.valueType();
     intent = Intent.fromProtocolValue(valueType, bodyDecoder.intent());
 
@@ -180,6 +193,7 @@ public final class ExecuteCommandRequest implements BufferReader, BufferWriter {
         .wrap(buffer, offset)
         .partitionId(partitionId)
         .key(key)
+        .operationReference(operationReference)
         .valueType(valueType)
         .intent(intent.value())
         .putValue(value, 0, value.capacity())

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/CopiedRecord.java
@@ -34,6 +34,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   private final String brokerVersion;
   private final AuthInfo authorization;
   private final int recordVersion;
+  private final long operationReference;
 
   public CopiedRecord(
       final T recordValue,
@@ -58,6 +59,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     brokerVersion = metadata.getBrokerVersion().toString();
     authorization = metadata.getAuthorization();
     recordVersion = metadata.getRecordVersion();
+    operationReference = metadata.getOperationReference();
   }
 
   private CopiedRecord(final CopiedRecord<T> copiedRecord) {
@@ -92,6 +94,7 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
     brokerVersion = copiedRecord.brokerVersion;
     authorization = copiedRecord.authorization;
     recordVersion = copiedRecord.recordVersion;
+    operationReference = copiedRecord.operationReference;
   }
 
   @Override
@@ -162,6 +165,11 @@ public final class CopiedRecord<T extends UnifiedRecordValue> implements Record<
   @Override
   public T getValue() {
     return recordValue;
+  }
+
+  @Override
+  public long getOperationReference() {
+    return operationReference;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -312,7 +312,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         authorization,
         protocolVersion,
         brokerVersion,
-        recordVersion);
+        recordVersion,
+        operationReference);
   }
 
   @Override
@@ -334,7 +335,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         && rejectionReason.equals(that.rejectionReason)
         && authorization.equals(that.authorization)
         && brokerVersion.equals(that.brokerVersion)
-        && recordVersion == that.recordVersion;
+        && recordVersion == that.recordVersion
+        && operationReference == that.operationReference;
   }
 
   @Override

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/RecordMetadata.java
@@ -55,6 +55,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
   private int protocolVersion = Protocol.PROTOCOL_VERSION;
   private VersionInfo brokerVersion = CURRENT_BROKER_VERSION;
   private int recordVersion = DEFAULT_RECORD_VERSION;
+  private long operationReference;
 
   public RecordMetadata() {
     reset();
@@ -78,6 +79,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     valueType = decoder.valueType();
     intent = Intent.fromProtocolValue(valueType, decoder.intent());
     rejectionType = decoder.rejectionType();
+    operationReference = decoder.operationReference();
 
     brokerVersion =
         Optional.ofNullable(decoder.brokerVersion())
@@ -146,7 +148,8 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
         .valueType(valueType)
         .intent(intentValue)
         .rejectionType(rejectionType)
-        .recordVersion(recordVersion);
+        .recordVersion(recordVersion)
+        .operationReference(operationReference);
 
     encoder
         .brokerVersion()
@@ -270,6 +273,15 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     return recordVersion;
   }
 
+  public RecordMetadata operationReference(final long operationReference) {
+    this.operationReference = operationReference;
+    return this;
+  }
+
+  public long getOperationReference() {
+    return operationReference;
+  }
+
   public RecordMetadata reset() {
     recordType = RecordType.NULL_VAL;
     requestId = RecordMetadataEncoder.requestIdNullValue();
@@ -283,6 +295,7 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
     authorization.reset();
     brokerVersion = CURRENT_BROKER_VERSION;
     recordVersion = DEFAULT_RECORD_VERSION;
+    operationReference = RecordMetadataEncoder.operationReferenceNullValue();
     return this;
   }
 
@@ -348,6 +361,9 @@ public final class RecordMetadata implements BufferWriter, BufferReader {
 
     if (!authorization.isEmpty()) {
       builder.append(", authorization=").append(authorization);
+    }
+    if (operationReference != RecordMetadataEncoder.operationReferenceNullValue()) {
+      builder.append(", operationReference=").append(operationReference);
     }
 
     builder.append('}');

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -152,7 +152,8 @@ final class JsonSerializableToJsonTest {
                   .rejectionType(rejectionType)
                   .requestId(requestId)
                   .requestStreamId(requestStreamId)
-                  .authorization(authInfo);
+                  .authorization(authInfo)
+                  .operationReference(1234);
 
               final String resourceName = "resource";
               final DirectBuffer resource = wrapString("contents");
@@ -204,6 +205,7 @@ final class JsonSerializableToJsonTest {
             ]
           },
           "recordVersion": 10,
+          "operationReference": 1234,
           "sourceRecordPosition": 231,
           "value": {
             "processesMetadata": [
@@ -267,6 +269,7 @@ final class JsonSerializableToJsonTest {
             ]
           },
           "recordVersion": 1,
+          "operationReference": -1,
           "value": {
               "resources": [],
               "decisionRequirementsMetadata": [],

--- a/zeebe/protocol/ignored-changes.json
+++ b/zeebe/protocol/ignored-changes.json
@@ -12,6 +12,60 @@
             "matcher": "java",
             "match": "type * { int io.camunda.zeebe.protocol.**::^initialOffset(); }"
           }
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.record.ExecuteCommandRequestDecoder.BLOCK_LENGTH",
+          "justification": "Block length was updated as part of generated code due to the addition of operation reference field",
+          "newValue": "20",
+          "oldValue": "12"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.record.ExecuteCommandRequestEncoder.BLOCK_LENGTH",
+          "justification": "Block length was updated as part of generated code due to the addition of operation reference field",
+          "newValue": "20",
+          "oldValue": "12"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.record.ExecuteCommandResponseDecoder.BLOCK_LENGTH",
+          "justification": "Block length was updated as part of generated code due to the addition of operation reference field",
+          "newValue": "22",
+          "oldValue": "14"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.ExecuteCommandResponseEncoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.record.ExecuteCommandResponseEncoder.BLOCK_LENGTH",
+          "justification": "Block length was updated as part of generated code due to the addition of operation reference field",
+          "newValue": "22",
+          "oldValue": "14"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataDecoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.record.RecordMetadataDecoder.BLOCK_LENGTH",
+          "justification": "Block length was updated as part of generated code due to the addition of operation reference field",
+          "newValue": "40",
+          "oldValue": "32"
+        },
+        {
+          "ignore": true,
+          "code": "java.field.constantValueChanged",
+          "old": "field io.camunda.zeebe.protocol.record.RecordMetadataEncoder.BLOCK_LENGTH",
+          "new": "field io.camunda.zeebe.protocol.record.RecordMetadataEncoder.BLOCK_LENGTH",
+          "justification": "Block length was updated as part of generated code due to the addition of operation reference field",
+          "newValue": "40",
+          "oldValue": "32"
         }
       ]
     }

--- a/zeebe/protocol/pom.xml
+++ b/zeebe/protocol/pom.xml
@@ -25,7 +25,7 @@
   <properties>
     <version.java>8</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <protocol.version>4</protocol.version>
+    <protocol.version>5</protocol.version>
   </properties>
 
   <dependencies>

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/Record.java
@@ -130,6 +130,14 @@ public interface Record<T extends RecordValue> extends JsonSerializable {
   T getValue();
 
   /**
+   * The operationReference is an id passed from clients to correlate operations with resulted
+   * records
+   *
+   * @return the reference for the operation that produced this record
+   */
+  long getOperationReference();
+
+  /**
    * Creates a deep copy of the current record. Can be used to collect records.
    *
    * @return a deep copy of this record

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -106,6 +106,8 @@
     <field name="key" id="4" type="uint64"/>
     <field name="valueType" id="5" type="ValueType"/>
     <field name="intent" id="6" type="uint8"/>
+    <!-- populated when the client passes an operation reference to the gateway-->
+    <field name="operationReference" id="9" type="uint64" presence="optional" sinceVersion="5"/>
     <data name="value" id="7" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->
     <data name="authorization" id="8" type="varDataEncoding" sinceVersion="4"/>
@@ -120,6 +122,8 @@
     <field name="intent" id="5" type="uint8"/>
     <!-- populated when RecordType is COMMAND_REJECTION -->
     <field name="rejectionType" id="6" type="RejectionType"/>
+    <!-- populated when the client passes an operation reference to the gateway-->
+    <field name="operationReference" id="9" type="uint64" presence="optional" sinceVersion="5"/>
     <data name="value" id="7" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND_REJECTION; UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
@@ -149,6 +153,8 @@
     <field name="recordVersion" id="10" type="uint16" sinceVersion="3" presence="optional"/>
     <!-- populated when RecordType is COMMAND_REJECTION -->
     <field name="rejectionType" id="7" type="RejectionType"/>
+    <!-- populated when the client passes an operation reference to the gateway-->
+    <field name="operationReference" id="12" type="uint64" presence="optional" sinceVersion="5"/>
     <!-- populated when RecordType is COMMAND_REJECTION, UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND -->

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -122,8 +122,6 @@
     <field name="intent" id="5" type="uint8"/>
     <!-- populated when RecordType is COMMAND_REJECTION -->
     <field name="rejectionType" id="6" type="RejectionType"/>
-    <!-- populated when the client passes an operation reference to the gateway-->
-    <field name="operationReference" id="9" type="uint64" presence="optional" sinceVersion="5"/>
     <data name="value" id="7" type="varDataEncoding"/>
     <!-- populated when RecordType is COMMAND_REJECTION; UTF-8-encoded String -->
     <data name="rejectionReason" id="8" type="varDataEncoding"/>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
@@ -81,7 +81,12 @@ public class OperationReferenceTest {
             .getFirst();
 
     final var followUpRecords =
-        RecordingExporter.records().withSourceRecordPosition(cancelCommand.getPosition());
+        RecordingExporter.records()
+            .withSourceRecordPosition(cancelCommand.getPosition())
+            .limit(
+                r ->
+                    r.getKey() == processInstanceKey
+                        && r.getIntent() == ProcessInstanceIntent.ELEMENT_TERMINATED);
 
     assertThat(followUpRecords)
         .hasSizeGreaterThan(0)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
-import io.camunda.zeebe.test.util.record.ProcessInstanceRecordStream;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
 import org.junit.jupiter.api.Test;
@@ -81,10 +80,8 @@ public class OperationReferenceTest {
             .limit(1)
             .getFirst();
 
-    final ProcessInstanceRecordStream followUpRecords =
-        RecordingExporter.processInstanceRecords()
-            .withProcessInstanceKey(processInstanceKey)
-            .withSourceRecordPosition(cancelCommand.getPosition());
+    final var followUpRecords =
+        RecordingExporter.records().withSourceRecordPosition(cancelCommand.getPosition());
 
     assertThat(followUpRecords)
         .hasSizeGreaterThan(0)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/OperationReferenceTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.ProcessInstanceRecordStream;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class OperationReferenceTest {
+  private static final long OPERATION_REFERENCE = 1234L;
+
+  @TestZeebe
+  private static final TestStandaloneBroker ZEEBE =
+      new TestStandaloneBroker().withRecordingExporter(true);
+
+  @AutoCloseResource
+  private final ZeebeClient client =
+      ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofMinutes(2)).build();
+
+  @Test
+  void shouldIncludeOperationReferenceInExportedCommandRecord() {
+    // Given
+    final ZeebeResourcesHelper helper = new ZeebeResourcesHelper(client);
+    final var modelInstance = helper.createSingleJobModelInstance("test", c -> {});
+    final long processDefinitionKey = helper.deployProcess(modelInstance);
+    final long processInstanceKey = helper.createProcessInstance(processDefinitionKey);
+
+    // When
+    client
+        .newCancelInstanceCommand(processInstanceKey)
+        .operationReference(OPERATION_REFERENCE)
+        .send()
+        .join();
+
+    // Then
+    assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
+                .withRecordKey(processInstanceKey)
+                .limit(1)
+                .getFirst()
+                .getOperationReference())
+        .describedAs("Should contain client operationReference")
+        .isEqualTo(OPERATION_REFERENCE);
+  }
+
+  @Test
+  void shouldIncludeOperationReferenceInFollowUpRecords() {
+    // Given
+    final ZeebeResourcesHelper helper = new ZeebeResourcesHelper(client);
+    final var modelInstance = helper.createSingleJobModelInstance("test", c -> {});
+    final long processDefinitionKey = helper.deployProcess(modelInstance);
+    final long processInstanceKey = helper.createProcessInstance(processDefinitionKey);
+
+    // When
+    client
+        .newCancelInstanceCommand(processInstanceKey)
+        .operationReference(OPERATION_REFERENCE)
+        .send()
+        .join();
+
+    // Then
+    final var cancelCommand =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.CANCEL)
+            .withRecordKey(processInstanceKey)
+            .limit(1)
+            .getFirst();
+
+    final ProcessInstanceRecordStream followUpRecords =
+        RecordingExporter.processInstanceRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .withSourceRecordPosition(cancelCommand.getPosition());
+
+    assertThat(followUpRecords)
+        .hasSizeGreaterThan(0)
+        .describedAs("Should contain client operationReference")
+        .allMatch(r -> r.getOperationReference() == OPERATION_REFERENCE);
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -38,6 +38,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
 
   private final RecordBatch mutableRecordBatch;
   private ProcessingResponseImpl processingResponse;
+  private long operationReference;
 
   BufferedProcessingResultBuilder(final RecordBatchSizePredicate predicate) {
     mutableRecordBatch = new RecordBatch(predicate);
@@ -47,13 +48,15 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   public Either<RuntimeException, ProcessingResultBuilder> appendRecordReturnEither(
       final long key, final RecordValue value, final RecordMetadata metadata) {
 
+    metadata.operationReference(operationReference);
+
     final ValueType valueType = TypedEventRegistry.TYPE_REGISTRY.get(value.getClass());
     if (valueType == null) {
       // usually happens when the record is not registered at the TypedStreamEnvironment
       throw new IllegalStateException("Missing value type mapping for record: " + value.getClass());
     }
 
-    if (value instanceof UnifiedRecordValue unifiedRecordValue) {
+    if (value instanceof final UnifiedRecordValue unifiedRecordValue) {
       final var metadataWithValueType = metadata.valueType(valueType);
       final var either =
           mutableRecordBatch.appendRecord(key, metadataWithValueType, -1, unifiedRecordValue);
@@ -87,7 +90,8 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
             .intent(intent)
             .rejectionType(rejectionType)
             .rejectionReason(rejectionReason)
-            .valueType(valueType);
+            .valueType(valueType)
+            .operationReference(operationReference);
     final var entry = RecordBatchEntry.createEntry(key, metadata, -1, value);
     processingResponse = new ProcessingResponseImpl(entry, requestId, requestStreamId);
     return this;
@@ -113,6 +117,11 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   @Override
   public boolean canWriteEventOfLength(final int eventLength) {
     return mutableRecordBatch.canAppendRecordOfLength(eventLength);
+  }
+
+  public ProcessingResultBuilder withOperationReference(final long operationReference) {
+    this.operationReference = operationReference;
+    return this;
   }
 
   record ProcessingResponseImpl(RecordBatchEntry responseValue, long requestId, int requestStreamId)

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -342,8 +342,11 @@ public final class ProcessingStateMachine {
    * commands are created.
    */
   private void batchProcessing(final TypedRecord<?> initialCommand) {
-    final ProcessingResultBuilder processingResultBuilder =
-        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
+    // propagate the operation reference from the initial command to the processingResultBuilder to
+    // be appended to the followup events
+    final var processingResultBuilder =
+        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents)
+            .withOperationReference(initialCommand.getOperationReference());
     var lastProcessingResultSize = 0;
 
     // It might be that we reached the batch size limit during processing a command.
@@ -526,7 +529,8 @@ public final class ProcessingStateMachine {
   private void tryRejectingIfUserCommand(final String errorMessage) {
     final var rejectionReason = errorMessage != null ? errorMessage : "";
     final ProcessingResultBuilder processingResultBuilder =
-        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
+        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents)
+            .withOperationReference(typedCommand.getOperationReference());
     final var errorRecord = new ErrorRecord();
     errorRecord.initErrorRecord(
         new CommandRejectionException(rejectionReason), currentRecord.getPosition());
@@ -538,7 +542,8 @@ public final class ProcessingStateMachine {
             .intent(ErrorIntent.CREATED)
             .recordVersion(RecordMetadata.DEFAULT_RECORD_VERSION)
             .rejectionType(RejectionType.NULL_VAL)
-            .rejectionReason("");
+            .rejectionReason("")
+            .operationReference(typedCommand.getOperationReference());
     processingResultBuilder.appendRecord(currentRecord.getKey(), errorRecord, recordMetadata);
     processingResultBuilder.withResponse(
         RecordType.COMMAND_REJECTION,
@@ -565,7 +570,8 @@ public final class ProcessingStateMachine {
     zeebeDbTransaction.run(
         () -> {
           final ProcessingResultBuilder processingResultBuilder =
-              new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents);
+              new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents)
+                  .withOperationReference(typedCommand.getOperationReference());
           currentProcessingResult =
               currentProcessor.onProcessingError(
                   processingException, typedCommand, processingResultBuilder);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -345,8 +345,8 @@ public final class ProcessingStateMachine {
     // propagate the operation reference from the initial command to the processingResultBuilder to
     // be appended to the followup events
     final var processingResultBuilder =
-        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents)
-            .withOperationReference(initialCommand.getOperationReference());
+        new BufferedProcessingResultBuilder(
+            logStreamWriter::canWriteEvents, initialCommand.getOperationReference());
     var lastProcessingResultSize = 0;
 
     // It might be that we reached the batch size limit during processing a command.
@@ -529,8 +529,8 @@ public final class ProcessingStateMachine {
   private void tryRejectingIfUserCommand(final String errorMessage) {
     final var rejectionReason = errorMessage != null ? errorMessage : "";
     final ProcessingResultBuilder processingResultBuilder =
-        new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents)
-            .withOperationReference(typedCommand.getOperationReference());
+        new BufferedProcessingResultBuilder(
+            logStreamWriter::canWriteEvents, typedCommand.getOperationReference());
     final var errorRecord = new ErrorRecord();
     errorRecord.initErrorRecord(
         new CommandRejectionException(rejectionReason), currentRecord.getPosition());
@@ -570,8 +570,8 @@ public final class ProcessingStateMachine {
     zeebeDbTransaction.run(
         () -> {
           final ProcessingResultBuilder processingResultBuilder =
-              new BufferedProcessingResultBuilder(logStreamWriter::canWriteEvents)
-                  .withOperationReference(typedCommand.getOperationReference());
+              new BufferedProcessingResultBuilder(
+                  logStreamWriter::canWriteEvents, typedCommand.getOperationReference());
           currentProcessingResult =
               currentProcessor.onProcessingError(
                   processingException, typedCommand, processingResultBuilder);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/TypedRecordImpl.java
@@ -104,6 +104,11 @@ public final class TypedRecordImpl implements TypedRecord {
   }
 
   @Override
+  public long getOperationReference() {
+    return metadata.getOperationReference();
+  }
+
+  @Override
   public Record copyOf() {
     return CopiedRecords.createCopiedRecord(getPartitionId(), rawEvent);
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/records/UnwrittenRecord.java
@@ -94,6 +94,11 @@ public class UnwrittenRecord implements TypedRecord {
   }
 
   @Override
+  public long getOperationReference() {
+    return metadata.getOperationReference();
+  }
+
+  @Override
   public long getKey() {
     return key;
   }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/RecordBatchTest.java
@@ -159,7 +159,7 @@ class RecordBatchTest {
     assertThat(either.isLeft()).isTrue();
     assertThat(either.getLeft())
         .hasMessageContaining("Can't append entry")
-        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 326]");
+        .hasMessageContaining("[ currentBatchEntryCount: 1, currentBatchSize: 334]");
   }
 
   @Test
@@ -189,7 +189,7 @@ class RecordBatchTest {
   @Test
   void shouldOnlyReturnTrueUntilMaxBatchSizeIsReached() {
     // given
-    final var recordBatch = new RecordBatch((count, size) -> size < 330);
+    final var recordBatch = new RecordBatch((count, size) -> size < 335);
     final var processInstanceRecord = Records.processInstance(1);
 
     recordBatch.appendRecord(1, RECORD_METADATA, -1, processInstanceRecord);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/util/RecordToWrite.java
@@ -55,6 +55,12 @@ public final class RecordToWrite implements LogAppendEntry {
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));
   }
 
+  public static RecordToWrite command(final long operationReference) {
+    final var recordMetadata =
+        new RecordMetadata().recordType(RecordType.COMMAND).operationReference(operationReference);
+    return new RecordToWrite(recordMetadata);
+  }
+
   public static RecordToWrite userCommand() {
     final RecordMetadata recordMetadata = new RecordMetadata().requestId(100).requestStreamId(10);
     return new RecordToWrite(recordMetadata.recordType(RecordType.COMMAND));

--- a/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
+++ b/zeebe/test-util/src/test/java/io/camunda/zeebe/test/util/record/RecordingExporterTest.java
@@ -126,6 +126,11 @@ public final class RecordingExporterTest {
     }
 
     @Override
+    public long getOperationReference() {
+      return 0;
+    }
+
+    @Override
     public Record<TestValue> copyOf() {
       return this;
     }


### PR DESCRIPTION
## Description
Allow zeebe clients to send an `operation reference` to be included in the resulted record metadata.

- Created a new interface `CommandWithOperationReferenceStep` that could be used to extend any existing command steps to have operation reference be passed to them.
- Extended the following commands to have the `operationReference`: 
  - CancelProcessInstanceCommand
  - DeleteResourceCommand 
  - MigrateProcessInstanceCommand
  - ModifyProcessInstanceCommand
  - ResolveIncidentCommand
  - SetVariablesCommand
  - UpdateRetriesJobCommand
  - UpdateTimeoutJobCommand
- Updated `zeebe-record-template` to include the `operationReference` in elasticsearch and opensearch indexes


- An example of how to use it with the `CancelProcessInstanceCommand` would look like 
```java
client
  .newCancelInstanceCommand(processInstanceKey)
  .operationReference(OPERATION_REFERENCE)
  .send()
  .join();
```
## Related issues

closes #16916

## Context
I initially implemented https://github.com/camunda/zeebe/pull/17877 as a solution to the same problem, yet, after a discussion with @korthout, we agreed that having zeebe generate the requestId and send it response could result in edge cases where a request is processed but a network partition (or similar issue) happens before a client gets a response, and hence missing the `requestId` correlated for their operation.

While the above problem should necessarily be a rare edge case, and it's not very important to cover right now for our main stakeholder (operate), I thought I'll create another POC PR quickly and compare the two solutions afterwards.