### PR TITLE
8.5 Backport - feat: add call activity type support in instance migration mode

### DIFF
--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "camunda-operate",
-  "version": "8.5.1-SNAPSHOT",
+  "version": "8.5.2-SNAPSHOT",
   "private": true,
   "dependencies": {
     "@axe-core/playwright": "4.8.5",

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
@@ -53,6 +53,12 @@ const shipArticles = {
   type: 'userTask',
 };
 
+const confirmDelivery = {
+  id: 'confirmDelivery',
+  name: 'Confirm delivery',
+  type: 'callActivity',
+};
+
 const Wrapper = ({children}: Props) => {
   processXmlMigrationSourceStore.setProcessXml(open('instanceMigration.bpmn'));
   processInstanceMigrationStore.enable();
@@ -99,14 +105,19 @@ describe('MigrationView/BottomPanel', () => {
       screen.getByRole('cell', {name: shippingSubProcess.name}),
     ).toBeInTheDocument();
 
-    // expect table to have 1 header + 4 content rows
-    expect(screen.getAllByRole('row')).toHaveLength(5);
+    expect(
+      screen.getByRole('cell', {name: confirmDelivery.name}),
+    ).toBeInTheDocument();
+
+    // expect table to have 1 header + 5 content rows
+    expect(screen.getAllByRole('row')).toHaveLength(6);
   });
 
   it.each([
     {source: checkPayment, target: checkPayment},
     {source: shipArticles, target: shipArticles},
     {source: shippingSubProcess, target: shippingSubProcess},
+    {source: confirmDelivery, target: confirmDelivery},
   ])(
     'should allow $source.type -> $target.type mapping',
     async ({source, target}) => {
@@ -136,10 +147,16 @@ describe('MigrationView/BottomPanel', () => {
   it.each([
     {source: checkPayment, target: shipArticles},
     {source: checkPayment, target: shippingSubProcess},
+    {source: checkPayment, target: confirmDelivery},
     {source: shipArticles, target: checkPayment},
     {source: shipArticles, target: shippingSubProcess},
+    {source: shipArticles, target: confirmDelivery},
     {source: shippingSubProcess, target: checkPayment},
     {source: shippingSubProcess, target: shipArticles},
+    {source: shippingSubProcess, target: confirmDelivery},
+    {source: confirmDelivery, target: checkPayment},
+    {source: confirmDelivery, target: shipArticles},
+    {source: confirmDelivery, target: shippingSubProcess},
   ])(
     'should not allow $source.type -> $target.type mapping',
     async ({source, target}) => {

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.tsx
@@ -30,6 +30,12 @@ import {
 } from './styled';
 
 const BottomPanel: React.FC = observer(() => {
+  const {selectedSourceFlowNodeIds} = processInstanceMigrationStore;
+
+  const handleCheckIsRowSelected = (selectedSourceFlowNodes?: string[]) => {
+    return (rowId: string) => selectedSourceFlowNodes?.includes(rowId) ?? false;
+  };
+
   return (
     <BottomSection>
       {!processXmlMigrationSourceStore.hasSelectableFlowNodes ? (
@@ -57,10 +63,9 @@ const BottomPanel: React.FC = observer(() => {
           onRowClick={(rowId) => {
             processInstanceMigrationStore.selectSourceFlowNode(rowId);
           }}
-          checkIsRowSelected={(
-            (selectedSourceFlowNodes) => (rowId) =>
-              selectedSourceFlowNodes?.includes(rowId) ?? false
-          )(processInstanceMigrationStore.selectedSourceFlowNodeIds)}
+          checkIsRowSelected={handleCheckIsRowSelected(
+            selectedSourceFlowNodeIds,
+          )}
           rows={processXmlMigrationSourceStore.selectableFlowNodes.map(
             (sourceFlowNode) => {
               const selectableFlowNodes =

--- a/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
+++ b/operate/client/src/modules/mocks/diagrams/instanceMigration.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.21.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.23.0">
   <bpmn:process id="orderProcess" name="Order process" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Order received">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
@@ -14,7 +14,7 @@
       <bpmn:outgoing>SequenceFlow_1s6g17c</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:endEvent id="EndEvent_042s0oc">
-      <bpmn:incoming>Flow_14zxms3</bpmn:incoming>
+      <bpmn:incoming>Flow_0k3om5o</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1qqmrb8" name="Payment OK?">
       <bpmn:incoming>SequenceFlow_1s6g17c</bpmn:incoming>
@@ -52,7 +52,15 @@
       <bpmn:sequenceFlow id="Flow_0n8gs7h" sourceRef="shipArticles" targetRef="Event_0rg692j" />
       <bpmn:sequenceFlow id="Flow_1iyep4f" sourceRef="Event_0lv0fih" targetRef="shipArticles" />
     </bpmn:subProcess>
-    <bpmn:sequenceFlow id="Flow_14zxms3" sourceRef="shippingSubProcess" targetRef="EndEvent_042s0oc" />
+    <bpmn:sequenceFlow id="Flow_14zxms3" sourceRef="shippingSubProcess" targetRef="confirmDelivery" />
+    <bpmn:callActivity id="confirmDelivery" name="Confirm delivery">
+      <bpmn:extensionElements>
+        <zeebe:calledElement propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_14zxms3</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k3om5o</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0k3om5o" sourceRef="confirmDelivery" targetRef="EndEvent_042s0oc" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcess">
@@ -75,10 +83,14 @@
         <dc:Bounds x="444" y="260" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
-        <dc:Bounds x="1032" y="120" width="36" height="36" />
+        <dc:Bounds x="1172" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d5b5q4_di" bpmnElement="confirmDelivery">
+        <dc:Bounds x="1020" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zhf45a_di" bpmnElement="shippingSubProcess" isExpanded="true">
         <dc:Bounds x="610" y="38" width="350" height="200" />
@@ -93,13 +105,13 @@
       <bpmndi:BPMNShape id="Event_0rg692j_di" bpmnElement="Event_0rg692j">
         <dc:Bounds x="892" y="120" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1iyep4f_di" bpmnElement="Flow_1iyep4f">
-        <di:waypoint x="686" y="138" />
-        <di:waypoint x="740" y="138" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0n8gs7h_di" bpmnElement="Flow_0n8gs7h">
         <di:waypoint x="840" y="138" />
         <di:waypoint x="892" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1iyep4f_di" bpmnElement="Flow_1iyep4f">
+        <di:waypoint x="686" y="138" />
+        <di:waypoint x="740" y="138" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
         <di:waypoint x="211" y="138" />
@@ -139,7 +151,11 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14zxms3_di" bpmnElement="Flow_14zxms3">
         <di:waypoint x="960" y="138" />
-        <di:waypoint x="1032" y="138" />
+        <di:waypoint x="1020" y="138" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k3om5o_di" bpmnElement="Flow_0k3om5o">
+        <di:waypoint x="1120" y="138" />
+        <di:waypoint x="1172" y="138" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.test.ts
@@ -39,6 +39,7 @@ describe('stores/processXml/processXml.list', () => {
       'requestForPayment',
       'shippingSubProcess',
       'shipArticles',
+      'confirmDelivery',
     ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.source.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.source.ts
@@ -36,6 +36,7 @@ class ProcessesXml extends ProcessXmlBase {
           'bpmn:ServiceTask',
           'bpmn:UserTask',
           'bpmn:SubProcess',
+          'bpmn:CallActivity',
         ].includes(flowNode.$type);
       })
       .map((flowNode) => {

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.test.ts
@@ -39,6 +39,7 @@ describe('stores/processXml/processXml.list', () => {
       'requestForPayment',
       'shippingSubProcess',
       'shipArticles',
+      'confirmDelivery',
     ]);
   });
 });

--- a/operate/client/src/modules/stores/processXml/processXml.migration.target.ts
+++ b/operate/client/src/modules/stores/processXml/processXml.migration.target.ts
@@ -34,6 +34,7 @@ class ProcessesXml extends ProcessXmlBase {
           'bpmn:ServiceTask',
           'bpmn:UserTask',
           'bpmn:SubProcess',
+          'bpmn:CallActivity',
         ].includes(flowNode.$type);
       })
       .map((flowNode) => {


### PR DESCRIPTION
## Description

Adds Call Activity as a supported type in process instance migration mode.

## Related issues

backport for https://github.com/camunda/zeebe/pull/18647
relates to https://github.com/camunda/zeebe/issues/18492
