### PR TITLE
ci: address actionlint findings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,6 @@ indent_size = 2
 
 [*.md]
 indent_size = 2
+
+[*.yml,*.yaml]
+indent_size = 2

--- a/.github/actionlint-matcher.json
+++ b/.github/actionlint-matcher.json
@@ -1,0 +1,17 @@
+{
+    "problemMatcher": [
+      {
+        "owner": "actionlint",
+        "pattern": [
+          {
+            "regexp": "^(?:\\x1b\\[\\d+m)?(.+?)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*:(?:\\x1b\\[\\d+m)*(\\d+)(?:\\x1b\\[\\d+m)*: (?:\\x1b\\[\\d+m)*(.+?)(?:\\x1b\\[\\d+m)* \\[(.+?)\\]$",
+            "file": 1,
+            "line": 2,
+            "column": 3,
+            "message": 4,
+            "code": 5
+          }
+        ]
+      }
+    ]
+  }

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,53 @@
+---
+self-hosted-runner:
+  # Labels of available self-hosted runners (array of string)
+  labels:
+  # by Infra team
+  - aws-arm-core-2-release
+  - aws-arm-core-4-release
+  - aws-arm-core-8-release
+  - aws-arm-core-16-release
+  - aws-arm-core-32-release
+  - aws-arm-core-2-longrunning
+  - aws-arm-core-4-longrunning
+  - aws-arm-core-8-longrunning
+  - aws-arm-core-16-longrunning
+  - aws-arm-core-32-longrunning
+  - aws-arm-core-2-default
+  - aws-arm-core-4-default
+  - aws-arm-core-8-default
+  - aws-arm-core-16-default
+  - aws-arm-core-32-default
+  - aws-core-2-release
+  - aws-core-4-release
+  - aws-core-8-release
+  - aws-core-16-release
+  - aws-core-32-release
+  - aws-core-2-longrunning
+  - aws-core-4-longrunning
+  - aws-core-8-longrunning
+  - aws-core-16-longrunning
+  - aws-core-32-longrunning
+  - aws-core-2-default
+  - aws-core-4-default
+  - aws-core-8-default
+  - aws-core-16-default
+  - aws-core-32-default
+  - gcp-core-2-release
+  - gcp-core-4-release
+  - gcp-core-8-release
+  - gcp-core-16-release
+  - gcp-core-32-release
+  - gcp-core-2-longrunning
+  - gcp-core-4-longrunning
+  - gcp-core-8-longrunning
+  - gcp-core-16-longrunning
+  - gcp-core-32-longrunning
+  - gcp-core-2-default
+  - gcp-core-4-default
+  - gcp-core-8-default
+  - gcp-core-16-default
+  - gcp-core-32-default
+  # by Zeebe team, to be deprecated after https://github.com/camunda/camunda/issues/18212
+  - amd64
+  - '16'

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,16 @@
+---
+name: Github Action lint
+on:
+  pull_request:
+    paths:
+      - '.github/**'
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "::add-matcher::.github/actionlint-matcher.json"
+      - run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -shellcheck '' -ignore 'property "vault_.+" is not defined in object type' -ignore 'object type "{}" cannot be filtered by object filtering `.*` since it has no object element'

--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -297,7 +297,7 @@ jobs:
           then
             # Next, add the release labels to the release's issues, specifying the previous and current release in place of ZCL_FROM_REV and ZCL_TARGET_REV, respectively.
             #
-            # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and 
+            # ZCL_TARGET_REV should be replaced with the tag name for the version you are releasing, and
             # ZCL_FROM_REV should be replaced as the tag name for the previous version, based on the release type:
             #
             # PATCH: the tag for the previous patch version on the same minor branch. e.g. if you're releasing 1.2.3, then ZCL_FROM_REV=1.2.2.

--- a/.github/workflows/operate-check-project-versions.yml
+++ b/.github/workflows/operate-check-project-versions.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check versions
         env:
           RELEASE_VERSION: ${{ inputs.releaseVersion }}
-          BRANCH_NAME: ${{ inputs.branchName }}
+          BRANCH_NAME: ${{ inputs.branch }}
         run: |
           IDENTITY_VERSION=$(mvn -f operate help:evaluate -Dexpression=version.identity -q -DforceStdout)
 

--- a/.github/workflows/operate-ci-build-observe-reusable.yml
+++ b/.github/workflows/operate-ci-build-observe-reusable.yml
@@ -7,6 +7,11 @@ on:
         description: "The branch name to be used for the workflow"
         required: true
         type: string
+      forkCount:
+        description: "The number of VMs to fork in parallel in order to execute the tests"
+        required: false
+        default: 4
+        type: number
       command:
         description: "Maven command to trigger the test"
         required: true

--- a/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
+++ b/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
@@ -50,7 +50,7 @@ jobs:
           cache: 'maven'
       - uses: ./.github/actions/setup-zeebe
         with:
-          maven-cache-key-modifier: it-${{ matrix.group }}
+          maven-cache-key-modifier: sdk-build
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -84,6 +84,7 @@ jobs:
           name: "unit tests"
       - name: Java Checks
         run: ./mvnw -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs -f spring-boot-starter-camunda-sdk verify
+
   sdk-test-summary:
     # Used by the merge queue to check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!
@@ -92,11 +93,12 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     outputs:
-      flakyUnitTests: ${{ needs.unit-tests.outputs.flakyTests }}
+      flakyUnitTests: ${{ needs.build-sdk.outputs.flakyTests }}
     needs:
       - build-sdk
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+
   notify-if-failed:
     name: Send slack notification on build failure
     runs-on: ubuntu-latest
@@ -135,21 +137,14 @@ jobs:
                     "type": "mrkdwn",
                     "text": "*Detected flaky unit tests:* \n ${{ env.FLAKY_UNIT_TESTS }}"
                   }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Detected flaky integration tests:* \n ${{ env.FLAKY_INTEGRATION_TESTS }}"
-                  }
                 }
               ]
             }
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-          FLAKY_UNIT_TESTS: ${{needs.test-summary.outputs.flakyUnitTests}}
-          FLAKY_INTEGRATION_TESTS: ${{needs.test-summary.outputs.flakyIntegrationTests}}
+          FLAKY_UNIT_TESTS: ${{needs.sdk-test-summary.outputs.flakyUnitTests}}
+
   auto-merge:
     # This workflow will auto merge a PR authored by backport-action.
     # It runs only on open PRs ready for review.

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -443,9 +443,6 @@ jobs:
         with:
           # fixed to avoid triggering false positive; see https://github.com/golangci/golangci-lint-action/issues/535
           version: v1.55.2
-          # caching issues, see: https://github.com/golangci/golangci-lint-action/issues/244#issuecomment-1052190775
-          skip-pkg-cache: true
-          skip-build-cache: true
           working-directory: clients/go
       - name: Observe build status
         if: always()

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -196,8 +196,6 @@ jobs:
           -f zeebe
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
-      - name: Normalize artifact name
-        run: echo "ARTIFACT_NAME=$(echo ${{ matrix.project }} | sed 's/\//-/g')" >> $GITHUB_ENV
       - name: Analyze Test Runs
         id: analyze-test-run
         if: always()

--- a/.github/workflows/zeebe-pr-benchmark.yaml
+++ b/.github/workflows/zeebe-pr-benchmark.yaml
@@ -11,8 +11,8 @@ jobs:
   create-benchmark:
     name: Benchmark
     if: >
-      (github.event.action == 'labeled' && github.event.label.name == 'benchmark')
-      || (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+      (github.event.action == 'labeled' && github.event.label.name == 'benchmark') ||
+      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
     uses: ./.github/workflows/zeebe-benchmark.yml
     secrets: inherit
     with:
@@ -21,11 +21,12 @@ jobs:
       cluster-region: europe-west1-b
       ref: ${{ github.event.pull_request.head.ref }}
       publish: "comment"
+
   delete-benchmark:
     name: Benchmark Cleanup
     if: >
-      (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark')
-      || (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
+      (github.event.action == 'unlabeled' && github.event.label.name == 'benchmark') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'benchmark'))
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -40,5 +41,7 @@ jobs:
           cluster_name: zeebe-cluster
           location: europe-west1-b
       - name: Delete benchmarks
+        env:
+          PR_HEAD_REF: ${{github.event.pull_request.head.ref}}
         run: |
-          kubectl delete ns ${{github.event.pull_request.head.ref}}-benchmark
+          kubectl delete ns "$PR_HEAD_REF"-benchmark


### PR DESCRIPTION
## Description

Find and fix most obvious problems reported by https://github.com/rhysd/actionlint on the GHA workflow files (**not** shell scripts yet in the first step) in the monorepo CI, to avoid subtle mistakes and unexpected errors. See [this run](https://github.com/camunda/camunda/actions/runs/9299275226?pr=18929) for the discovered problems.

To avoid introducing more errors add `actionlint` CI with ignores on known problems.