### PR TITLE
fix: add allowlist to SortValuesWrapper to prevent untrusted deserialization [Backport stable/operate-8.5]

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapper.java
@@ -16,15 +16,16 @@
  */
 package io.camunda.operate.webapp.rest.dto.listview;
 
-import static io.camunda.operate.util.LambdaExceptionUtil.rethrowFunction;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,56 +33,89 @@ public class SortValuesWrapper implements Serializable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SortValuesWrapper.class);
 
+  private static final Set<Class<?>> ALLOWED_SORTVALUE_TYPES = new HashSet<>();
+
+  static {
+    ALLOWED_SORTVALUE_TYPES.add(String.class);
+    ALLOWED_SORTVALUE_TYPES.add(Integer.class);
+    ALLOWED_SORTVALUE_TYPES.add(Double.class);
+    ALLOWED_SORTVALUE_TYPES.add(Long.class);
+    ALLOWED_SORTVALUE_TYPES.add(Short.class);
+    ALLOWED_SORTVALUE_TYPES.add(Float.class);
+    ALLOWED_SORTVALUE_TYPES.add(Boolean.class);
+  }
+
   public String value;
   public Class valueType;
 
   public SortValuesWrapper() {}
 
-  public SortValuesWrapper(String value, Class valueType) {
+  public SortValuesWrapper(final String value, final Class valueType) {
     this.value = value;
     this.valueType = valueType;
   }
 
-  public static SortValuesWrapper[] createFrom(Object[] sortValues, ObjectMapper objectMapper) {
+  public static SortValuesWrapper[] createFrom(
+      final Object[] sortValues, final ObjectMapper objectMapper) {
     if (sortValues == null) {
       return null;
     }
     try {
-      return Arrays.stream(sortValues)
-          .map(
-              rethrowFunction(
-                  value ->
-                      new SortValuesWrapper(
-                          objectMapper.writeValueAsString(value), value.getClass())))
-          .toArray(SortValuesWrapper[]::new);
-    } catch (JsonProcessingException e) {
+      final List<SortValuesWrapper> sortValuesWrappers = new LinkedList<>();
+
+      for (final Object sv : sortValues) {
+        // Log if we are serializing a value that can't be deserialized later, will allow us to
+        // discover new types to put in the allowlist
+        if (!ALLOWED_SORTVALUE_TYPES.contains(sv.getClass())) {
+          LOGGER.warn(
+              "Serializing a sort value type that is not in the deserialization allowed list: {}",
+              sv.getClass());
+        }
+        sortValuesWrappers.add(
+            new SortValuesWrapper(objectMapper.writeValueAsString(sv), sv.getClass()));
+      }
+      return sortValuesWrappers.toArray(new SortValuesWrapper[0]);
+
+    } catch (final JsonProcessingException e) {
       LOGGER.warn("Unable to serialize sortValues. Error: " + e.getMessage(), e);
       throw new OperateRuntimeException(e);
     }
   }
 
   public static Object[] convertSortValues(
-      SortValuesWrapper[] sortValuesWrappers, ObjectMapper objectMapper) {
+      final SortValuesWrapper[] sortValuesWrappers, final ObjectMapper objectMapper) {
     if (sortValuesWrappers == null) {
       return null;
     }
-    try {
-      return Arrays.stream(sortValuesWrappers)
-          .map(
-              rethrowFunction(
-                  value -> objectMapper.readValue(value.value.getBytes(), value.valueType)))
-          .toArray(Object[]::new);
-    } catch (IOException e) {
-      LOGGER.warn("Unable to deserialize sortValues. Error: " + e.getMessage(), e);
-      throw new OperateRuntimeException(e);
+    final List<Object> sortValues = new LinkedList<>();
+
+    for (final SortValuesWrapper svw : sortValuesWrappers) {
+      final var classType = svw.valueType;
+      // These values can come as input from potentially untrusted sources. Sort values
+      // are only expected to be of certain types, ensure that we don't try to deserialize
+      // a bad type (both to prevent deserialization exploits and to not pass unsupported
+      // types to elasticsearch/opensearch)
+      if (ALLOWED_SORTVALUE_TYPES.contains(classType)) {
+        try {
+          sortValues.add(objectMapper.readValue(svw.value.getBytes(), classType));
+        } catch (final IOException e) {
+          LOGGER.warn("Unable to deserialize sortValues. Error: {}", e.getMessage());
+          throw new OperateRuntimeException(e);
+        }
+      } else {
+        LOGGER.warn("Unable to deserialize sortValues. Type {} is not allowed ", classType);
+        throw new OperateRuntimeException("Invalid sortValues type: " + classType);
+      }
     }
+
+    return sortValues.toArray();
   }
 
   public Object getValue() {
     return value;
   }
 
-  public SortValuesWrapper setValue(String value) {
+  public SortValuesWrapper setValue(final String value) {
     this.value = value;
     return this;
   }
@@ -90,7 +124,7 @@ public class SortValuesWrapper implements Serializable {
     return valueType;
   }
 
-  public SortValuesWrapper setValueType(Class valueType) {
+  public SortValuesWrapper setValueType(final Class valueType) {
     this.valueType = valueType;
     return this;
   }
@@ -101,7 +135,7 @@ public class SortValuesWrapper implements Serializable {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapper.java
@@ -21,11 +21,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import java.io.IOException;
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import org.elasticsearch.common.text.Text;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,14 +37,19 @@ public class SortValuesWrapper implements Serializable {
 
   private static final Set<Class<?>> ALLOWED_SORTVALUE_TYPES = new HashSet<>();
 
+  // These values were taken from org.elasticsearch.search.searchafter.SearchAfterBuilder.
+  // Opensearch does not have a filter and just passes any type further on
   static {
     ALLOWED_SORTVALUE_TYPES.add(String.class);
-    ALLOWED_SORTVALUE_TYPES.add(Integer.class);
-    ALLOWED_SORTVALUE_TYPES.add(Double.class);
+    ALLOWED_SORTVALUE_TYPES.add(Text.class);
     ALLOWED_SORTVALUE_TYPES.add(Long.class);
+    ALLOWED_SORTVALUE_TYPES.add(Integer.class);
     ALLOWED_SORTVALUE_TYPES.add(Short.class);
+    ALLOWED_SORTVALUE_TYPES.add(Byte.class);
+    ALLOWED_SORTVALUE_TYPES.add(Double.class);
     ALLOWED_SORTVALUE_TYPES.add(Float.class);
     ALLOWED_SORTVALUE_TYPES.add(Boolean.class);
+    ALLOWED_SORTVALUE_TYPES.add(BigInteger.class);
   }
 
   public String value;
@@ -99,11 +106,11 @@ public class SortValuesWrapper implements Serializable {
         try {
           sortValues.add(objectMapper.readValue(svw.value.getBytes(), classType));
         } catch (final IOException e) {
-          LOGGER.warn("Unable to deserialize sortValues. Error: {}", e.getMessage());
+          LOGGER.error("Unable to deserialize sortValues. Error: {}", e.getMessage());
           throw new OperateRuntimeException(e);
         }
       } else {
-        LOGGER.warn("Unable to deserialize sortValues. Type {} is not allowed ", classType);
+        LOGGER.error("Unable to deserialize sortValues. Type {} is not allowed ", classType);
         throw new OperateRuntimeException("Invalid sortValues type: " + classType);
       }
     }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
@@ -14,6 +14,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.util.Tuple;
+import java.math.BigInteger;
+import org.elasticsearch.common.text.Text;
 import org.junit.jupiter.api.Test;
 
 public class SortValuesWrapperTest {
@@ -34,16 +36,16 @@ public class SortValuesWrapperTest {
   }
 
   @Test
-  public void testConvertSortValuesInteger() throws JsonProcessingException {
+  public void testConvertSortValuesText() throws JsonProcessingException {
     final SortValuesWrapper[] sortValuesWrappers = {
-      new SortValuesWrapper(objectMapper.writeValueAsString(123), Integer.class)
+      new SortValuesWrapper("\"testString\"", Text.class)
     };
 
     final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
 
     assertThat(result.length).isEqualTo(1);
-    assertThat(result[0]).isEqualTo(123);
-    assertThat(result[0].getClass()).isEqualTo(Integer.class);
+    assertThat(result[0]).isEqualTo(new Text("testString"));
+    assertThat(result[0].getClass()).isEqualTo(Text.class);
   }
 
   @Test
@@ -60,6 +62,19 @@ public class SortValuesWrapperTest {
   }
 
   @Test
+  public void testConvertSortValuesInteger() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(123), Integer.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(123);
+    assertThat(result[0].getClass()).isEqualTo(Integer.class);
+  }
+
+  @Test
   public void testConvertSortValuesShort() throws JsonProcessingException {
     final SortValuesWrapper[] sortValuesWrappers = {
       new SortValuesWrapper(objectMapper.writeValueAsString(Short.MIN_VALUE), Short.class)
@@ -73,16 +88,29 @@ public class SortValuesWrapperTest {
   }
 
   @Test
-  public void testConvertSortValuesBoolean() throws JsonProcessingException {
+  public void testConvertSortValuesByte() throws JsonProcessingException {
     final SortValuesWrapper[] sortValuesWrappers = {
-      new SortValuesWrapper(objectMapper.writeValueAsString(false), Boolean.class)
+      new SortValuesWrapper(objectMapper.writeValueAsString(Byte.MIN_VALUE), Byte.class)
     };
 
     final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
 
     assertThat(result.length).isEqualTo(1);
-    assertThat(result[0]).isEqualTo(false);
-    assertThat(result[0].getClass()).isEqualTo(Boolean.class);
+    assertThat(result[0]).isEqualTo(Byte.MIN_VALUE);
+    assertThat(result[0].getClass()).isEqualTo(Byte.class);
+  }
+
+  @Test
+  public void testConvertSortValuesDouble() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(Double.MIN_VALUE), Double.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(Double.MIN_VALUE);
+    assertThat(result[0].getClass()).isEqualTo(Double.class);
   }
 
   @Test
@@ -99,16 +127,30 @@ public class SortValuesWrapperTest {
   }
 
   @Test
-  public void testConvertSortValuesDouble() throws JsonProcessingException {
+  public void testConvertSortValuesBoolean() throws JsonProcessingException {
     final SortValuesWrapper[] sortValuesWrappers = {
-      new SortValuesWrapper(objectMapper.writeValueAsString(Double.MIN_VALUE), Double.class)
+      new SortValuesWrapper(objectMapper.writeValueAsString(false), Boolean.class)
     };
 
     final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
 
     assertThat(result.length).isEqualTo(1);
-    assertThat(result[0]).isEqualTo(Double.MIN_VALUE);
-    assertThat(result[0].getClass()).isEqualTo(Double.class);
+    assertThat(result[0]).isEqualTo(false);
+    assertThat(result[0].getClass()).isEqualTo(Boolean.class);
+  }
+
+  @Test
+  public void testConvertSortValuesBigInteger() throws JsonProcessingException {
+
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(BigInteger.TWO), BigInteger.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(BigInteger.TWO);
+    assertThat(result[0].getClass()).isEqualTo(BigInteger.class);
   }
 
   @Test
@@ -147,25 +189,13 @@ public class SortValuesWrapperTest {
   }
 
   @Test
-  public void testCreateFromInteger() throws JsonProcessingException {
-    final Object[] sortValues = {Integer.MAX_VALUE};
+  public void testCreateFromText() throws JsonProcessingException {
+    final Object[] sortValues = {new Text("testString")};
 
     final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
 
     assertThat(result.length).isEqualTo(1);
-    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Integer.MAX_VALUE));
-    assertThat(result[0].getValueType()).isEqualTo(Integer.class);
-  }
-
-  @Test
-  public void testCreateFromDouble() throws JsonProcessingException {
-    final Object[] sortValues = {Double.MAX_VALUE};
-
-    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
-
-    assertThat(result.length).isEqualTo(1);
-    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Double.MAX_VALUE));
-    assertThat(result[0].getValueType()).isEqualTo(Double.class);
+    assertThat(result[0].getValueType()).isEqualTo(Text.class);
   }
 
   @Test
@@ -180,6 +210,17 @@ public class SortValuesWrapperTest {
   }
 
   @Test
+  public void testCreateFromInteger() throws JsonProcessingException {
+    final Object[] sortValues = {Integer.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Integer.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Integer.class);
+  }
+
+  @Test
   public void testCreateFromShort() throws JsonProcessingException {
     final Object[] sortValues = {Short.MAX_VALUE};
 
@@ -188,6 +229,28 @@ public class SortValuesWrapperTest {
     assertThat(result.length).isEqualTo(1);
     assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Short.MAX_VALUE));
     assertThat(result[0].getValueType()).isEqualTo(Short.class);
+  }
+
+  @Test
+  public void testCreateFromByte() throws JsonProcessingException {
+    final Object[] sortValues = {Byte.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Byte.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Byte.class);
+  }
+
+  @Test
+  public void testCreateFromDouble() throws JsonProcessingException {
+    final Object[] sortValues = {Double.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Double.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Double.class);
   }
 
   @Test
@@ -210,6 +273,17 @@ public class SortValuesWrapperTest {
     assertThat(result.length).isEqualTo(1);
     assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(true));
     assertThat(result[0].getValueType()).isEqualTo(Boolean.class);
+  }
+
+  @Test
+  public void testCreateFromBigInteger() throws JsonProcessingException {
+    final Object[] sortValues = {BigInteger.TWO};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(BigInteger.TWO));
+    assertThat(result[0].getValueType()).isEqualTo(BigInteger.class);
   }
 
   @Test

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
@@ -1,0 +1,239 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.rest.dto.listview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.exceptions.OperateRuntimeException;
+import io.camunda.operate.util.Tuple;
+import org.junit.jupiter.api.Test;
+
+public class SortValuesWrapperTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  public void testConvertSortValuesString() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString("testString"), String.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo("testString");
+    assertThat(result[0].getClass()).isEqualTo(String.class);
+  }
+
+  @Test
+  public void testConvertSortValuesInteger() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(123), Integer.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(123);
+    assertThat(result[0].getClass()).isEqualTo(Integer.class);
+  }
+
+  @Test
+  public void testConvertSortValuesLong() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(Long.MAX_VALUE), Long.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(Long.MAX_VALUE);
+    assertThat(result[0].getClass()).isEqualTo(Long.class);
+  }
+
+  @Test
+  public void testConvertSortValuesShort() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(Short.MIN_VALUE), Short.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(Short.MIN_VALUE);
+    assertThat(result[0].getClass()).isEqualTo(Short.class);
+  }
+
+  @Test
+  public void testConvertSortValuesBoolean() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(false), Boolean.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(false);
+    assertThat(result[0].getClass()).isEqualTo(Boolean.class);
+  }
+
+  @Test
+  public void testConvertSortValuesFloat() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(Float.MIN_VALUE), Float.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(Float.MIN_VALUE);
+    assertThat(result[0].getClass()).isEqualTo(Float.class);
+  }
+
+  @Test
+  public void testConvertSortValuesDouble() throws JsonProcessingException {
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(Double.MIN_VALUE), Double.class)
+    };
+
+    final Object[] result = SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0]).isEqualTo(Double.MIN_VALUE);
+    assertThat(result[0].getClass()).isEqualTo(Double.class);
+  }
+
+  @Test
+  public void testConvertSortValuesBadType() throws JsonProcessingException {
+    final Tuple<String, String> tupleVal = new Tuple<>("left", "right");
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(tupleVal), Tuple.class)
+    };
+
+    assertThrows(
+        OperateRuntimeException.class,
+        () -> SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper));
+  }
+
+  @Test
+  public void testConvertSortValuesRecordType() throws JsonProcessingException {
+    record Result(String id) {}
+    final SortValuesWrapper[] sortValuesWrappers = {
+      new SortValuesWrapper(objectMapper.writeValueAsString(new Result("foo")), Result.class)
+    };
+
+    assertThrows(
+        OperateRuntimeException.class,
+        () -> SortValuesWrapper.convertSortValues(sortValuesWrappers, objectMapper));
+  }
+
+  @Test
+  public void testCreateFromString() throws JsonProcessingException {
+    final Object[] sortValues = {"testString"};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString("testString"));
+    assertThat(result[0].getValueType()).isEqualTo(String.class);
+  }
+
+  @Test
+  public void testCreateFromInteger() throws JsonProcessingException {
+    final Object[] sortValues = {Integer.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Integer.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Integer.class);
+  }
+
+  @Test
+  public void testCreateFromDouble() throws JsonProcessingException {
+    final Object[] sortValues = {Double.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Double.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Double.class);
+  }
+
+  @Test
+  public void testCreateFromLong() throws JsonProcessingException {
+    final Object[] sortValues = {Long.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Long.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Long.class);
+  }
+
+  @Test
+  public void testCreateFromShort() throws JsonProcessingException {
+    final Object[] sortValues = {Short.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Short.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Short.class);
+  }
+
+  @Test
+  public void testCreateFromFloat() throws JsonProcessingException {
+    final Object[] sortValues = {Float.MAX_VALUE};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(Float.MAX_VALUE));
+    assertThat(result[0].getValueType()).isEqualTo(Float.class);
+  }
+
+  @Test
+  public void testCreateFromBoolean() throws JsonProcessingException {
+    final Object[] sortValues = {true};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(true));
+    assertThat(result[0].getValueType()).isEqualTo(Boolean.class);
+  }
+
+  @Test
+  public void testCreateFromTypeNotAllowedInDeserialization() throws JsonProcessingException {
+    final Tuple<String, String> tupleVal = new Tuple<>("left", "right");
+    final Object[] sortValues = {tupleVal};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(tupleVal));
+    assertThat(result[0].getValueType()).isEqualTo(Tuple.class);
+  }
+
+  @Test
+  public void testCreateFromRecordNotAllowedInDeserialization() throws JsonProcessingException {
+    record Result(String id) {}
+    final var recordVal = new Result("id");
+    final Object[] sortValues = {recordVal};
+
+    final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
+
+    assertThat(result.length).isEqualTo(1);
+    assertThat(result[0].getValue()).isEqualTo(objectMapper.writeValueAsString(recordVal));
+    assertThat(result[0].getValueType()).isEqualTo(Result.class);
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/listview/SortValuesWrapperTest.java
@@ -1,9 +1,18 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
  */
 package io.camunda.operate.webapp.rest.dto.listview;
 
@@ -36,7 +45,7 @@ public class SortValuesWrapperTest {
   }
 
   @Test
-  public void testConvertSortValuesText() throws JsonProcessingException {
+  public void testConvertSortValuesText() {
     final SortValuesWrapper[] sortValuesWrappers = {
       new SortValuesWrapper("\"testString\"", Text.class)
     };
@@ -189,11 +198,13 @@ public class SortValuesWrapperTest {
   }
 
   @Test
-  public void testCreateFromText() throws JsonProcessingException {
+  public void testCreateFromText() {
     final Object[] sortValues = {new Text("testString")};
 
     final SortValuesWrapper[] result = SortValuesWrapper.createFrom(sortValues, objectMapper);
 
+    // The object mapper does not have a module registered that correctly serializes Text types
+    // (the result is a string that reads "{fragment:true}")
     assertThat(result.length).isEqualTo(1);
     assertThat(result[0].getValueType()).isEqualTo(Text.class);
   }


### PR DESCRIPTION
## Description
Backport of https://github.com/camunda/camunda/pull/18779

## Related issues

closes https://github.com/camunda/camunda/issues/18862
