### PR TITLE
feat: flow control includes exporting

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -615,6 +615,9 @@
           # minLimit: 1
           # maxLimit: 1000
           # backoffRatio: 0.9
+      # Configure flow control for exporting. Disabled by default. When enabled, writes are limited by exporting throughput.
+      # export:
+        # enabled: false
 
     # backpressure:
       # Configure backpressure below.

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -507,6 +507,10 @@
           # minLimit: 1
           # maxLimit: 1000
           # backoffRatio: 0.9
+      # Configure flow control for exporting. Disabled by default. When enabled, writes are limited by exporting throughput.
+      # export:
+        # enabled: false
+
 
     # backpressure:
       # Configure backpressure below.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -508,7 +508,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     for (final ExporterContainer container : containers) {
       container.updatePositionOnSkipIfUpToDate(eventPosition);
     }
-
+    logStream.getFlowControl().onExported(eventPosition);
     actor.submit(this::readNextEvent);
   }
 
@@ -555,6 +555,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                   LOG.error(ERROR_MESSAGE_EXPORTING_ABORTED, event, throwable);
                   onFailure();
                 } else {
+                  logStream.getFlowControl().onExported(event.getPosition());
                   metrics.eventExported(recordExporter.getTypedEvent().getValueType());
                   inExportingPhase = false;
                   actor.submit(this::readNextEvent);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FlowControlCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FlowControlCfg.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.system.configuration.backpressure.LimitCfg.LimitA
 public class FlowControlCfg implements ConfigurationEntry {
   private LimitCfg append = new LimitCfg();
   private LimitCfg request = null;
+  private LimitCfg export = null;
 
   public FlowControlCfg() {
     append.setAlgorithm(LimitAlgorithm.LEGACY_VEGAS);
@@ -33,5 +34,13 @@ public class FlowControlCfg implements ConfigurationEntry {
 
   public void setRequest(final LimitCfg request) {
     this.request = request;
+  }
+
+  public LimitCfg getExport() {
+    return export;
+  }
+
+  public void setExport(final LimitCfg export) {
+    this.export = export;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -101,6 +101,8 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
             flowControlCfg.getRequest() != null
                 ? flowControlCfg.getRequest().buildLimit()
                 : context.getBrokerCfg().getBackpressure().buildLimit())
+        .withExportLimit(
+            flowControlCfg.getExport() != null ? flowControlCfg.getExport().buildLimit() : null)
         .buildAsync();
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -82,6 +82,24 @@ public final class LogStreamMetrics {
           .labelNames("partition")
           .register();
 
+  private static final Gauge EXPORT_LIMIT =
+      Gauge.build()
+          .namespace("zeebe")
+          .subsystem("flow_control")
+          .name("export_limit")
+          .help("Current limit for number of unexported entries")
+          .labelNames("partition")
+          .register();
+
+  private static final Gauge INFLIGHT_EXPORT =
+      Gauge.build()
+          .namespace("zeebe")
+          .subsystem("flow_control")
+          .name("export_inflight")
+          .help("Current number of unexported entries")
+          .labelNames("partition")
+          .register();
+
   private static final Gauge LAST_COMMITTED_POSITION =
       Gauge.build()
           .namespace("zeebe")
@@ -130,6 +148,8 @@ public final class LogStreamMetrics {
   private final Counter.Child droppedRequests;
   private final Gauge.Child inflightRequests;
   private final Gauge.Child requestLimit;
+  private final Gauge.Child exportLimit;
+  private final Gauge.Child inflightExport;
   private final Gauge.Child lastCommitted;
   private final Gauge.Child lastWritten;
   private final Histogram.Child commitLatency;
@@ -146,6 +166,8 @@ public final class LogStreamMetrics {
     droppedRequests = TOTAL_DROPPED_REQUESTS.labels(partitionLabel);
     inflightRequests = INFLIGHT_REQUESTS.labels(partitionLabel);
     requestLimit = REQUEST_LIMIT.labels(partitionLabel);
+    exportLimit = EXPORT_LIMIT.labels(partitionLabel);
+    inflightExport = INFLIGHT_EXPORT.labels(partitionLabel);
     lastCommitted = LAST_COMMITTED_POSITION.labels(partitionLabel);
     lastWritten = LAST_WRITTEN_POSITION.labels(partitionLabel);
     commitLatency = COMMIT_LATENCY.labels(partitionLabel);
@@ -192,6 +214,18 @@ public final class LogStreamMetrics {
 
   public void decreaseInflightRequests() {
     inflightRequests.dec();
+  }
+
+  public void setExportLimit(final long limit) {
+    exportLimit.set(limit);
+  }
+
+  public void increaseInflightExport() {
+    inflightExport.inc();
+  }
+
+  public void decreaseInflightExport() {
+    inflightExport.dec();
   }
 
   public Timer startWriteTimer() {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/ExportLimiter.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/ExportLimiter.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import com.netflix.concurrency.limits.limiter.AbstractLimiter;
+import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
+import java.util.Optional;
+
+final class ExportLimiter extends AbstractLimiter<Void> {
+  private final LogStreamMetrics metrics;
+
+  private ExportLimiter(final Builder<?> builder, final LogStreamMetrics metrics) {
+    super(builder);
+    this.metrics = metrics;
+  }
+
+  @Override
+  public Optional<Listener> acquire(final Void context) {
+    if (getInflight() >= getLimit()) {
+      return createRejectedListener();
+    } else {
+      return Optional.of(createListener());
+    }
+  }
+
+  @Override
+  protected void onNewLimit(final int newLimit) {
+    super.onNewLimit(newLimit);
+    metrics.setExportLimit(newLimit);
+  }
+
+  public static ExportLimiterBuilder builder() {
+    return new ExportLimiterBuilder();
+  }
+
+  static final class ExportLimiterBuilder extends AbstractLimiter.Builder<ExportLimiterBuilder> {
+    private LogStreamMetrics metrics;
+
+    public ExportLimiterBuilder metrics(final LogStreamMetrics metrics) {
+      this.metrics = metrics;
+      return this;
+    }
+
+    public ExportLimiter build() {
+      return new ExportLimiter(this, metrics);
+    }
+
+    @Override
+    protected ExportLimiterBuilder self() {
+      return this;
+    }
+  }
+}

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -10,7 +10,6 @@ package io.camunda.zeebe.logstreams.impl.flowcontrol;
 import com.netflix.concurrency.limits.Limit;
 import com.netflix.concurrency.limits.Limiter;
 import com.netflix.concurrency.limits.limit.VegasLimit;
-import com.netflix.concurrency.limits.limiter.SimpleLimiter;
 import io.camunda.zeebe.logstreams.impl.LogStreamMetrics;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection.AppendLimitExhausted;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection.ExportLimitExhausted;
@@ -68,7 +67,7 @@ public final class FlowControl implements AppendListener {
             : new NoopLimiter<>();
     exportLimiter =
         exportLimit != null
-            ? SimpleLimiter.newBuilder().limit(exportLimit).build()
+            ? ExportLimiter.builder().limit(exportLimit).metrics(metrics).build()
             : new NoopLimiter<>();
   }
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -122,6 +122,8 @@ public final class FlowControl implements AppendListener {
     cleanupUnprocessed(position);
   }
 
+  public void onExported(final long position) {}
+
   private void cleanupUncommitted(final long highestPosition) {
     final var size = uncommitted.size();
     final var limit = appendLimit != null ? 2 * appendLimit.getLimit() : 2048;

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/InFlightEntry.java
@@ -65,7 +65,7 @@ public final class InFlightEntry {
     }
 
     public Unexported unexported() {
-      return new Unexported(exportListener);
+      return new Unexported(metrics, exportListener);
     }
   }
 
@@ -130,14 +130,18 @@ public final class InFlightEntry {
   }
 
   public static final class Unexported {
+    private final LogStreamMetrics metrics;
     private final Listener exportListener;
 
-    Unexported(final Listener exportListener) {
+    Unexported(final LogStreamMetrics metrics, final Listener exportListener) {
+      this.metrics = metrics;
       this.exportListener = exportListener;
+      metrics.increaseInflightExport();
     }
 
     public void finish() {
       exportListener.onSuccess();
+      metrics.decreaseInflightExport();
     }
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamBuilderImpl.java
@@ -25,6 +25,7 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   private String logName;
   private Limit appendLimit;
   private Limit requestLimit;
+  private Limit exportLimit;
 
   @Override
   public LogStreamBuilder withActorSchedulingService(
@@ -70,12 +71,24 @@ public final class LogStreamBuilderImpl implements LogStreamBuilder {
   }
 
   @Override
+  public LogStreamBuilder withExportLimit(final Limit exportLimit) {
+    this.exportLimit = exportLimit;
+    return this;
+  }
+
+  @Override
   public ActorFuture<LogStream> buildAsync() {
     validate();
 
     final var logStreamService =
         new LogStreamImpl(
-            logName, partitionId, maxFragmentSize, logStorage, appendLimit, requestLimit);
+            logName,
+            partitionId,
+            maxFragmentSize,
+            logStorage,
+            appendLimit,
+            requestLimit,
+            exportLimit);
 
     final var logstreamInstallFuture = new CompletableActorFuture<LogStream>();
     actorSchedulingService

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -49,6 +49,7 @@ public final class LogStreamImpl extends Actor
   private HealthReport healthReport = HealthReport.healthy(this);
   private final Limit appendLimit;
   private final Limit requestLimit;
+  private final Limit exportLimit;
   private final LogStreamMetrics logStreamMetrics;
   private FlowControl flowControl;
 
@@ -58,7 +59,8 @@ public final class LogStreamImpl extends Actor
       final int maxFragmentSize,
       final LogStorage logStorage,
       final Limit appendLimit,
-      final Limit requestLimit) {
+      final Limit requestLimit,
+      final Limit exportLimit) {
     this.logName = logName;
 
     this.partitionId = partitionId;
@@ -69,6 +71,7 @@ public final class LogStreamImpl extends Actor
     this.appendLimit = appendLimit;
     this.requestLimit = requestLimit;
     logStreamMetrics = new LogStreamMetrics(partitionId);
+    this.exportLimit = exportLimit;
     closeFuture = new CompletableActorFuture<>();
     readers = new ArrayList<>();
   }
@@ -163,7 +166,8 @@ public final class LogStreamImpl extends Actor
         () -> {
           try {
             if (sequencer == null) {
-              flowControl = new FlowControl(logStreamMetrics, appendLimit, requestLimit);
+              flowControl =
+                  new FlowControl(logStreamMetrics, appendLimit, requestLimit, exportLimit);
               sequencer =
                   new Sequencer(
                       logStorage,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
@@ -61,6 +61,8 @@ public interface LogStreamBuilder {
 
   LogStreamBuilder withRequestLimit(Limit requestLimit);
 
+  LogStreamBuilder withExportLimit(Limit exportLimit);
+
   /**
    * Returns a future which, when completed, contains a log stream that can be read from/written to.
    *

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
@@ -74,6 +74,12 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
   }
 
   @Override
+  public LogStreamBuilder withExportLimit(final Limit exportLimit) {
+    delegate.withExportLimit(exportLimit);
+    return this;
+  }
+
+  @Override
   public ActorFuture<LogStream> buildAsync() {
     return delegate.buildAsync();
   }


### PR DESCRIPTION
## Description

This allows to configure a limit on the amount of unexported entries via `zeebe.broker.flowControl.export`. This limit is disabled by default.

## Related issues

closes #18867
