### PR TITLE
Add success notification for other release workflows

### DIFF
--- a/.github/workflows/dispatch-release-8-2.yaml
+++ b/.github/workflows/dispatch-release-8-2.yaml
@@ -17,6 +17,33 @@ jobs:
       nextDevelopmentVersion: ${{ github.event.client_payload.nextDevelopmentVersion }}
       isLatest: ${{ github.event.client_payload.isLatest }}
       dryRun: ${{ github.event.client_payload.dryRun }}
+  notify-on-success:
+    name: Send slack notification on success
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    if: ${{ success() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-release-8-3.yaml
+++ b/.github/workflows/dispatch-release-8-3.yaml
@@ -17,6 +17,33 @@ jobs:
       nextDevelopmentVersion: ${{ github.event.client_payload.nextDevelopmentVersion }}
       isLatest: ${{ github.event.client_payload.isLatest }}
       dryRun: ${{ github.event.client_payload.dryRun }}
+  notify-on-success:
+    name: Send slack notification on success
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    if: ${{ success() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-release-8-4.yaml
+++ b/.github/workflows/dispatch-release-8-4.yaml
@@ -17,6 +17,33 @@ jobs:
       nextDevelopmentVersion: ${{ github.event.client_payload.nextDevelopmentVersion }}
       isLatest: ${{ github.event.client_payload.isLatest }}
       dryRun: ${{ github.event.client_payload.dryRun }}
+  notify-on-success:
+    name: Send slack notification on success
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    if: ${{ success() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-release-8-5.yaml
+++ b/.github/workflows/dispatch-release-8-5.yaml
@@ -17,6 +17,33 @@ jobs:
       nextDevelopmentVersion: ${{ github.event.client_payload.nextDevelopmentVersion }}
       isLatest: ${{ github.event.client_payload.isLatest }}
       dryRun: ${{ github.event.client_payload.dryRun }}
+  notify-on-success:
+    name: Send slack notification on success
+    runs-on: ubuntu-latest
+    needs: [ run-release ]
+    if: ${{ success() }}
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest

--- a/.github/workflows/dispatch-release-8-6.yaml
+++ b/.github/workflows/dispatch-release-8-6.yaml
@@ -32,7 +32,7 @@ jobs:
           payload: |
             {
               "text": ":success: Release job for ${{ github.event.client_payload.releaseVersion }} succeeded! :success:\n",
-             	"blocks": [
+              "blocks": [
                 {
                   "type": "section",
                   "text": {
@@ -44,7 +44,7 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK      
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
   notify-if-failed:
     name: Send slack notification on failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Add notification for a successful release, to all releases.


> [!Note]
> 
> As the release is triggered async, we need to follow the progress of the release on GitHub. To make this easier, we send a success notification to Slack (not only for failures).
> This allows us to just follow the slack channel, and do other things in the meantime (and get notified). Furthermore, we can reference back to the success message if necessary.

## Related issues
related PR https://github.com/camunda/zeebe/pull/18661
