### PR TITLE
Give Identity Common maven artifact a name

### DIFF
--- a/identity/common/pom.xml
+++ b/identity/common/pom.xml
@@ -16,6 +16,7 @@
   </parent>
 
   <artifactId>identity-common</artifactId>
+  <name>Identity Common</name>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>


### PR DESCRIPTION
## Description

Our release process requires all maven artifacts to have a name. This is
a rule set by nexus which will fail staging during release.

## Related issues

- `release-8.6.0-alpha2-rc1`