### PR TITLE
Clarify API proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-proposal.md
@@ -1,7 +1,7 @@
 ---
 
-name: API proposal
-about: General proposal for the API strategy
+name: API Guidelines proposal
+about: Proposal for the general API strategy (not for specific endpoints)
 title: ''
 labels: ['component/c8-api', 'kind/proposal']
 assignees: ''
@@ -12,6 +12,9 @@ projects: ['camunda/111']
 ## Description
 
 _A clear and concise description of what this proposal is about and what problem it solves._
+
+> [!NOTE]
+> To propose specific new API endpoints, create a regular feature request, not a guidelines proposal.
 
 ## Proposal
 


### PR DESCRIPTION
## Description 

Adjusts the API proposal issue template name and description to clarify its purpose. This highlights that the proposal are for the strategy, not specific new API endpoints.

## Related issues

* Came up in an internal [Slack discussion](https://camunda.slack.com/archives/C06P6H2FL5T/p1716979389409329?thread_ts=1716958831.048489&cid=C06P6H2FL5T)
