### PR TITLE
Add mapping functionality to Actor futures

### DIFF
--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -309,7 +309,8 @@ class ClusterConfigurationManagementIntegrationTest {
             if (error == null) {
               service.registerPartitionChangeExecutor(new NoopPartitionChangeExecutor());
             }
-          });
+          },
+          Runnable::run);
       return startFuture;
     }
 

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -108,7 +108,7 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * Convenience wrapper over {@link #andThen(Function, Executor)} for the case where the next step
    * does not require the result of this future.
    */
-  ActorFuture<V> andThen(Supplier<ActorFuture<V>> next, Executor executor);
+  <U> ActorFuture<U> andThen(Supplier<ActorFuture<U>> next, Executor executor);
 
   /**
    * Similar to {@link CompletableFuture#thenCompose(Function)} in that it applies a function to the
@@ -122,6 +122,25 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * @return a new future that completes with the result of applying the function to the result of
    *     this future or exceptionally if this future completes exceptionally. This future can be
    *     used for further chaining.
+   * @param <U> the type of the new future
    */
-  ActorFuture<V> andThen(Function<V, ActorFuture<V>> next, Executor executor);
+  <U> ActorFuture<U> andThen(Function<V, ActorFuture<U>> next, Executor executor);
+
+  /**
+   * Similar to {@link CompletableFuture#thenApply(Function)} in that it applies a function to the
+   * result of this future, allowing you to change types on the fly.
+   *
+   * <p>Implementations may be somewhat inefficient and create intermediate futures, schedule
+   * completion callbacks on the provided executor etc. As such, it should normally be used for
+   * orchestrating futures in a non-performance critical context, for example for startup and
+   * shutdown sequence.
+   *
+   * @param next function to apply to the result of this future.
+   * @param executor The executor used to handle completion callbacks.
+   * @return a new future that completes with the result of applying the function to the result of
+   *     this future or exceptionally if this future completes exceptionally. This future can be
+   *     used for further chaining.
+   * @param <U> the type of the new future
+   */
+  <U> ActorFuture<U> thenApply(Function<V, U> next, Executor executor);
 }

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/future/ActorFuture.java
@@ -8,9 +8,7 @@
 package io.camunda.zeebe.scheduler.future;
 
 import io.camunda.zeebe.scheduler.ActorTask;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -129,39 +127,6 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
   <U> ActorFuture<U> andThen(Function<V, ActorFuture<U>> next, Executor executor);
 
   /**
-   * Similar to {@link #andThen(Function, Executor)}, but with better integration into the scheduler
-   * module. While it creates an intermediate future for chaining, it will respect the concurrency
-   * control's lifecycle. If, for example, it's closed, it will simply throw an exception on call.
-   *
-   * @param next function to apply to the result of this future.
-   * @param executor The executor used to handle completion callbacks.
-   * @return a new future that completes with the result of applying the function to the result of
-   *     this future or exceptionally if this future completes exceptionally. This future can be
-   *     used for further chaining.
-   * @param <U> the type of the new future
-   */
-  default <U> ActorFuture<U> andThen(
-      final Function<V, ActorFuture<U>> next, final ConcurrencyControl executor) {
-    final ActorFuture<U> result = executor.createFuture();
-    executor.runOnCompletion(
-        this,
-        (thisResult, thisError) -> {
-          if (thisError != null) {
-            result.completeExceptionally(thisError);
-            return;
-          }
-
-          try {
-            executor.runOnCompletion(next.apply(thisResult), result);
-          } catch (final Exception e) {
-            result.completeExceptionally(new CompletionException(e));
-          }
-        });
-
-    return result;
-  }
-
-  /**
    * Similar to {@link CompletableFuture#thenApply(Function)} in that it applies a function to the
    * result of this future, allowing you to change types on the fly.
    *
@@ -178,37 +143,4 @@ public interface ActorFuture<V> extends Future<V>, BiConsumer<V, Throwable> {
    * @param <U> the type of the new future
    */
   <U> ActorFuture<U> thenApply(Function<V, U> next, Executor executor);
-
-  /**
-   * Similar to {@link #thenApply(Function, Executor)}, but with better integration into the
-   * scheduler module. While it creates an intermediate future for chaining, it will respect the
-   * concurrency control's lifecycle. If, for example, it's closed, it will simply throw an
-   * exception on call.
-   *
-   * @param next function to apply to the result of this future.
-   * @param executor The executor used to handle completion callbacks.
-   * @return a new future that completes with the result of applying the function to the result of
-   *     this future or exceptionally if this future completes exceptionally. This future can be
-   *     used for further chaining.
-   * @param <U> the type of the new future
-   */
-  default <U> ActorFuture<U> thenApply(
-      final Function<V, U> next, final ConcurrencyControl executor) {
-    final ActorFuture<U> nextFuture = executor.createFuture();
-    executor.runOnCompletion(
-        this,
-        (result, error) -> {
-          if (error != null) {
-            nextFuture.completeExceptionally(error);
-            return;
-          }
-
-          try {
-            nextFuture.complete(next.apply(result));
-          } catch (final Exception e) {
-            nextFuture.completeExceptionally(new CompletionException(e));
-          }
-        });
-    return nextFuture;
-  }
 }

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
@@ -163,11 +163,7 @@ final class ActorFutureTest {
         new Actor() {
           @Override
           protected void onActorStarted() {
-            actor.runOnCompletion(
-                futures,
-                t -> {
-                  invocations.add(t);
-                });
+            actor.runOnCompletion(futures, invocations::add);
           }
         };
 
@@ -190,7 +186,7 @@ final class ActorFutureTest {
         new Actor() {
           @Override
           protected void onActorStarted() {
-            actor.runOnCompletion(Arrays.asList(future1, future2), t -> invocations.add(t));
+            actor.runOnCompletion(Arrays.asList(future1, future2), invocations::add);
           }
         };
 
@@ -212,7 +208,7 @@ final class ActorFutureTest {
 
     // then
     assertThat(invocations).hasSize(1);
-    assertThat(invocations.get(0).getMessage()).isEqualTo("bar");
+    assertThat(invocations.getFirst().getMessage()).isEqualTo("bar");
   }
 
   @Test
@@ -319,7 +315,7 @@ final class ActorFutureTest {
   @Test
   void shouldReturnCompletedExceptionallyFuture() {
     // given
-    final RuntimeException result = new RuntimeException("Something bad happend!");
+    final RuntimeException result = new RuntimeException("Something bad happened!");
 
     // when
     final CompletableActorFuture<Object> completed =
@@ -329,7 +325,7 @@ final class ActorFutureTest {
     assertThat(completed).isDone();
     assertThat(completed.isCompletedExceptionally()).isTrue();
 
-    assertThatThrownBy(() -> completed.join()).hasMessageContaining("Something bad happend!");
+    assertThatThrownBy(completed::join).hasMessageContaining("Something bad happened!");
   }
 
   @Test
@@ -384,7 +380,7 @@ final class ActorFutureTest {
 
     // then
     final AbstractThrowableAssert<?, ? extends Throwable> thrownBy =
-        assertThatThrownBy(() -> future.join());
+        assertThatThrownBy(future::join);
     thrownBy.isInstanceOf(ExecutionException.class);
     thrownBy.hasCause(throwable);
   }
@@ -438,9 +434,7 @@ final class ActorFutureTest {
     }.start();
 
     // expect
-    assertThatThrownBy(() -> future.get())
-        .isInstanceOf(ExecutionException.class)
-        .hasMessage("moep");
+    assertThatThrownBy(future::get).isInstanceOf(ExecutionException.class).hasMessage("moep");
   }
 
   @Test

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
@@ -37,7 +37,7 @@ final class ActorFutureTest {
   final ControlledActorSchedulerExtension schedulerRule = new ControlledActorSchedulerExtension();
 
   @Test
-  public void shouldInvokeCallbackOnFutureCompletion() {
+  void shouldInvokeCallbackOnFutureCompletion() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicInteger callbackInvocations = new AtomicInteger(0);
@@ -74,7 +74,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnBlockPhaseForFutureCompletion() {
+  void shouldInvokeCallbackOnBlockPhaseForFutureCompletion() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicInteger callbackInvocations = new AtomicInteger(0);
@@ -108,7 +108,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnAllFutureCompletedSuccessfully() {
+  void shouldInvokeCallbackOnAllFutureCompletedSuccessfully() {
     // given
     final CompletableActorFuture<String> future1 = new CompletableActorFuture<>();
     final CompletableActorFuture<String> future2 = new CompletableActorFuture<>();
@@ -153,7 +153,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnEmptyFutureList() {
+  void shouldInvokeCallbackOnEmptyFutureList() {
     // given
     final List<ActorFuture<Void>> futures = Collections.emptyList();
 
@@ -179,7 +179,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnAllFutureCompletedExceptionally() {
+  void shouldInvokeCallbackOnAllFutureCompletedExceptionally() {
     // given
     final CompletableActorFuture<String> future1 = new CompletableActorFuture<>();
     final CompletableActorFuture<String> future2 = new CompletableActorFuture<>();
@@ -216,7 +216,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldNotBlockExecutionWhenRegisteredOnFuture() {
+  void shouldNotBlockExecutionWhenRegisteredOnFuture() {
     // given
     final BlockedCallActor actor = new BlockedCallActor();
     schedulerRule.submitActor(actor);
@@ -233,7 +233,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldNotBlockExecutionOnRunOnCompletion() {
+  void shouldNotBlockExecutionOnRunOnCompletion() {
     // given
     final BlockedCallActorWithRunOnCompletion actor = new BlockedCallActorWithRunOnCompletion();
     schedulerRule.submitActor(actor);
@@ -250,7 +250,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnCompletedFuture() {
+  void shouldInvokeCallbackOnCompletedFuture() {
     // given
     final AtomicReference<String> futureResult = new AtomicReference<>();
 
@@ -271,7 +271,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnBlockPhaseForCompletedFuture() {
+  void shouldInvokeCallbackOnBlockPhaseForCompletedFuture() {
     // given
     final AtomicReference<String> futureResult = new AtomicReference<>();
 
@@ -292,7 +292,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldReturnCompletedFutureWithNullValue() {
+  void shouldReturnCompletedFutureWithNullValue() {
     // given
 
     // when
@@ -304,7 +304,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldReturnCompletedFuture() {
+  void shouldReturnCompletedFuture() {
     // given
     final Object result = new Object();
 
@@ -317,7 +317,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldReturnCompletedExceptionallyFuture() {
+  void shouldReturnCompletedExceptionallyFuture() {
     // given
     final RuntimeException result = new RuntimeException("Something bad happend!");
 
@@ -333,7 +333,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbacksAfterCloseIsCalled() {
+  void shouldInvokeCallbacksAfterCloseIsCalled() {
     // given
     final CompletableActorFuture<Object> f1 = new CompletableActorFuture<>();
     final CompletableActorFuture<Object> f2 = new CompletableActorFuture<>();
@@ -374,7 +374,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void joinShouldThrowExecutionException() {
+  void joinShouldThrowExecutionException() {
     // given
     final CompletableActorFuture<Object> future = new CompletableActorFuture<>();
     final RuntimeException throwable = new RuntimeException();
@@ -390,7 +390,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldCompleteFutureAndWaitOnNonActorThread() throws Exception {
+  void shouldCompleteFutureAndWaitOnNonActorThread() throws Exception {
     // given
     final CompletableActorFuture<Integer> future = new CompletableActorFuture<>();
 
@@ -417,7 +417,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldCompleteFutureExceptionallyAndWaitOnNonActorThread() {
+  void shouldCompleteFutureExceptionallyAndWaitOnNonActorThread() {
     // given
     final CompletableActorFuture<Integer> future = new CompletableActorFuture<>();
 
@@ -444,7 +444,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldReturnValueOnNonActorThread() throws Exception {
+  void shouldReturnValueOnNonActorThread() throws Exception {
     // given
     final CompletableActorFuture<String> future = CompletableActorFuture.completed("value");
 
@@ -456,7 +456,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldThrowExceptionOnNonActorThread() {
+  void shouldThrowExceptionOnNonActorThread() {
     // given
     final CompletableActorFuture<String> future =
         CompletableActorFuture.completedExceptionally(new IllegalArgumentException("moep"));
@@ -468,7 +468,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldThrowTimeoutOnNonActorThread() {
+  void shouldThrowTimeoutOnNonActorThread() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
 
@@ -479,7 +479,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldFailToStaticallyCreateExceptionallyCompletedFutureWithNull() {
+  void shouldFailToStaticallyCreateExceptionallyCompletedFutureWithNull() {
     // when
     final RuntimeException result = null;
 
@@ -490,7 +490,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldFailToExceptionallyCompleteFutureWithNull() {
+  void shouldFailToExceptionallyCompleteFutureWithNull() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final RuntimeException result = null;
@@ -502,7 +502,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldFailToExceptionallyCompleteFutureWithNullAndMessage() {
+  void shouldFailToExceptionallyCompleteFutureWithNullAndMessage() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final RuntimeException result = null;
@@ -515,7 +515,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldRunOnComplete() {
+  void shouldRunOnComplete() {
     // given
     final ActorB actorB = new ActorB();
     schedulerRule.submitActor(actorB);
@@ -532,7 +532,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnFutureCompletionIfCallerIsNotActor() {
+  void shouldInvokeCallbackOnFutureCompletionIfCallerIsNotActor() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicInteger callbackInvocations = new AtomicInteger(0);
@@ -556,7 +556,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnFutureCompletionOnProvidedExecutor() {
+  void shouldInvokeCallbackOnFutureCompletionOnProvidedExecutor() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicInteger callbackInvocations = new AtomicInteger(0);
@@ -588,7 +588,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnFutureCompletionExceptionIfCallerIsNotActor() {
+  void shouldInvokeCallbackOnFutureCompletionExceptionIfCallerIsNotActor() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicReference<Throwable> callBackError = new AtomicReference<>();
@@ -614,7 +614,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackOnFutureCompletionErrorOnProvidedExecutor() {
+  void shouldInvokeCallbackOnFutureCompletionErrorOnProvidedExecutor() {
     // given
     final CompletableActorFuture<Void> future = new CompletableActorFuture<>();
     final AtomicReference<Throwable> callBackError = new AtomicReference<>();
@@ -648,7 +648,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackAddedAfterCompletionIfCallerIsNonActor() {
+  void shouldInvokeCallbackAddedAfterCompletionIfCallerIsNonActor() {
     // given
     final CompletableActorFuture<Integer> future = new CompletableActorFuture<>();
     final AtomicInteger futureResult = new AtomicInteger();
@@ -680,7 +680,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldInvokeCallbackAddedAfterCompletionErrorIfCallerIsNonActor() {
+  void shouldInvokeCallbackAddedAfterCompletionErrorIfCallerIsNonActor() {
     // given
     final CompletableActorFuture<Integer> future = new CompletableActorFuture<>();
     final AtomicReference<Throwable> futureResult = new AtomicReference<>();
@@ -715,7 +715,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldChainWithAndThen() {
+  void shouldChainWithAndThen() {
     // given
     final AtomicInteger executorCount = new AtomicInteger(0);
     final Executor decoratedExecutor =
@@ -750,7 +750,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void andThenChainPropagatesInitialException() {
+  void andThenChainPropagatesInitialException() {
     // given
     final var future1 = new CompletableActorFuture<>();
     final var future2 = new CompletableActorFuture<>();
@@ -768,7 +768,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void andThenChainPropagatesValue() {
+  void andThenChainPropagatesValue() {
     // given
     final var chained =
         CompletableActorFuture.completed("expected")
@@ -779,7 +779,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldChainThenApply() {
+  void shouldChainThenApply() {
     // given
     final var future = new CompletableActorFuture<Integer>();
     final var chained = future.thenApply(value -> value + 1, Runnable::run);
@@ -792,7 +792,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldShortCircuitThenApplyOnFailure() {
+  void shouldShortCircuitThenApplyOnFailure() {
     // given
     final var future = new CompletableActorFuture<Integer>();
     final var called = new AtomicBoolean(false);
@@ -818,7 +818,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldChainAndCompleteIntermediateFuturesOnApply() {
+  void shouldChainAndCompleteIntermediateFuturesOnApply() {
     // given
     final var original = new CompletableActorFuture<Integer>();
     final var firstElement = original.thenApply(value -> value + 1, Runnable::run);
@@ -833,7 +833,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldApplyOnExecutor() {
+  void shouldApplyOnExecutor() {
     // given
     final var future = new CompletableActorFuture<Integer>();
     final var onExecutor = new AtomicBoolean(false);
@@ -859,7 +859,7 @@ final class ActorFutureTest {
   }
 
   @Test
-  public void shouldShortCircuitMiddleOfChain() {
+  void shouldShortCircuitMiddleOfChain() {
     // given
     final var original = new CompletableActorFuture<Integer>();
     final var failure = new RuntimeException("foo");

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/functional/ActorFutureTest.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorThread;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerRule;
+import io.camunda.zeebe.scheduler.testing.ControlledActorSchedulerExtension;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -29,12 +29,12 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import org.assertj.core.api.AbstractThrowableAssert;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
-public final class ActorFutureTest {
-  @Rule
-  public final ControlledActorSchedulerRule schedulerRule = new ControlledActorSchedulerRule();
+final class ActorFutureTest {
+  @RegisterExtension
+  final ControlledActorSchedulerExtension schedulerRule = new ControlledActorSchedulerExtension();
 
   @Test
   public void shouldInvokeCallbackOnFutureCompletion() {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
@@ -10,11 +10,13 @@ package io.camunda.zeebe.scheduler.testing;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.util.LockUtil;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -40,7 +42,8 @@ import java.util.function.Consumer;
  */
 public class TestConcurrencyControl implements ConcurrencyControl {
 
-  private final Object lock = new Object();
+  // use concrete type to allow us to query if we're holding the lock below
+  private final ReentrantLock lock = new ReentrantLock();
 
   @Override
   public <T> void runOnCompletion(
@@ -79,26 +82,25 @@ public class TestConcurrencyControl implements ConcurrencyControl {
 
   @Override
   public void run(final Runnable action) {
-    synchronized (lock) {
-      action.run();
-    }
+    LockUtil.withLock(lock, action);
   }
 
   @Override
   public <T> ActorFuture<T> call(final Callable<T> callable) {
     final T call;
     try {
-      call = callable.call();
+      call = LockUtil.withLock(lock, callable);
     } catch (final Exception e) {
       return TestActorFuture.failedFuture(e);
     }
+
     return TestActorFuture.completedFuture(call);
   }
 
   @Override
   public ScheduledTimer schedule(final Duration delay, final Runnable runnable) {
     // Schedule immediately
-    runnable.run();
+    LockUtil.withLock(lock, runnable);
     return () -> {};
   }
 

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/LockUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/LockUtil.java
@@ -38,17 +38,6 @@ public final class LockUtil {
    * @param lock the lock to acquire
    * @param callable the operation to run
    */
-  public static <V> V withLock(final Lock lock, final Supplier<V> callable) {
-    return withLock(lock, callable, IGNORE_ERROR_HANDLER);
-  }
-
-  /**
-   * Runs the given operation only when the lock has been obtained. Locks interruptibly, meaning if
-   * the thread is interrupted while waiting for the lock, the runnable is not executed.
-   *
-   * @param lock the lock to acquire
-   * @param callable the operation to run
-   */
   public static <V> V withLock(final Lock lock, final Callable<V> callable) {
     return withLock(lock, callable, IGNORE_ERROR_HANDLER);
   }


### PR DESCRIPTION
## Description

This PR adds mapping functionality similar to `CompletionStage#thenApply`, allowing you to chain futures and map the result only on success, but short-circuiting the chain if any error occurs at any point.

Additionally refactors one place as an example of where/how to use `thenApply`.

I've keep the warning about performance, but honestly I'd like to challenge it. Creating an intermediate future is pretty much required if you're gonna chain things _and_ allow changing the type of the result. The other option is essentially building your own stream-like pipeline, but wouldn't allow for branching, just pipelining, the results. So there's definite advantages to intermediate futures, and I'm not sure it's sure a performance hit.

As for executing callbacks on the given executor, is that so terrible? :thinking: 