### PR TITLE
deps: remove log4j-core test jar dependency

### DIFF
--- a/operate/common/pom.xml
+++ b/operate/common/pom.xml
@@ -263,8 +263,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <type>test-jar</type>
+      <artifactId>log4j-core-test</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/util/StackdriverJSONLayoutTest.java
@@ -16,8 +16,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.junit.LoggerContextRule;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextRule;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -32,7 +32,7 @@ public class StackdriverJSONLayoutTest {
 
   @Rule public LoggerContextRule loggerRule = new LoggerContextRule("log4j2.xml");
 
-  private ObjectReader jsonReader = new ObjectMapper().reader();
+  private final ObjectReader jsonReader = new ObjectMapper().reader();
 
   @Test
   public void testLayout() throws Exception {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -153,7 +153,6 @@
     <version.node>v20.12.2</version.node>
     <version.yarn>v1.22.21</version.yarn>
 
-    <version.log4j.testjar>2.19.0</version.log4j.testjar>
     <version.aws-java-sdk>1.12.731</version.aws-java-sdk>
     <version.elasticsearch-test-container>1.19.8</version.elasticsearch-test-container>
     <version.postgres-test-container>1.19.8</version.postgres-test-container>
@@ -1768,13 +1767,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-collections4</artifactId>
         <version>${version.commons-collections4}</version>
-      </dependency>
-
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${version.log4j.testjar}</version>
-        <type>test-jar</type>
       </dependency>
 
       <dependency>

--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -239,8 +239,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <type>test-jar</type>
+      <artifactId>log4j-core-test</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/tasklist/common/src/test/java/io/camunda/tasklist/util/StackdriverJSONLayoutTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/util/StackdriverJSONLayoutTest.java
@@ -16,9 +16,9 @@ import java.util.List;
 import java.util.Map;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.junit.LoggerContextSource;
-import org.apache.logging.log4j.junit.Named;
-import org.apache.logging.log4j.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.appender.ListAppender;
+import org.apache.logging.log4j.core.test.junit.LoggerContextSource;
+import org.apache.logging.log4j.core.test.junit.Named;
 import org.junit.jupiter.api.Test;
 
 /**


### PR DESCRIPTION
## Description
Replacing it with `org.apache.logging.log4j:log4j-core-test` as suggested in https://issues.apache.org/jira/browse/LOG4J2-3650
## Related issues

closes #
