### PR TITLE
Add empty Javadoc Jar for Operate/Tasklist

### DIFF
--- a/operate/pom.xml
+++ b/operate/pom.xml
@@ -43,18 +43,30 @@
     <includeITNames>**/*IT.java</includeITNames>
     <excludeITNames>**/OpenSearch*IT.java, **/Opensearch*IT.java</excludeITNames>
     <itDatabase>elasticsearch</itDatabase>
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <build>
     <pluginManagement>
       <plugins>
 
+       <!-- Javadoc generation fails under Java 11 -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
+          <artifactId>maven-jar-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>empty-javadoc-jar</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <phase>package</phase>
+              <configuration>
+                <classifier>javadoc</classifier>
+                <classesDirectory>${basedir}/javadoc</classesDirectory>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>

--- a/tasklist/pom.xml
+++ b/tasklist/pom.xml
@@ -40,18 +40,29 @@
     <maven.compiler.source>21</maven.compiler.source>
 
     <skip.fe.build>true</skip.fe.build>
-
+    <maven.javadoc.skip>true</maven.javadoc.skip>
   </properties>
 
   <build>
     <pluginManagement>
       <plugins>
+       <!-- Javadoc generation fails under Java 11 -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-javadoc-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
+          <artifactId>maven-jar-plugin</artifactId>
+          <executions>
+            <execution>
+              <id>empty-javadoc-jar</id>
+              <goals>
+                <goal>jar</goal>
+              </goals>
+              <phase>package</phase>
+              <configuration>
+                <classifier>javadoc</classifier>
+                <classesDirectory>${basedir}/javadoc</classesDirectory>
+              </configuration>
+            </execution>
+          </executions>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
## Description

Skip javadoc generation, configure plugin to allow empty javadoc.

## Related issues

- `release-8.6.0-alpha2`