### PR TITLE
fix: add exception path to ism policy retrieval

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/ILMPolicyUpdateElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/ILMPolicyUpdateElasticSearch.java
@@ -14,7 +14,6 @@ import io.camunda.tasklist.schema.manager.ElasticsearchSchemaManager;
 import java.io.IOException;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyRequest;
 import org.elasticsearch.client.indexlifecycle.GetLifecyclePolicyResponse;
 import org.elasticsearch.common.settings.Settings;
@@ -48,10 +47,11 @@ public class ILMPolicyUpdateElasticSearch implements ILMPolicyUpdate {
             + "-.*-\\d+\\.\\d+\\.\\d+_\\d{4}-\\d{2}-\\d{2}$";
     LOGGER.info("Applying ILM policy to all existent indices");
 
-    final GetLifecyclePolicyResponse policy = retryElasticsearchClient.getLifeCyclePolicy(
-          new GetLifecyclePolicyRequest(TASKLIST_DELETE_ARCHIVED_INDICES));
+    final GetLifecyclePolicyResponse policy =
+        retryElasticsearchClient.getLifeCyclePolicy(
+            new GetLifecyclePolicyRequest(TASKLIST_DELETE_ARCHIVED_INDICES));
 
-    if(policy == null) {
+    if (policy == null) {
       LOGGER.info("ILM policy not found, creating it");
       schemaManager.createIndexLifeCycles();
     }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -793,7 +793,8 @@ public class RetryElasticsearchClient {
 
   public GetLifecyclePolicyResponse getLifeCyclePolicy(
       final GetLifecyclePolicyRequest getLifecyclePolicyRequest) {
-    return executeWithRetries(
+    return executeWithGivenRetries(
+        3,
         String.format("Get LifeCyclePolicy %s ", getLifecyclePolicyRequest.getPolicyNames()),
         () ->
             esClient.indexLifecycle().getLifecyclePolicy(getLifecyclePolicyRequest, requestOptions),

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -792,12 +792,14 @@ public class RetryElasticsearchClient {
   }
 
   public GetLifecyclePolicyResponse getLifeCyclePolicy(
-      final GetLifecyclePolicyRequest getLifecyclePolicyRequest) {
-    return executeWithGivenRetries(
-        3,
-        String.format("Get LifeCyclePolicy %s ", getLifecyclePolicyRequest.getPolicyNames()),
-        () ->
-            esClient.indexLifecycle().getLifecyclePolicy(getLifecyclePolicyRequest, requestOptions),
-        null);
+      final GetLifecyclePolicyRequest getLifecyclePolicyRequest) throws IOException {
+    try{
+      return esClient.indexLifecycle().getLifecyclePolicy(getLifecyclePolicyRequest, requestOptions);
+    } catch (final ElasticsearchException e) {
+      if (e.status().equals(RestStatus.NOT_FOUND)) {
+        return null;
+      }
+      throw e;
+    }
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -799,7 +799,7 @@ public class RetryElasticsearchClient {
       if (e.status().equals(RestStatus.NOT_FOUND)) {
         return null;
       }
-      throw e;
+      throw new TasklistRuntimeException("Error to get lifecycle policy", e);
     }
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -748,16 +748,18 @@ public class RetryElasticsearchClient {
       if (predicate != null) {
         retryPolicy.handleResultIf(predicate);
       }
-      return Failsafe.with(retryPolicy).get(() -> {
-        try {
-          return operation.get();
-        } catch (final ElasticsearchException e) {
-          if (e.status().equals(RestStatus.NOT_FOUND)) {
-            return null;
-          }
-          throw e;
-        }
-      });
+      return Failsafe.with(retryPolicy)
+          .get(
+              () -> {
+                try {
+                  return operation.get();
+                } catch (final ElasticsearchException e) {
+                  if (e.status().equals(RestStatus.NOT_FOUND)) {
+                    return null;
+                  }
+                  throw e;
+                }
+              });
     } catch (final Exception e) {
       throw new TasklistRuntimeException(
           "Couldn't execute operation "
@@ -804,7 +806,8 @@ public class RetryElasticsearchClient {
       final GetLifecyclePolicyRequest getLifecyclePolicyRequest) {
     return executeWithRetries(
         String.format("Get LifeCyclePolicy %s", getLifecyclePolicyRequest.getPolicyNames()),
-        () -> esClient.indexLifecycle().getLifecyclePolicy(getLifecyclePolicyRequest, requestOptions),
+        () ->
+            esClient.indexLifecycle().getLifecyclePolicy(getLifecyclePolicyRequest, requestOptions),
         null);
   }
 }


### PR DESCRIPTION
## Description

The goal of this PR is fix a bug over the ISM Policy Creation, once when the policy was never created, the retryClient on Elastic Search keeps retrying until throw an error of number of retries. 

Steps to reproduce:
- Start Tasklist with ISM =false
- Stop Tasklist
- Start Tasklist with ISM = true

Expected behaviour:
- Check the policy does not exist, create a new one

Current behaviour:
- Error, once retryElasticSearch client keep retrying and does not throw not found error (as Open Search)

Affects: Self-managed.

## Related issues

closes https://github.com/camunda/tasklist/issues/4938
