### PR TITLE
ci: add dummy workflow

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -1,0 +1,26 @@
+name: Common CI
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.ci/**'
+      - '.github/actions/**'
+      - '.github/workflows/zeebe-*'
+      - 'Dockerfile'
+      - 'bom/*'
+      - 'build-tools/**'
+      - 'clients/**'
+      - 'dist/**'
+      - 'parent/*'
+      - 'pom.xml'
+      - 'zeebe/**'
+
+jobs:
+  test-summary:
+    # Dummy job used for pull requests that do not trigger zeebe-ci or operate-ci
+    # This name is hard-coded in the branch rules; remember to update that if this name changes
+    name: Test summary
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 0


### PR DESCRIPTION
## Description

In order to unblock other component CI (Spring SDK) a dummy workflow is needed to match the branch protection rule

## Related issues

closes #18718 