### PR TITLE
Write full integration test for Single application

### DIFF
--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -460,6 +460,11 @@
       <artifactId>zeebe-backup-store-azure</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-webapp</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/application/StandaloneCamundaTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/application/StandaloneCamundaTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneCamunda;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class StandaloneCamundaTest {
+
+  @TestZeebe final TestStandaloneCamunda testStandaloneCamunda = new TestStandaloneCamunda();
+
+  @Test
+  public void shouldCreateAndRetrieveInstance() {
+    // givne
+    final var zeebeClient = testStandaloneCamunda.newClientBuilder().build();
+
+    // when
+    zeebeClient
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess("process")
+                .startEvent()
+                .serviceTask("test")
+                .zeebeJobType("type")
+                .endEvent()
+                .done(),
+            "simple.bpmn")
+        .send()
+        .join();
+
+    final var processInstanceEvent =
+        zeebeClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .send()
+            .join();
+
+    // then
+    // Query REST API
+    final URI restAddress = testStandaloneCamunda.restAddress();
+    final HttpClient httpClient = HttpClient.newHttpClient();
+
+    Awaitility.await("should receive data from ES")
+        .untilAsserted(
+            () -> {
+              final HttpRequest request =
+                  HttpRequest.newBuilder()
+                      .uri(new URI(String.format("%sv1/process-instances/search", restAddress)))
+                      .header("content-type", "application/json")
+                      .POST(
+                          HttpRequest.BodyPublishers.ofString(
+                              String.format(
+                                  "{\"filter\":{\"key\":%d}, \"sort\":{\"field\":\"endDate\",\"order\":\"ASC\"},\"page\":{\"form\":0,\"size\":20}}",
+                                  processInstanceEvent.getProcessInstanceKey())))
+                      .build();
+              final HttpResponse<String> response =
+                  httpClient.send(request, BodyHandlers.ofString());
+
+              assertThat(response.statusCode())
+                  .withFailMessage(
+                      () ->
+                          "Expect success response, got "
+                              + response.body()
+                              + " with code: "
+                              + response.statusCode())
+                  .isEqualTo(200);
+            });
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/application/StandaloneCamundaTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/application/StandaloneCamundaTest.java
@@ -9,23 +9,15 @@ package io.camunda.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import io.camunda.operate.webapp.api.v1.entities.ProcessInstance;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.qa.util.cluster.TestRestOperateClient.ProcessInstanceResult;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneCamunda;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
+import io.camunda.zeebe.util.Either;
 import java.time.Duration;
-import java.util.List;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @ZeebeIntegration
 public class StandaloneCamundaTest {
@@ -60,51 +52,28 @@ public class StandaloneCamundaTest {
             .join();
 
     // then
-    // Query REST API
-    final URI restAddress = testStandaloneCamunda.restAddress();
-    final HttpClient httpClient = HttpClient.newHttpClient();
-
+    final var operateClient = testStandaloneCamunda.newOperateClient();
     Awaitility.await("should receive data from ES")
         .timeout(Duration.ofMinutes(1))
         .untilAsserted(
             () -> {
-              final HttpRequest request =
-                  HttpRequest.newBuilder()
-                      .uri(new URI(String.format("%sv1/process-instances/search", restAddress)))
-                      .header("content-type", "application/json")
-                      .POST(
-                          HttpRequest.BodyPublishers.ofString(
-                              String.format(
-                                  "{\"filter\":{\"key\":%d},\"sort\":[{\"field\":\"endDate\",\"order\":\"ASC\"}],\"size\":20}",
-                                  processInstanceEvent.getProcessInstanceKey())))
-                      .build();
-              final HttpResponse<String> response =
-                  httpClient.send(request, BodyHandlers.ofString());
+              final Either<Exception, ProcessInstanceResult> eitherProcessInstanceResult =
+                  operateClient.getProcessInstanceWith(
+                      processInstanceEvent.getProcessInstanceKey());
 
-              assertThat(response.statusCode())
-                  .withFailMessage(
-                      () ->
-                          "Expect success response, got "
-                              + response.body()
-                              + " with code: "
-                              + response.statusCode())
-                  .isEqualTo(200);
+              // has no exception
+              assertThat(eitherProcessInstanceResult.isRight())
+                  .withFailMessage("Expect no error on retrieving process instance")
+                  .isTrue();
 
-              final ObjectMapper objectMapper = new ObjectMapper();
-              final ProcessInstanceResult processInstanceResult =
-                  objectMapper.readValue(response.body(), ProcessInstanceResult.class);
-              assertThat(processInstanceResult.total)
+              final var processInstanceResult = eitherProcessInstanceResult.get();
+              assertThat(processInstanceResult.total())
                   .withFailMessage("Expect to read a process instance from ES")
                   .isGreaterThan(0);
 
-              assertThat(processInstanceResult.processInstances.getFirst().getKey())
+              assertThat(processInstanceResult.processInstances().getFirst().getKey())
                   .withFailMessage("Expect to read the expected process instance from ES")
                   .isEqualTo(processInstanceEvent.getProcessInstanceKey());
             });
   }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  public record ProcessInstanceResult(
-      @JsonProperty("items") List<ProcessInstance> processInstances,
-      @JsonProperty("total") long total) {}
 }

--- a/zeebe/qa/integration-tests/src/test/resources/elasticsearch-fast-startup.options
+++ b/zeebe/qa/integration-tests/src/test/resources/elasticsearch-fast-startup.options
@@ -1,0 +1,2 @@
+-Xlog:disable
+-XX:TieredStopAtLevel=1

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -181,6 +181,29 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-schema</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-webapp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>operate-common</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -20,6 +20,10 @@
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>elasticsearch</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>io.zeebe</groupId>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestElasticsearchSchemaManager.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestElasticsearchSchemaManager.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.camunda.operate.conditions.ElasticsearchCondition;
+import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component("schemaManager")
+@Conditional(ElasticsearchCondition.class)
+@Profile("test")
+public class TestElasticsearchSchemaManager extends ElasticsearchSchemaManager {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(TestElasticsearchSchemaManager.class);
+
+  public void deleteSchema() {
+    final String prefix = operateProperties.getElasticsearch().getIndexPrefix();
+    LOGGER.info("Removing indices {}*", prefix);
+    retryElasticsearchClient.deleteIndicesFor(prefix + "*");
+    retryElasticsearchClient.deleteTemplatesFor(prefix + "*");
+  }
+
+  public void setCreateSchema(final boolean createSchema) {
+    operateProperties.getElasticsearch().setCreateSchema(createSchema);
+  }
+
+  public void setIndexPrefix(final String indexPrefix) {
+    operateProperties.getElasticsearch().setIndexPrefix(indexPrefix);
+  }
+
+  public void setDefaultIndexPrefix() {
+    operateProperties.getElasticsearch().setDefaultIndexPrefix();
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestElasticsearchSchemaManager.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestElasticsearchSchemaManager.java
@@ -27,6 +27,7 @@ public class TestElasticsearchSchemaManager extends ElasticsearchSchemaManager {
     final String prefix = operateProperties.getElasticsearch().getIndexPrefix();
     LOGGER.info("Removing indices {}*", prefix);
     retryElasticsearchClient.deleteIndicesFor(prefix + "*");
+    LOGGER.info("Removing templates {}*", prefix);
     retryElasticsearchClient.deleteTemplatesFor(prefix + "*");
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestOperateClient.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestRestOperateClient.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.webapp.api.v1.entities.ProcessInstance;
+import io.camunda.zeebe.util.Either;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.List;
+
+public class TestRestOperateClient implements AutoCloseable {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final URI endpoint;
+  private final HttpClient httpClient;
+
+  public TestRestOperateClient(final URI endpoint) {
+    this.endpoint = endpoint;
+
+    httpClient = HttpClient.newHttpClient();
+  }
+
+  private Either<Exception, HttpRequest> createProcessInstanceRequest(final long key) {
+    final HttpRequest request;
+    try {
+      request =
+          HttpRequest.newBuilder()
+              .uri(new URI(String.format("%sv1/process-instances/search", endpoint)))
+              .header("content-type", "application/json")
+              .POST(
+                  HttpRequest.BodyPublishers.ofString(
+                      String.format(
+                          "{\"filter\":{\"key\":%d},\"sort\":[{\"field\":\"endDate\",\"order\":\"ASC\"}],\"size\":20}",
+                          key)))
+              .build();
+    } catch (final URISyntaxException e) {
+      return Either.left(e);
+    }
+    return Either.right(request);
+  }
+
+  private Either<Exception, HttpResponse<String>> sendProcessInstanceQuery(
+      final HttpRequest request) {
+    try {
+      return Either.right(httpClient.send(request, BodyHandlers.ofString()));
+    } catch (final IOException | InterruptedException e) {
+      return Either.left(e);
+    }
+  }
+
+  private Either<Exception, ProcessInstanceResult> mapProcessInstanceResult(
+      final HttpResponse<String> response) {
+    if (response.statusCode() != 200) {
+      return Either.left(
+          new IllegalStateException(
+              String.format(
+                  "Expected status code 200, but got %d. [Response body: %s, Endpoint: %s].",
+                  response.statusCode(), response.body(), response.uri())));
+    }
+
+    try {
+      return Either.right(OBJECT_MAPPER.readValue(response.body(), ProcessInstanceResult.class));
+    } catch (final JsonProcessingException e) {
+      return Either.left(e);
+    }
+  }
+
+  public Either<Exception, ProcessInstanceResult> getProcessInstanceWith(final long key) {
+    return createProcessInstanceRequest(key)
+        .flatMap(this::sendProcessInstanceQuery)
+        .flatMap(this::mapProcessInstanceResult);
+  }
+
+  @Override
+  public void close() throws Exception {
+    httpClient.close();
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record ProcessInstanceResult(
+      @JsonProperty("items") List<ProcessInstance> processInstances,
+      @JsonProperty("total") long total) {}
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSchemaStartup.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSchemaStartup.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.camunda.operate.schema.SchemaStartup;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component("schemaStartup")
+@Profile("test")
+public class TestSchemaStartup extends SchemaStartup {}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -27,7 +27,7 @@ import org.springframework.http.client.ReactorResourceFactory;
 
 abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     implements TestApplication<T> {
-  private final Class<?> springApplication;
+  private final Class<?>[] springApplications;
   private final Map<String, Bean<?>> beans;
   private final Map<String, Object> propertyOverrides;
   private final Collection<String> additionalProfiles;
@@ -35,16 +35,16 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
 
   private ConfigurableApplicationContext springContext;
 
-  public TestSpringApplication(final Class<?> springApplication) {
-    this(springApplication, new HashMap<>(), new HashMap<>(), new ArrayList<>());
+  public TestSpringApplication(final Class<?>... springApplications) {
+    this(new HashMap<>(), new HashMap<>(), new ArrayList<>(), springApplications);
   }
 
   private TestSpringApplication(
-      final Class<?> springApplication,
       final Map<String, Bean<?>> beans,
       final Map<String, Object> propertyOverrides,
-      final Collection<String> additionalProfiles) {
-    this.springApplication = springApplication;
+      final Collection<String> additionalProfiles,
+      final Class<?>... springApplications) {
+    this.springApplications = springApplications;
     this.beans = beans;
     this.propertyOverrides = propertyOverrides;
     this.additionalProfiles = new ArrayList<>(additionalProfiles);
@@ -108,9 +108,8 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     return switch (port) {
       case REST -> restPort();
       case MONITORING -> monitoringPort();
-      default ->
-          throw new IllegalArgumentException(
-              "No known port %s; must one of MONITORING".formatted(port));
+      default -> throw new IllegalArgumentException(
+          "No known port %s; must one of MONITORING".formatted(port));
     };
   }
 
@@ -167,7 +166,7 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
             new ContextOverrideInitializer(beans, propertyOverrides),
             new HealthConfigurationInitializer())
         .profiles(additionalProfiles.toArray(String[]::new))
-        .sources(springApplication);
+        .sources(springApplications);
   }
 
   @Override

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -113,8 +113,9 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     return switch (port) {
       case REST -> restPort();
       case MONITORING -> monitoringPort();
-      default -> throw new IllegalArgumentException(
-          "No known port %s; must one of MONITORING".formatted(port));
+      default ->
+          throw new IllegalArgumentException(
+              "No known port %s; must one of MONITORING".formatted(port));
     };
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestSpringApplication.java
@@ -108,8 +108,9 @@ abstract class TestSpringApplication<T extends TestSpringApplication<T>>
     return switch (port) {
       case REST -> restPort();
       case MONITORING -> monitoringPort();
-      default -> throw new IllegalArgumentException(
-          "No known port %s; must one of MONITORING".formatted(port));
+      default ->
+          throw new IllegalArgumentException(
+              "No known port %s; must one of MONITORING".formatted(port));
     };
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
@@ -65,7 +65,13 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
   private final OperateProperties operateProperties;
 
   public TestStandaloneCamunda() {
-    super(BrokerModuleConfiguration.class, OperateModuleConfiguration.class);
+    super(
+        BrokerModuleConfiguration.class,
+        OperateModuleConfiguration.class,
+        // test overrides - to control data clean up; (and some components are not installed on
+        // Tests)
+        TestElasticsearchSchemaManager.class,
+        TestSchemaStartup.class);
 
     brokerProperties = new BrokerProperties();
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
@@ -9,9 +9,11 @@ package io.camunda.zeebe.qa.util.cluster;
 
 import io.atomix.cluster.MemberId;
 import io.camunda.application.Profile;
+import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.SchemaManager;
+import io.camunda.webapps.WebappsModuleConfiguration;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.broker.shared.BrokerConfiguration.BrokerProperties;
 import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
@@ -68,6 +70,7 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     super(
         BrokerModuleConfiguration.class,
         OperateModuleConfiguration.class,
+        WebappsModuleConfiguration.class,
         // test overrides - to control data clean up; (and some components are not installed on
         // Tests)
         TestElasticsearchSchemaManager.class,
@@ -91,7 +94,8 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     withBean("config", brokerProperties, BrokerProperties.class)
         .withBean("operate-config", operateProperties, OperateProperties.class)
         .withAdditionalProfile(Profile.BROKER)
-        .withAdditionalProfile(Profile.OPERATE);
+        .withAdditionalProfile(Profile.OPERATE)
+        .withAdditionalInitializer(new WebappsConfigurationInitializer());
   }
 
   @Override

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
@@ -139,6 +139,10 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     return super.createSpringBuilder();
   }
 
+  public TestRestOperateClient newOperateClient() {
+    return new TestRestOperateClient(restAddress());
+  }
+
   @Override
   public TestStandaloneCamunda self() {
     return this;

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.test.util.socket.SocketUtil;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Map;
 import java.util.function.Consumer;
 import org.elasticsearch.client.RestClient;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -88,6 +89,12 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
     esContainer.start();
 
     final String esURL = String.format("http://%s", esContainer.getHttpHostAddress());
+
+    final ExporterCfg exporterCfg = new ExporterCfg();
+    exporterCfg.setClassName("io.camunda.zeebe.exporter.ElasticsearchExporter");
+    exporterCfg.setArgs(Map.of("url", esURL)); // new ElasticsearchExporterConfiguration();
+    brokerProperties.getExporters().put("elasticsearch", exporterCfg);
+
     operateProperties.getElasticsearch().setUrl(esURL);
     operateProperties.getZeebeElasticsearch().setUrl(esURL);
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.cluster;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.application.Profile;
+import io.camunda.operate.OperateModuleConfiguration;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.zeebe.broker.BrokerModuleConfiguration;
+import io.camunda.zeebe.broker.shared.BrokerConfiguration.BrokerProperties;
+import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
+import io.camunda.zeebe.qa.util.actuator.BrokerHealthActuator;
+import io.camunda.zeebe.qa.util.actuator.GatewayHealthActuator;
+import io.camunda.zeebe.qa.util.actuator.HealthActuator;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.socket.SocketUtil;
+import java.net.URI;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.function.Consumer;
+import org.elasticsearch.client.RestClient;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.util.unit.DataSize;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+/** Represents an instance of the {@link BrokerModuleConfiguration} Spring application. */
+@SuppressWarnings("UnusedReturnValue")
+public final class TestStandaloneCamunda extends TestSpringApplication<TestStandaloneCamunda>
+    implements TestGateway<TestStandaloneCamunda> {
+
+  private static final DockerImageName ELASTIC_IMAGE =
+      DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
+          .withTag(RestClient.class.getPackage().getImplementationVersion());
+  private static final ElasticsearchContainer esContainer =
+      new ElasticsearchContainer(ELASTIC_IMAGE)
+          // use JVM option files to avoid overwriting default options set by the ES container class
+          .withClasspathResourceMapping(
+              "elasticsearch-fast-startup.options",
+              "/usr/share/elasticsearch/config/jvm.options.d/ elasticsearch-fast-startup.options",
+              BindMode.READ_ONLY)
+          // can be slow in CI
+          .withStartupTimeout(Duration.ofMinutes(5))
+          .withEnv("action.auto_create_index", "true")
+          .withEnv("xpack.security.enabled", "false")
+          .withEnv("xpack.watcher.enabled", "false")
+          .withEnv("xpack.ml.enabled", "false")
+          .withEnv("action.destructive_requires_name", "false");
+  private static final String RECORDING_EXPORTER_ID = "recordingExporter";
+  private final BrokerProperties brokerProperties;
+  private final OperateProperties operateProperties;
+
+  public TestStandaloneCamunda() {
+    super(BrokerModuleConfiguration.class, OperateModuleConfiguration.class);
+
+    brokerProperties = new BrokerProperties();
+
+    brokerProperties.getNetwork().getCommandApi().setPort(SocketUtil.getNextAddress().getPort());
+    brokerProperties.getNetwork().getInternalApi().setPort(SocketUtil.getNextAddress().getPort());
+    brokerProperties.getGateway().getNetwork().setPort(SocketUtil.getNextAddress().getPort());
+
+    // set a smaller default log segment size since we pre-allocate, which might be a lot in tests
+    // for local development; also lower the watermarks for local testing
+    brokerProperties.getData().setLogSegmentSize(DataSize.ofMegabytes(16));
+    brokerProperties.getData().getDisk().getFreeSpace().setProcessing(DataSize.ofMegabytes(128));
+    brokerProperties.getData().getDisk().getFreeSpace().setReplication(DataSize.ofMegabytes(64));
+
+    operateProperties = new OperateProperties();
+
+    //noinspection resource
+    withBean("config", brokerProperties, BrokerProperties.class)
+        .withBean("operate-config", operateProperties, OperateProperties.class)
+        .withAdditionalProfile(Profile.BROKER)
+        .withAdditionalProfile(Profile.OPERATE);
+  }
+
+  @Override
+  public TestStandaloneCamunda start() {
+    esContainer.start();
+
+    final String esURL = String.format("http://%s", esContainer.getHttpHostAddress());
+    operateProperties.getElasticsearch().setUrl(esURL);
+    operateProperties.getZeebeElasticsearch().setUrl(esURL);
+
+    return super.start();
+  }
+
+  @Override
+  public int mappedPort(final TestZeebePort port) {
+    return switch (port) {
+      case COMMAND -> brokerProperties.getNetwork().getCommandApi().getPort();
+      case GATEWAY -> brokerProperties.getGateway().getNetwork().getPort();
+      case CLUSTER -> brokerProperties.getNetwork().getInternalApi().getPort();
+      default -> super.mappedPort(port);
+    };
+  }
+
+  @Override
+  protected SpringApplicationBuilder createSpringBuilder() {
+    // because @ConditionalOnRestGatewayEnabled relies on the zeebe.broker.gateway.enable property,
+    // we need to hook in at the last minute and set the property as it won't resolve from the
+    // config bean
+    withProperty("zeebe.broker.gateway.enable", brokerProperties.getGateway().isEnable());
+    return super.createSpringBuilder();
+  }
+
+  @Override
+  public TestStandaloneCamunda self() {
+    return this;
+  }
+
+  @Override
+  public MemberId nodeId() {
+    return MemberId.from(String.valueOf(brokerProperties.getCluster().getNodeId()));
+  }
+
+  @Override
+  public String host() {
+    return brokerProperties.getNetwork().getHost();
+  }
+
+  @Override
+  public HealthActuator healthActuator() {
+    return BrokerHealthActuator.of(monitoringUri().toString());
+  }
+
+  @Override
+  public boolean isGateway() {
+    return brokerProperties.getGateway().isEnable();
+  }
+
+  @Override
+  public URI grpcAddress() {
+    if (!isGateway()) {
+      throw new IllegalStateException(
+          "Expected to get the gateway address for this broker, but the embedded gateway is not enabled");
+    }
+
+    return TestGateway.super.grpcAddress();
+  }
+
+  @Override
+  public GatewayHealthActuator gatewayHealth() {
+    throw new UnsupportedOperationException("Brokers do not support the gateway health indicators");
+  }
+
+  @Override
+  public TestStandaloneCamunda withGatewayConfig(final Consumer<GatewayCfg> modifier) {
+    modifier.accept(brokerProperties.getGateway());
+    return this;
+  }
+
+  @Override
+  public GatewayCfg gatewayConfig() {
+    return brokerProperties.getGateway();
+  }
+
+  @Override
+  public ZeebeClientBuilder newClientBuilder() {
+    if (!isGateway()) {
+      throw new IllegalStateException(
+          "Cannot create a new client for this broker, as it does not have an embedded gateway");
+    }
+
+    return TestGateway.super.newClientBuilder();
+  }
+
+  /** Returns the broker configuration */
+  public BrokerProperties brokerConfig() {
+    return brokerProperties;
+  }
+
+  /**
+   * Modifies the broker configuration. Will still mutate the configuration if the broker is
+   * started, but likely has no effect until it's restarted.
+   */
+  public TestStandaloneCamunda withBrokerConfig(final Consumer<BrokerProperties> modifier) {
+    modifier.accept(brokerProperties);
+    return this;
+  }
+
+  /**
+   * Enables/disables usage of the recording exporter using {@link #RECORDING_EXPORTER_ID} as its
+   * unique ID.
+   *
+   * @param useRecordingExporter if true, will enable the exporter; if false, will remove it from
+   *     the config
+   * @return itself for chaining
+   */
+  public TestStandaloneCamunda withRecordingExporter(final boolean useRecordingExporter) {
+    if (!useRecordingExporter) {
+      brokerProperties.getExporters().remove(RECORDING_EXPORTER_ID);
+      return this;
+    }
+
+    return withExporter(
+        RECORDING_EXPORTER_ID, cfg -> cfg.setClassName(RecordingExporter.class.getName()));
+  }
+
+  /**
+   * Adds or replaces a new exporter with the given ID. If it was already existing, the existing
+   * configuration is passed to the modifier. If it's new, a blank configuration is passed.
+   *
+   * @param id the ID of the exporter
+   * @param modifier a configuration function
+   * @return itself for chaining
+   */
+  public TestStandaloneCamunda withExporter(final String id, final Consumer<ExporterCfg> modifier) {
+    final var exporterConfig =
+        brokerProperties.getExporters().computeIfAbsent(id, ignored -> new ExporterCfg());
+    modifier.accept(exporterConfig);
+
+    return this;
+  }
+
+  /**
+   * Sets the broker's working directory, aka its data directory. If a path is given, the broker
+   * will not delete it on shutdown.
+   *
+   * @param directory path to the broker's root data directory
+   * @return itself for chaining
+   */
+  public TestStandaloneCamunda withWorkingDirectory(final Path directory) {
+    return withBean(
+        "workingDirectory", new WorkingDirectory(directory, false), WorkingDirectory.class);
+  }
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneCamunda.java
@@ -46,7 +46,8 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
   private static final DockerImageName ELASTIC_IMAGE =
       DockerImageName.parse("docker.elastic.co/elasticsearch/elasticsearch")
           .withTag(RestClient.class.getPackage().getImplementationVersion());
-  private static final ElasticsearchContainer esContainer =
+  private static final String RECORDING_EXPORTER_ID = "recordingExporter";
+  private final ElasticsearchContainer esContainer =
       new ElasticsearchContainer(ELASTIC_IMAGE)
           // use JVM option files to avoid overwriting default options set by the ES container class
           .withClasspathResourceMapping(
@@ -60,7 +61,6 @@ public final class TestStandaloneCamunda extends TestSpringApplication<TestStand
           .withEnv("xpack.watcher.enabled", "false")
           .withEnv("xpack.ml.enabled", "false")
           .withEnv("action.destructive_requires_name", "false");
-  private static final String RECORDING_EXPORTER_ID = "recordingExporter";
   private final BrokerProperties brokerProperties;
   private final OperateProperties operateProperties;
 


### PR DESCRIPTION
## Description

The PR does the following:

1. Write a standalone TestCamundapplication, that includes Broker, Gateway, Operate, which started the right components and profiles needed to write a fully functional integration test
2. The test application can be used with JUNIT 5 extension and annotation, we reuse here [already existing infrastructure provided/created by the Zeebe team](https://github.com/camunda/camunda/tree/main/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster). The test application is essential a copy from the [standalone broker app](https://github.com/camunda/camunda/blob/main/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java) with some additions/extensions.
3. The test application provides a REST Operate client, that allows to write more easily tests against our REST api
4. Add an IT that bootstraps the Camunda application and allows us to:
    - Deploy a process model
    - Create an instance
    - Observe/Query this via the REST API


## Related issues

Based on the knowledge/information we have gained in the POC https://github.com/camunda/camunda/pull/18751 
