### PR TITLE
ci: re-enable tasklist migration tests

### DIFF
--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -96,6 +96,6 @@ jobs:
           payload: |
             {
               "workflow_name": "Backup and restore tests",
-              "github_run_url": "https://github.com/camunda/tasklist/actions/runs/${{ github.run_id }}",
+              "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
               "branch": "${{ github.head_ref || github.ref_name }}"
             }

--- a/.github/workflows/tasklist-migrate-elasticsearch-data.yml
+++ b/.github/workflows/tasklist-migrate-elasticsearch-data.yml
@@ -93,6 +93,6 @@ jobs:
           payload: |
             {
               "workflow_name": "Migrate elasticsearch data",
-              "github_run_url": "https://github.com/camunda/tasklist/actions/runs/${{ github.run_id }}",
+              "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
               "branch": "${{ github.head_ref || github.ref_name }}"
             }

--- a/.github/workflows/tasklist-migrate-elasticsearch-data.yml
+++ b/.github/workflows/tasklist-migrate-elasticsearch-data.yml
@@ -69,7 +69,7 @@ jobs:
       # Tests: run migration tests
       - name: Run migration tests
         run: |
-          mvn -B -pl tasklist/qa/migration-tests -DskipTests=false -DskipChecks verify
+          mvn -B -f tasklist/qa/migration-tests -DskipTests=false -DskipChecks verify
 
       # Reports: publish test results
       - name: Publish Test Results

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -156,7 +156,7 @@ public class BackupRestoreTest {
   }
 
   private void startTasklist() {
-    testContainerUtil.startTasklistContainer(tasklistContainer, testContext);
+    testContainerUtil.startTasklistContainer(tasklistContainer, VERSION, testContext);
     LOGGER.info("************ Tasklist started  ************");
     testContext.setTasklistRestClient(tasklistAPICaller.createGraphQLTestTemplate(testContext));
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
@@ -74,7 +74,7 @@ public class StartupIT {
         .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_HOST", elsHost)
         .withEnv("CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_PORT", String.valueOf(elsPort));
 
-    testContainerUtil.startTasklistContainer(tasklistContainer, testContext);
+    testContainerUtil.startTasklistContainer(tasklistContainer, VERSION, testContext);
     LOGGER.info("************ Tasklist started  ************");
 
     // when


### PR DESCRIPTION
Currently the migration tests are not running

test workflow: https://github.com/camunda/camunda/actions/runs/9259474866