### PR TITLE
test: increase timeout for reconfigure operations

### DIFF
--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -32,6 +32,7 @@ import java.util.function.Function;
 public class TestRaftServerProtocol implements RaftServerProtocol {
 
   private static final long REQUEST_TIMEOUT_MS = 1000;
+  private static final long CONFIGURATION_REQUEST_TIMEOUT_MS = 4000;
 
   private Function<ConfigureRequest, CompletableFuture<ConfigureResponse>> configureHandler;
   private Function<ReconfigureRequest, CompletableFuture<ReconfigureResponse>> reconfigureHandler;
@@ -91,7 +92,7 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
         .thenCompose(listener -> intercept(listener, request, ReconfigureRequest.class))
         .thenCompose(listener -> listener.reconfigure(request))
         .thenCompose(response -> transformResponse(response, ReconfigureResponse.class))
-        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        .orTimeout(CONFIGURATION_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -110,7 +111,7 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
         .thenCompose(listener -> intercept(listener, request, JoinRequest.class))
         .thenCompose(listener -> listener.join(request))
         .thenCompose(response -> transformResponse(response, JoinResponse.class))
-        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        .orTimeout(CONFIGURATION_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 
   @Override
@@ -120,7 +121,7 @@ public class TestRaftServerProtocol implements RaftServerProtocol {
         .thenCompose(listener -> intercept(listener, request, LeaveRequest.class))
         .thenCompose(listener -> listener.leave(request))
         .thenCompose(response -> transformResponse(response, LeaveResponse.class))
-        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        .orTimeout(CONFIGURATION_REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
   }
 
   @Override


### PR DESCRIPTION
## Description

In production code, we use a higher timeout for configuration change requests because it requires multiple round trips between the members. In the failed test run, we can see that the operation eventually completed but the request had failed due to the lower timeout. To prevent the flakiness of the test, it is better to increase the timeout similar to the production code.

## Related issues

closes #18054 
