### PR TITLE
deps: update dependency-analyzer plugin to fixed 1.14.1 version

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -199,7 +199,7 @@
     <plugin.version.build-helper>3.6.0</plugin.version.build-helper>
     <plugin.version.checkstyle>3.3.1</plugin.version.checkstyle>
     <plugin.version.compiler>3.13.0</plugin.version.compiler>
-    <plugin.version.dependency-analyzer>1.13.2</plugin.version.dependency-analyzer>
+    <plugin.version.dependency-analyzer>1.14.1</plugin.version.dependency-analyzer>
     <plugin.version.dependency>3.6.1</plugin.version.dependency>
     <plugin.version.enforcer>3.5.0</plugin.version.enforcer>
     <plugin.version.exec>3.3.0</plugin.version.exec>


### PR DESCRIPTION
## Description

1.14.0 of this dependency had a bug that did not correctly support java record types and caused failures when building and running tests. 1.14.1 fixed this issue, so it is safe to update now.

Related renovate PR: https://github.com/camunda/camunda/pull/18570

## Related issues

closes #
