### PR TITLE
Operate 8.5 fix release procedure issues

### DIFF
--- a/.github/workflows/add-to-projects.yml
+++ b/.github/workflows/add-to-projects.yml
@@ -23,7 +23,7 @@ jobs:
             }
           variables: |
             owner: "camunda"
-            repo: "zeebe"
+            repo: "camunda"
             issue: ${{ github.event.issue.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_PROJECT_AUTOMATION_TOKEN }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: wagoid/commitlint-github-action@v5
         with:
           commitDepth: ${{ github.event.pull_request.commits }}
-          helpURL: https://github.com/camunda/zeebe/blob/main/CONTRIBUTING.md/#commit-message-guidelines
+          helpURL: https://github.com/camunda/camunda/blob/main/CONTRIBUTING.md/#commit-message-guidelines

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -100,6 +100,6 @@ jobs:
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",
-              "github_run_url": "https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}",
+              "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
               "branch": "${{ github.head_ref || github.ref_name }}"
             }

--- a/.github/workflows/operate-release-manual.yml
+++ b/.github/workflows/operate-release-manual.yml
@@ -15,7 +15,7 @@
 # This can be done through GitHub's UI by navigating to the "Actions" tab of the `operate` repository, then clicking on the
 # "Run workflow" dropdown, selecting the workflow, filling in the input fields and clicking "Run workflow".
 #
-# Link to Release manual workflow: https://github.com/camunda/zeebe/actions/workflows/release-manual.yml
+# Link to Release manual workflow: https://github.com/camunda/camunda/actions/workflows/release-manual.yml
 
 name: Operate Release manual
 

--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -65,6 +65,6 @@ jobs:
           payload: |
             {
               "workflow_name": "${{ github.workflow }}",
-              "github_run_url": "https://github.com/camunda/zeebe/actions/runs/${{ github.run_id }}",
+              "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
               "branch": "${{ github.head_ref || github.ref_name }}"
             }


### PR DESCRIPTION
## Description

* Replace `zeebe` with `camunda` in `repo` parameter and github urls

## Related issues

closes #
