### PR TITLE
[Backport stable/8.5] fix: spring sdk remove clients secrets

### DIFF
--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -179,6 +179,12 @@
       <artifactId>junit-platform-commons</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -684,10 +684,10 @@ public class ZeebeClientConfigurationProperties {
           + clusterId
           + '\''
           + ", clientId='"
-          + clientId
+          + "***"
           + '\''
           + ", clientSecret='"
-          + clientSecret
+          + "***"
           + '\''
           + ", region='"
           + region

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCloudTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationCloudTest.java
@@ -23,21 +23,22 @@ import io.camunda.zeebe.spring.client.CamundaAutoConfiguration;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@ExtendWith(SpringExtension.class)
-@TestPropertySource(
-    properties = {
-      "zeebe.client.cloud.clusterId=123-abc-456-def",
-    })
-@ContextConfiguration(
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
     classes = {
       CamundaAutoConfiguration.class,
       ZeebeClientStarterAutoConfigurationCloudTest.TestConfig.class
+    },
+    properties = {
+      "zeebe.client.cloud.clusterId=123-abc-456-def",
+      "zeebe.client.cloud.clientSecret=client-secret",
+      "zeebe.client.cloud.clientId=client-id",
     })
 public class ZeebeClientStarterAutoConfigurationCloudTest {
 
@@ -52,6 +53,12 @@ public class ZeebeClientStarterAutoConfigurationCloudTest {
         .isEqualTo("https://123-abc-456-def.bru-2.zeebe.camunda.io:443");
     assertThat(client.getConfiguration().getRestAddress().toString())
         .isEqualTo("https://bru-2.zeebe.camunda.io:443/123-abc-456-def");
+  }
+
+  @Test
+  void shouldNotLogClientInfoAtStartup(final CapturedOutput output) {
+    assertThat(output).contains("clientId='***'");
+    assertThat(output).contains("clientSecret='***'");
   }
 
   public static class TestConfig {

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
@@ -28,15 +28,19 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
-@ExtendWith(SpringExtension.class)
-@TestPropertySource(
+@ExtendWith(OutputCaptureExtension.class)
+@SpringBootTest(
+    classes = {
+      CamundaAutoConfiguration.class,
+      ZeebeClientStarterAutoConfigurationTest.TestConfig.class
+    },
     properties = {
       "zeebe.client.broker.gatewayAddress=localhost:1234",
       "zeebe.client.broker.grpcAddress=https://localhost:1234",
@@ -51,12 +55,9 @@ import org.springframework.test.util.ReflectionTestUtils;
       "zeebe.client.worker.override.foo.enabled=false",
       "zeebe.client.message.timeToLive=99s",
       "zeebe.client.security.certpath=aPath",
-      "zeebe.client.security.plaintext=true"
-    })
-@ContextConfiguration(
-    classes = {
-      CamundaAutoConfiguration.class,
-      ZeebeClientStarterAutoConfigurationTest.TestConfig.class
+      "zeebe.client.security.plaintext=true",
+      "zeebe.client.cloud.clientSecret=client-secret",
+      "zeebe.client.cloud.clientId=client-id",
     })
 public class ZeebeClientStarterAutoConfigurationTest {
 
@@ -106,6 +107,12 @@ public class ZeebeClientStarterAutoConfigurationTest {
     assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(client.getConfiguration().getDefaultJobPollInterval())
         .isEqualTo(Duration.ofSeconds(99));
+  }
+
+  @Test
+  void shouldNotLogClientInfoAtStartup(final CapturedOutput output) {
+    assertThat(output).contains("clientId='***'");
+    assertThat(output).contains("clientSecret='***'");
   }
 
   public static class TestConfig {


### PR DESCRIPTION
# Description
Backport of #18679 to `stable/8.5`.

relates to #18656 
