### PR TITLE
ExporterDirector can enable an exporter and initializes its metadata at runtime

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterDescriptor.java
@@ -39,4 +39,8 @@ public class ExporterDescriptor {
   public String getId() {
     return configuration.id();
   }
+
+  public boolean isSameTypeAs(final ExporterDescriptor other) {
+    return exporterClass.equals(other.exporterClass);
+  }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -75,6 +75,14 @@ final class ExporterContainer implements Controller {
     }
   }
 
+  void initMetadata(final long metadataVersion, final String initializeFrom) {
+    if (initializeFrom != null) {
+      final DirectBuffer metadata = exportersState.getExporterMetadata(initializeFrom);
+      final long otherPosition = exportersState.getPosition(initializeFrom);
+      exportersState.initializeExporterState(getId(), otherPosition, metadata, metadataVersion);
+    }
+  }
+
   void openExporter() {
     LOG.debug("Open exporter with id '{}'", getId());
     ThreadContextUtil.runWithClassLoader(

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.broker.exporter.stream;
 
 import io.camunda.zeebe.broker.Loggers;
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.ExporterMode;
 import io.camunda.zeebe.broker.system.partitions.PartitionMessagingService;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -223,6 +224,57 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       LOG.info("No exporters are configured. Closing the exporter director '{}'.", name);
       actor.close();
     }
+  }
+
+  /**
+   * Enables an exporter with the given id and descriptor. The exporter will start exporting records
+   * after this operation completes.
+   *
+   * <p>It is expected that the exporter to initialize from the metadata is of same type as the
+   * exporter to enable. The caller of this method must verify that.
+   *
+   * @param exporterId id of the exporter to enable
+   * @param initializationInfo the info required to initialize the exporter state
+   * @param descriptor the descriptor of the exporter to enable
+   * @return future which will be completed after the exporter is enabled.
+   */
+  public ActorFuture<Void> enableExporter(
+      final String exporterId,
+      final ExporterInitializationInfo initializationInfo,
+      final ExporterDescriptor descriptor) {
+    if (actor.isClosed()) {
+      return CompletableActorFuture.completed(null);
+    }
+
+    return actor.call(
+        () ->
+            addExporter(
+                exporterId,
+                initializationInfo.metadataVersion(),
+                initializationInfo.initializeFrom(),
+                descriptor));
+  }
+
+  private void addExporter(
+      final String exporterId,
+      final long metadataVersion,
+      final String initializeFrom,
+      final ExporterDescriptor descriptor) {
+    final ExporterContainer container = new ExporterContainer(descriptor, partitionId);
+    container.initContainer(actor, metrics, state, exporterPhase);
+    try {
+      container.configureExporter();
+    } catch (final Exception e) {
+      LOG.error("Failed to configure exporter '{}'", exporterId, e);
+      LangUtil.rethrowUnchecked(e);
+    }
+    // initializes metadata in the runtime state
+    container.initMetadata(metadataVersion, initializeFrom);
+    // initialized position in memory
+    container.initPosition();
+    container.openExporter();
+    containers.add(container);
+    LOG.info("Exporter '{}' is enabled.", exporterId);
   }
 
   public ActorFuture<ExporterPhase> getPhase() {
@@ -561,6 +613,12 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     }
     return actor.call(() -> state.getLowestPosition());
   }
+
+  /**
+   * @param metadataVersion the version of the metadata to initialize the exporter with
+   * @param initializeFrom the id of the exporter to initialize the metadata of the exporter from
+   */
+  public record ExporterInitializationInfo(long metadataVersion, String initializeFrom) {}
 
   private static class ExporterEventFilter implements EventFilter {
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -249,25 +249,15 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       return CompletableActorFuture.completed(null);
     }
 
-    return actor.call(
-        () ->
-            addExporter(
-                exporterId,
-                initializationInfo.metadataVersion(),
-                initializationInfo.initializeFrom(),
-                descriptor));
+    return actor.call(() -> addExporter(exporterId, initializationInfo, descriptor));
   }
 
   private void addExporter(
       final String exporterId,
-      final long metadataVersion,
-      final String initializeFrom,
+      final ExporterInitializationInfo initializationInfo,
       final ExporterDescriptor descriptor) {
     final ExporterContainer container =
-        new ExporterContainer(
-            descriptor,
-            partitionId,
-            new ExporterInitializationInfo(metadataVersion, initializeFrom));
+        new ExporterContainer(descriptor, partitionId, initializationInfo);
     container.initContainer(actor, metrics, state, exporterPhase);
     try {
       container.configureExporter();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -92,8 +92,8 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     logStream = Objects.requireNonNull(context.getLogStream());
     partitionId = logStream.getPartitionId();
     containers =
-        context.getDescriptors().stream()
-            .map(descriptor -> new ExporterContainer(descriptor, partitionId))
+        context.getDescriptors().entrySet().stream()
+            .map(descriptorEntry -> new ExporterContainer(descriptorEntry.getKey(), partitionId))
             .collect(Collectors.toCollection(ArrayList::new));
     metrics = new ExporterMetrics(partitionId);
     metrics.initializeExporterState(exporterPhase);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -8,12 +8,13 @@
 package io.camunda.zeebe.broker.exporter.stream;
 
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.broker.system.partitions.PartitionMessagingService;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.api.EventFilter;
 import java.time.Duration;
-import java.util.Collection;
+import java.util.Map;
 
 public final class ExporterDirectorContext {
 
@@ -22,7 +23,7 @@ public final class ExporterDirectorContext {
   private int id;
   private String name;
   private LogStream logStream;
-  private Collection<ExporterDescriptor> descriptors;
+  private Map<ExporterDescriptor, ExporterInitializationInfo> descriptors;
   private ZeebeDb zeebeDb;
   private PartitionMessagingService partitionMessagingService;
   private ExporterMode exporterMode = ExporterMode.ACTIVE; // per default we export records
@@ -41,7 +42,7 @@ public final class ExporterDirectorContext {
     return logStream;
   }
 
-  public Collection<ExporterDescriptor> getDescriptors() {
+  public Map<ExporterDescriptor, ExporterInitializationInfo> getDescriptors() {
     return descriptors;
   }
 
@@ -80,7 +81,8 @@ public final class ExporterDirectorContext {
     return this;
   }
 
-  public ExporterDirectorContext descriptors(final Collection<ExporterDescriptor> descriptors) {
+  public ExporterDirectorContext descriptors(
+      final Map<ExporterDescriptor, ExporterInitializationInfo> descriptors) {
     this.descriptors = descriptors;
     return this;
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -122,5 +122,5 @@ public final class ExporterDirectorContext {
      * positions and stores them in the state. This mode is used on the follower side.
      */
     PASSIVE
-  }
+  };
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterStateEntry.java
@@ -23,9 +23,13 @@ public class ExporterStateEntry extends UnpackedObject implements DbValue {
   private final BinaryProperty metadataProp =
       new BinaryProperty("exporterMetadata", EMPTY_METADATA);
 
+  private final LongProperty metadataVersionProp = new LongProperty("metadataVersion", 0L);
+
   public ExporterStateEntry() {
-    super(2);
-    declareProperty(positionProp).declareProperty(metadataProp);
+    super(3);
+    declareProperty(positionProp)
+        .declareProperty(metadataProp)
+        .declareProperty(metadataVersionProp);
   }
 
   public long getPosition() {
@@ -44,6 +48,15 @@ public class ExporterStateEntry extends UnpackedObject implements DbValue {
 
   public ExporterStateEntry setMetadata(final DirectBuffer metadata) {
     metadataProp.setValue(metadata);
+    return this;
+  }
+
+  public long getMetadataVersion() {
+    return metadataVersionProp.getValue();
+  }
+
+  public ExporterStateEntry setMetadataVersion(final long metadataVersion) {
+    metadataVersionProp.setValue(metadataVersion);
     return this;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -59,10 +59,7 @@ public final class ExportersState {
       final long metadataVersion) {
     this.exporterId.wrapString(exporterId);
     final var exporterStateEntry = new ExporterStateEntry();
-    exporterStateEntry
-        .setPosition(position)
-        .setMetadata(metadata)
-        .setMetadataVersion(metadataVersion);
+    exporterStateEntry.setPosition(position).setMetadataVersion(metadataVersion);
     if (metadata != null) {
       exporterStateEntry.setMetadata(metadata);
     }
@@ -79,6 +76,12 @@ public final class ExportersState {
     return findExporterStateEntry(exporterId)
         .map(ExporterStateEntry::getMetadata)
         .orElse(METADATA_NOT_FOUND);
+  }
+
+  public long getMetadataVersion(final String exporterId) {
+    return findExporterStateEntry(exporterId)
+        .map(ExporterStateEntry::getMetadataVersion)
+        .orElse(0L);
   }
 
   private Optional<ExporterStateEntry> findExporterStateEntry(final String exporterId) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExportersState.java
@@ -52,6 +52,23 @@ public final class ExportersState {
     exporterPositionColumnFamily.upsert(this.exporterId, exporterStateEntry);
   }
 
+  public void initializeExporterState(
+      final String exporterId,
+      final long position,
+      final DirectBuffer metadata,
+      final long metadataVersion) {
+    this.exporterId.wrapString(exporterId);
+    final var exporterStateEntry = new ExporterStateEntry();
+    exporterStateEntry
+        .setPosition(position)
+        .setMetadata(metadata)
+        .setMetadataVersion(metadataVersion);
+    if (metadata != null) {
+      exporterStateEntry.setMetadata(metadata);
+    }
+    exporterPositionColumnFamily.upsert(this.exporterId, exporterStateEntry);
+  }
+
   public long getPosition(final String exporterId) {
     return findExporterStateEntry(exporterId)
         .map(ExporterStateEntry::getPosition)

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -67,8 +67,14 @@ public final class ExporterContainerRuntime implements CloseableSilently {
 
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor, final int partitionId) {
-    final var container =
-        new ExporterContainer(descriptor, partitionId, new ExporterInitializationInfo(0, null));
+    return newContainer(descriptor, partitionId, new ExporterInitializationInfo(0, null));
+  }
+
+  public ExporterContainer newContainer(
+      final ExporterDescriptor descriptor,
+      final int partitionId,
+      final ExporterInitializationInfo initializationInfo) {
+    final var container = new ExporterContainer(descriptor, partitionId, initializationInfo);
     container.initContainer(actor.getActorControl(), metrics, state, ExporterPhase.EXPORTING);
 
     return container;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.exporter.stream;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
 import io.camunda.zeebe.broker.exporter.repo.ExporterRepository;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
@@ -66,7 +67,8 @@ public final class ExporterContainerRuntime implements CloseableSilently {
 
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor, final int partitionId) {
-    final var container = new ExporterContainer(descriptor, partitionId);
+    final var container =
+        new ExporterContainer(descriptor, partitionId, new ExporterInitializationInfo(0, null));
     container.initContainer(actor.getActorControl(), metrics, state, ExporterPhase.EXPORTING);
 
     return container;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.nio.file.Path;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.api.parallel.Execution;
@@ -38,433 +39,6 @@ final class ExporterContainerTest {
   private ExporterContainerRuntime runtime;
   private FakeExporter exporter;
   private ExporterContainer exporterContainer;
-
-  @BeforeEach
-  void beforeEach(final @TempDir Path storagePath) throws ExporterLoadException {
-    runtime = new ExporterContainerRuntime(storagePath);
-
-    final var descriptor =
-        runtime.getRepository().load(EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
-    exporterContainer = runtime.newContainer(descriptor, PARTITION_ID);
-    exporter = (FakeExporter) exporterContainer.getExporter();
-  }
-
-  @Test
-  void shouldConfigureExporter() throws Exception {
-    // given
-
-    // when
-    exporterContainer.configureExporter();
-
-    // then
-    assertThat(exporter.getContext()).isNotNull();
-    assertThat(exporter.getContext().getLogger()).isNotNull();
-    assertThat(exporter.getContext().getConfiguration()).isNotNull();
-    assertThat(exporter.getContext().getConfiguration().getId()).isEqualTo(EXPORTER_ID);
-    assertThat(exporter.getContext().getPartitionId()).isEqualTo(PARTITION_ID);
-    assertThat(exporter.getContext().getConfiguration().getArguments())
-        .isEqualTo(Map.of("key", "value"));
-  }
-
-  @Test
-  void shouldOpenExporter() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-
-    // when
-    exporterContainer.openExporter();
-
-    // then
-    assertThat(exporter.getController()).isNotNull();
-    assertThat(exporter.getController()).isEqualTo(exporterContainer);
-  }
-
-  @Test
-  void shouldInitPositionToDefaultIfNotExistInState() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-
-    // when
-    exporterContainer.initMetadata();
-
-    // then
-    assertThat(exporterContainer.getPosition()).isEqualTo(-1);
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1);
-  }
-
-  @Test
-  void shouldInitPositionWithStateValues() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0xCAFE);
-
-    // when
-    exporterContainer.initMetadata();
-
-    // then
-    assertThat(exporterContainer.getPosition()).isEqualTo(0xCAFE);
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(0xCAFE);
-  }
-
-  @Test
-  void shouldNotExportWhenRecordPositionIsSmaller() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0xCAFE);
-    exporterContainer.initMetadata();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-
-    // when
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // then
-    assertThat(exporter.getRecord()).isNull();
-  }
-
-  @Test
-  void shouldUpdateUnacknowledgedPositionOnExport() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-
-    // when
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // then
-    assertThat(exporter.getRecord()).isNotNull();
-    assertThat(exporter.getRecord()).isEqualTo(mockedRecord);
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isZero();
-  }
-
-  @Test
-  void shouldUpdateUnacknowledgedPositionMultipleTimes() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // when
-    final var secondRecord = mock(TypedRecord.class);
-    when(secondRecord.getPosition()).thenReturn(2L);
-    exporterContainer.exportRecord(recordMetadata, secondRecord);
-
-    // then
-    assertThat(exporter.getRecord()).isNotNull();
-    assertThat(exporter.getRecord()).isEqualTo(secondRecord);
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
-    assertThat(exporterContainer.getPosition()).isZero();
-  }
-
-  @Test
-  void shouldUpdateExporterPosition() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-    exporterContainer.openExporter();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // when
-    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
-    awaitPreviousCall();
-
-    // then
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(1);
-    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(1);
-  }
-
-  @Test
-  void shouldNotUpdateExporterPositionToSmallerValue() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-    exporterContainer.openExporter();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // when
-    exporterContainer.updateLastExportedRecordPosition(-1);
-    awaitPreviousCall();
-
-    // then
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isZero();
-    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isZero();
-  }
-
-  @Test
-  void shouldNotUpdateExporterPositionInDifferentOrder() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-    exporterContainer.openExporter();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-    when(mockedRecord.getPosition()).thenReturn(2L);
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // when
-    exporterContainer.updateLastExportedRecordPosition(2);
-    exporterContainer.updateLastExportedRecordPosition(1);
-    awaitPreviousCall();
-
-    // then
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
-    assertThat(exporterContainer.getPosition()).isEqualTo(2);
-    assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(2);
-  }
-
-  @Test
-  void shouldNotUpdateExporterPositionIfSoftPaused() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-    exporterContainer.openExporter();
-    exporterContainer.softPauseExporter();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // when
-    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
-    awaitPreviousCall();
-
-    // then
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isZero();
-  }
-
-  @Test
-  void shouldUpdatePositionWhenResumedAfterSoftPaused() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-    exporterContainer.openExporter();
-    exporterContainer.softPauseExporter();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final byte[] metadata = "metadata".getBytes();
-    final var recordMetadata = new RecordMetadata().requestId(1L);
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition(), metadata);
-    awaitPreviousCall();
-
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isZero();
-    assertThat(exporterContainer.readMetadata()).isNotPresent();
-
-    // when
-    exporterContainer.undoSoftPauseExporter();
-    awaitPreviousCall();
-
-    // then
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(1);
-    assertThat(exporterContainer.readMetadata()).isPresent().hasValue(metadata);
-  }
-
-  @Test
-  void shouldUpdatePositionsWhenRecordIsFiltered() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    exporter.getContext().setFilter(new AlwaysRejectingFilter());
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-
-    // when
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // then
-    assertThat(exporter.getRecord()).isNull();
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
-    assertThat(exporterContainer.getPosition()).isEqualTo(1);
-  }
-
-  @Test
-  void shouldUpdatePositionsWhenRecordIsFilteredAndPositionsAreEqual() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-
-    final var mockedRecord = mock(TypedRecord.class);
-    when(mockedRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-    exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
-    awaitPreviousCall();
-
-    // when
-    exporter.getContext().setFilter(new AlwaysRejectingFilter());
-    when(mockedRecord.getPosition()).thenReturn(2L);
-    exporterContainer.exportRecord(recordMetadata, mockedRecord);
-
-    // then
-    assertThat(exporter.getRecord()).isNotNull();
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isEqualTo(2);
-  }
-
-  @Test
-  void shouldNotUpdatePositionsWhenRecordIsFilteredAndLastEventWasUnacknowledged()
-      throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-
-    final var firstRecord = mock(TypedRecord.class);
-    when(firstRecord.getPosition()).thenReturn(1L);
-    final var recordMetadata = new RecordMetadata();
-    exporterContainer.exportRecord(recordMetadata, firstRecord);
-
-    // when
-    final var secondRecord = mock(TypedRecord.class);
-    when(secondRecord.getPosition()).thenReturn(2L);
-    exporter.getContext().setFilter(new AlwaysRejectingFilter());
-    exporterContainer.exportRecord(recordMetadata, secondRecord);
-
-    // then
-    assertThat(exporter.getRecord()).isNotNull();
-    assertThat(exporter.getRecord()).isEqualTo(firstRecord);
-    assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
-    assertThat(exporterContainer.getPosition()).isZero();
-  }
-
-  @Test
-  void shouldCloseExporter() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-    runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initMetadata();
-
-    // when
-    exporterContainer.close();
-
-    // then
-    assertThat(exporter.isClosed()).isTrue();
-  }
-
-  @Test
-  void shouldReturnEmptyMetadataIfNotExistInState() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-
-    // when
-    final var metadata = exporterContainer.readMetadata();
-
-    // then
-    assertThat(metadata).isNotPresent();
-  }
-
-  @Test
-  void shouldReadMetadataFromState() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-
-    final var metadata = "metadata".getBytes();
-    runtime.getState().setExporterState(EXPORTER_ID, 10, BufferUtil.wrapArray(metadata));
-
-    // when
-    final var readMetadata = exporterContainer.readMetadata();
-
-    // then
-    assertThat(readMetadata).isPresent().hasValue(metadata);
-  }
-
-  @Test
-  void shouldStoreMetadataInState() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-
-    // when
-    final var metadata = "metadata".getBytes();
-    exporterContainer.updateLastExportedRecordPosition(10, metadata);
-    awaitPreviousCall();
-
-    // then
-    final var metadataInState = runtime.getState().getExporterMetadata(EXPORTER_ID);
-    assertThat(metadataInState).isNotNull().isEqualTo(BufferUtil.wrapArray(metadata));
-  }
-
-  @Test
-  void shouldNotUpdateMetadataInStateIfPositionIsSmaller() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-
-    final var metadataBefore = "m1".getBytes();
-    exporterContainer.updateLastExportedRecordPosition(20, metadataBefore);
-    awaitPreviousCall();
-
-    // when
-    final var metadataUpdated = "m2".getBytes();
-    exporterContainer.updateLastExportedRecordPosition(10, metadataUpdated);
-    awaitPreviousCall();
-
-    // then
-    final var metadataInState = runtime.getState().getExporterMetadata(EXPORTER_ID);
-    assertThat(metadataInState).isNotNull().isEqualTo(BufferUtil.wrapArray(metadataBefore));
-  }
-
-  @Test
-  void shouldStoreAndReadMetadata() throws Exception {
-    // given
-    exporterContainer.configureExporter();
-
-    final var metadata = "metadata".getBytes();
-
-    // when
-    exporterContainer.updateLastExportedRecordPosition(10, metadata);
-    awaitPreviousCall();
-
-    final var readMetadata = exporterContainer.readMetadata();
-
-    // then
-    assertThat(readMetadata).isPresent().hasValue(metadata);
-  }
-
-  private void awaitPreviousCall() {
-    // call is enqueued in queue and will be run after the previous call
-    // when we await the call we can be sure that the previous call is also done
-    runtime.getActor().getActorControl().call(() -> null).join();
-  }
 
   public static final class FakeExporter implements Exporter {
 
@@ -520,6 +94,437 @@ final class ExporterContainerTest {
     @Override
     public boolean acceptValue(final ValueType valueType) {
       return false;
+    }
+  }
+
+  @Nested
+  class WithDefaultInitialization {
+
+    @BeforeEach
+    void beforeEach(final @TempDir Path storagePath) throws ExporterLoadException {
+      runtime = new ExporterContainerRuntime(storagePath);
+
+      final var descriptor =
+          runtime.getRepository().load(EXPORTER_ID, FakeExporter.class, Map.of("key", "value"));
+      exporterContainer = runtime.newContainer(descriptor, PARTITION_ID);
+      exporter = (FakeExporter) exporterContainer.getExporter();
+    }
+
+    @Test
+    void shouldConfigureExporter() throws Exception {
+      // given
+
+      // when
+      exporterContainer.configureExporter();
+
+      // then
+      assertThat(exporter.getContext()).isNotNull();
+      assertThat(exporter.getContext().getLogger()).isNotNull();
+      assertThat(exporter.getContext().getConfiguration()).isNotNull();
+      assertThat(exporter.getContext().getConfiguration().getId()).isEqualTo(EXPORTER_ID);
+      assertThat(exporter.getContext().getPartitionId()).isEqualTo(PARTITION_ID);
+      assertThat(exporter.getContext().getConfiguration().getArguments())
+          .isEqualTo(Map.of("key", "value"));
+    }
+
+    @Test
+    void shouldOpenExporter() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+
+      // when
+      exporterContainer.openExporter();
+
+      // then
+      assertThat(exporter.getController()).isNotNull();
+      assertThat(exporter.getController()).isEqualTo(exporterContainer);
+    }
+
+    @Test
+    void shouldInitPositionToDefaultIfNotExistInState() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+
+      // when
+      exporterContainer.initMetadata();
+
+      // then
+      assertThat(exporterContainer.getPosition()).isEqualTo(-1);
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(-1);
+    }
+
+    @Test
+    void shouldInitPositionWithStateValues() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0xCAFE);
+
+      // when
+      exporterContainer.initMetadata();
+
+      // then
+      assertThat(exporterContainer.getPosition()).isEqualTo(0xCAFE);
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(0xCAFE);
+    }
+
+    @Test
+    void shouldNotExportWhenRecordPositionIsSmaller() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0xCAFE);
+      exporterContainer.initMetadata();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+
+      // when
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // then
+      assertThat(exporter.getRecord()).isNull();
+    }
+
+    @Test
+    void shouldUpdateUnacknowledgedPositionOnExport() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+
+      // when
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // then
+      assertThat(exporter.getRecord()).isNotNull();
+      assertThat(exporter.getRecord()).isEqualTo(mockedRecord);
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isZero();
+    }
+
+    @Test
+    void shouldUpdateUnacknowledgedPositionMultipleTimes() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // when
+      final var secondRecord = mock(TypedRecord.class);
+      when(secondRecord.getPosition()).thenReturn(2L);
+      exporterContainer.exportRecord(recordMetadata, secondRecord);
+
+      // then
+      assertThat(exporter.getRecord()).isNotNull();
+      assertThat(exporter.getRecord()).isEqualTo(secondRecord);
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
+      assertThat(exporterContainer.getPosition()).isZero();
+    }
+
+    @Test
+    void shouldUpdateExporterPosition() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // when
+      exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+      awaitPreviousCall();
+
+      // then
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isEqualTo(1);
+      assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(1);
+    }
+
+    @Test
+    void shouldNotUpdateExporterPositionToSmallerValue() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // when
+      exporterContainer.updateLastExportedRecordPosition(-1);
+      awaitPreviousCall();
+
+      // then
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(runtime.getState().getPosition(EXPORTER_ID)).isZero();
+    }
+
+    @Test
+    void shouldNotUpdateExporterPositionInDifferentOrder() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+      when(mockedRecord.getPosition()).thenReturn(2L);
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // when
+      exporterContainer.updateLastExportedRecordPosition(2);
+      exporterContainer.updateLastExportedRecordPosition(1);
+      awaitPreviousCall();
+
+      // then
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(2);
+      assertThat(exporterContainer.getPosition()).isEqualTo(2);
+      assertThat(runtime.getState().getPosition(EXPORTER_ID)).isEqualTo(2);
+    }
+
+    @Test
+    void shouldNotUpdateExporterPositionIfSoftPaused() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter();
+      exporterContainer.softPauseExporter();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // when
+      exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+      awaitPreviousCall();
+
+      // then
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isZero();
+    }
+
+    @Test
+    void shouldUpdatePositionWhenResumedAfterSoftPaused() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+      exporterContainer.openExporter();
+      exporterContainer.softPauseExporter();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final byte[] metadata = "metadata".getBytes();
+      final var recordMetadata = new RecordMetadata().requestId(1L);
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition(), metadata);
+      awaitPreviousCall();
+
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isZero();
+      assertThat(exporterContainer.readMetadata()).isNotPresent();
+
+      // when
+      exporterContainer.undoSoftPauseExporter();
+      awaitPreviousCall();
+
+      // then
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isEqualTo(1);
+      assertThat(exporterContainer.readMetadata()).isPresent().hasValue(metadata);
+    }
+
+    @Test
+    void shouldUpdatePositionsWhenRecordIsFiltered() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      exporter.getContext().setFilter(new AlwaysRejectingFilter());
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+
+      // when
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // then
+      assertThat(exporter.getRecord()).isNull();
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isZero();
+      assertThat(exporterContainer.getPosition()).isEqualTo(1);
+    }
+
+    @Test
+    void shouldUpdatePositionsWhenRecordIsFilteredAndPositionsAreEqual() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+
+      final var mockedRecord = mock(TypedRecord.class);
+      when(mockedRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+      exporterContainer.updateLastExportedRecordPosition(mockedRecord.getPosition());
+      awaitPreviousCall();
+
+      // when
+      exporter.getContext().setFilter(new AlwaysRejectingFilter());
+      when(mockedRecord.getPosition()).thenReturn(2L);
+      exporterContainer.exportRecord(recordMetadata, mockedRecord);
+
+      // then
+      assertThat(exporter.getRecord()).isNotNull();
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isEqualTo(2);
+    }
+
+    @Test
+    void shouldNotUpdatePositionsWhenRecordIsFilteredAndLastEventWasUnacknowledged()
+        throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+
+      final var firstRecord = mock(TypedRecord.class);
+      when(firstRecord.getPosition()).thenReturn(1L);
+      final var recordMetadata = new RecordMetadata();
+      exporterContainer.exportRecord(recordMetadata, firstRecord);
+
+      // when
+      final var secondRecord = mock(TypedRecord.class);
+      when(secondRecord.getPosition()).thenReturn(2L);
+      exporter.getContext().setFilter(new AlwaysRejectingFilter());
+      exporterContainer.exportRecord(recordMetadata, secondRecord);
+
+      // then
+      assertThat(exporter.getRecord()).isNotNull();
+      assertThat(exporter.getRecord()).isEqualTo(firstRecord);
+      assertThat(exporterContainer.getLastUnacknowledgedPosition()).isEqualTo(1);
+      assertThat(exporterContainer.getPosition()).isZero();
+    }
+
+    @Test
+    void shouldCloseExporter() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+      runtime.getState().setPosition(EXPORTER_ID, 0);
+      exporterContainer.initMetadata();
+
+      // when
+      exporterContainer.close();
+
+      // then
+      assertThat(exporter.isClosed()).isTrue();
+    }
+
+    @Test
+    void shouldReturnEmptyMetadataIfNotExistInState() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+
+      // when
+      final var metadata = exporterContainer.readMetadata();
+
+      // then
+      assertThat(metadata).isNotPresent();
+    }
+
+    @Test
+    void shouldReadMetadataFromState() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+
+      final var metadata = "metadata".getBytes();
+      runtime.getState().setExporterState(EXPORTER_ID, 10, BufferUtil.wrapArray(metadata));
+
+      // when
+      final var readMetadata = exporterContainer.readMetadata();
+
+      // then
+      assertThat(readMetadata).isPresent().hasValue(metadata);
+    }
+
+    @Test
+    void shouldStoreMetadataInState() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+
+      // when
+      final var metadata = "metadata".getBytes();
+      exporterContainer.updateLastExportedRecordPosition(10, metadata);
+      awaitPreviousCall();
+
+      // then
+      final var metadataInState = runtime.getState().getExporterMetadata(EXPORTER_ID);
+      assertThat(metadataInState).isNotNull().isEqualTo(BufferUtil.wrapArray(metadata));
+    }
+
+    @Test
+    void shouldNotUpdateMetadataInStateIfPositionIsSmaller() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+
+      final var metadataBefore = "m1".getBytes();
+      exporterContainer.updateLastExportedRecordPosition(20, metadataBefore);
+      awaitPreviousCall();
+
+      // when
+      final var metadataUpdated = "m2".getBytes();
+      exporterContainer.updateLastExportedRecordPosition(10, metadataUpdated);
+      awaitPreviousCall();
+
+      // then
+      final var metadataInState = runtime.getState().getExporterMetadata(EXPORTER_ID);
+      assertThat(metadataInState).isNotNull().isEqualTo(BufferUtil.wrapArray(metadataBefore));
+    }
+
+    @Test
+    void shouldStoreAndReadMetadata() throws Exception {
+      // given
+      exporterContainer.configureExporter();
+
+      final var metadata = "metadata".getBytes();
+
+      // when
+      exporterContainer.updateLastExportedRecordPosition(10, metadata);
+      awaitPreviousCall();
+
+      final var readMetadata = exporterContainer.readMetadata();
+
+      // then
+      assertThat(readMetadata).isPresent().hasValue(metadata);
+    }
+
+    private void awaitPreviousCall() {
+      // call is enqueued in queue and will be run after the previous call
+      // when we await the call we can be sure that the previous call is also done
+      runtime.getActor().getActorControl().call(() -> null).join();
     }
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerTest.java
@@ -85,7 +85,7 @@ final class ExporterContainerTest {
     exporterContainer.configureExporter();
 
     // when
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     // then
     assertThat(exporterContainer.getPosition()).isEqualTo(-1);
@@ -99,7 +99,7 @@ final class ExporterContainerTest {
     runtime.getState().setPosition(EXPORTER_ID, 0xCAFE);
 
     // when
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     // then
     assertThat(exporterContainer.getPosition()).isEqualTo(0xCAFE);
@@ -111,7 +111,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0xCAFE);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
@@ -129,7 +129,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
@@ -150,7 +150,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
@@ -174,7 +174,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
     exporterContainer.openExporter();
 
     final var mockedRecord = mock(TypedRecord.class);
@@ -197,7 +197,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
     exporterContainer.openExporter();
 
     final var mockedRecord = mock(TypedRecord.class);
@@ -220,7 +220,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
     exporterContainer.openExporter();
 
     final var mockedRecord = mock(TypedRecord.class);
@@ -246,7 +246,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
     exporterContainer.openExporter();
     exporterContainer.softPauseExporter();
 
@@ -269,7 +269,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
     exporterContainer.openExporter();
     exporterContainer.softPauseExporter();
 
@@ -302,7 +302,7 @@ final class ExporterContainerTest {
     exporterContainer.configureExporter();
     exporter.getContext().setFilter(new AlwaysRejectingFilter());
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
@@ -322,7 +322,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     final var mockedRecord = mock(TypedRecord.class);
     when(mockedRecord.getPosition()).thenReturn(1L);
@@ -348,7 +348,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     final var firstRecord = mock(TypedRecord.class);
     when(firstRecord.getPosition()).thenReturn(1L);
@@ -373,7 +373,7 @@ final class ExporterContainerTest {
     // given
     exporterContainer.configureExporter();
     runtime.getState().setPosition(EXPORTER_ID, 0);
-    exporterContainer.initPosition();
+    exporterContainer.initMetadata();
 
     // when
     exporterContainer.close();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDisableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDisableTest.java
@@ -27,7 +27,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-public class ExporterEnableDisableTest {
+public class ExporterDisableTest {
   private static final String EXPORTER_ID_1 = "exporter-1";
   private static final String EXPORTER_ID_2 = "exporter-2";
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterEnableTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.exporter.stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import org.awaitility.Awaitility;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ExporterEnableTest {
+  private static final String EXPORTER_ID_1 = "exporter-1";
+  private static final String EXPORTER_ID_2 = "exporter-2";
+
+  @Rule public final ExporterRule rule = ExporterRule.activeExporter();
+  private final Map<String, ControlledTestExporterWithMetadata> exporters = new HashMap<>();
+  private final List<ExporterDescriptor> exporterDescriptors = new ArrayList<>();
+
+  @Before
+  public void init() {
+    exporters.clear();
+    exporterDescriptors.clear();
+
+    createExporter(EXPORTER_ID_1, Collections.singletonMap("x", 1));
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    rule.closeExporterDirector();
+  }
+
+  private ExporterDescriptor createExporter(
+      final String exporterId, final Map<String, Object> arguments) {
+    final var exporter = spy(new ControlledTestExporterWithMetadata());
+
+    final ExporterDescriptor descriptor =
+        spy(new ExporterDescriptor(exporterId, exporter.getClass(), arguments));
+    doAnswer(c -> exporter).when(descriptor).newInstance();
+
+    exporters.put(exporterId, exporter);
+    exporterDescriptors.add(descriptor);
+    return descriptor;
+  }
+
+  @Test
+  public void shouldEnableExporter() {
+    // given
+    rule.startExporterDirector(exporterDescriptors);
+    rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(exporters.get(EXPORTER_ID_1).getExportedRecords()).hasSize(1));
+
+    // when
+    final var descriptor = createExporter(EXPORTER_ID_2, Collections.singletonMap("x", 1));
+    rule.getDirector()
+        .enableExporter(EXPORTER_ID_2, new ExporterInitializationInfo(1, null), descriptor)
+        .join();
+
+    rule.writeEvent(JobIntent.COMPLETED, new JobRecord());
+
+    // then
+    waitUntilExportersHaveSeenTheExpectedRecords();
+    assertThat(exporters.get(EXPORTER_ID_1).metadata()).isEqualTo(2);
+    assertThat(exporters.get(EXPORTER_ID_2).metadata())
+        .describedAs("Exporter 2 starts with the default initial metadata")
+        .isEqualTo(1);
+  }
+
+  @Test
+  public void shouldEnableExporterAndInitializeMetadata() {
+    // given
+    rule.startExporterDirector(exporterDescriptors);
+    rule.writeEvent(DeploymentIntent.CREATED, new DeploymentRecord());
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(exporters.get(EXPORTER_ID_1).getExportedRecords()).hasSize(1));
+
+    // when
+    final var descriptor = createExporter(EXPORTER_ID_2, Collections.singletonMap("x", 1));
+    rule.getDirector()
+        .enableExporter(EXPORTER_ID_2, new ExporterInitializationInfo(1, EXPORTER_ID_1), descriptor)
+        .join();
+
+    rule.writeEvent(JobIntent.COMPLETED, new JobRecord());
+
+    // then
+    waitUntilExportersHaveSeenTheExpectedRecords();
+    assertThat(exporters.get(EXPORTER_ID_2).metadata())
+        .describedAs("Exporter 2 starts with the metadata of exporter 1")
+        .isEqualTo(2);
+  }
+
+  private void waitUntilExportersHaveSeenTheExpectedRecords() {
+    Awaitility.await()
+        .untilAsserted(
+            () -> assertThat(exporters.get(EXPORTER_ID_1).getExportedRecords()).hasSize(2));
+    Awaitility.await()
+        .untilAsserted(
+            () ->
+                assertThat(exporters.get(EXPORTER_ID_2).getExportedRecords())
+                    .hasSize(1)
+                    .first()
+                    .extracting(Record::getIntent)
+                    .isEqualTo(JobIntent.COMPLETED));
+  }
+
+  static class ControlledTestExporterWithMetadata implements Exporter {
+    private final List<Record<?>> exportedRecords = new CopyOnWriteArrayList<>();
+    private Controller controller;
+    private int metadata = 0;
+
+    public List<Record<?>> getExportedRecords() {
+      return exportedRecords;
+    }
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+      controller.readMetadata().ifPresent(b -> metadata = ByteBuffer.wrap(b).getInt());
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      final Record<?> copiedRecord = record.copyOf();
+      exportedRecords.add(copiedRecord);
+      metadata++;
+      controller.updateLastExportedRecordPosition(
+          copiedRecord.getPosition(), ByteBuffer.allocate(4).putInt(metadata).array());
+    }
+
+    public int metadata() {
+      return metadata;
+    }
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.broker.exporter.stream;
 import static org.mockito.Mockito.spy;
 
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.ExporterMode;
 import io.camunda.zeebe.broker.system.partitions.PartitionMessagingService;
 import io.camunda.zeebe.db.ZeebeDb;
@@ -28,6 +29,7 @@ import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.time.Duration;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
@@ -107,6 +109,13 @@ public final class ExporterRule implements TestRule {
     final var runtimeFolder = streams.createRuntimeFolder(stream);
     capturedZeebeDb = spy(zeebeDbFactory.createDb(runtimeFolder.toFile()));
 
+    final var descriptorsWithInitializationInfo =
+        exporterDescriptors.stream()
+            .collect(
+                Collectors.toMap(
+                    descriptor -> descriptor,
+                    descriptor -> new ExporterInitializationInfo(0, null)));
+
     final ExporterDirectorContext context =
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
@@ -116,7 +125,7 @@ public final class ExporterRule implements TestRule {
             .exporterMode(exporterMode)
             .distributionInterval(distributionInterval)
             .partitionMessagingService(partitionMessagingService)
-            .descriptors(exporterDescriptors)
+            .descriptors(descriptorsWithInitializationInfo)
             .positionsToSkipFilter(positionsToSkipFilter);
 
     director = new ExporterDirector(context, phase);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.exporter.repo.ExporterLoadException;
+import io.camunda.zeebe.broker.exporter.stream.ExporterDirector.ExporterInitializationInfo;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.exporter.api.context.Controller;
@@ -129,7 +130,8 @@ final class ExternalExporterContainerTest {
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
-    final var container = new ExporterContainer(descriptor, 0);
+    final var container =
+        new ExporterContainer(descriptor, 0, new ExporterInitializationInfo(0, null));
 
     // when
     container.close();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -149,7 +149,8 @@ class ExporterDirectorPartitionTransitionStepTest {
     exporterDirectorStep.transitionTo(transitionContext, 1, Role.LEADER).join();
 
     // then
-    assertThat(capturedContext.get().getDescriptors().stream().map(ExporterDescriptor::getId))
+    assertThat(
+            capturedContext.get().getDescriptors().keySet().stream().map(ExporterDescriptor::getId))
         .containsExactly(enabledExporterId);
   }
 

--- a/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
+++ b/zeebe/msgpack-value/src/test/java/io/camunda/zeebe/msgpack/UnpackedObjectTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.spy;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.nio.ByteBuffer;
 import org.agrona.MutableDirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -23,10 +24,10 @@ import org.mockito.Mockito;
 public class UnpackedObjectTest {
 
   @Nested
-  public class GreyBox {
+  class GreyBox {
 
     @Test
-    public void shouldResetObjectBeforeReadingValue() {
+    void shouldResetObjectBeforeReadingValue() {
       // given
       final var property = new StringProperty("property", "default");
       final var unpackedObject = new UnpackedObject(1);
@@ -50,7 +51,7 @@ public class UnpackedObjectTest {
   }
 
   @Nested
-  public class SchemaEvolution {
+  class SchemaEvolution {
     private final StringProperty sharedProperty = new StringProperty("shared", "default");
 
     private final UnpackedObject oldSchemaObject = new UnpackedObject(2);
@@ -60,6 +61,9 @@ public class UnpackedObjectTest {
     private final BooleanProperty addedProperty = new BooleanProperty("addedProperty", false);
 
     private final MutableDirectBuffer bufferSerializedWithOldSchema =
+        new UnsafeBuffer(ByteBuffer.allocate(100));
+
+    private final MutableDirectBuffer bufferSerializedWithNewSchema =
         new UnsafeBuffer(ByteBuffer.allocate(100));
 
     {
@@ -73,7 +77,7 @@ public class UnpackedObjectTest {
     }
 
     @Test
-    public void newPropertiesShouldHaveDefaultValueAfterReadingOldSerialization() {
+    void newPropertiesShouldHaveDefaultValueAfterReadingOldSerialization() {
       // given
 
       // set the new property to a value that is different from the default value
@@ -89,8 +93,25 @@ public class UnpackedObjectTest {
     }
 
     @Test
+    void oldVersionCanReadDataSerializedInNewSchemaAndProvideDefaultValues() {
+      // given
+      sharedProperty.setValue("updated");
+      addedProperty.setValue(true);
+      newSchemaObject.write(bufferSerializedWithNewSchema, 0);
+
+      // when
+      oldSchemaObject.wrap(bufferSerializedWithNewSchema);
+
+      // then
+      assertThat(removedProperty.getValue())
+          .describedAs("value of removed property after reading")
+          .isEqualTo(42);
+      assertThat(BufferUtil.bufferAsString(sharedProperty.getValue())).isEqualTo("updated");
+    }
+
+    @Test
     /* Motivated by https://github.com/camunda/camunda/pull/7143 */
-    public void shouldNotAccumulateSizeWithUndeclaredProperties() {
+    void shouldNotAccumulateSizeWithUndeclaredProperties() {
 
       // given
       newSchemaObject.wrap(bufferSerializedWithOldSchema);


### PR DESCRIPTION
## Description

- Added a `metadataVersion` to the `ExporterStateEntry`. This should be backwards compatible. To verify that the test for msg-pack schema evolution is extended.
- `ExporterDirector` allows enabling an exporter via the method `enableExporter`.
- During startup/restart ExporterDirector re-initializes the metadata if required by comparing the expected `metadataVersion` and the actual `metadataVersion` in the runtime state. A re-initialization would be necessary if an exporter was enabled, but the  `ExporterDirector` started with an older snapshot that may contain outdate state for the re-enabled exporter.

## Related issues

closes #18854 
