### PR TITLE
feat: extend fail job with incident key

### DIFF
--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/value/JobRecordValueImpl.java
@@ -30,6 +30,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   private String errorCode;
   private String tenantId;
   private JobKind jobKind;
+  private long incidentKey;
 
   public JobRecordValueImpl() {}
 
@@ -38,7 +39,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
     return processInstanceKey;
   }
 
-  public void setProcessInstanceKey(long processInstanceKey) {
+  public void setProcessInstanceKey(final long processInstanceKey) {
     this.processInstanceKey = processInstanceKey;
   }
 
@@ -117,61 +118,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
     return processDefinitionKey;
   }
 
-  @Override
-  public String getTenantId() {
-    return tenantId;
-  }
-
-  public void setProcessDefinitionKey(long processDefinitionKey) {
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public void setProcessDefinitionVersion(int processDefinitionVersion) {
-    this.processDefinitionVersion = processDefinitionVersion;
-  }
-
-  public void setBpmnProcessId(String bpmnProcessId) {
-    this.bpmnProcessId = bpmnProcessId;
-  }
-
-  public void setElementInstanceKey(long elementInstanceKey) {
-    this.elementInstanceKey = elementInstanceKey;
-  }
-
-  public void setElementId(String elementId) {
-    this.elementId = elementId;
-  }
-
-  public void setErrorCode(String errorCode) {
-    this.errorCode = errorCode;
-  }
-
-  public void setErrorMessage(String errorMessage) {
-    this.errorMessage = errorMessage;
-  }
-
-  public void setDeadline(long deadline) {
-    this.deadline = deadline;
-  }
-
-  public void setRetries(int retries) {
-    this.retries = retries;
-  }
-
-  public void setWorker(String worker) {
-    this.worker = worker;
-  }
-
-  public void setCustomHeaders(Map<String, String> customHeaders) {
-    this.customHeaders = customHeaders;
-  }
-
-  public void setType(String type) {
-    this.type = type;
-  }
-
-  public void setTenantId(String tenantId) {
-    this.tenantId = tenantId;
   }
 
   @Override
@@ -179,13 +127,97 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
     return jobKind;
   }
 
-  public JobRecordValueImpl setJobKind(JobKind jobKind) {
+  public JobRecordValueImpl setJobKind(final JobKind jobKind) {
     this.jobKind = jobKind;
     return this;
   }
 
   @Override
-  public boolean equals(Object o) {
+  public long getIncidentKey() {
+    return incidentKey;
+  }
+
+  public void setIncidentKey(final long incidentKey) {
+    this.incidentKey = incidentKey;
+  }
+
+  public void setProcessDefinitionVersion(final int processDefinitionVersion) {
+    this.processDefinitionVersion = processDefinitionVersion;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public void setElementInstanceKey(final long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+  }
+
+  public void setElementId(final String elementId) {
+    this.elementId = elementId;
+  }
+
+  public void setErrorCode(final String errorCode) {
+    this.errorCode = errorCode;
+  }
+
+  public void setErrorMessage(final String errorMessage) {
+    this.errorMessage = errorMessage;
+  }
+
+  public void setDeadline(final long deadline) {
+    this.deadline = deadline;
+  }
+
+  public void setRetries(final int retries) {
+    this.retries = retries;
+  }
+
+  public void setWorker(final String worker) {
+    this.worker = worker;
+  }
+
+  public void setCustomHeaders(final Map<String, String> customHeaders) {
+    this.customHeaders = customHeaders;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        bpmnProcessId,
+        elementId,
+        elementInstanceKey,
+        processInstanceKey,
+        processDefinitionKey,
+        processDefinitionVersion,
+        type,
+        worker,
+        deadline,
+        customHeaders,
+        retries,
+        errorMessage,
+        errorCode,
+        tenantId,
+        jobKind,
+        incidentKey);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -210,28 +242,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         && Objects.equals(errorMessage, that.errorMessage)
         && Objects.equals(errorCode, that.errorCode)
         && Objects.equals(tenantId, that.tenantId)
-        && jobKind == that.jobKind;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        super.hashCode(),
-        bpmnProcessId,
-        elementId,
-        elementInstanceKey,
-        processInstanceKey,
-        processDefinitionKey,
-        processDefinitionVersion,
-        type,
-        worker,
-        deadline,
-        customHeaders,
-        retries,
-        errorMessage,
-        errorCode,
-        tenantId,
-        jobKind);
+        && jobKind == that.jobKind
+        && incidentKey == that.incidentKey;
   }
 
   @Override
@@ -274,6 +286,9 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + '\''
         + ", jobKind="
         + jobKind
+        + '\''
+        + ", incidentKey="
+        + incidentKey
         + '}';
   }
 }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/JobRecordValueImpl.java
@@ -30,6 +30,7 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
   private String errorCode;
   private String tenantId;
   private JobKind jobKind;
+  private long incidentKey;
 
   public JobRecordValueImpl() {}
 
@@ -131,6 +132,15 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
     return this;
   }
 
+  @Override
+  public long getIncidentKey() {
+    return incidentKey;
+  }
+
+  public void setIncidentKey(final long incidentKey) {
+    this.incidentKey = incidentKey;
+  }
+
   public void setProcessDefinitionVersion(final int processDefinitionVersion) {
     this.processDefinitionVersion = processDefinitionVersion;
   }
@@ -202,7 +212,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         errorMessage,
         errorCode,
         tenantId,
-        jobKind);
+        jobKind,
+        incidentKey);
   }
 
   @Override
@@ -231,7 +242,8 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         && Objects.equals(errorMessage, that.errorMessage)
         && Objects.equals(errorCode, that.errorCode)
         && Objects.equals(tenantId, that.tenantId)
-        && jobKind == that.jobKind;
+        && jobKind == that.jobKind
+        && incidentKey == that.incidentKey;
   }
 
   @Override
@@ -274,6 +286,9 @@ public class JobRecordValueImpl extends RecordValueWithPayloadImpl implements Jo
         + '\''
         + ", jobKind="
         + jobKind
+        + '\''
+        + ", incidentKey="
+        + incidentKey
         + '}';
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/incident/IncidentResolveProcessor.java
@@ -153,6 +153,7 @@ public final class IncidentResolveProcessor implements TypedRecordProcessor<Inci
   private void publishIncidentRelatedJob(final long jobKey) {
     if (isJobRelatedIncident(jobKey)) {
       final JobRecord failedJobRecord = jobState.getJob(jobKey);
+      failedJobRecord.resetIncidentKey();
       jobActivationBehavior.publishWork(jobKey, failedJobRecord);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -41,6 +41,7 @@ public final class JobUpdateRetriesProcessor implements CommandProcessor<JobReco
       if (job != null) {
         // update retries for response sent to client
         job.setRetries(retries);
+        job.resetIncidentKey();
 
         commandControl.accept(JobIntent.RETRIES_UPDATED, job);
       } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbJobState.java
@@ -220,6 +220,9 @@ public final class DbJobState implements JobState, MutableJobState {
     final JobRecord job = getJob(jobKey);
     if (job != null) {
       job.setRetries(retries);
+      if (retries > 0) {
+        job.resetIncidentKey();
+      }
       updateJobRecord(jobKey, job);
     }
     return job;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -75,6 +75,9 @@
             },
             "jobKind": {
               "type": "keyword"
+            },
+            "incidentKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-job-template.json
@@ -75,6 +75,9 @@
             },
             "jobKind": {
               "type": "keyword"
+            },
+            "incidentKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -431,6 +431,8 @@ message FailJobRequest {
   // "b" respectively, with their associated values. [{ "a": 1, "b": 2 }] would not be a
   // valid argument, as the root of the JSON document is an array and not an object.
   string variables = 5;
+  // the incident key of the corresponding job
+  int64 incidentKey = 6;
 }
 
 message FailJobResponse {

--- a/zeebe/gateway-protocol/src/main/proto/proto.lock
+++ b/zeebe/gateway-protocol/src/main/proto/proto.lock
@@ -864,6 +864,11 @@
                 "id": 5,
                 "name": "variables",
                 "type": "string"
+              },
+              {
+                "id": 6,
+                "name": "incidentKey",
+                "type": "int64"
               }
             ]
           },

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/FailJobTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/FailJobTest.java
@@ -62,5 +62,6 @@ public final class FailJobTest extends GatewayTest {
 
     MsgPackUtil.assertEqualityExcluding(brokerRequestValue.getVariablesBuffer(), variables);
     assertThat(brokerRequestValue.getVariables().get("foo")).isEqualTo("bar");
+    assertThat(brokerRequestValue.getIncidentKey()).isEqualTo(-1L);
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/UpdateJobRetriesTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/job/UpdateJobRetriesTest.java
@@ -44,5 +44,6 @@ public final class UpdateJobRetriesTest extends GatewayTest {
 
     final JobRecord brokerRequestValue = brokerRequest.getRequestWriter();
     assertThat(brokerRequestValue.getRetries()).isEqualTo(retries);
+    assertThat(brokerRequestValue.getIncidentKey()).isEqualTo(-1L);
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -126,6 +126,11 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     return this;
   }
 
+  public JobRecord resetIncidentKey() {
+    incidentKeyProp.reset();
+    return this;
+  }
+
   @JsonIgnore
   public DirectBuffer getCustomHeadersBuffer() {
     return customHeadersProp.getValue();

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/job/JobRecord.java
@@ -67,6 +67,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   private final LongProperty elementInstanceKeyProp = new LongProperty("elementInstanceKey", -1L);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty incidentKeyProp = new LongProperty("incidentKey", -1L);
 
   public JobRecord() {
     super(19);
@@ -88,7 +89,8 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
         .declareProperty(jobKindProp)
         .declareProperty(elementIdProp)
         .declareProperty(elementInstanceKeyProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(incidentKeyProp);
   }
 
   public void wrapWithoutVariables(final JobRecord record) {
@@ -111,6 +113,7 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
     elementIdProp.setValue(record.getElementIdBuffer());
     elementInstanceKeyProp.setValue(record.getElementInstanceKey());
     tenantIdProp.setValue(record.getTenantId());
+    incidentKeyProp.setValue(record.getIncidentKey());
   }
 
   public void wrap(final JobRecord record) {
@@ -221,6 +224,16 @@ public final class JobRecord extends UnifiedRecordValue implements JobRecordValu
   @Override
   public JobKind getJobKind() {
     return jobKindProp.getValue();
+  }
+
+  @Override
+  public long getIncidentKey() {
+    return incidentKeyProp.getValue();
+  }
+
+  public JobRecord setIncidentKey(final long incidentKey) {
+    incidentKeyProp.setValue(incidentKey);
+    return this;
   }
 
   public JobRecord setJobKind(final JobKind jobKind) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -592,6 +592,7 @@ final class JsonSerializableToJsonTest {
               final int processInstanceKey = 1234;
               final String activityId = "activity";
               final int activityInstanceKey = 123;
+              final int incidentKey = -1;
 
               jobRecord
                   .setWorker(wrapString(worker))
@@ -608,7 +609,8 @@ final class JsonSerializableToJsonTest {
                   .setProcessDefinitionVersion(processDefinitionVersion)
                   .setProcessInstanceKey(processInstanceKey)
                   .setElementId(wrapString(activityId))
-                  .setElementInstanceKey(activityInstanceKey);
+                  .setElementInstanceKey(activityInstanceKey)
+                  .setIncidentKey(incidentKey);
 
               return record;
             },
@@ -643,7 +645,8 @@ final class JsonSerializableToJsonTest {
               "customHeaders": {},
               "deadline": 1000,
               "timeout": -1,
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "incidentKey": -1
             }
           ],
           "timeout": 2,
@@ -693,6 +696,7 @@ final class JsonSerializableToJsonTest {
               final int processInstanceKey = 1234;
               final String elementId = "activity";
               final int activityInstanceKey = 123;
+              final int incidentKey = -1;
 
               final Map<String, String> customHeaders =
                   Collections.singletonMap("workerVersion", "42");
@@ -714,7 +718,8 @@ final class JsonSerializableToJsonTest {
                       .setProcessDefinitionVersion(processDefinitionVersion)
                       .setProcessInstanceKey(processInstanceKey)
                       .setElementId(wrapString(elementId))
-                      .setElementInstanceKey(activityInstanceKey);
+                      .setElementInstanceKey(activityInstanceKey)
+                      .setIncidentKey(incidentKey);
 
               record.setCustomHeaders(wrapArray(MsgPackConverter.convertToMsgPack(customHeaders)));
               return record;
@@ -743,7 +748,8 @@ final class JsonSerializableToJsonTest {
           },
           "deadline": 13,
           "timeout": 14,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "incidentKey": -1
         }
         """
       },
@@ -774,7 +780,8 @@ final class JsonSerializableToJsonTest {
           "customHeaders": {},
           "deadline": -1,
           "timeout": -1,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "incidentKey": -1
         }
         """
       },
@@ -810,7 +817,8 @@ final class JsonSerializableToJsonTest {
           "errorCode": "",
           "processDefinitionVersion": -1,
           "customHeaders": {},
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "incidentKey": -1
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/JobRecordValue.java
@@ -118,4 +118,9 @@ public interface JobRecordValue
    * @return the job kind indicating the specific category of the job
    */
   JobKind getJobKind();
+
+  /**
+   * @return the incident key of the corresponding service task
+   */
+  long getIncidentKey();
 }

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -430,6 +430,7 @@ public class CompactRecordLogger {
     }
 
     result.append(" ").append(value.getRetries()).append(" retries,");
+    result.append(" ").append(value.getIncidentKey()).append(" incidentKey,");
 
     if (!StringUtils.isEmpty(value.getErrorCode())) {
       result.append(" ").append(value.getErrorCode()).append(":").append(value.getErrorMessage());


### PR DESCRIPTION
## Description
As this issue feature request descripted [Proposal: Extend FailJobResponse and ThrowErrorResponse with incidentKey #16580](https://github.com/camunda/zeebe/issues/16580) ,the zeebe engine should response a fail job with incident key.

## Related issues

part of #16580 
