### PR TITLE
ci: create section for each renovate PR

### DIFF
--- a/.github/workflows/daily-renovate-status.yaml
+++ b/.github/workflows/daily-renovate-status.yaml
@@ -35,7 +35,7 @@ jobs:
             createdAt=$(echo $pr | jq --raw-output '.createdAt')
             status=$(echo $pr | jq --raw-output '.mergeStateStatus')
 
-            renovateStatusString+="\n • <https://github.com/camunda/camunda/pull/$prNumber|PR $prNumber ($status)>: $title (created $createdAt)"
+            renovateStatusString+=",{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\": \"<https://github.com/camunda/camunda/pull/$prNumber|PR $prNumber ($status)>: $title (created $createdAt)\"}}"
           done
 
 
@@ -66,14 +66,8 @@ jobs:
                     "type": "mrkdwn",
                     "text": ":renovate-party: *Daily Renovate status:* :renovate-party:"
                   }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${{ needs.extract-renovate-pr-status.outputs.status }}"
-                  }
                 }
+                ${{ needs.extract-renovate-pr-status.outputs.status }}
               ]
             }
         env:


### PR DESCRIPTION
## Description


The daily updates failed, since we had to many renovate PRs open which exceeded the slack message text length

![2024-05-28_15-20](https://github.com/camunda/camunda/assets/2758593/1d2f6e8a-9243-4821-9176-cd2b8201c45e)
![2024-05-28_15-19](https://github.com/camunda/camunda/assets/2758593/95abf25e-376e-46c3-a0de-8914c61a37c3)


The alternative was to create an own section for each PR instead of appending them into one string.

Result:

![2024-05-28_15-30](https://github.com/camunda/camunda/assets/2758593/2f511eee-536e-4465-9873-3b874e0de09f)
