### PR TITLE
Stop redundant logging of first commit index

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -873,10 +873,10 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * @param firstCommitIndex The first commit index.
    */
   public void setFirstCommitIndex(final long firstCommitIndex) {
-    if (firstCommitIndex == 0) {
-      return;
-    }
     if (this.firstCommitIndex == 0) {
+      if (firstCommitIndex == 0) {
+        return;
+      }
       this.firstCommitIndex = firstCommitIndex;
       log.info(
           "Setting firstCommitIndex to {}. RaftServer is ready only after it has committed events upto this index",

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -873,6 +873,9 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
    * @param firstCommitIndex The first commit index.
    */
   public void setFirstCommitIndex(final long firstCommitIndex) {
+    if (firstCommitIndex == 0) {
+      return;
+    }
     if (this.firstCommitIndex == 0) {
       this.firstCommitIndex = firstCommitIndex;
       log.info(


### PR DESCRIPTION
## Description
Stops redundant logging of first commit index being set.

## Related issues

closes #13403 
