### PR TITLE
fix: fix test timeout for batchMoveModification e2e test

### DIFF
--- a/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
+++ b/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
@@ -155,7 +155,7 @@ test.describe('Process Instance Batch Modification', () => {
             .getByTestId('state-overlay-shipArticles-active')
             .textContent();
         },
-        {timeout: 2000},
+        {intervals: [2000], timeout: 30000},
       )
       .toBe(NUM_SELECTED_PROCESS_INSTANCES.toString());
 


### PR DESCRIPTION
## Description

This fixes a test timeout. Initially I wanted `expect.poll` to poll every 2 seconds. I mistakenly configured the 2 seconds as timeout.

Now `expect.poll` should have the right options:

- poll every 2 seconds
- with a 30 seconds timeout


