### PR TITLE
[Backport stable/8.3] Do not reset snapshot replication when a single request timedout

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationTimeoutTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftSnapshotReplicationTimeoutTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2020 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.raft;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.raft.protocol.InstallRequest;
+import io.atomix.raft.protocol.InstallResponse;
+import io.atomix.raft.protocol.TestRaftServerProtocol;
+import io.atomix.raft.protocol.TestRaftServerProtocol.ResponseInterceptor;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class RaftSnapshotReplicationTimeoutTest {
+
+  @Rule public RaftRule raftRule = RaftRule.withBootstrappedNodes(3);
+
+  @Test
+  public void shouldNotRestartFromFirstChunkWhenInstallRequestTimesOut() throws Throwable {
+    // given
+    final var follower = raftRule.getFollower().orElseThrow();
+    raftRule.partition(follower);
+
+    final var leader = raftRule.getLeader().orElseThrow();
+    leader.getContext().setPreferSnapshotReplicationThreshold(1);
+    final var commitIndex = raftRule.appendEntries(2); // awaits commit
+
+    final int numberOfChunks = 10;
+    raftRule.takeSnapshot(leader, commitIndex, numberOfChunks);
+    raftRule.appendEntry();
+
+    final TestRaftServerProtocol leaderProtocol =
+        (TestRaftServerProtocol) leader.getContext().getProtocol();
+    final AtomicInteger totalInstallRequest = new AtomicInteger(0);
+    leaderProtocol.interceptRequest(
+        InstallRequest.class, (request) -> totalInstallRequest.incrementAndGet());
+    leaderProtocol.interceptResponse(
+        InstallResponse.class, new TimingOutInterceptor(numberOfChunks - 1));
+
+    // when
+    // leader appended new entries and took snapshot when the follower was disconnected. When
+    // follower reconnects, it should receive a new snapshot.
+    final var snapshotReceived = new CountDownLatch(1);
+    raftRule
+        .getPersistedSnapshotStore(follower.name())
+        .addSnapshotListener(s -> snapshotReceived.countDown());
+    raftRule.reconnect(follower);
+
+    assertThat(snapshotReceived.await(30, TimeUnit.SECONDS)).isTrue();
+
+    // then
+    // Total 10 chunks + 1 retry
+    assertThat(totalInstallRequest.get()).isEqualTo(numberOfChunks + 1);
+  }
+
+  private static class TimingOutInterceptor implements ResponseInterceptor<InstallResponse> {
+    private int count = 0;
+    private final int timeoutAtRequest;
+
+    public TimingOutInterceptor(final int timeoutAtRequest) {
+      this.timeoutAtRequest = timeoutAtRequest;
+    }
+
+    @Override
+    public CompletableFuture<InstallResponse> apply(final InstallResponse installResponse) {
+      count++;
+      if (count == timeoutAtRequest) {
+        return CompletableFuture.failedFuture(new TimeoutException());
+      } else {
+        return CompletableFuture.completedFuture(installResponse);
+      }
+    }
+  }
+}

--- a/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
@@ -41,6 +41,12 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   private Function<VersionedAppendRequest, CompletableFuture<AppendResponse>> appendHandler;
   private final Set<MemberId> partitions = Sets.newCopyOnWriteArraySet();
   private final Map<Class<?>, Consumer<?>> interceptors = new ConcurrentHashMap<>();
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+=======
+  private final Map<MemberId, TestRaftServerProtocol> servers;
+  private final Map<Class<?>, ResponseInterceptor<?>> responseInterceptors =
+      new ConcurrentHashMap<>();
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
 
   public TestRaftServerProtocol(
       final MemberId memberId,
@@ -69,48 +75,122 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public CompletableFuture<ConfigureResponse> configure(
       final MemberId memberId, final ConfigureRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(
         getServer(memberId).thenCompose(listener -> listener.configure(request)));
+=======
+    intercept(request, ConfigureRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.configure(request))
+        .thenCompose(response -> transformResponse(response, ConfigureResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
   public CompletableFuture<ReconfigureResponse> reconfigure(
       final MemberId memberId, final ReconfigureRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(
         getServer(memberId).thenCompose(listener -> listener.reconfigure(request)));
+=======
+    intercept(request, ReconfigureRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.reconfigure(request))
+        .thenCompose(response -> transformResponse(response, ReconfigureResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+  }
+
+  @Override
+  public CompletableFuture<ForceConfigureResponse> forceConfigure(
+      final MemberId memberId, final ForceConfigureRequest request) {
+    intercept(request, ForceConfigureRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.forceConfigure(request))
+        .thenCompose(response -> transformResponse(response, ForceConfigureResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
   public CompletableFuture<JoinResponse> join(final MemberId memberId, final JoinRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.join(request)));
+=======
+    intercept(request, JoinRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.join(request))
+        .thenCompose(response -> transformResponse(response, JoinResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
   public CompletableFuture<LeaveResponse> leave(
       final MemberId memberId, final LeaveRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.leave(request)));
+=======
+    intercept(request, LeaveRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.leave(request))
+        .thenCompose(response -> transformResponse(response, LeaveResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
   public CompletableFuture<InstallResponse> install(
       final MemberId memberId, final InstallRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.install(request)));
+=======
+    intercept(request, InstallRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.install(request))
+        .thenCompose(response -> transformResponse(response, InstallResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
   public CompletableFuture<TransferResponse> transfer(
       final MemberId memberId, final TransferRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.transfer(request)));
+=======
+    intercept(request, TransferRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.transfer(request))
+        .thenCompose(response -> transformResponse(response, TransferResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
   public CompletableFuture<PollResponse> poll(final MemberId memberId, final PollRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.poll(request)));
+=======
+    intercept(request, PollRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.poll(request))
+        .thenCompose(response -> transformResponse(response, PollResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
   public CompletableFuture<VoteResponse> vote(final MemberId memberId, final VoteRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.vote(request)));
+=======
+    intercept(request, VoteRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.vote(request))
+        .thenCompose(response -> transformResponse(response, VoteResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
@@ -122,7 +202,15 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
   @Override
   public CompletableFuture<AppendResponse> append(
       final MemberId memberId, final VersionedAppendRequest request) {
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
     return scheduleTimeout(getServer(memberId).thenCompose(listener -> listener.append(request)));
+=======
+    intercept(request, VersionedAppendRequest.class);
+    return getServer(memberId)
+        .thenCompose(listener -> listener.append(request))
+        .thenCompose(response -> transformResponse(response, AppendResponse.class))
+        .orTimeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
   }
 
   @Override
@@ -323,4 +411,37 @@ public class TestRaftServerProtocol extends TestRaftProtocol implements RaftServ
       return CompletableFuture.failedFuture(new ConnectException());
     }
   }
+<<<<<<< HEAD:atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
+=======
+
+  public <T> void interceptRequest(final Class<T> requestType, final Consumer<T> interceptor) {
+    interceptors.put(requestType, interceptor);
+  }
+
+  public <T extends RaftResponse> void interceptResponse(
+      final Class<T> responseType, final ResponseInterceptor<T> interceptor) {
+    responseInterceptors.put(responseType, interceptor);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> CompletableFuture<T> transformResponse(
+      final T response, final Class<T> responseType) {
+    final var interceptor = (ResponseInterceptor<T>) responseInterceptors.get(responseType);
+    if (interceptor != null) {
+      return interceptor.apply(response);
+    }
+    return CompletableFuture.completedFuture(response);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> void intercept(final T request, final Class<T> requestType) {
+    final var interceptor = (Consumer<T>) interceptors.get(requestType);
+    if (interceptor != null) {
+      interceptor.accept(request);
+    }
+  }
+
+  @FunctionalInterface
+  public interface ResponseInterceptor<T> extends Function<T, CompletableFuture<T>> {}
+>>>>>>> 281eb95c (test: verify install requests retry behavior on timeout):zeebe/atomix/cluster/src/test/java/io/atomix/raft/protocol/TestRaftServerProtocol.java
 }


### PR DESCRIPTION
# Description
Backport of #16971 to `stable/8.3`.

relates to #11496
original author: @deepthidevaki