### PR TITLE
refactor: add @Qualifier to autowired objectMappers in Operate and Ta…

### DIFF
--- a/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
+++ b/operate/archiver/src/main/java/io/camunda/operate/archiver/ElasticsearchArchiverRepository.java
@@ -83,7 +83,10 @@ public class ElasticsearchArchiverRepository implements ArchiverRepository {
   @Autowired private OperateProperties operateProperties;
   @Autowired private Metrics metrics;
   @Autowired private RestHighLevelClient esClient;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   private ArchiveBatch createArchiveBatch(
       final SearchResponse searchResponse,

--- a/operate/common/src/main/java/io/camunda/operate/util/PayloadUtil.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/PayloadUtil.java
@@ -17,12 +17,15 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PayloadUtil {
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   public Map<String, Object> parsePayload(String payload) throws IOException {
 

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/util/DecisionDataUtil.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/util/DecisionDataUtil.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -53,7 +54,11 @@ public class DecisionDataUtil {
   @Autowired protected DecisionStore decisionStore;
   private Map<Class<? extends OperateEntity>, String> entityToESAliasMap;
   private final Random random = new Random();
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
+
   @Autowired private DecisionInstanceTemplate decisionInstanceTemplate;
 
   @Autowired private DecisionRequirementsIndex decisionRequirementsIndex;

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/DecisionZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/DecisionZeebeRecordProcessor.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -36,7 +37,9 @@ public class DecisionZeebeRecordProcessor {
     STATES.add(ProcessIntent.CREATED.name());
   }
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private DecisionIndex decisionIndex;
 

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/ImportBulkProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/ImportBulkProcessor.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -68,7 +69,9 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
 
   @Autowired private Metrics metrics;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   private ObjectMapper localObjectMapper;
 

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/DecisionZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/DecisionZeebeRecordProcessor.java
@@ -23,6 +23,7 @@ import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -36,7 +37,9 @@ public class DecisionZeebeRecordProcessor {
     STATES.add(ProcessIntent.CREATED.name());
   }
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private DecisionIndex decisionIndex;
 

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ImportBulkProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/ImportBulkProcessor.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -68,7 +69,9 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
 
   @Autowired private Metrics metrics;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   private ObjectMapper localObjectMapper;
 

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/IncidentNotifier.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/IncidentNotifier.java
@@ -56,7 +56,9 @@ public class IncidentNotifier {
   private static final Logger LOGGER = LoggerFactory.getLogger(IncidentNotifier.class);
   @Autowired private OperateProperties operateProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private M2mTokenManager m2mTokenManager;
 

--- a/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/M2mTokenManager.java
+++ b/operate/importer-common/src/main/java/io/camunda/operate/zeebeimport/M2mTokenManager.java
@@ -15,6 +15,7 @@ import io.camunda.operate.property.OperateProperties;
 import java.util.Date;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -37,7 +38,9 @@ public class M2mTokenManager {
 
   @Autowired private OperateProperties operateProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private RestTemplateBuilder builder;
 

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/ImportJob.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +51,9 @@ public class ImportJob implements Callable<Boolean> {
 
   @Autowired private ZeebeStore zeebeStore;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private OperateProperties operateProperties;
 

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/elasticsearch/ElasticsearchIncidentPostImportAction.java
@@ -53,6 +53,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.lang.Nullable;
@@ -79,7 +80,9 @@ public class ElasticsearchIncidentPostImportAction extends AbstractIncidentPostI
 
   @Autowired private PostImporterQueueTemplate postImporterQueueTemplate;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   public ElasticsearchIncidentPostImportAction(final int partitionId) {
     super(partitionId);

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/BatchOperationRestServiceIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/BatchOperationRestServiceIT.java
@@ -10,7 +10,11 @@ package io.camunda.operate.rest;
 import static io.camunda.operate.webapp.rest.dto.listview.SortValuesWrapper.createFrom;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
+import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.util.OperateAbstractIT;
 import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.operate.webapp.reader.BatchOperationReader;
@@ -25,7 +29,11 @@ import org.springframework.test.web.servlet.MvcResult;
     classes = {
       TestApplicationWithNoBeans.class,
       BatchOperationRestService.class,
-      OperateProfileService.class
+      OperateProfileService.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class,
+      OperateProperties.class
     })
 public class BatchOperationRestServiceIT extends OperateAbstractIT {
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/HealthCheckAuthenticationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/rest/HealthCheckAuthenticationIT.java
@@ -11,9 +11,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
 import io.camunda.operate.connect.OpensearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.management.IndicesHealthIndicator;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.rest.HealthCheckIT.AddManagementPropertiesInitializer;
@@ -66,6 +69,9 @@ import org.springframework.test.context.junit4.SpringRunner;
       OpensearchTaskStore.class,
       RichOpenSearchClient.class,
       OpensearchConnector.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class,
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ContextConfiguration(initializers = AddManagementPropertiesInitializer.class)

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexOldSchemaValidatorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/IndexOldSchemaValidatorIT.java
@@ -14,8 +14,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.OpensearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.qa.util.TestElasticsearchSchemaManager;
@@ -52,6 +54,10 @@ import org.springframework.test.context.junit4.SpringRunner;
       RichOpenSearchClient.class,
       OpensearchConnector.class,
       IndexDescriptor.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
       // Assume we have only 3 indices:
       ProcessIndex.class,
       UserIndex.class,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchChecks.java
@@ -61,7 +61,9 @@ public class ElasticsearchChecks {
 
   @Autowired UserTaskReader userTaskReader;
   @Autowired private RestHighLevelClient esClient;
+
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private ProcessReader processReader;
   @Autowired private ProcessInstanceReader processInstanceReader;
   @Autowired private FlowNodeInstanceReader flowNodeInstanceReader;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/ElasticsearchTestRuleProvider.java
@@ -108,7 +108,9 @@ public class ElasticsearchTestRuleProvider implements SearchTestRuleProvider {
   @Autowired private DecisionRequirementsIndex decisionRequirementsIndex;
   @Autowired private DecisionIndex decisionIndex;
   @Autowired private SchemaManager schemaManager;
+
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private TestImportListener testImportListener;
   private String indexPrefix;
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/InternalAPIErrorControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/InternalAPIErrorControllerIT.java
@@ -54,7 +54,9 @@ public class InternalAPIErrorControllerIT {
   @Autowired private MockMvc mockMvc;
   @MockBean private OperationReader operationReader;
   @MockBean private OperateProfileService mockProfileService;
+
   @Autowired private ObjectMapper objectMapper;
+
   private MockHttpServletRequestBuilder mockGetRequest;
 
   @Before

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/es/AuthenticationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/es/AuthenticationIT.java
@@ -13,8 +13,11 @@ import static io.camunda.operate.webapp.security.Permission.WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.entities.UserEntity;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.UserStore;
@@ -76,7 +79,10 @@ import org.springframework.test.context.junit4.SpringRunner;
       ElasticsearchTaskStore.class,
       RetryElasticsearchClient.class,
       OperateProfileService.class,
-      ElasticsearchConnector.class
+      ElasticsearchConnector.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/es/AuthenticationWithPersistentSessionsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/es/AuthenticationWithPersistentSessionsIT.java
@@ -14,8 +14,11 @@ import static io.camunda.operate.webapp.security.Permission.WRITE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.entities.UserEntity;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.indices.OperateWebSessionIndex;
@@ -86,7 +89,10 @@ import org.springframework.test.context.junit4.SpringRunner;
       OperateWebSessionIndex.class,
       OperateProfileService.class,
       ElasticsearchConnector.class,
-      ElasticsearchSessionRepository.class
+      ElasticsearchSessionRepository.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/es/CsrfTokenIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/es/CsrfTokenIT.java
@@ -15,8 +15,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
 
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.entities.UserEntity;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.store.UserStore;
@@ -79,7 +82,10 @@ import org.springframework.util.MultiValueMap;
       OperateProfileService.class,
       ElasticsearchConnector.class,
       ProcessRestService.class,
-      ProcessDefinitionController.class
+      ProcessDefinitionController.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
     properties = {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationWithPersistentSessionsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/identity/AuthenticationWithPersistentSessionsIT.java
@@ -17,9 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
 import io.camunda.operate.connect.OpensearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.indices.OperateWebSessionIndex;
 import io.camunda.operate.store.elasticsearch.ElasticsearchTaskStore;
@@ -87,7 +90,10 @@ import org.springframework.test.context.junit4.SpringRunner;
       RichOpenSearchClient.class,
       OpensearchConnector.class,
       PermissionConverter.class,
-      SecurityContextWrapper.class
+      SecurityContextWrapper.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class
     },
     properties = {
       "server.servlet.context-path=" + AuthenticationWithPersistentSessionsIT.CONTEXT_PATH,

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/ldap/AuthenticationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/ldap/AuthenticationIT.java
@@ -9,8 +9,11 @@ package io.camunda.operate.webapp.security.ldap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.indices.OperateWebSessionIndex;
 import io.camunda.operate.store.elasticsearch.ElasticsearchTaskStore;
@@ -58,7 +61,10 @@ import org.testcontainers.containers.GenericContainer;
       SessionService.class,
       OperateWebSessionIndex.class,
       OperateProfileService.class,
-      ElasticsearchConnector.class
+      ElasticsearchConnector.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class
     },
     properties = {
       "camunda.operate.ldap.baseDn=dc=planetexpress,dc=com",

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationIT.java
@@ -120,7 +120,9 @@ public class AuthenticationIT implements AuthenticationTestable {
   @MockBean private AuthenticationController authenticationController;
   @SpyBean private Auth0Service auth0Service;
   @Autowired private BeanFactory beanFactory;
+
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private ApplicationContext applicationContext;
 
   @MockBean

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/security/sso/AuthenticationWithPersistentSessionsIT.java
@@ -27,9 +27,12 @@ import com.auth0.AuthenticationController;
 import com.auth0.AuthorizeUrl;
 import com.auth0.IdentityVerificationException;
 import com.auth0.Tokens;
+import io.camunda.operate.JacksonConfig;
 import io.camunda.operate.OperateProfileService;
+import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.connect.ElasticsearchConnector;
 import io.camunda.operate.connect.OpensearchConnector;
+import io.camunda.operate.connect.OperateDateTimeFormatter;
 import io.camunda.operate.management.IndicesCheck;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.indices.OperateWebSessionIndex;
@@ -112,7 +115,10 @@ import org.springframework.web.client.RestTemplate;
       ElasticsearchSessionRepository.class,
       OpensearchSessionRepository.class,
       RichOpenSearchClient.class,
-      OpensearchConnector.class
+      OpensearchConnector.class,
+      JacksonConfig.class,
+      OperateDateTimeFormatter.class,
+      DatabaseInfo.class
     },
     properties = {
       "server.servlet.context-path=" + AuthenticationWithPersistentSessionsIT.CONTEXT_PATH,

--- a/operate/qa/migration-performance-test/src/main/java/io/camunda/operate/qa/migration/performance/DataMultiplicator.java
+++ b/operate/qa/migration-performance-test/src/main/java/io/camunda/operate/qa/migration/performance/DataMultiplicator.java
@@ -67,6 +67,7 @@ public class DataMultiplicator implements CommandLineRunner {
               SequenceFlowTemplate.class, SequenceFlowEntity.class,
               VariableTemplate.class, VariableEntity.class,
               IncidentTemplate.class, IncidentEntity.class);
+
   @Autowired private ObjectMapper objectMapper;
 
   public static void main(final String[] args) {

--- a/operate/qa/query-performance-tests/src/test/java/io/camunda/operate/qa/performance/ParametersResolver.java
+++ b/operate/qa/query-performance-tests/src/test/java/io/camunda/operate/qa/performance/ParametersResolver.java
@@ -71,6 +71,7 @@ public class ParametersResolver {
   private String prefix;
 
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private ProcessIndex processIndex;
   @Autowired private ListViewTemplate listViewTemplate;
   @Autowired private VariableTemplate variableTemplate;

--- a/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/elasticsearch/ElasticsearchSchemaManager.java
@@ -52,6 +52,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -71,7 +72,10 @@ public class ElasticsearchSchemaManager implements SchemaManager {
   @Autowired protected OperateProperties operateProperties;
   @Autowired private List<AbstractIndexDescriptor> indexDescriptors;
   @Autowired private List<TemplateDescriptor> templateDescriptors;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public void createSchema() {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchFillPostImporterQueuePlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchFillPostImporterQueuePlan.java
@@ -47,6 +47,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -63,7 +64,10 @@ public class ElasticsearchFillPostImporterQueuePlan implements FillPostImporterQ
 
   @Autowired private MigrationProperties migrationProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
+
   @Autowired private RestHighLevelClient esClient;
 
   private Long flowNodesWithIncidentsCount;

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchReindexWithQueryAndScriptPlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchReindexWithQueryAndScriptPlan.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -60,7 +61,9 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
   @Autowired private MigrationProperties migrationProperties;
   private String listViewIndexName;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private RestHighLevelClient esClient;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchBatchRequest.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchBatchRequest.java
@@ -31,6 +31,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -44,7 +45,9 @@ public class ElasticsearchBatchRequest implements BatchRequest {
 
   private final BulkRequest bulkRequest = new BulkRequest();
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private OperateProperties operateProperties;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchImportStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchImportStore.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -53,7 +54,9 @@ public class ElasticsearchImportStore implements ImportStore {
 
   @Autowired private RetryElasticsearchClient retryElasticsearchClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchIncidentStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchIncidentStore.java
@@ -47,6 +47,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -61,7 +62,9 @@ public class ElasticsearchIncidentStore implements IncidentStore {
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private IncidentTemplate incidentTemplate;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchOperationStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchOperationStore.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -52,7 +53,10 @@ import org.springframework.stereotype.Component;
 public class ElasticsearchOperationStore implements OperationStore {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchOperationStore.class);
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private RestHighLevelClient esClient;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchSequenceFlowStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchSequenceFlowStore.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +44,9 @@ public class ElasticsearchSequenceFlowStore implements SequenceFlowStore {
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public List<SequenceFlowEntity> getSequenceFlowsByProcessInstanceKey(Long processInstanceKey) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchTaskStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchTaskStore.java
@@ -26,6 +26,7 @@ import org.elasticsearch.tasks.TaskInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +45,9 @@ public class ElasticsearchTaskStore implements TaskStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchTaskStore.class);
   @Autowired private RestHighLevelClient esClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   public Either<IOException, TaskResponse> getTaskResponse(final String taskId) {
     try {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/RetryElasticsearchClient.java
@@ -81,6 +81,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -99,7 +100,11 @@ public class RetryElasticsearchClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(RetryElasticsearchClient.class);
   @Autowired private RestHighLevelClient esClient;
   @Autowired private ElasticsearchTaskStore elasticsearchTaskStore;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
+
   private RequestOptions requestOptions = RequestOptions.DEFAULT;
   private int numberOfRetries = DEFAULT_NUMBER_OF_RETRIES;
   private int delayIntervalInSeconds = DEFAULT_DELAY_INTERVAL_IN_SECONDS;

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchImportStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchImportStore.java
@@ -33,6 +33,7 @@ import org.opensearch.client.opensearch.indices.PutMappingRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -44,7 +45,9 @@ public class OpensearchImportStore implements ImportStore {
   @Autowired private ImportPositionIndex importPositionType;
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchSequenceFlowStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchSequenceFlowStore.java
@@ -22,6 +22,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +34,9 @@ public class OpensearchSequenceFlowStore implements SequenceFlowStore {
 
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public List<SequenceFlowEntity> getSequenceFlowsByProcessInstanceKey(Long processInstanceKey) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/backup/ElasticsearchBackupRepository.java
@@ -61,6 +61,7 @@ import org.elasticsearch.transport.TransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -72,7 +73,10 @@ public class ElasticsearchBackupRepository implements BackupRepository {
       "type=repository_missing_exception";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchBackupRepository.class);
   @Autowired private RestHighLevelClient esClient;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public void deleteSnapshot(String repositoryName, String snapshotName) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/BatchOperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/BatchOperationReader.java
@@ -35,6 +35,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +51,9 @@ public class BatchOperationReader implements io.camunda.operate.webapp.reader.Ba
 
   @Autowired private RestHighLevelClient esClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public List<BatchOperationEntity> getBatchOperations(

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ListViewReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ListViewReader.java
@@ -45,6 +45,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -56,7 +57,9 @@ public class ListViewReader implements io.camunda.operate.webapp.reader.ListView
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private OperationReader operationReader;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/writer/BatchOperationWriter.java
@@ -64,6 +64,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -81,7 +82,9 @@ public class BatchOperationWriter implements io.camunda.operate.webapp.writer.Ba
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private OperationTemplate operationTemplate;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchBatchOperationReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchBatchOperationReader.java
@@ -28,6 +28,7 @@ import org.opensearch.client.opensearch._types.SortOptions;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -36,7 +37,11 @@ import org.springframework.stereotype.Component;
 public class OpensearchBatchOperationReader implements BatchOperationReader {
   @Autowired private BatchOperationTemplate batchOperationTemplate;
   @Autowired private UserService<?> userService;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
+
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
   @Override

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchVariableReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/reader/OpensearchVariableReader.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +47,9 @@ public class OpensearchVariableReader implements VariableReader {
 
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public List<VariableDto> getVariables(String processInstanceId, VariableRequestDto request) {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/opensearch/writer/OpensearchBatchOperationWriter.java
@@ -67,6 +67,7 @@ import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -84,7 +85,9 @@ public class OpensearchBatchOperationWriter
 
   @Autowired private RichOpenSearchClient richOpenSearchClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private OperationTemplate operationTemplate;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/BatchOperationRestService.java
@@ -20,6 +20,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -34,7 +35,9 @@ public class BatchOperationRestService extends InternalAPIErrorController {
 
   @Autowired private BatchOperationReader batchOperationReader;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Operation(summary = "Query batch operations")
   @PostMapping

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/SingleStepModifyProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/process/modify/SingleStepModifyProcessInstanceHandler.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 // Modify Process Instance Implementation to execute all given modifications in one Zeebe
@@ -38,7 +39,11 @@ public class SingleStepModifyProcessInstanceHandler extends AbstractOperationHan
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(SingleStepModifyProcessInstanceHandler.class);
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
+
   @Autowired private OperationsManager operationsManager;
   @Autowired private MoveTokenHandler moveTokenHandler;
   @Autowired private AddTokenHandler addTokenHandler;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -61,6 +61,7 @@ import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBui
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -78,7 +79,10 @@ public class OpenSearchConnector {
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchConnector.class);
 
   @Autowired private TasklistProperties tasklistProperties;
-  @Autowired private ObjectMapper tasklistObjectMapper;
+
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper tasklistObjectMapper;
 
   @Bean
   public OpenSearchClient openSearchClient() {

--- a/tasklist/common/src/main/java/io/camunda/tasklist/util/PayloadUtil.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/util/PayloadUtil.java
@@ -17,12 +17,15 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class PayloadUtil {
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public Map<String, Object> parsePayload(String payload) throws IOException {
 

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -54,7 +55,9 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
 
   private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   private boolean shutdown = false;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/ElasticsearchInternalTask.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/ElasticsearchInternalTask.java
@@ -28,6 +28,7 @@ import org.elasticsearch.tasks.TaskInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -59,7 +60,9 @@ public class ElasticsearchInternalTask {
 
   @Autowired private RestHighLevelClient esClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public Either<IOException, TaskResponse> getTaskResponse(final String taskId) {
     try {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
@@ -43,6 +43,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -57,7 +58,10 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
   @Autowired private RestHighLevelClient esClient;
   @Autowired private DraftTaskVariableTemplate draftTaskVariableTemplate;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public void createOrUpdate(Collection<DraftTaskVariableEntity> draftVariables) {
     final BulkRequest bulkRequest = new BulkRequest();

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +56,9 @@ public class FormStoreElasticSearch implements FormStore {
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private RestHighLevelClient esClient;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessInstanceStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessInstanceStoreElasticSearch.java
@@ -37,6 +37,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -61,7 +62,9 @@ public class ProcessInstanceStoreElasticSearch implements ProcessInstanceStore {
 
   @Autowired TasklistProperties tasklistProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public DeletionStatus deleteProcessInstance(final String processInstanceId) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/ProcessStoreElasticSearch.java
@@ -38,6 +38,7 @@ import org.elasticsearch.search.collapse.CollapseBuilder;
 import org.elasticsearch.search.sort.SortBuilders;
 import org.elasticsearch.search.sort.SortOrder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -53,7 +54,9 @@ public class ProcessStoreElasticSearch implements ProcessStore {
 
   @Autowired private ProcessIndex processIndex;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TasklistProperties tasklistProperties;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -54,7 +55,10 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskMetricsStoreElasticSearch.class);
   @Autowired private MetricIndex index;
   @Autowired private RestHighLevelClient esClient;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public void registerTaskCompleteEvent(TaskEntity task) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -74,6 +74,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -99,7 +100,9 @@ public class TaskStoreElasticSearch implements TaskStore {
 
   @Autowired private TaskVariableTemplate taskVariableTemplate;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public TaskEntity getTask(final String id) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -73,6 +73,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -87,7 +88,10 @@ public class VariableStoreElasticSearch implements VariableStore {
   @Autowired private VariableIndex variableIndex;
   @Autowired private TaskVariableTemplate taskVariableTemplate;
   @Autowired private TasklistProperties tasklistProperties;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public List<VariableEntity> getVariablesByFlowNodeInstanceIds(
       List<String> flowNodeInstanceIds, List<String> varNames, final Set<String> fieldNames) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/ProcessStoreOpenSearch.java
@@ -43,6 +43,7 @@ import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.search.FieldCollapse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -62,7 +63,9 @@ public class ProcessStoreOpenSearch implements ProcessStore {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public ProcessEntity getProcessByProcessDefinitionKey(String processDefinitionKey) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -90,7 +90,9 @@ public class TaskStoreOpenSearch implements TaskStore {
 
   @Autowired private TaskTemplate taskTemplate;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private VariableStore variableStoreElasticSearch;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/BulkProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/BulkProcessorElasticSearch.java
@@ -33,6 +33,7 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +56,9 @@ public class BulkProcessorElasticSearch extends AbstractImportBatchProcessorElas
 
   @Autowired private UserTaskZeebeRecordProcessorElasticSearch userTaskZeebeRecordProcessor;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/FormZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/FormZeebeRecordProcessorElasticSearch.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -35,7 +36,9 @@ public class FormZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FormZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private FormIndex formIndex;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/JobZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/JobZeebeRecordProcessorElasticSearch.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +47,9 @@ public class JobZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -62,7 +63,9 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
     PROCESS_INSTANCE_STATES.add(ELEMENT_TERMINATED.name());
   }
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private FlowNodeInstanceIndex flowNodeInstanceIndex;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -47,7 +48,9 @@ public class ProcessZeebeRecordProcessorElasticSearch {
   private static final Set<String> STATES_TO_PERSIST = Set.of(ProcessIntent.CREATED.name());
   private static final Set<String> STATES_TO_DELETE = Set.of(ProcessIntent.DELETED.name());
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private ProcessIndex processIndex;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -42,7 +43,9 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(UserTaskZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/VariableZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/VariableZeebeRecordProcessorElasticSearch.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,7 +35,9 @@ public class VariableZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(VariableZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private VariableIndex variableIndex;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/JobZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/JobZeebeRecordProcessorOpenSearch.java
@@ -35,6 +35,7 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -45,7 +46,9 @@ public class JobZeebeRecordProcessorOpenSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorOpenSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/OpenSearchBulkProcessor.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/OpenSearchBulkProcessor.java
@@ -33,6 +33,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +56,9 @@ public class OpenSearchBulkProcessor extends AbstractImportBatchProcessorOpenSea
 
   @Autowired private UserTaskZeebeRecordProcessorOpenSearch userTaskZeebeRecordProcessor;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
@@ -34,6 +34,7 @@ import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -62,7 +63,9 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
     PROCESS_INSTANCE_STATES.add(ELEMENT_TERMINATED.name());
   }
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private FlowNodeInstanceIndex flowNodeInstanceIndex;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
@@ -34,6 +34,7 @@ import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -46,7 +47,9 @@ public class ProcessZeebeRecordProcessorOpenSearch {
 
   private static final Set<String> STATES_TO_DELETE = Set.of(ProcessIntent.DELETED.name());
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private ProcessIndex processIndex;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -33,6 +33,7 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +44,9 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(UserTaskZeebeRecordProcessorOpenSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/BulkProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/BulkProcessorElasticSearch.java
@@ -33,6 +33,7 @@ import org.elasticsearch.action.bulk.BulkRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +56,9 @@ public class BulkProcessorElasticSearch extends AbstractImportBatchProcessorElas
 
   @Autowired private UserTaskZeebeRecordProcessorElasticSearch userTaskZeebeRecordProcessor;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/FormZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/FormZeebeRecordProcessorElasticSearch.java
@@ -27,6 +27,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -35,7 +36,9 @@ public class FormZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(FormZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private FormIndex formIndex;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/JobZeebeRecordProcessorElasticSearch.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -46,7 +47,9 @@ public class JobZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessInstanceZeebeRecordProcessorElasticSearch.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -62,7 +63,9 @@ public class ProcessInstanceZeebeRecordProcessorElasticSearch {
     PROCESS_INSTANCE_STATES.add(ELEMENT_TERMINATED.name());
   }
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private FlowNodeInstanceIndex flowNodeInstanceIndex;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
@@ -36,6 +36,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -47,7 +48,9 @@ public class ProcessZeebeRecordProcessorElasticSearch {
   private static final Set<String> STATES_TO_PERSIST = Set.of(ProcessIntent.CREATED.name());
   private static final Set<String> STATES_TO_DELETE = Set.of(ProcessIntent.DELETED.name());
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private ProcessIndex processIndex;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/UserTaskZeebeRecordProcessorElasticSearch.java
@@ -32,6 +32,7 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -42,7 +43,9 @@ public class UserTaskZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(UserTaskZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/VariableZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/VariableZeebeRecordProcessorElasticSearch.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -34,7 +35,9 @@ public class VariableZeebeRecordProcessorElasticSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(VariableZeebeRecordProcessorElasticSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private VariableIndex variableIndex;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/JobZeebeRecordProcessorOpenSearch.java
@@ -35,6 +35,7 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -45,7 +46,9 @@ public class JobZeebeRecordProcessorOpenSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(JobZeebeRecordProcessorOpenSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/OpenSearchBulkProcessor.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/OpenSearchBulkProcessor.java
@@ -33,6 +33,7 @@ import org.opensearch.client.opensearch.core.bulk.BulkOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -55,7 +56,9 @@ public class OpenSearchBulkProcessor extends AbstractImportBatchProcessorOpenSea
 
   @Autowired private UserTaskZeebeRecordProcessorOpenSearch userTaskZeebeRecordProcessor;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessInstanceZeebeRecordProcessorOpenSearch.java
@@ -34,6 +34,7 @@ import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -62,7 +63,9 @@ public class ProcessInstanceZeebeRecordProcessorOpenSearch {
     PROCESS_INSTANCE_STATES.add(ELEMENT_TERMINATED.name());
   }
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private FlowNodeInstanceIndex flowNodeInstanceIndex;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
@@ -34,6 +34,7 @@ import org.opensearch.client.opensearch.core.bulk.IndexOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -46,7 +47,9 @@ public class ProcessZeebeRecordProcessorOpenSearch {
 
   private static final Set<String> STATES_TO_DELETE = Set.of(ProcessIntent.DELETED.name());
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private ProcessIndex processIndex;
 

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/UserTaskZeebeRecordProcessorOpenSearch.java
@@ -33,6 +33,7 @@ import org.opensearch.client.opensearch.core.bulk.UpdateOperation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -43,7 +44,9 @@ public class UserTaskZeebeRecordProcessorOpenSearch {
   private static final Logger LOGGER =
       LoggerFactory.getLogger(UserTaskZeebeRecordProcessorOpenSearch.class);
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/CUSTOMCopyProcessesFromOptimize.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/CUSTOMCopyProcessesFromOptimize.java
@@ -37,6 +37,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 // TODO This class was used on the recover of aliases (I'm keeping it here for one release just in
 // case - This should be removed on 8.5 -- notice that is not enabled with @Component and is not
@@ -54,7 +55,9 @@ public class CUSTOMCopyProcessesFromOptimize {
 
   @Autowired private FormIndex formIndex;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public void copyProcesses() {
     String scrollId = null;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.given;
 
+import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.es.ElasticsearchConnector;
 import io.camunda.tasklist.es.ElasticsearchInternalTask;
 import io.camunda.tasklist.es.RetryElasticsearchClient;
@@ -51,7 +52,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       RetryElasticsearchClient.class,
       ElasticsearchInternalTask.class,
       TasklistProperties.class,
-      ElasticsearchConnector.class
+      ElasticsearchConnector.class,
+      JacksonConfig.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({AUTH_PROFILE, "tasklist", "test"})

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckIT.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import io.camunda.tasklist.JacksonConfig;
 import io.camunda.tasklist.es.ElasticsearchConnector;
 import io.camunda.tasklist.es.ElasticsearchInternalTask;
 import io.camunda.tasklist.es.RetryElasticsearchClient;
@@ -47,7 +48,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       RetryElasticsearchClient.class,
       ElasticsearchInternalTask.class,
       TasklistProperties.class,
-      ElasticsearchConnector.class
+      ElasticsearchConnector.class,
+      JacksonConfig.class
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({"tasklist", "test"})

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -80,7 +80,9 @@ public class ElasticsearchTestExtension
   @Autowired protected RecordsReaderHolder recordsReaderHolder;
   protected boolean failed = false;
   @Autowired private SchemaManager elasticsearchSchemaManager;
+
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private TestImportListener testImportListener;
   private String indexPrefix;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/IdentityTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/IdentityTester.java
@@ -52,7 +52,9 @@ public abstract class IdentityTester extends SessionlessTasklistZeebeIntegration
       Map.of(USER, KEYCLOAK_PASSWORD, USER_2, KEYCLOAK_PASSWORD_2);
   private static JwtDecoder jwtDecoder;
   @Autowired private static TestContainerUtil testContainerUtil;
+
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private IdentityJwt2AuthenticationTokenConverter jwtAuthenticationConverter;
 
   protected static void beforeClass(final boolean multiTenancyEnabled) {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -75,7 +75,9 @@ public class OpenSearchTestExtension
   @Autowired protected RecordsReaderHolder recordsReaderHolder;
   protected boolean failed = false;
   @Autowired private SchemaManager schemaManager;
+
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private TestImportListener testImportListener;
   private String indexPrefix;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/SessionlessTasklistZeebeIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/SessionlessTasklistZeebeIntegrationTest.java
@@ -68,6 +68,7 @@ public abstract class SessionlessTasklistZeebeIntegrationTest extends TasklistIn
   @Autowired private ProcessService processService;
   private String workerName;
   @Autowired private MeterRegistry meterRegistry;
+
   @Autowired private ObjectMapper objectMapper;
 
   private HttpClient httpClient = HttpClient.newHttpClient();

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/FormControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/FormControllerIT.java
@@ -30,6 +30,7 @@ public class FormControllerIT extends TasklistZeebeIntegrationTest {
   @Autowired private WebApplicationContext context;
 
   @Autowired private ObjectMapper objectMapper;
+
   private MockMvcHelper mockMvcHelper;
 
   private boolean initializedLinkedTests = false;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/se/AuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/se/AuthenticationIT.java
@@ -51,6 +51,7 @@ public class AuthenticationIT extends TasklistIntegrationTest implements Authent
   @Autowired private TestRestTemplate testRestTemplate;
 
   @Autowired private PasswordEncoder encoder;
+
   @Autowired private ObjectMapper objectMapper;
 
   @MockBean private UserStore userStore;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/se/AuthenticationWithPersistentSessionIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/se/AuthenticationWithPersistentSessionIT.java
@@ -51,6 +51,7 @@ public class AuthenticationWithPersistentSessionIT extends TasklistIntegrationTe
   @Autowired private TestRestTemplate testRestTemplate;
 
   @Autowired private PasswordEncoder encoder;
+
   @Autowired private ObjectMapper objectMapper;
 
   @MockBean private UserStore userStore;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportDeleteProcessIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportDeleteProcessIT.java
@@ -27,6 +27,7 @@ public class ZeebeImportDeleteProcessIT extends TasklistZeebeIntegrationTest {
   @Autowired private WebApplicationContext context;
 
   @Autowired private ObjectMapper objectMapper;
+
   private MockMvcHelper mockMvcHelper;
 
   @BeforeEach

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportMigrateProcessTaskIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportMigrateProcessTaskIT.java
@@ -33,6 +33,7 @@ public class ZeebeImportMigrateProcessTaskIT extends TasklistZeebeIntegrationTes
   @Autowired private WebApplicationContext context;
 
   @Autowired private ObjectMapper objectMapper;
+
   private MockMvcHelper mockMvcHelper;
 
   @BeforeEach

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportMultipleProcessesIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportMultipleProcessesIT.java
@@ -32,6 +32,7 @@ public class ZeebeImportMultipleProcessesIT extends TasklistZeebeIntegrationTest
   @Autowired private WebApplicationContext context;
 
   @Autowired private ObjectMapper objectMapper;
+
   @Autowired private ProcessStore processStore;
   private MockMvcHelper mockMvcHelper;
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -62,6 +62,7 @@ import org.elasticsearch.transport.TransportException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -82,7 +83,9 @@ public class BackupManagerElasticSearch extends BackupManager {
 
   @Autowired private RestHighLevelClient esClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   private Queue<CreateSnapshotRequest> requestsQueue = new ConcurrentLinkedQueue<>();
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/OpenSearchSessionRepository.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/OpenSearchSessionRepository.java
@@ -68,7 +68,9 @@ public class OpenSearchSessionRepository
 
   @Autowired private HttpServletRequest request;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @PostConstruct
   private void setUp() {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
@@ -56,7 +57,10 @@ public class UserStoreElasticSearch implements UserStore {
 
   @Autowired private UserIndex userIndex;
   @Autowired private RestHighLevelClient esClient;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public UserEntity getByUserId(String userId) {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
@@ -34,6 +34,7 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -42,7 +43,9 @@ public class ProcessService {
 
   @Autowired private ZeebeClient zeebeClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private TenantService tenantService;
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpServerErrorException;
 
@@ -50,7 +51,11 @@ public class TaskService {
   @Autowired private ZeebeClient zeebeClient;
   @Autowired private TaskStore taskStore;
   @Autowired private VariableService variableService;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
+
   @Autowired private Metrics metrics;
   @Autowired private TaskMetricsStore taskMetricsStore;
   @Autowired private AssigneeMigrator assigneeMigrator;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/VariableService.java
@@ -50,6 +50,7 @@ import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -63,7 +64,10 @@ public class VariableService {
   @Autowired private DraftVariableStore draftVariableStore;
   @Autowired private TasklistProperties tasklistProperties;
   @Autowired private TaskValidator taskValidator;
-  @Autowired private ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   public void persistDraftTaskVariables(String taskId, List<VariableInputDTO> draftTaskVariables) {
     try {


### PR DESCRIPTION
…sklist

## Description
Adding `@Qualifier("operateObjectMapper")` and `@Qualifier("tasklistObjectMapper")` to the autowired ObjectMappers in Operate and Tasklist. This is required to the select right `ObjectMapper` bean defined in [Operate](https://github.com/camunda/camunda/blob/d0c38ef50b69fdf2b5d18137bddb22b70755df4e/operate/common/src/main/java/io/camunda/operate/JacksonConfig.java#L31) or [Tasklist](https://github.com/camunda/camunda/blob/d0c38ef50b69fdf2b5d18137bddb22b70755df4e/tasklist/common/src/main/java/io/camunda/tasklist/JacksonConfig.java#L31), when they are run together in Single application mode.

it would have been better if we create a single bean implementation for both. But the dateTime serialization configuration is different and having a single implementation requires assessing the impacts on the API and the datetime stored in ES

## Related issues

closes #
