### PR TITLE
[Backport stable/8.4] fix: return resource_exhausted when sequencer buffer is full

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -133,7 +133,10 @@ public final class ErrorResponseWriter implements BufferWriter {
                       + " but the writer is closed. Most likely, this node is not the"
                       + " leader for this partition.")
                   .formatted(partitionId));
-      case FULL -> raiseInternalError("because the writer is full.", partitionId);
+      case FULL -> resourceExhausted(
+          String.format(
+              "Failed to write client request to partition '%d', because the writer buffer is full.",
+              partitionId));
       case INVALID_ARGUMENT -> raiseInternalError("due to invalid entry.", partitionId);
     };
   }


### PR DESCRIPTION
## Description

Backport of #18548

## Related issues

closes #13018 
