### PR TITLE
test: fix Tasklist integration tests after springboot 3.3 upgrade

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -286,7 +286,7 @@
 
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
 
     <dependency>
@@ -605,7 +605,7 @@
             <!-- Needed for Spring Actuators, and REST API -->
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
             <dependency>org.openapitools:jackson-databind-nullable</dependency>
-            <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
+            <dependency>io.micrometer:micrometer-registry-prometheus-simpleclient</dependency>
             <dependency>jakarta.servlet:jakarta.servlet-api</dependency>
 
             <!-- Needed for configuring the Identity SDK by providing an IdentityConfiguration bean -->

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -258,7 +258,7 @@
     <!-- Micrometer Prometheus -->
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
     <dependency>
       <groupId>io.micrometer</groupId>
@@ -418,7 +418,7 @@
             <dependency>org.springframework.session:spring-session-data-redis</dependency>
             <dependency>org.thymeleaf:thymeleaf</dependency>
             <dependency>jakarta.json:jakarta.json-api</dependency>
-            <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
+            <dependency>io.micrometer:micrometer-registry-prometheus-simpleclient</dependency>
             <!-- This dependency is indirectly used by the awssk auth plugin. It requires these
      classes on the classpath in order to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -123,7 +123,7 @@
     <!-- Micrometer Prometheus -->
     <dependency>
       <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus</artifactId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
     </dependency>
 
     <!-- OAuth0 -->
@@ -527,7 +527,7 @@
             <dependency>com.graphql-java-kickstart:graphql-spring-boot-starter</dependency>
             <dependency>org.thymeleaf:thymeleaf</dependency>
             <dependency>jakarta.json:jakarta.json-api</dependency>
-            <dependency>io.micrometer:micrometer-registry-prometheus</dependency>
+            <dependency>io.micrometer:micrometer-registry-prometheus-simpleclient</dependency>
             <!-- Thesse dependencies are indirectly used by the awssdk auth plugin. It requires these
      classes on the classpath in order to resolve the AWS credentials -->
             <dependency>software.amazon.awssdk:sts</dependency>


### PR DESCRIPTION
## Description
Since [SpringBoot migration to 3.3.0](https://github.com/camunda/camunda/pull/18776), including a new micrometer version, we have [MetricIT](https://github.com/camunda/camunda/blob/6c859092a05dd0780bc73b21370953df2a913d60/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/metric/MetricIT.java#L85) test failing because of the missing trailing comma in Prometheus text format. It is documented here:
https://github.com/micrometer-metrics/micrometer/wiki/1.13-Migration-Guide#trailing-commas-were-removed-prometheus-text-format-only

It suggests the usage of `micrometer-registry-prometheus-simpleclient` to keep the old format. This will be deprecated with springboot 3.5, so we may need to anticipate the impact of changing the format.

## Related issues

closes #
