### PR TITLE
fix: Tasklist cannot update ISM policy in AWS OpenSearch

### DIFF
--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -118,6 +118,16 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sdk-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.github.acm19</groupId>
+      <artifactId>aws-request-signing-apache-interceptor</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
     </dependency>

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -106,12 +106,7 @@ public class OpenSearchConnector {
 
   @Bean
   public RestClient opensearchRestClient() {
-    final var originalHttpHost = getHttpHost(tasklistProperties.getOpenSearch());
-    final org.apache.http.HttpHost httpHost =
-        new org.apache.http.HttpHost(
-            originalHttpHost.getHostName(),
-            originalHttpHost.getPort(),
-            originalHttpHost.getSchemeName());
+    final var httpHost = getHttpHost(tasklistProperties.getOpenSearch());
     return RestClient.builder(httpHost)
         .setHttpClientConfigCallback(
             b -> configureApacheHttpClient(b, tasklistProperties.getOpenSearch()))
@@ -120,12 +115,7 @@ public class OpenSearchConnector {
 
   @Bean
   public RestClient opensearchZeebeRestClient() {
-    final var originalHttpHost = getHttpHost(tasklistProperties.getZeebeOpenSearch());
-    final org.apache.http.HttpHost httpHost =
-        new org.apache.http.HttpHost(
-            originalHttpHost.getHostName(),
-            originalHttpHost.getPort(),
-            originalHttpHost.getSchemeName());
+    final var httpHost = getHttpHost(tasklistProperties.getZeebeOpenSearch());
     return RestClient.builder(httpHost)
         .setHttpClientConfigCallback(
             b -> configureApacheHttpClient(b, tasklistProperties.getZeebeOpenSearch()))

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -15,6 +15,7 @@ import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.property.OpenSearchProperties;
 import io.camunda.tasklist.property.SslProperties;
 import io.camunda.tasklist.property.TasklistProperties;
+import io.github.acm19.aws.interceptor.http.AwsRequestSigningApacheInterceptor;
 import java.io.BufferedInputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -43,6 +44,8 @@ import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.nio.ssl.TlsStrategy;
 import org.apache.hc.core5.util.Timeout;
+import org.apache.http.HttpRequestInterceptor;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
 import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
 import org.apache.http.ssl.SSLContexts;
@@ -68,6 +71,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.util.StringUtils;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.signer.Aws4Signer;
 import software.amazon.awssdk.http.async.SdkAsyncHttpClient;
 import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
@@ -77,6 +81,7 @@ import software.amazon.awssdk.regions.Region;
 public class OpenSearchConnector {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchConnector.class);
+  private static final String AWS_OPENSEARCH_SERVICE_NAME = "es";
 
   @Autowired private TasklistProperties tasklistProperties;
 
@@ -90,7 +95,7 @@ public class OpenSearchConnector {
     try {
       final HealthResponse response = openSearchClient.cluster().health();
       LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error(
           "Error in getting health status from localhost:"
               + tasklistProperties.getOpenSearch().getPort(),
@@ -107,7 +112,10 @@ public class OpenSearchConnector {
             originalHttpHost.getHostName(),
             originalHttpHost.getPort(),
             originalHttpHost.getSchemeName());
-    return RestClient.builder(httpHost).build();
+    return RestClient.builder(httpHost)
+        .setHttpClientConfigCallback(
+            b -> configureApacheHttpClient(b, tasklistProperties.getOpenSearch()))
+        .build();
   }
 
   @Bean
@@ -118,7 +126,10 @@ public class OpenSearchConnector {
             originalHttpHost.getHostName(),
             originalHttpHost.getPort(),
             originalHttpHost.getSchemeName());
-    return RestClient.builder(httpHost).build();
+    return RestClient.builder(httpHost)
+        .setHttpClientConfigCallback(
+            b -> configureApacheHttpClient(b, tasklistProperties.getZeebeOpenSearch()))
+        .build();
   }
 
   @Bean
@@ -139,7 +150,7 @@ public class OpenSearchConnector {
               LOGGER.info("OpenSearch cluster health: {}", response.status());
             }
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
     return openSearchClient;
@@ -151,19 +162,19 @@ public class OpenSearchConnector {
     return createOsClient(tasklistProperties.getZeebeOpenSearch());
   }
 
-  public OpenSearchAsyncClient createAsyncOsClient(OpenSearchProperties osConfig) {
+  public OpenSearchAsyncClient createAsyncOsClient(final OpenSearchProperties osConfig) {
     LOGGER.debug("Creating Async OpenSearch connection...");
     LOGGER.debug("Creating OpenSearch connection...");
     if (isAws()) {
       return getAwsAsyncClient(osConfig);
     }
-    final HttpHost host = getHttpHost(osConfig);
+    final HttpHost host = getHttpHostForClient5(osConfig);
     final ApacheHttpClient5TransportBuilder builder =
         ApacheHttpClient5TransportBuilder.builder(host);
 
     builder.setHttpClientConfigCallback(
         httpClientBuilder -> {
-          configureHttpClient(httpClientBuilder, osConfig);
+          configureApacheHttpClient5(httpClientBuilder, osConfig);
           return httpClientBuilder;
         });
 
@@ -194,7 +205,7 @@ public class OpenSearchConnector {
               LOGGER.info("OpenSearch cluster health: {}", response.status());
             }
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new TasklistRuntimeException(e);
     }
 
@@ -206,18 +217,18 @@ public class OpenSearchConnector {
     return openSearchAsyncClient;
   }
 
-  public OpenSearchClient createOsClient(OpenSearchProperties osConfig) {
+  public OpenSearchClient createOsClient(final OpenSearchProperties osConfig) {
     LOGGER.debug("Creating OpenSearch connection...");
     if (isAws()) {
       return getAwsClient(osConfig);
     }
-    final HttpHost host = getHttpHost(osConfig);
+    final HttpHost host = getHttpHostForClient5(osConfig);
     final ApacheHttpClient5TransportBuilder builder =
         ApacheHttpClient5TransportBuilder.builder(host);
 
     builder.setHttpClientConfigCallback(
         httpClientBuilder -> {
-          configureHttpClient(httpClientBuilder, osConfig);
+          configureApacheHttpClient5(httpClientBuilder, osConfig);
           return httpClientBuilder;
         });
 
@@ -235,7 +246,7 @@ public class OpenSearchConnector {
     try {
       final HealthResponse response = openSearchClient.cluster().health();
       LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error(
           "Error in getting health status from localhost:"
               + tasklistProperties.getOpenSearch().getPort(),
@@ -250,19 +261,27 @@ public class OpenSearchConnector {
     return openSearchClient;
   }
 
-  private HttpHost getHttpHost(OpenSearchProperties osConfig) {
+  private HttpHost getHttpHostForClient5(final OpenSearchProperties osConfig) {
+    final URI uri = getOsUri(osConfig);
+    return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
+  }
+
+  private org.apache.http.HttpHost getHttpHost(final OpenSearchProperties osConfig) {
+    final URI uri = getOsUri(osConfig);
+    return new org.apache.http.HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+  }
+
+  private URI getOsUri(final OpenSearchProperties osConfig) {
     try {
-      final URI uri = new URI(osConfig.getUrl());
-      return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
-    } catch (URISyntaxException e) {
+      return new URI(osConfig.getUrl());
+    } catch (final URISyntaxException e) {
       throw new TasklistRuntimeException("Error in url: " + osConfig.getUrl(), e);
     }
   }
 
   private HttpAsyncClientBuilder setupAuthentication(
-      final HttpAsyncClientBuilder builder, OpenSearchProperties osConfig) {
-    if (!StringUtils.hasText(osConfig.getUsername())
-        || !StringUtils.hasText(osConfig.getPassword())) {
+      final HttpAsyncClientBuilder builder, final OpenSearchProperties osConfig) {
+    if (!useBasicAuthentication(osConfig)) {
       LOGGER.warn(
           "Username and/or password for are empty. Basic authentication for OpenSearch is not used.");
       return builder;
@@ -270,7 +289,7 @@ public class OpenSearchConnector {
 
     final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     credentialsProvider.setCredentials(
-        new AuthScope(getHttpHost(osConfig)),
+        new AuthScope(getHttpHostForClient5(osConfig)),
         new UsernamePasswordCredentials(
             osConfig.getUsername(), osConfig.getPassword().toCharArray()));
 
@@ -279,7 +298,7 @@ public class OpenSearchConnector {
   }
 
   private void setupSSLContext(
-      HttpAsyncClientBuilder httpAsyncClientBuilder, SslProperties sslConfig) {
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final SslProperties sslConfig) {
     try {
       final ClientTlsStrategyBuilder tlsStrategyBuilder = ClientTlsStrategyBuilder.create();
       tlsStrategyBuilder.setSslContext(getSSLContext(sslConfig));
@@ -293,12 +312,12 @@ public class OpenSearchConnector {
 
       httpAsyncClientBuilder.setConnectionManager(connectionManager);
 
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error("Error in setting up SSLContext", e);
     }
   }
 
-  private SSLContext getSSLContext(SslProperties sslConfig)
+  private SSLContext getSSLContext(final SslProperties sslConfig)
       throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
     final KeyStore truststore = loadCustomTrustStore(sslConfig);
     final TrustStrategy trustStrategy =
@@ -311,7 +330,7 @@ public class OpenSearchConnector {
     }
   }
 
-  private KeyStore loadCustomTrustStore(SslProperties sslConfig) {
+  private KeyStore loadCustomTrustStore(final SslProperties sslConfig) {
     try {
       final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
       trustStore.load(null);
@@ -321,7 +340,7 @@ public class OpenSearchConnector {
         setCertificateInTrustStore(trustStore, serverCertificate);
       }
       return trustStore;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final String message =
           "Could not create certificate trustStore for the secured OpenSearch Connection!";
       throw new TasklistRuntimeException(message, e);
@@ -333,7 +352,7 @@ public class OpenSearchConnector {
     try {
       final Certificate cert = loadCertificateFromPath(serverCertificate);
       trustStore.setCertificateEntry("opensearch-host", cert);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final String message =
           "Could not load configured server certificate for the secured OpenSearch Connection!";
       throw new TasklistRuntimeException(message, e);
@@ -343,7 +362,8 @@ public class OpenSearchConnector {
   private Certificate loadCertificateFromPath(final String certificatePath)
       throws IOException, CertificateException {
     final Certificate cert;
-    try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(certificatePath))) {
+    try (final BufferedInputStream bis =
+        new BufferedInputStream(new FileInputStream(certificatePath))) {
       final CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
       if (bis.available() > 0) {
@@ -357,8 +377,8 @@ public class OpenSearchConnector {
     return cert;
   }
 
-  private HttpAsyncClientBuilder configureHttpClient(
-      HttpAsyncClientBuilder httpAsyncClientBuilder, OpenSearchProperties osConfig) {
+  private HttpAsyncClientBuilder configureApacheHttpClient5(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final OpenSearchProperties osConfig) {
     setupAuthentication(httpAsyncClientBuilder, osConfig);
     if (osConfig.getSsl() != null) {
       setupSSLContext(httpAsyncClientBuilder, osConfig.getSsl());
@@ -378,7 +398,7 @@ public class OpenSearchConnector {
     return builder;
   }
 
-  public boolean checkHealth(OpenSearchClient osClient) {
+  public boolean checkHealth(final OpenSearchClient osClient) {
     final OpenSearchProperties osConfig = tasklistProperties.getOpenSearch();
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)
@@ -390,7 +410,7 @@ public class OpenSearchConnector {
             });
   }
 
-  public boolean checkHealth(OpenSearchAsyncClient osAsyncClient) {
+  public boolean checkHealth(final OpenSearchAsyncClient osAsyncClient) {
     final OpenSearchProperties osConfig = tasklistProperties.getOpenSearch();
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)
@@ -434,13 +454,13 @@ public class OpenSearchConnector {
       credentialsProvider.resolveCredentials();
       LOGGER.info("AWS Credentials can be resolved. Use AWS Opensearch");
       return true;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.warn("AWS not configured due to: {} ", e.getMessage());
       return false;
     }
   }
 
-  private OpenSearchAsyncClient getAwsAsyncClient(OpenSearchProperties osConfig) {
+  private OpenSearchAsyncClient getAwsAsyncClient(final OpenSearchProperties osConfig) {
     final String region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     final AwsSdk2Transport transport =
@@ -454,7 +474,7 @@ public class OpenSearchConnector {
     return new OpenSearchAsyncClient(transport);
   }
 
-  private OpenSearchClient getAwsClient(OpenSearchProperties osConfig) {
+  private OpenSearchClient getAwsClient(final OpenSearchProperties osConfig) {
     final String region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     final AwsSdk2Transport transport =
@@ -466,5 +486,50 @@ public class OpenSearchConnector {
                 .setMapper(new JacksonJsonpMapper(tasklistObjectMapper))
                 .build());
     return new OpenSearchClient(transport);
+  }
+
+  private org.apache.http.impl.nio.client.HttpAsyncClientBuilder configureApacheHttpClient(
+      final org.apache.http.impl.nio.client.HttpAsyncClientBuilder builder,
+      final OpenSearchProperties osConfig) {
+
+    if (isAws()) {
+      configureAwsSigningForApacheHttpClient(builder);
+    } else if (useBasicAuthentication(osConfig)) {
+      configureBasicAuthenticationForApacheHttpClient(osConfig, builder);
+    }
+
+    return builder;
+  }
+
+  private void configureAwsSigningForApacheHttpClient(
+      final org.apache.http.impl.nio.client.HttpAsyncClientBuilder builder) {
+    final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
+    credentialsProvider.resolveCredentials();
+    final Aws4Signer signer = Aws4Signer.create();
+    final HttpRequestInterceptor signInterceptor =
+        new AwsRequestSigningApacheInterceptor(
+            AWS_OPENSEARCH_SERVICE_NAME,
+            signer,
+            credentialsProvider,
+            new DefaultAwsRegionProviderChain().getRegion());
+    builder.addInterceptorLast(signInterceptor);
+  }
+
+  private void configureBasicAuthenticationForApacheHttpClient(
+      final OpenSearchProperties osConfig,
+      final org.apache.http.impl.nio.client.HttpAsyncClientBuilder builder) {
+    final CredentialsProvider credentialsProvider =
+        new org.apache.http.impl.client.BasicCredentialsProvider();
+    credentialsProvider.setCredentials(
+        new org.apache.http.auth.AuthScope(getHttpHost(osConfig)),
+        new org.apache.http.auth.UsernamePasswordCredentials(
+            osConfig.getUsername(), osConfig.getPassword()));
+
+    builder.setDefaultCredentialsProvider(credentialsProvider);
+  }
+
+  private boolean useBasicAuthentication(final OpenSearchProperties osConfig) {
+    return StringUtils.hasText(osConfig.getUsername())
+        && StringUtils.hasText(osConfig.getPassword());
   }
 }

--- a/tasklist/docker-compose.yml
+++ b/tasklist/docker-compose.yml
@@ -113,13 +113,14 @@ services:
     environment:
       - camunda.tasklist.opensearch.url=http://opensearch:9200
       - camunda.tasklist.zeebeOpensearch.url=http://opensearch:9200
-      - camunda.tasklist.zeebe.gatewayAddress=zeebe:26500
+      - camunda.tasklist.zeebe.gatewayAddress=zeebe-opensearch:26500
       #- server.servlet.context-path=/tasklist/
       - spring.profiles.active=dev,dev-data,auth
       - graphql.playground.enabled=true
       - graphql.playground.settings.request.credentials=include
       - camunda.tasklist.database=opensearch
-      - CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS=http://zeebe:8080
+      - CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS=http://zeebe-opensearch:8080
+      - camunda.tasklist.archiver.ilmEnabled=true
     depends_on:
       - opensearch
       - zeebe-opensearch

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearch.java
@@ -8,7 +8,6 @@
 package io.camunda.tasklist.os;
 
 import io.camunda.tasklist.data.conditionals.OpenSearchCondition;
-import io.camunda.tasklist.es.ILMPolicyUpdateElasticSearch;
 import io.camunda.tasklist.management.ILMPolicyUpdate;
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.schema.manager.OpenSearchSchemaManager;
@@ -33,7 +32,7 @@ import org.springframework.stereotype.Component;
 public class ILMPolicyUpdateOpenSearch implements ILMPolicyUpdate {
 
   private static final String TASKLIST_DELETE_ARCHIVED_INDICES = "tasklist_delete_archived_indices";
-  private static final Logger LOGGER = LoggerFactory.getLogger(ILMPolicyUpdateElasticSearch.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ILMPolicyUpdateOpenSearch.class);
 
   @Autowired private RetryOpenSearchClient retryOpenSearchClient;
 
@@ -121,7 +120,10 @@ public class ILMPolicyUpdateOpenSearch implements ILMPolicyUpdate {
           final String requiredPolicyId = applyPolicy ? TASKLIST_DELETE_ARCHIVED_INDICES : null;
 
           if (isPolicyAlreadyApplied(existingSettings, requiredPolicyId)) {
-            LOGGER.info("ISM policy already applied to index template {}", templateName);
+            LOGGER.info(
+                "ISM policy already {} index template {}",
+                applyPolicy ? "applied to" : "removed from",
+                templateName);
             continue;
           }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/ILMPolicyUpdateOpenSearch.java
@@ -20,7 +20,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.opensearch.client.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -48,12 +47,7 @@ public class ILMPolicyUpdateOpenSearch implements ILMPolicyUpdate {
             + tasklistProperties.getOpenSearch().getIndexPrefix()
             + "-.*-\\d+\\.\\d+\\.\\d+_\\d{4}-\\d{2}-\\d{2}$";
     LOGGER.info("Applying ISM policy to all existent indices");
-    final Response policyExists =
-        retryOpenSearchClient.getLifecyclePolicy(TASKLIST_DELETE_ARCHIVED_INDICES);
-    if (policyExists == null) {
-      LOGGER.info("ISM policy does not exist, creating it");
-      schemaManager.createIndexLifeCycles();
-    }
+    schemaManager.createIndexLifeCyclesIfNotExist();
     applyIlmPolicyToIndexTemplate(true);
     final Pattern indexNamePattern = Pattern.compile(archiveTemplatePatterndNameRegex);
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
@@ -621,13 +621,13 @@ public class RetryOpenSearchClient {
         });
   }
 
-  public Response getLifecyclePolicy(final String policyName) {
+  public Optional<Response> getLifecyclePolicy(final String policyName) {
     final Request request = new Request("GET", "/_plugins/_ism/policies/" + policyName);
     try {
-      return opensearchRestClient.performRequest(request);
+      return Optional.ofNullable(opensearchRestClient.performRequest(request));
     } catch (final ResponseException e) {
       if (e.getResponse().getStatusLine().getStatusCode() == HttpStatus.NOT_FOUND.value()) {
-        return null;
+        return Optional.empty();
       } else {
         throw new TasklistRuntimeException("Communication error with OpenSearch", e);
       }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -64,14 +64,18 @@ public class OpenSearchSchemaManager implements SchemaManager {
   @Override
   public void createSchema() {
     if (tasklistProperties.getArchiver().isIlmEnabled()) {
-      createIndexLifeCycles();
+      createIndexLifeCyclesIfNotExist();
     }
     createDefaults();
     createTemplates();
     createIndices();
   }
 
-  public void createIndexLifeCycles() {
+  public void createIndexLifeCyclesIfNotExist() {
+    if (retryOpenSearchClient.getLifecyclePolicy(TASKLIST_DELETE_ARCHIVED_INDICES).isPresent()) {
+      LOGGER.info("{} ISM policy already exists", TASKLIST_DELETE_ARCHIVED_INDICES);
+      return;
+    }
     LOGGER.info("Creating ISM Policy for deleting archived indices");
 
     final Request request =

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -75,7 +75,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
     LOGGER.info("Creating ISM Policy for deleting archived indices");
 
     final Request request =
-        new Request("PUT", "_plugins/_ism/policies/" + TASKLIST_DELETE_ARCHIVED_INDICES);
+        new Request("PUT", "/_plugins/_ism/policies/" + TASKLIST_DELETE_ARCHIVED_INDICES);
     final JSONObject requestJson = new JSONObject();
     final JSONArray statesJson = new JSONArray();
     final JSONObject openState = new JSONObject();


### PR DESCRIPTION
## Description

Adding AWS and basic authentication to OpenSearch rest client used for ISM and index template management 
Mainly inspired from https://github.com/camunda/camunda/blob/main/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/RestClientFactory.java

Tested with real AWS opensearch domain as documented in https://confluence.camunda.com/pages/viewpage.action?pageId=226133974

## Related issues

closes #18891 
