### PR TITLE
feat: pre-select migration target process version

### DIFF
--- a/operate/client/src/App/Processes/MigrationView/index.tsx
+++ b/operate/client/src/App/Processes/MigrationView/index.tsx
@@ -26,6 +26,7 @@ const MigrationView: React.FC = observer(() => {
   }, []);
 
   useEffect(() => {
+    processesStore.init();
     processesStore.fetchProcesses();
 
     return () => {

--- a/operate/client/src/modules/stores/processes/processes.migration.test.ts
+++ b/operate/client/src/modules/stores/processes/processes.migration.test.ts
@@ -289,4 +289,40 @@ describe('processes.migration store', () => {
     ]);
     window.clientConfig = undefined;
   });
+
+  it('should pre-set target process version', async () => {
+    // given: demoProcess version 1 as source process
+    locationSpy.mockImplementation(() => ({
+      ...originalWindow.location,
+      search: '?active=true&incidents=true&process=demoProcess&version=1',
+    }));
+
+    // when initializing processesStore
+    processesStore.init();
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+
+    await processesStore.fetchProcesses();
+
+    // then expect demoProcess version 3 to be pre-selected
+    expect(processesStore.selectedTargetProcessId).toBe('demoProcess3');
+    expect(processesStore.latestProcessVersion).toEqual(3);
+  });
+
+  it('should not pre-set target process version', async () => {
+    // given: demoProcess version 3 (latest version) as source process
+    locationSpy.mockImplementation(() => ({
+      ...originalWindow.location,
+      search: '?active=true&incidents=true&process=demoProcess&version=3',
+    }));
+
+    // when initializing processesStore
+    processesStore.init();
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+
+    await processesStore.fetchProcesses();
+
+    // then expect no target version to be selected
+    expect(processesStore.selectedTargetProcessId).toBe(undefined);
+    expect(processesStore.latestProcessVersion).toEqual(undefined);
+  });
 });


### PR DESCRIPTION
## Description

### Update processes migration store 
`latestProcessVersion`: determine if there is a newer version available for the selected source process.
`init`: add autorun to check `latestProcessVersion` and update selected target process and version if possible

This will pre-select the target process and version in the dropdown

## Related issues

closes #18761 
