### PR TITLE
ci: use multiline string output

### DIFF
--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -38,7 +38,15 @@ jobs:
             renovateStatusString+="\n • <https://github.com/camunda/camunda/pull/$prNumber|PR $prNumber ($status)>: $title (created $createdAt)"
           done
 
-          echo "status=${renovateStatusString}" >> $GITHUB_OUTPUT
+
+          
+          # With multiline strings the output needs to be set differently.
+          #
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-a-multiline-string
+          #
+          echo 'STATUS<<EOF' >> $GITHUB_OUTPUT
+          echo $renovateStatusString >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
   slack-notify:
     name: Send slack notification for Renovate PR status
     runs-on: ubuntu-latest


### PR DESCRIPTION


## Description

We had no longer daily updates from existing Renovate PRs, as
[revious build failed due to large content in output https://github.com/camunda/camunda/actions/runs/9267388298