### PR TITLE
deps: undo lucene Renovate major update and disable it

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -47,6 +47,13 @@
       "enabled": false
     },
     {
+      "description": "Skip lucene major updates to avoid breaking changes.",
+      "matchManagers": ["maven"],
+      "matchPackagePrefixes": ["org.apache.lucene"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
+    },
+    {
       "matchManagers": ["maven"],
       "matchPackagePrefixes": ["com.graphql-java"],
       "matchUpdateTypes": ["major"],

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -158,7 +158,7 @@
     <version.elasticsearch-test-container>1.19.8</version.elasticsearch-test-container>
     <version.postgres-test-container>1.19.8</version.postgres-test-container>
     <version.elasticsearch7>7.17.21</version.elasticsearch7>
-    <version.lucene>9.10.0</version.lucene>
+    <version.lucene>8.11.3</version.lucene>
     <version.android-json>0.0.20131108.vaadin1</version.android-json>
     <version.hdr-histogram>2.2.1</version.hdr-histogram>
     <version.joda-time>2.12.7</version.joda-time>


### PR DESCRIPTION
## Description
Reverting Renovate PR https://github.com/camunda/camunda/pull/18829 containing breaking changes (Operate and Tasklist CIs are failing)
Disabling Lucene major updates to avoid this happening again
## Related issues

closes #
