### PR TITLE
deps: revert carbon update, prevent future ones for Operate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -83,12 +83,13 @@
       "enabled": false
     },
     {
-      "description": "Exclude frontend deps until migration is done in Operate (see issues #17736, #17844)",
+      "description": "Exclude frontend deps until migration is done in Operate (see issues #17736, #17844, #18851)",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["operate/**"],
       "matchPackagePatterns": [
         "react-router-dom",
-        "msw"
+        "msw",
+        "@carbon/react"
       ],
       "enabled": false
     },

--- a/operate/client/package.json
+++ b/operate/client/package.json
@@ -7,7 +7,7 @@
     "@bpmn-io/element-template-icon-renderer": "0.5.2",
     "@camunda/camunda-composite-components": "0.7.0",
     "@carbon/elements": "11.46.0",
-    "@carbon/react": "1.58.1",
+    "@carbon/react": "1.57.0",
     "@devbookhq/splitter": "1.4.2",
     "@floating-ui/react-dom": "2.1.0",
     "@loadable/component": "^5.15.3",

--- a/operate/client/yarn.lock
+++ b/operate/client/yarn.lock
@@ -1275,7 +1275,7 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
-"@carbon/icons-react@^11.42.0":
+"@carbon/icons-react@^11.41.0":
   version "11.42.0"
   resolved "https://registry.yarnpkg.com/@carbon/icons-react/-/icons-react-11.42.0.tgz#a02b5f7a728adce403b64edf98fe159e250d2e54"
   integrity sha512-tQDV9qqa3wcOgd8IIyXT/MN2ltJ1DfxsRF6H2HHsCs5I8uHQ5W+bNF9sKxdh6J+LzJAC8pNRAwLatguWpNwACg==
@@ -1305,16 +1305,16 @@
   dependencies:
     "@ibm/telemetry-js" "^1.5.0"
 
-"@carbon/react@1.58.1":
-  version "1.58.1"
-  resolved "https://registry.yarnpkg.com/@carbon/react/-/react-1.58.1.tgz#3ce948d0fdf1ae5dc978bedafe448bef6a0a6f43"
-  integrity sha512-AmQ6TV+JxqEoFAQZC1E/gj8poIfkIjnOcMOoeHmX5c+HgvOIg+dN5xl0K0Irfh+aqTn23DOzwJQGLjCe8EOf1Q==
+"@carbon/react@1.57.0":
+  version "1.57.0"
+  resolved "https://registry.yarnpkg.com/@carbon/react/-/react-1.57.0.tgz#a5788700a21bdf561f814d192a1e0927ca16faff"
+  integrity sha512-NjK9hgwJ8sdvUwYPcb33kTgSJ1uTLh1N5ebzEYwNxckgUePtaiv8fOBUxyLJ1hqohenVhw3/x4DiG3pzgVJi7Q==
   dependencies:
     "@babel/runtime" "^7.18.3"
     "@carbon/feature-flags" "^0.20.0"
-    "@carbon/icons-react" "^11.42.0"
+    "@carbon/icons-react" "^11.41.0"
     "@carbon/layout" "^11.22.0"
-    "@carbon/styles" "^1.58.0"
+    "@carbon/styles" "^1.57.0"
     "@floating-ui/react" "^0.26.0"
     "@ibm/telemetry-js" "^1.5.0"
     classnames "2.5.1"
@@ -1334,7 +1334,7 @@
     wicg-inert "^3.1.1"
     window-or-global "^1.0.1"
 
-"@carbon/styles@^1.58.0":
+"@carbon/styles@^1.57.0":
   version "1.58.0"
   resolved "https://registry.yarnpkg.com/@carbon/styles/-/styles-1.58.0.tgz#102dd0e7a83f6fcc0fc531676a0eb87036136877"
   integrity sha512-Prc2eAyK9n4tW1qB/gci3hPJfc8ThO4PFHWaLYu+W1unJ9BFkLaW5rTJ/K3p91FQcBlHRA5cGNCOrEphfTMqEw==


### PR DESCRIPTION
## Description

- Revert carbon update
- Exclude @carbon/react from renovate updates until bugfix is provided (see https://github.com/camunda/camunda/issues/18851)

## Related issues

related to https://github.com/camunda/camunda/issues/18851
