### PR TITLE
Enable improved conflict resolution for backports

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -43,3 +43,8 @@ jobs:
 
             relates to ${issue_refs}
             original author: @${pull_author}
+
+          experimental: >
+            {
+              "conflict_resolution": "draft_commit_conflicts"
+            }

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -28,13 +28,11 @@ jobs:
           # Token for git actions, e.g. git push
           token: ${{ secrets.BACKPORT_ACTION_PAT }}
       - name: Create backport PRs
-        uses: korthout/backport-action@v2
+        uses: korthout/backport-action@v3
         with:
-          # Optional
           # Token to authenticate requests to GitHub
           github_token: ${{ secrets.BACKPORT_ACTION_PAT }}
 
-          # Optional
           # Template used as description in the pull requests created by this action.
           # Placeholders can be used to define variable values.
           # These are indicated by a dollar sign and curly braces (`${placeholder}`).


### PR DESCRIPTION
## Description

Enables the [experimental conflict resolution feature](https://github.com/korthout/backport-action?tab=readme-ov-file#conflict_resolution). When there are conflicts encountered during the cherry-picking, the conflicts are committed and pushed. The resulting pull request is opened in draft mode, with additional instructions how to resolve the conflicts. This helps reduce the manual efforts like opening the pull request (choosing the base, providing a pull request title and description and such).

---

This pull request also bumps [backport-action](https://github.com/korthout/backport-action) to the latest version: `v3`. This major version changes which commits are cherry-picked based on the method used to merge the pull request:
- For "Squash and merge", the action cherry-picks the squashed commit.
- For "Rebase and merge", the action cherry-picks the rebased commits.
- For "Merged as a merge commit", the action cherry-picks the commits from the pull request.

AFAIK, all projects in this repo only merge pull requests using a merge commit. This was the behavior prior to v3. This means this behavior change doesn't affect us.

## Related issues

NA
