### PR TITLE
fix: run scheduled tasks at a given timestamp

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutChecker.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.scheduler.clock.ActorClock.currentTimeMillis;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.DeadlineIndex;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
@@ -46,7 +47,9 @@ final class JobTimeoutChecker implements Task {
 
   public void schedule(final Duration idleInterval) {
     if (shouldReschedule) {
-      processingContext.getScheduleService().runDelayed(idleInterval, this);
+      processingContext
+          .getScheduleService()
+          .runAt(ActorClock.currentTimeMillis() + idleInterval.toMillis(), this);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.time.Duration;
@@ -61,7 +62,9 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
     if (enableMessageTtlCheckerAsync) {
       scheduleService.runDelayedAsync(messagesTtlCheckerInterval, timeToLiveChecker);
     } else {
-      scheduleService.runDelayed(messagesTtlCheckerInterval, timeToLiveChecker);
+      scheduleService.runAt(
+          ActorClock.currentTimeMillis() + messagesTtlCheckerInterval.toMillis(),
+          timeToLiveChecker);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageObserver.java
@@ -52,6 +52,7 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
   private void scheduleMessageTtlChecker(final ReadonlyStreamProcessorContext context) {
     final var scheduleService = context.getScheduleService();
     final var messageState = scheduledTaskStateFactory.get().getMessageState();
+    final var timestamp = ActorClock.currentTimeMillis() + messagesTtlCheckerInterval.toMillis();
     final var timeToLiveChecker =
         new MessageTimeToLiveChecker(
             messagesTtlCheckerInterval,
@@ -60,11 +61,9 @@ public final class MessageObserver implements StreamProcessorLifecycleAware {
             scheduleService,
             messageState);
     if (enableMessageTtlCheckerAsync) {
-      scheduleService.runDelayedAsync(messagesTtlCheckerInterval, timeToLiveChecker);
+      scheduleService.runAtAsync(timestamp, timeToLiveChecker);
     } else {
-      scheduleService.runAt(
-          ActorClock.currentTimeMillis() + messagesTtlCheckerInterval.toMillis(),
-          timeToLiveChecker);
+      scheduleService.runAt(timestamp, timeToLiveChecker);
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -107,10 +107,11 @@ public final class MessageTimeToLiveChecker implements Task {
   }
 
   private void reschedule(final Duration idleInterval) {
+    final var timestamp = ActorClock.currentTimeMillis() + idleInterval.toMillis();
     if (enableMessageTtlCheckerAsync) {
-      scheduleService.runDelayedAsync(idleInterval, this);
+      scheduleService.runAtAsync(timestamp, this);
     } else {
-      scheduleService.runAt(ActorClock.currentTimeMillis() + idleInterval.toMillis(), this);
+      scheduleService.runAt(timestamp, this);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -110,7 +110,7 @@ public final class MessageTimeToLiveChecker implements Task {
     if (enableMessageTtlCheckerAsync) {
       scheduleService.runDelayedAsync(idleInterval, this);
     } else {
-      scheduleService.runDelayed(idleInterval, this);
+      scheduleService.runAt(ActorClock.currentTimeMillis() + idleInterval.toMillis(), this);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -67,7 +67,12 @@ public final class PendingProcessMessageSubscriptionChecker
 
   private void rescheduleTimer() {
     if (schouldRescheduleTimer) {
-      scheduleService.runDelayed(SUBSCRIPTION_CHECK_INTERVAL, this::checkPendingSubscriptions);
+      scheduleService.runAt(
+          ActorClock.currentTimeMillis() + SUBSCRIPTION_CHECK_INTERVAL.toMillis(),
+          taskResultBuilder -> {
+            checkPendingSubscriptions();
+            return taskResultBuilder.build();
+          });
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingProcessMessageSubscriptionChecker.java
@@ -69,10 +69,7 @@ public final class PendingProcessMessageSubscriptionChecker
     if (schouldRescheduleTimer) {
       scheduleService.runAt(
           ActorClock.currentTimeMillis() + SUBSCRIPTION_CHECK_INTERVAL.toMillis(),
-          taskResultBuilder -> {
-            checkPendingSubscriptions();
-            return taskResultBuilder.build();
-          });
+          this::checkPendingSubscriptions);
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
@@ -31,6 +31,7 @@ import java.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 
 public class JobTimeoutCheckerTest {
   public static final int NUMBER_OF_ACTIVE_JOBS = 10;
@@ -97,7 +98,7 @@ public class JobTimeoutCheckerTest {
     inOrder.verify(mockTaskResultBuilder).build();
     verifyNoMoreInteractions(mockTaskResultBuilder);
 
-    verify(mockScheduleService, times(1)).runDelayed(eq(pollingInterval), any(Task.class));
+    verify(mockScheduleService, times(1)).runAt(anyLong(), any(Task.class));
   }
 
   @Test
@@ -123,7 +124,7 @@ public class JobTimeoutCheckerTest {
     inOrder.verify(mockTaskResultBuilder).build();
     verifyNoMoreInteractions(mockTaskResultBuilder);
 
-    verify(mockScheduleService, times(1)).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService, times(1)).runAt(anyLong(), any(Task.class));
 
     /* TEST verify next execute will start where left off */
 
@@ -164,6 +165,6 @@ public class JobTimeoutCheckerTest {
 
     verifyNoMoreInteractions(mockTaskResultBuilder);
 
-    verify(mockScheduleService, times(1)).runDelayed(eq(Duration.ZERO), any(Task.class));
+    verify(mockScheduleService, times(1)).runAt(anyLong(), ArgumentMatchers.<Task>any());
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.job;
 
 import static io.camunda.zeebe.protocol.record.intent.JobIntent.TIME_OUT;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
@@ -31,6 +33,7 @@ import java.time.Duration;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 
 public class JobTimeoutCheckerTest {
@@ -79,6 +82,7 @@ public class JobTimeoutCheckerTest {
   public void shouldRescheduleWithPollingIntervalAfterSuccessfulExecution() {
     // Given
     when(mockTaskResultBuilder.appendCommandRecord(anyLong(), any(), any())).thenReturn(true);
+    final ArgumentCaptor<Long> timestampCaptor = ArgumentCaptor.forClass(Long.class);
 
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = Integer.MAX_VALUE;
@@ -98,13 +102,17 @@ public class JobTimeoutCheckerTest {
     inOrder.verify(mockTaskResultBuilder).build();
     verifyNoMoreInteractions(mockTaskResultBuilder);
 
-    verify(mockScheduleService, times(1)).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService, times(1))
+        .runAt(timestampCaptor.capture(), ArgumentMatchers.<Task>any());
+    assertThat(timestampCaptor.getValue())
+        .isLessThanOrEqualTo(ActorClock.currentTimeMillis() + pollingInterval.toMillis());
   }
 
   @Test
   public void shouldRescheduleImmediatelyIfYieldedDueToBatchLimit() {
     // Given
     when(mockTaskResultBuilder.appendCommandRecord(anyLong(), any(), any())).thenReturn(true);
+    final ArgumentCaptor<Long> timestampCaptor = ArgumentCaptor.forClass(Long.class);
 
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = 3;
@@ -124,7 +132,9 @@ public class JobTimeoutCheckerTest {
     inOrder.verify(mockTaskResultBuilder).build();
     verifyNoMoreInteractions(mockTaskResultBuilder);
 
-    verify(mockScheduleService, times(1)).runAt(anyLong(), any(Task.class));
+    verify(mockScheduleService, times(1))
+        .runAt(timestampCaptor.capture(), ArgumentMatchers.<Task>any());
+    assertThat(timestampCaptor.getValue()).isLessThanOrEqualTo(ActorClock.currentTimeMillis());
 
     /* TEST verify next execute will start where left off */
 
@@ -145,6 +155,7 @@ public class JobTimeoutCheckerTest {
     when(mockTaskResultBuilder.appendCommandRecord(anyLong(), any(), any()))
         .thenReturn(true)
         .thenReturn(false);
+    final ArgumentCaptor<Long> timestampCaptor = ArgumentCaptor.forClass(Long.class);
 
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = Integer.MAX_VALUE;
@@ -164,7 +175,8 @@ public class JobTimeoutCheckerTest {
     inOrder.verify(mockTaskResultBuilder).build();
 
     verifyNoMoreInteractions(mockTaskResultBuilder);
-
-    verify(mockScheduleService, times(1)).runAt(anyLong(), ArgumentMatchers.<Task>any());
+    verify(mockScheduleService, times(1))
+        .runAt(timestampCaptor.capture(), ArgumentMatchers.<Task>any());
+    assertThat(timestampCaptor.getValue()).isLessThanOrEqualTo(ActorClock.currentTimeMillis());
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/scheduling/SimpleProcessingScheduleService.java
@@ -36,6 +36,14 @@ public interface SimpleProcessingScheduleService {
   ScheduledTask runAt(long timestamp, Task task);
 
   /**
+   * Schedules the task to run at or after the given timestamp.
+   *
+   * @implNote Can be silently ignored if the scheduling service is not ready.
+   * @return A representation of the scheduled task.
+   */
+  ScheduledTask runAt(long timestamp, Runnable task);
+
+  /**
    * Schedule a task to execute at a fixed rate. After an initial delay, the task is executed. Once
    * the task is executed, it is rescheduled with the same delay again.
    *

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -68,11 +68,16 @@ public class ProcessingScheduleServiceImpl
 
   @Override
   public ScheduledTask runAt(final long timestamp, final Task task) {
+    return runAt(timestamp, toRunnable(task));
+  }
+
+  @Override
+  public ScheduledTask runAt(final long timestamp, final Runnable task) {
     if (actorControl == null) {
       LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
-    final var scheduledTimer = actorControl.runAt(timestamp, toRunnable(task));
+    final var scheduledTimer = actorControl.runAt(timestamp, task);
     return scheduledTimer::cancel;
   }
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -454,6 +454,22 @@ class ProcessingScheduleServiceTest {
     }
 
     @Override
+    public ScheduledTask runAt(final long timestamp, final Runnable task) {
+      final var futureScheduledTask =
+          actor.call(() -> processingScheduleService.runAt(timestamp, task));
+      return () ->
+          actor.run(
+              () ->
+                  actor.runOnCompletion(
+                      futureScheduledTask,
+                      (scheduledTask, throwable) -> {
+                        if (scheduledTask != null) {
+                          scheduledTask.cancel();
+                        }
+                      }));
+    }
+
+    @Override
     public void runAtFixedRate(final Duration delay, final Task task) {
       actor.submit(() -> processingScheduleService.runAtFixedRate(delay, task));
     }


### PR DESCRIPTION
## Description

Checkers were scheduled by the `SimpleProcessingScheduleService#runDelayed` method which did not guarantee the exact execution time, but only the delay for which the scheduler will wait before triggering the task. Unfortunately, the delay may be extended. A fix is to replace the above-mentioned `runDelayed` method with the `runAt` method which will schedule a task to run at a given timestamp or exactly after it, which guarantees the same delay every time.

:information_source: Note 1:

The following classes and their related tests also invoke the `SimpleProcessingScheduleService#runDelayed` method. However, I was hesitant to refactor them as they are not "checker" classes, and I am not aware of the impact this refactoring may have on them.

* `ExtendedProcessingScheduleServiceImpl`
* `ProcessingScheduleServiceImpl`
* `CheckpointRecordsProcessor`

:information_source: Note 2:

It would be good to get some feedback on the changes in the `JobTimeoutCheckerTest` as they reduce the exactness of the `runAt` call verification. In my opinion, this doesn't impact the correctness of the test.

## Related issues

closes #17648
