### PR TITLE
feat: removed combined checksum check

### DIFF
--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -276,13 +276,6 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
       return;
     }
 
-    if (expectedSnapshotChecksum != checksumCollection.getCombinedValue()) {
-      future.completeExceptionally(
-          new InvalidSnapshotChecksum(
-              directory, expectedSnapshotChecksum, checksumCollection.getCombinedValue()));
-      return;
-    }
-
     try {
       if (metadata == null) {
         // backward compatibility

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
-import io.camunda.zeebe.snapshots.impl.InvalidSnapshotChecksum;
 import io.camunda.zeebe.snapshots.impl.SnapshotWriteException;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -324,30 +323,6 @@ public class ReceivedSnapshotTest {
           .as("the chunk should not be applied as its content checksum is not 0xCAFEL")
           .hasCauseInstanceOf(SnapshotWriteException.class);
     }
-  }
-
-  @Test
-  public void shouldNotPersistWhenSnapshotChecksumIsWrong() {
-    // given
-    final var persistedSnapshot = takePersistedSnapshot();
-
-    // when
-    final var receivedSnapshot =
-        receiverSnapshotStore.newReceivedSnapshot(persistedSnapshot.getId()).join();
-    try (final var snapshotChunkReader = persistedSnapshot.newChunkReader()) {
-      while (snapshotChunkReader.hasNext()) {
-        final var originalChunk = snapshotChunkReader.next();
-        final var corruptedChunk =
-            SnapshotChunkWrapper.withSnapshotChecksum(originalChunk, 0xDEADBEEFL);
-        receivedSnapshot.apply(corruptedChunk).join();
-      }
-    }
-
-    // then
-    assertThatThrownBy(() -> receivedSnapshot.persist().join())
-        .as(
-            "the snapshot should not be persisted since the computed checksum is not the reported one")
-        .hasCauseInstanceOf(InvalidSnapshotChecksum.class);
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -25,7 +25,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.time.Duration;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.Assertions;
@@ -153,33 +152,6 @@ public class FileBasedReceivedSnapshotTest {
         .as(
             "the latest pending snapshot should not be deleted because it is newer than the persisted one")
         .isDirectoryContainingAllOf(olderReceivedSnapshot.getPath(), receivedSnapshot.getPath());
-  }
-
-  @Test
-  public void shouldNotPersistOnPartialSnapshotOnInvalidChecksumPersist() {
-    // given
-    final var persistedSnapshot = (FileBasedSnapshot) takePersistedSnapshot(1L);
-    final var corruptedSnapshot =
-        new FileBasedSnapshot(
-            persistedSnapshot.getDirectory(),
-            persistedSnapshot.getChecksumPath(),
-            0xDEADBEEFL,
-            persistedSnapshot.getSnapshotId(),
-            null,
-            s -> {},
-            null);
-
-    // when
-    final var receivedSnapshot = receiveSnapshot(corruptedSnapshot);
-    final var didPersist = receivedSnapshot.persist();
-
-    // then
-    assertThat(didPersist)
-        .as("the snapshot was not persisted as it has a checksum mismatch")
-        .failsWithin(Duration.ofSeconds(5));
-    assertThat(receiverSnapshotsDir)
-        .as("the partial snapshot was rolled back")
-        .isDirectoryNotContaining(name -> name.getFileName().toString().equals("1-0-1-0.checksum"));
   }
 
   @Test


### PR DESCRIPTION
## Description
removed combined checksum check as `applyInternal` already checks the checksum of each individual file against that file's expected checksum no need for the double check which breaks compatibility between different versions of computing checksums (which result in the same file checksums) but a different combined checksum field.

Part 1/3 of PR to address https://github.com/camunda/zeebe/issues/17920
## Related issues

closes #
