### PR TITLE
[Backport 8.5]: use new repo name

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/VersionCompatibilityMatrix.java
@@ -117,7 +117,7 @@ final class VersionCompatibilityMatrix {
       }
     }
     final var endpoint =
-        URI.create("https://api.github.com/repos/camunda/zeebe/git/matching-refs/tags/8.");
+        URI.create("https://api.github.com/repos/camunda/camunda/git/matching-refs/tags/8.");
     try (final var httpClient = HttpClient.newHttpClient()) {
       final var retry =
           Retry.of(


### PR DESCRIPTION
## Description

Currently, our Rolling update tests on stable/8.5 are failing, see [slack](https://camunda.slack.com/archives/C05DH1F5TAR/p1716900282355599).

The issue is that we renamed the repo, and GitHub has put redirects in place.
We need to use the correct repo name, as the used HTTP client doesn't follow redirects.

