### PR TITLE
Coordinator can handle exporter enable request

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementApi.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.dynamic.config.api;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -48,6 +49,9 @@ public interface ClusterConfigurationManagementApi {
 
   ActorFuture<ClusterConfigurationChangeResponse> disableExporter(
       ExporterDisableRequest exporterDisableRequest);
+
+  ActorFuture<ClusterConfigurationChangeResponse> enableExporter(
+      ExporterEnableRequest enableRequest);
 
   ActorFuture<ClusterConfiguration> cancelTopologyChange(
       ClusterConfigurationManagementRequest.CancelChangeRequest cancelChangeRequest);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequest.java
@@ -45,6 +45,9 @@ public sealed interface ClusterConfigurationManagementRequest {
   record ExporterDisableRequest(String exporterId, boolean dryRun)
       implements ClusterConfigurationManagementRequest {}
 
+  record ExporterEnableRequest(String exporterId, Optional<String> initializeFrom, boolean dryRun)
+      implements ClusterConfigurationManagementRequest {}
+
   record CancelChangeRequest(long changeId) implements ClusterConfigurationManagementRequest {
 
     @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestSender.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.dynamic.config.api;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -121,6 +122,17 @@ public final class ClusterConfigurationManagementRequestSender {
         ClusterConfigurationRequestTopics.DISABLE_EXPORTER.topic(),
         exporterDisableRequest,
         serializer::encodeExporterDisableRequest,
+        serializer::decodeTopologyChangeResponse,
+        coordinatorSupplier.getDefaultCoordinator(),
+        TIMEOUT);
+  }
+
+  public CompletableFuture<Either<ErrorResponse, ClusterConfigurationChangeResponse>>
+      enableExporter(final ExporterEnableRequest enableRequest) {
+    return communicationService.send(
+        ClusterConfigurationRequestTopics.ENABLE_EXPORTER.topic(),
+        enableRequest,
+        serializer::encodeExporterEnableRequest,
         serializer::decodeTopologyChangeResponse,
         coordinatorSupplier.getDefaultCoordinator(),
         TIMEOUT);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationManagementRequestsHandler.java
@@ -11,6 +11,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.CancelChangeRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -133,6 +134,15 @@ public final class ClusterConfigurationManagementRequestsHandler
     return handleRequest(
         exporterDisableRequest.dryRun(),
         new ExporterDisableRequestTransformer(exporterDisableRequest.exporterId()));
+  }
+
+  @Override
+  public ActorFuture<ClusterConfigurationChangeResponse> enableExporter(
+      final ExporterEnableRequest enableRequest) {
+    return handleRequest(
+        enableRequest.dryRun(),
+        new ExporterEnableRequestTransformer(
+            enableRequest.exporterId(), enableRequest.initializeFrom()));
   }
 
   @Override

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestServer.java
@@ -45,6 +45,7 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
     registerTopologyCancelHandler();
     registerForceScaleDownHandler();
     registerDisableExporterHandler();
+    registerEnableExporterHandler();
   }
 
   @Override
@@ -149,6 +150,14 @@ public final class ClusterConfigurationRequestServer implements AutoCloseable {
         ClusterConfigurationRequestTopics.DISABLE_EXPORTER.topic(),
         serializer::decodeExporterDisableRequest,
         request -> mapResponse(clusterConfigurationManagementApi.disableExporter(request)),
+        this::encodeResponse);
+  }
+
+  private void registerEnableExporterHandler() {
+    communicationService.replyTo(
+        ClusterConfigurationRequestTopics.ENABLE_EXPORTER.topic(),
+        serializer::decodeExporterEnableRequest,
+        request -> mapResponse(clusterConfigurationManagementApi.enableExporter(request)),
         this::encodeResponse);
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ClusterConfigurationRequestTopics.java
@@ -17,7 +17,8 @@ public enum ClusterConfigurationRequestTopics {
   QUERY_TOPOLOGY("topology-query"),
   CANCEL_CHANGE("topology-change-cancel"),
   FORCE_SCALE_DOWN("topology-force-scale-down"),
-  DISABLE_EXPORTER("topology-exporter-disable");
+  DISABLE_EXPORTER("topology-exporter-disable"),
+  ENABLE_EXPORTER("topology-exporter-enable");
   private final String topic;
 
   ClusterConfigurationRequestTopics(final String topic) {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeCoordinator.ConfigurationChangeRequest;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+final class ExporterEnableRequestTransformer implements ConfigurationChangeRequest {
+
+  private final String exporterId;
+  private final Optional<String> initializeFrom;
+
+  public ExporterEnableRequestTransformer(
+      final String exporterId, final Optional<String> initializeFrom) {
+    this.exporterId = exporterId;
+    this.initializeFrom = initializeFrom;
+  }
+
+  @Override
+  public Either<Exception, List<ClusterConfigurationChangeOperation>> operations(
+      final ClusterConfiguration clusterConfiguration) {
+    final List<ClusterConfigurationChangeOperation> operations = new ArrayList<>();
+    for (final var member : clusterConfiguration.members().entrySet()) {
+      final var memberId = member.getKey();
+      for (final var partitions : member.getValue().partitions().entrySet()) {
+        final var partitionId = partitions.getKey();
+        operations.add(
+            new PartitionEnableExporterOperation(
+                memberId, partitionId, exporterId, initializeFrom));
+      }
+    }
+    return Either.right(operations);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ClusterConfigurationRequestsSerializer.java
@@ -35,6 +35,9 @@ public interface ClusterConfigurationRequestsSerializer {
   byte[] encodeExporterDisableRequest(
       ClusterConfigurationManagementRequest.ExporterDisableRequest exporterDisableRequest);
 
+  byte[] encodeExporterEnableRequest(
+      ClusterConfigurationManagementRequest.ExporterEnableRequest exporterEnableRequest);
+
   ClusterConfigurationManagementRequest.AddMembersRequest decodeAddMembersRequest(
       byte[] encodedState);
 
@@ -56,6 +59,9 @@ public interface ClusterConfigurationRequestsSerializer {
       byte[] encodedState);
 
   ClusterConfigurationManagementRequest.ExporterDisableRequest decodeExporterDisableRequest(
+      byte[] encodedRequest);
+
+  ClusterConfigurationManagementRequest.ExporterEnableRequest decodeExporterEnableRequest(
       byte[] encodedRequest);
 
   byte[] encodeResponse(ClusterConfigurationChangeResponse response);

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -156,6 +156,26 @@
             ]
           },
           {
+            "name": "ExporterEnableRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "exporterId",
+                "type": "string"
+              },
+              {
+                "id": 2,
+                "name": "initializeFrom",
+                "type": "string"
+              },
+              {
+                "id": 3,
+                "name": "dryRun",
+                "type": "bool"
+              }
+            ]
+          },
+          {
             "name": "CancelTopologyChangeRequest",
             "fields": [
               {

--- a/zeebe/dynamic-config/src/main/resources/proto/requests.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/requests.proto
@@ -45,6 +45,12 @@ message ExporterDisableRequest {
   bool dryRun = 2;
 }
 
+message ExporterEnableRequest {
+  string exporterId = 1;
+  optional string initializeFrom = 2;
+  bool dryRun = 3;
+}
+
 message CancelTopologyChangeRequest {
   int64 changeId = 1;
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ExporterEnableRequestTransformerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.test.util.asserts.EitherAssert;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class ExporterEnableRequestTransformerTest {
+
+  final String exporterId = "exporterA";
+  private final MemberId id0 = MemberId.from("0");
+  private final MemberId id1 = MemberId.from("1");
+  private final DynamicPartitionConfig config =
+      new DynamicPartitionConfig(
+          new ExportersConfig(
+              Map.of(exporterId, new ExporterState(1, State.DISABLED, Optional.empty()))));
+
+  @Test
+  void shouldGenerateOperationForAllPartitionsAndMembers() {
+    // given
+    final Optional<String> initializeFrom = Optional.empty();
+    final var transformer = new ExporterEnableRequestTransformer(exporterId, initializeFrom);
+
+    final var clusterConfiguration =
+        ClusterConfiguration.init()
+            .addMember(id0, MemberState.initializeAsActive(Map.of()))
+            .addMember(id1, MemberState.initializeAsActive(Map.of()))
+            .updateMember(id0, m -> m.addPartition(1, PartitionState.active(1, config)))
+            .updateMember(id0, m -> m.addPartition(2, PartitionState.active(2, config)))
+            .updateMember(id1, m -> m.addPartition(2, PartitionState.active(1, config)))
+            .updateMember(id1, m -> m.addPartition(1, PartitionState.active(2, config)));
+
+    // when
+    final var result = transformer.operations(clusterConfiguration);
+
+    // then
+    EitherAssert.assertThat(result).isRight();
+    assertThat(result.get())
+        .containsExactlyInAnyOrder(
+            new PartitionEnableExporterOperation(id0, 1, exporterId, initializeFrom),
+            new PartitionEnableExporterOperation(id0, 2, exporterId, initializeFrom),
+            new PartitionEnableExporterOperation(id1, 2, exporterId, initializeFrom),
+            new PartitionEnableExporterOperation(id1, 1, exporterId, initializeFrom));
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -13,6 +13,7 @@ import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationChangeResponse;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.AddMembersRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.JoinPartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.LeavePartitionRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ReassignPartitionsRequest;
@@ -162,6 +163,21 @@ final class ProtoBufSerializerTest {
     // then
     final var decodedRequest = protoBufSerializer.decodeExporterDisableRequest(encodedRequest);
     assertThat(decodedRequest).isEqualTo(exporterDisableRequest);
+  }
+
+  @Test
+  void shouldEncodeAndDecodeExporterEnableRequest() {
+    // given
+    final var exporterEnableRequest =
+        new ExporterEnableRequest("expId", Optional.of("expId2"), false);
+
+    // when
+    final var encodedRequest =
+        protoBufSerializer.encodeExporterEnableRequest(exporterEnableRequest);
+
+    // then
+    final var decodedRequest = protoBufSerializer.decodeExporterEnableRequest(encodedRequest);
+    assertThat(decodedRequest).isEqualTo(exporterEnableRequest);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR added request handlers in the broker to process request to enable an exporter. Similar to other configuration change requests, the handler generates a sequence of configuration change operations and starts a configuration change with these operations.

## Related issues

closes #18855 
