### PR TITLE
Add operations and applier to enable an exporter

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.scheduler.startup.StartupProcessShutdownException;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthStatus;

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -417,4 +417,21 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
         });
     return result;
   }
+
+  @Override
+  public ActorFuture<Void> enableExporter(
+      final int partitionId, final String exporterId, final long metadataVersionToUpdate) {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException("Not implemented"));
+  }
+
+  @Override
+  public ActorFuture<Void> enableExporter(
+      final int partitionId,
+      final String exporterId,
+      final long metadataVersionToUpdate,
+      final String initializeFrom) {
+    return CompletableActorFuture.completedExceptionally(
+        new UnsupportedOperationException("Not implemented"));
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.dynamic.config.util.RoundRobinPartitionDistributor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -59,7 +60,7 @@ public final class StaticConfigurationGenerator {
         .getExporters()
         .forEach(
             (exporterId, ignore) ->
-                exporters.put(exporterId, new ExporterState(0, State.ENABLED, null)));
+                exporters.put(exporterId, new ExporterState(0, State.ENABLED, Optional.empty())));
     return new DynamicPartitionConfig(new ExportersConfig(Map.copyOf(exporters)));
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -58,7 +58,8 @@ public final class StaticConfigurationGenerator {
     brokerCfg
         .getExporters()
         .forEach(
-            (exporterId, ignore) -> exporters.put(exporterId, new ExporterState(State.ENABLED)));
+            (exporterId, ignore) ->
+                exporters.put(exporterId, new ExporterState(0, State.ENABLED, null)));
     return new DynamicPartitionConfig(new ExportersConfig(Map.copyOf(exporters)));
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManager.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManager.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.broker.system.partitions;
 
-import io.camunda.zeebe.dynamic.config.state.ExporterState;
-import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import org.slf4j.Logger;
@@ -43,8 +41,7 @@ final class PartitionConfigurationManager {
     final var updatedConfig =
         context
             .getDynamicPartitionConfig()
-            .updateExporting(
-                config -> config.updateExporter(exporterId, new ExporterState(State.DISABLED)));
+            .updateExporting(config -> config.disableExporter(exporterId));
     context.setDynamicPartitionConfig(updatedConfig);
 
     final var exporterDirector = context.getExporterDirector();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManagerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/PartitionConfigurationManagerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -30,7 +31,6 @@ import org.slf4j.LoggerFactory;
 final class PartitionConfigurationManagerTest {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(PartitionConfigurationManagerTest.class);
-
   private final TestConcurrencyControl testConcurrencyControl = new TestConcurrencyControl();
   private TestPartitionTransitionContext partitionTransitionContext;
   private PartitionConfigurationManager partitionConfigurationManager;
@@ -46,13 +46,14 @@ final class PartitionConfigurationManagerTest {
   @Nested
   final class ExporterDisable {
     private final String exporterId = "exporterA";
+    private final DynamicPartitionConfig partitionConfig =
+        new DynamicPartitionConfig(
+            new ExportersConfig(
+                Map.of(exporterId, new ExporterState(0, State.ENABLED, Optional.empty()))));
 
     @Test
     void shouldDisableExporterAndUpdateConfigInContext() {
       // given
-      final var partitionConfig =
-          new DynamicPartitionConfig(
-              new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
       partitionTransitionContext.setDynamicPartitionConfig(partitionConfig);
       final ExporterDirector mockExporterDirector = mock(ExporterDirector.class);
       when(mockExporterDirector.disableExporter(exporterId))
@@ -78,9 +79,6 @@ final class PartitionConfigurationManagerTest {
     @Test
     void shouldUpdateConfigInContextWhenExporterDirectorIsNotAvailable() {
       // given
-      final var partitionConfig =
-          new DynamicPartitionConfig(
-              new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
       partitionTransitionContext.setDynamicPartitionConfig(partitionConfig);
 
       // when
@@ -101,9 +99,6 @@ final class PartitionConfigurationManagerTest {
     @Test
     void shouldFailFutureIfDisablingExporterFailed() {
       // given
-      final var partitionConfig =
-          new DynamicPartitionConfig(
-              new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
       partitionTransitionContext.setDynamicPartitionConfig(partitionConfig);
       final ExporterDirector mockExporterDirector = mock(ExporterDirector.class);
       when(mockExporterDirector.disableExporter(exporterId))

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiFunction;
 import org.junit.jupiter.api.BeforeEach;
@@ -220,9 +221,9 @@ class ExporterDirectorPartitionTransitionStepTest {
         new ExportersConfig(
             Map.of(
                 exporterOne,
-                new ExporterState(exporterOneState),
+                new ExporterState(0, exporterOneState, Optional.empty()),
                 exporterTwo,
-                new ExporterState(exporterTwoState))));
+                new ExporterState(0, exporterTwoState, Optional.empty()))));
   }
 
   private void initializeContext(final Role currentRole) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImpl.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -74,6 +75,13 @@ public class ConfigurationChangeAppliersImpl implements ConfigurationChangeAppli
               disableExporterOperation.partitionId(),
               disableExporterOperation.memberId(),
               disableExporterOperation.exporterId(),
+              partitionChangeExecutor);
+      case final PartitionEnableExporterOperation enableExporterOperation ->
+          new PartitionEnableExporterApplier(
+              enableExporterOperation.partitionId(),
+              enableExporterOperation.memberId(),
+              enableExporterOperation.exporterId(),
+              enableExporterOperation.initializeFrom(),
               partitionChangeExecutor);
       case null, default -> new FailingApplier(operation);
     };

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/NoopPartitionChangeExecutor.java
@@ -44,4 +44,19 @@ public final class NoopPartitionChangeExecutor implements PartitionChangeExecuto
   public ActorFuture<Void> disableExporter(final int partitionId, final String exporterId) {
     return CompletableActorFuture.completed(null);
   }
+
+  @Override
+  public ActorFuture<Void> enableExporter(
+      final int partitionId, final String exporterId, final long metadataVersionToUpdate) {
+    return CompletableActorFuture.completed(null);
+  }
+
+  @Override
+  public ActorFuture<Void> enableExporter(
+      final int partitionId,
+      final String exporterId,
+      final long metadataVersionToUpdate,
+      final String initializeFrom) {
+    return CompletableActorFuture.completed(null);
+  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionChangeExecutor.java
@@ -72,4 +72,10 @@ public interface PartitionChangeExecutor {
    * @return a future that completes when the exporter is disabled
    */
   ActorFuture<Void> disableExporter(final int partitionId, final String exporterId);
+
+  ActorFuture<Void> enableExporter(
+      int partitionId, String exporterId, long metadataVersionToUpdate);
+
+  ActorFuture<Void> enableExporter(
+      int partitionId, String exporterId, long metadataVersionToUpdate, String initializeFrom);
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplier.java
@@ -11,8 +11,6 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.ExporterState;
-import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
@@ -106,7 +104,6 @@ final class PartitionDisableExporterApplier implements MemberOperationApplier {
 
   private DynamicPartitionConfig disableExporter(
       final DynamicPartitionConfig config, final String exporterId) {
-    return config.updateExporting(
-        exporting -> exporting.updateExporter(exporterId, new ExporterState(State.DISABLED)));
+    return config.updateExporting(exporting -> exporting.disableExporter(exporterId));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplier.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliers.MemberOperationApplier;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.util.Either;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+
+final class PartitionEnableExporterApplier implements MemberOperationApplier {
+
+  private final int partitionId;
+  private final MemberId memberId;
+  private final String exporterId;
+  private final Optional<String> initializeFrom;
+  private final PartitionChangeExecutor partitionChangeExecutor;
+
+  private long metadataVersionToUpdate;
+
+  public PartitionEnableExporterApplier(
+      final int partitionId,
+      final MemberId memberId,
+      final String exporterId,
+      final Optional<String> initializeFrom,
+      final PartitionChangeExecutor partitionChangeExecutor) {
+    this.partitionId = partitionId;
+    this.memberId = memberId;
+    this.exporterId = exporterId;
+    this.initializeFrom = initializeFrom;
+    this.partitionChangeExecutor = partitionChangeExecutor;
+  }
+
+  @Override
+  public MemberId memberId() {
+    return memberId;
+  }
+
+  @Override
+  public Either<Exception, UnaryOperator<MemberState>> initMemberState(
+      final ClusterConfiguration currentClusterConfiguration) {
+    if (!currentClusterConfiguration.hasMember(memberId)) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to enable exporter, but the member '%s' does not exist in the cluster",
+                  memberId)));
+    }
+
+    final MemberState member = currentClusterConfiguration.getMember(memberId);
+    final var partitionExistsInLocalMember = member.hasPartition(partitionId);
+
+    if (!partitionExistsInLocalMember) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected to enable exporter, but the member '%s' does not have the partition '%s'",
+                  memberId, partitionId)));
+    }
+
+    final var exportersInPartition =
+        member.getPartition(partitionId).config().exporting().exporters();
+
+    if (initializeFrom.isPresent()) {
+      final String otherExporterId = initializeFrom.orElseThrow();
+      final var partitionHasOtherExporter = exportersInPartition.containsKey(otherExporterId);
+      if (!partitionHasOtherExporter) {
+        return Either.left(
+            new IllegalStateException(
+                String.format(
+                    "Expected to enable exporter and initialize from exporter '%s', but the partition '%s' does not have exporter '%s'",
+                    otherExporterId, partitionId, otherExporterId)));
+      } else {
+        final var otherExporter = exportersInPartition.get(otherExporterId);
+        if (otherExporter.state() == State.DISABLED) {
+          return Either.left(
+              new IllegalStateException(
+                  String.format(
+                      "Expected to enable exporter and initialize from exporter '%s', but the exporter '%s' is disabled",
+                      otherExporterId, otherExporterId)));
+        }
+      }
+    }
+
+    final var partitionHasExporter = exportersInPartition.containsKey(exporterId);
+
+    if (partitionHasExporter) {
+      // Increment by one when re-enabling the exporter
+      metadataVersionToUpdate = exportersInPartition.get(exporterId).metadataVersion() + 1;
+    } else {
+      metadataVersionToUpdate = 1;
+    }
+
+    return Either.right(memberState -> memberState);
+  }
+
+  @Override
+  public ActorFuture<UnaryOperator<MemberState>> applyOperation() {
+    final var result = new CompletableActorFuture<UnaryOperator<MemberState>>();
+
+    final ActorFuture<Void> enableFuture =
+        initializeFrom
+            .map(
+                otherExporterId ->
+                    partitionChangeExecutor.enableExporter(
+                        partitionId, exporterId, metadataVersionToUpdate, otherExporterId))
+            .orElse(
+                partitionChangeExecutor.enableExporter(
+                    partitionId, exporterId, metadataVersionToUpdate));
+
+    enableFuture.onComplete(
+        (nothing, error) -> {
+          if (error == null) {
+            result.complete(
+                memberState ->
+                    memberState.updatePartition(
+                        partitionId, partition -> partition.updateConfig(this::enableExporter)));
+          } else {
+            result.completeExceptionally(error);
+          }
+        });
+
+    return result;
+  }
+
+  private DynamicPartitionConfig enableExporter(final DynamicPartitionConfig config) {
+    return config.updateExporting(
+        c ->
+            initializeFrom
+                .map(otherExporterId -> c.enableExporter(exporterId, otherExporterId))
+                .orElse(c.enableExporter(exporterId)));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplier.java
@@ -96,7 +96,10 @@ final class PartitionEnableExporterApplier implements MemberOperationApplier {
     final var partitionHasExporter = exportersInPartition.containsKey(exporterId);
 
     if (partitionHasExporter) {
-      // Increment by one when re-enabling the exporter
+      // Increment by one when re-enabling the exporter so that the ExporterDirector can verify
+      // whether the runtime state has the latest state. This is useful when the operation is
+      // retried or if there was restart without a snapshot after a sequence of disable, enable
+      // operations.
       metadataVersionToUpdate = exportersInPartition.get(exporterId).metadataVersion() + 1;
     } else {
       metadataVersionToUpdate = 1;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -36,7 +36,9 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -389,11 +391,26 @@ public class ProtoBufSerializer
                   .setPartitionId(disableExporterOperation.partitionId())
                   .setExporterId(disableExporterOperation.exporterId())
                   .build());
+      case final PartitionEnableExporterOperation enableExporterOperation ->
+          builder.setPartitionEnableExporter(
+              encodeEnabledExporterOperation(enableExporterOperation));
       default ->
           throw new IllegalArgumentException(
               "Unknown operation type: " + operation.getClass().getSimpleName());
     }
     return builder.build();
+  }
+
+  private Topology.PartitionEnableExporterOperation encodeEnabledExporterOperation(
+      final PartitionChangeOperation.PartitionEnableExporterOperation enableExporterOperation) {
+    final var enableExporterOperationBuilder =
+        Topology.PartitionEnableExporterOperation.newBuilder()
+            .setPartitionId(enableExporterOperation.partitionId())
+            .setExporterId(enableExporterOperation.exporterId());
+    enableExporterOperation
+        .initializeFrom()
+        .ifPresent(enableExporterOperationBuilder::setInitializeFrom);
+    return enableExporterOperationBuilder.build();
   }
 
   private Topology.CompletedTopologyChangeOperation encodeCompletedOperation(
@@ -409,16 +426,12 @@ public class ProtoBufSerializer
   }
 
   private ClusterChangePlan decodeChangePlan(final Topology.ClusterChangePlan clusterChangePlan) {
-
-    final var version = clusterChangePlan.getVersion();
     final var pendingOperations =
-        clusterChangePlan.getPendingOperationsList().stream()
-            .map(this::decodeOperation)
-            .collect(Collectors.toList());
+        clusterChangePlan.getPendingOperationsList().stream().map(this::decodeOperation).toList();
     final var completedOperations =
         clusterChangePlan.getCompletedOperationsList().stream()
             .map(this::decodeCompletedOperation)
-            .collect(Collectors.toList());
+            .toList();
 
     return new ClusterChangePlan(
         clusterChangePlan.getId(),
@@ -479,6 +492,17 @@ public class ProtoBufSerializer
           MemberId.from(topologyChangeOperation.getMemberId()),
           topologyChangeOperation.getPartitionDisableExporter().getPartitionId(),
           topologyChangeOperation.getPartitionDisableExporter().getExporterId());
+    } else if (topologyChangeOperation.hasPartitionEnableExporter()) {
+      final var enableExporterOperation = topologyChangeOperation.getPartitionEnableExporter();
+      final Optional<String> initializeFrom =
+          enableExporterOperation.hasInitializeFrom()
+              ? Optional.of(enableExporterOperation.getInitializeFrom())
+              : Optional.empty();
+      return new PartitionEnableExporterOperation(
+          MemberId.from(topologyChangeOperation.getMemberId()),
+          enableExporterOperation.getPartitionId(),
+          enableExporterOperation.getExporterId(),
+          initializeFrom);
     } else {
       // If the node does not know of a type, the exception thrown will prevent
       // ClusterTopologyGossiper from processing the incoming topology. This helps to prevent any
@@ -777,7 +801,7 @@ public class ProtoBufSerializer
         decodeMemberStateMap(topologyChangeResponse.getExpectedTopologyMap()),
         topologyChangeResponse.getPlannedChangesList().stream()
             .map(this::decodeOperation)
-            .collect(Collectors.toList()));
+            .toList());
   }
 
   private ErrorCode encodeErrorCode(final ErrorResponse.ErrorCode status) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationChangeOperation.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.state;
 
 import io.atomix.cluster.MemberId;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * An operation that changes the configuration. The operation could be a member join or leave a
@@ -93,6 +94,18 @@ public sealed interface ClusterConfigurationChangeOperation {
      * @param exporterId id of the exporter to disable
      */
     record PartitionDisableExporterOperation(MemberId memberId, int partitionId, String exporterId)
+        implements PartitionChangeOperation {}
+
+    /**
+     * Operation to enable an exporter on a partition in the given member.
+     *
+     * @param memberId the member id of the member that will apply this operation
+     * @param partitionId id of the partition which enables the exporter
+     * @param exporterId id of the exporter to enable
+     * @param initializeFrom id of the exporter to initialize the metadata from
+     */
+    record PartitionEnableExporterOperation(
+        MemberId memberId, int partitionId, String exporterId, Optional<String> initializeFrom)
         implements PartitionChangeOperation {}
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ExporterState.java
@@ -7,12 +7,20 @@
  */
 package io.camunda.zeebe.dynamic.config.state;
 
+import java.util.Optional;
+
 /**
  * Represents the state of an exporter. The full configuration of this exporter must be provided as
  * part of the application configuration. Here we only keep track of whether it is enabled or
  * disabled. Sensitive information like access details must not be added here.
+ *
+ * @param metadataVersion the version of the metadata that is stored in the exporter runtime state.
+ *     This is incremented when ever the exporter is re-enabled.
+ * @param state the state of the exporter
+ * @param initializedFrom the id of the exporter that the metadata of this exporter was initialized
+ *     from.
  */
-public record ExporterState(State state) {
+public record ExporterState(long metadataVersion, State state, Optional<String> initializedFrom) {
   public enum State {
     ENABLED,
     DISABLED

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -441,6 +441,16 @@
                 "id": 1,
                 "name": "state",
                 "type": "EnabledDisabledState"
+              },
+              {
+                "id": 2,
+                "name": "metadataVersion",
+                "type": "int64"
+              },
+              {
+                "id": 3,
+                "name": "initializedFrom",
+                "type": "string"
               }
             ]
           },

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -563,6 +563,11 @@
                 "id": 9,
                 "name": "partitionDisableExporter",
                 "type": "PartitionDisableExporterOperation"
+              },
+              {
+                "id": 10,
+                "name": "partitionEnableExporter",
+                "type": "PartitionEnableExporterOperation"
               }
             ]
           },
@@ -648,6 +653,26 @@
               {
                 "id": 2,
                 "name": "exporterId",
+                "type": "string"
+              }
+            ]
+          },
+          {
+            "name": "PartitionEnableExporterOperation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "partitionId",
+                "type": "int32"
+              },
+              {
+                "id": 2,
+                "name": "exporterId",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "initializeFrom",
                 "type": "string"
               }
             ]

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -39,6 +39,8 @@ message ExportersConfig{
 
 message ExporterState {
   EnabledDisabledState state = 1;
+  int64 metadataVersion = 2;
+  optional string initializedFrom = 3;
 }
 
 message ClusterChangePlan {
@@ -48,7 +50,6 @@ message ClusterChangePlan {
   google.protobuf.Timestamp startedAt = 4;
   repeated CompletedTopologyChangeOperation completedOperations = 5;
   repeated TopologyChangeOperation pendingOperations = 6;
-
 }
 
 message CompletedChange {

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -70,6 +70,7 @@ message TopologyChangeOperation {
     PartitionForceReconfigureOperation partitionForceReconfigure = 7;
     MemberRemoveOperation memberRemove = 8;
     PartitionDisableExporterOperation partitionDisableExporter = 9;
+    PartitionEnableExporterOperation partitionEnableExporter = 10;
   }
 }
 
@@ -100,6 +101,12 @@ message PartitionForceReconfigureOperation {
 message PartitionDisableExporterOperation {
   int32 partitionId = 1;
   string exporterId = 2;
+}
+
+message PartitionEnableExporterOperation {
+  int32 partitionId = 1;
+  string exporterId = 2;
+  optional string initializeFrom = 3;
 }
 
 message MemberJoinOperation {}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApiTest.java
@@ -349,7 +349,8 @@ final class ClusterConfigurationManagementApiTest {
         new ClusterConfigurationManagementRequest.ExporterDisableRequest(exporterId, false);
     final var partitionConfigWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
+            new ExportersConfig(
+                Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var configurationWithExporter =
         initialTopology.updateMember(
             id0, m -> m.addPartition(1, PartitionState.active(1, partitionConfigWithExporter)));

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterDisableRequestTransformerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 final class ExporterDisableRequestTransformerTest {
@@ -29,7 +30,8 @@ final class ExporterDisableRequestTransformerTest {
   private final MemberId id1 = MemberId.from("1");
   private final DynamicPartitionConfig config =
       new DynamicPartitionConfig(
-          new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
+          new ExportersConfig(
+              Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
 
   @Test
   void shouldGenerateOperationForAllPartitionsAndMembers() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/ConfigurationChangeAppliersImplTest.java
@@ -14,11 +14,13 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionReconfigurePriorityOperation;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -56,6 +58,9 @@ final class ConfigurationChangeAppliersImplTest {
             PartitionForceReconfigureApplier.class),
         Arguments.of(
             new PartitionDisableExporterOperation(localMemberId, 1, "expId"),
-            PartitionDisableExporterApplier.class));
+            PartitionDisableExporterApplier.class),
+        Arguments.of(
+            new PartitionEnableExporterOperation(localMemberId, 1, "expId", Optional.empty()),
+            PartitionEnableExporterApplier.class));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionDisableExporterApplierTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.Test;
 
@@ -96,7 +97,8 @@ final class PartitionDisableExporterApplierTest {
     // given
     final var configWithExporter =
         new DynamicPartitionConfig(
-            new ExportersConfig(Map.of(exporterId, new ExporterState(State.ENABLED))));
+            new ExportersConfig(
+                Map.of(exporterId, new ExporterState(1, State.ENABLED, Optional.empty()))));
     final var clusterConfiguration =
         ClusterConfiguration.init()
             .addMember(
@@ -133,7 +135,7 @@ final class PartitionDisableExporterApplierTest {
   @Test
   void shouldCompleteFutureAndUpdateStateIfApplySucceeds() {
     // given
-    final var exporterState = new ExporterState(State.ENABLED);
+    final var exporterState = new ExporterState(1, State.ENABLED, Optional.empty());
     final var exporterConfig = new ExportersConfig(Map.of(exporterId, exporterState));
     final var partitionConfig = new DynamicPartitionConfig(exporterConfig);
     final var memberState =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionEnableExporterApplierTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.changes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.junit.jupiter.api.Test;
+
+final class PartitionEnableExporterApplierTest {
+
+  private final PartitionChangeExecutor partitionChangeExecutor =
+      mock(PartitionChangeExecutor.class);
+
+  private final String exporterId = "exporterA";
+  private final int partitionId = 2;
+  private final MemberId localMemberId = MemberId.from("3");
+
+  private final PartitionEnableExporterApplier applier =
+      new PartitionEnableExporterApplier(
+          partitionId, localMemberId, exporterId, Optional.of("other"), partitionChangeExecutor);
+  private final ClusterConfiguration clusterConfigWithPartition =
+      ClusterConfiguration.init()
+          .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))
+          .updateMember(
+              localMemberId,
+              m ->
+                  m.addPartition(
+                      partitionId,
+                      PartitionState.active(
+                          1, new DynamicPartitionConfig(new ExportersConfig(Map.of())))));
+
+  @Test
+  void shouldRejectWhenMemberDoesNotExist() {
+    // given
+    final var clusterConfiguration = ClusterConfiguration.init();
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("member '3' does not exist in the cluster");
+  }
+
+  @Test
+  void shouldRejectWhenPartitionDoesNotExist() {
+    // given
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(localMemberId, MemberState.initializeAsActive(Map.of()));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have the partition '2'");
+  }
+
+  @Test
+  void shouldFailIfOtherExporterDoesNotExist() {
+    // when
+    final var result = applier.initMemberState(clusterConfigWithPartition);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("does not have exporter 'other'");
+  }
+
+  @Test
+  void shouldFailIfOtherExporterIsDisabled() {
+    // given
+    final var configWithDisabledExporter =
+        new DynamicPartitionConfig(
+            new ExportersConfig(
+                Map.of("other", new ExporterState(0, State.DISABLED, Optional.empty()))));
+    final var clusterConfiguration =
+        clusterConfigWithPartition.updateMember(
+            localMemberId,
+            m -> m.updatePartition(partitionId, p -> p.updateConfig(configWithDisabledExporter)));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isLeft();
+    assertThat(result.getLeft())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("the exporter 'other' is disabled");
+  }
+
+  @Test
+  void shouldNotChangeStateOnInit() {
+    // given
+    final var configWithOtherExporter =
+        new DynamicPartitionConfig(
+            new ExportersConfig(
+                Map.of("other", new ExporterState(1, State.ENABLED, Optional.empty()))));
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, configWithOtherExporter))));
+
+    // when
+    final var result = applier.initMemberState(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    final MemberState memberState = clusterConfiguration.getMember(localMemberId);
+    assertThat(result.get().apply(memberState)).isEqualTo(memberState);
+  }
+
+  @Test
+  void shouldFailFutureIfApplyFailed() {
+    when(partitionChangeExecutor.enableExporter(partitionId, exporterId, 0, "other"))
+        .thenReturn(
+            CompletableActorFuture.completedExceptionally(new RuntimeException("force fail")));
+
+    // when
+    final var result = applier.applyOperation();
+
+    // then
+    assertThat(result)
+        .failsWithin(Duration.ofMillis(100))
+        .withThrowableOfType(ExecutionException.class)
+        .withMessageContaining("force fail");
+  }
+
+  @Test
+  void shouldUpdateStateAndMetadataVersionIfApplySucceeded() {
+    // given
+    when(partitionChangeExecutor.enableExporter(partitionId, exporterId, 1, "other"))
+        .thenReturn(CompletableActorFuture.completed(null));
+
+    final var configWithOtherExporter =
+        new DynamicPartitionConfig(
+            new ExportersConfig(
+                Map.of("other", new ExporterState(1, State.ENABLED, Optional.empty()))));
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(
+                localMemberId,
+                MemberState.initializeAsActive(
+                    Map.of(partitionId, PartitionState.active(1, configWithOtherExporter))));
+    applier.initMemberState(clusterConfiguration);
+
+    // when
+    final var result = applier.applyOperation();
+
+    // then
+    assertThat(result).succeedsWithin(Duration.ofMillis(100));
+    final var updatedState = result.join().apply(clusterConfiguration.getMember(localMemberId));
+    final ExporterState updatedExporterState =
+        updatedState.getPartition(partitionId).config().exporting().exporters().get(exporterId);
+    assertThat(updatedExporterState.state()).isEqualTo(State.ENABLED);
+    assertThat(updatedExporterState.metadataVersion()).isEqualTo(1);
+    assertThat(updatedExporterState.initializedFrom()).contains("other");
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/changes/PartitionJoinApplierTest.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import org.assertj.core.api.Assertions;
@@ -222,7 +223,10 @@ final class PartitionJoinApplierTest {
     // given
     final var config =
         new DynamicPartitionConfig(
-            new ExportersConfig(Map.of("expA", new ExporterState(ExporterState.State.ENABLED))));
+            new ExportersConfig(
+                Map.of(
+                    "expA",
+                    new ExporterState(1, ExporterState.State.ENABLED, Optional.of("expB")))));
     final var initialTopology =
         ClusterConfiguration.init()
             .addMember(localMemberId, MemberState.initializeAsActive(Map.of()))

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.MemberRemoveOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionForceReconfigureOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
@@ -203,7 +204,8 @@ final class ProtoBufSerializerTest {
         topologyWithCompletedClusterChangePlan(),
         topologyWithClusterChangePlanWithMemberOperations(),
         topologyWithExporterState(),
-        topologyWithExporterDisableOperation());
+        topologyWithExporterDisableOperation(),
+        topologyWithExporterEnableOperation());
   }
 
   private static ClusterConfiguration topologyWithOneMemberNoPartitions() {
@@ -330,5 +332,17 @@ final class ProtoBufSerializerTest {
     return topologyWithExporterState()
         .startConfigurationChange(
             List.of(new PartitionDisableExporterOperation(MemberId.from("1"), 1, "expA")));
+  }
+
+  private static ClusterConfiguration topologyWithExporterEnableOperation() {
+    return topologyWithExporterState()
+        .startConfigurationChange(
+            List.of(
+                // with initialize from another exporter
+                new PartitionEnableExporterOperation(
+                    MemberId.from("1"), 1, "expA", Optional.of("expB")),
+                // without initialize from another exporter
+                new PartitionEnableExporterOperation(
+                    MemberId.from("1"), 1, "expA", Optional.empty())));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
@@ -313,9 +314,9 @@ final class ProtoBufSerializerTest {
             new ExportersConfig(
                 Map.of(
                     "expA",
-                    new ExporterState(State.ENABLED),
+                    new ExporterState(10, State.ENABLED, Optional.of("expB")),
                     "expB",
-                    new ExporterState(State.DISABLED))));
+                    new ExporterState(5, State.DISABLED, Optional.empty()))));
     return ClusterConfiguration.init()
         .addMember(MemberId.from("1"), MemberState.initializeAsActive(Map.of()))
         .updateMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -260,7 +260,10 @@ class ClusterConfigurationTest {
     // given
     final String exporterName = "exporter";
     final var exportersConfig =
-        new ExportersConfig(Map.of(exporterName, new ExporterState(ExporterState.State.ENABLED)));
+        new ExportersConfig(
+            Map.of(
+                exporterName,
+                new ExporterState(1, ExporterState.State.ENABLED, Optional.of("other"))));
     final var config = new DynamicPartitionConfig(exportersConfig);
 
     final var initialTopology =
@@ -279,17 +282,13 @@ class ClusterConfigurationTest {
                     1,
                     p ->
                         p.updateConfig(
-                            c ->
-                                c.updateExporting(
-                                    e ->
-                                        e.updateExporter(
-                                            exporterName,
-                                            new ExporterState(ExporterState.State.DISABLED))))));
+                            c -> c.updateExporting(e -> e.disableExporter(exporterName)))));
 
     // then
     assertThat(
             updatedTopology.getMember(member(1)).getPartition(1).config().exporting().exporters())
-        .containsEntry(exporterName, new ExporterState(ExporterState.State.DISABLED));
+        .containsEntry(
+            exporterName, new ExporterState(1, ExporterState.State.DISABLED, Optional.empty()));
   }
 
   private MemberId member(final int id) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtilTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 
@@ -30,7 +31,8 @@ class ConfigurationUtilTest {
   private static final String GROUP_NAME = "test";
   private final DynamicPartitionConfig partitionConfig =
       new DynamicPartitionConfig(
-          new ExportersConfig(Map.of("expA", new ExporterState(ExporterState.State.ENABLED))));
+          new ExportersConfig(
+              Map.of("expA", new ExporterState(1, ExporterState.State.ENABLED, Optional.empty()))));
 
   @Test
   void shouldGenerateTopologyFromPartitionDistribution() {


### PR DESCRIPTION
## Description

This PR extends the state of exporter in the dynamic config with some additional metadata for enabling an exporter. When enabling the exporter, we can optionally provide the id of another exporter from which it can initialize its metadata from. The `ExporterDirector` should use this when enabling the exporter.

As discussed in the POC, there is a possibility that the exporter is disabled first, then re-enabled, then the node restarted. Since there was no snapshot in between, then restarted node will start with the exporter state before disabling. This is incorrect, because it was re-initialized with a different metadata. To allow detecting this case, we add a `metadataVersion` to the exporter state. This version is incremented everytime an exporter is enabled. The `ExporterDirector` can use this info to know whether the metadata in the runtime is up-to-date or not. The initial state for an already enabled exporter during cluster bootstrap will be 0.

This PR also adds the operation and applier for enabling an exporter. This follows the same approach all other configuration change operations. 

## Related issues

closes #18757 
closes #18808 
