### PR TITLE
fix: download/upload release artifacts from separate directory

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -243,32 +243,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Download Release Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          name: release-artifacts-${{ inputs.releaseVersion }}
-      - name: Create Artifact Checksums
-        id: checksum
-        run: |
-          for filename in *; do
-            checksumFile="${filename}.sha1sum"
-            sha1sum "${filename}" > "${checksumFile}"
-            sha1sumResult=$?
-            if [ ! -f "${checksumFile}" ]; then
-              echo "Failed to created checksum of ${filename} at ${checksumFile}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
-              exit 1
-            fi
-          done
-      - name: Determine if Pre-Release
-        id: pre-release
-        run: |
-          shopt -s nocasematch # set matching to case insensitive
-          PRE_RELEASE=false
-          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
-            PRE_RELEASE=true
-          fi
-          shopt -u nocasematch # reset it
-          echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v4
         with:
           ref: ${{ env.RELEASE_BRANCH }}
@@ -334,12 +308,40 @@ jobs:
 
           # To show the changelog also as step summary
           echo "$changelog" >> $GITHUB_STEP_SUMMARY
+      - name: Download Release Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-artifacts-${{ inputs.releaseVersion }}
+          path: release-artifacts
+      - name: Create Artifact Checksums
+        id: checksum
+        working-directory: ./release-artifacts
+        run: |
+          for filename in *; do
+            checksumFile="${filename}.sha1sum"
+            sha1sum "${filename}" > "${checksumFile}"
+            sha1sumResult=$?
+            if [ ! -f "${checksumFile}" ]; then
+              echo "Failed to created checksum of ${filename} at ${checksumFile}; [sha1sum] exited with result ${sha1sumResult}. Check the logs for errors."
+              exit 1
+            fi
+          done
+      - name: Determine if Pre-Release
+        id: pre-release
+        run: |
+          shopt -s nocasematch # set matching to case insensitive
+          PRE_RELEASE=false
+          if [[ "${RELEASE_VERSION}" =~ ^.*-(alpha|rc|SNAPSHOT)[\d]*$ ]]; then
+            PRE_RELEASE=true
+          fi
+          shopt -u nocasematch # reset it
+          echo "result=${PRE_RELEASE}" >> $GITHUB_OUTPUT
       - name: Create Github release
         uses: ncipollo/release-action@v1
         if: ${{ inputs.dryRun == false }}
         with:
           name: ${{ inputs.releaseVersion }}
-          artifacts: "*"
+          artifacts: "release-artifacts/*"
           artifactErrorsFailBuild: true
           draft: true
           body: ${{ steps.gen-changelog.outputs.changelog }}


### PR DESCRIPTION
## Description

Fixes a problem introduced with our recent [changelog version fix](https://github.com/camunda/camunda/pull/18342/files). The latter added a repo checkout between the download of artifacts and uploading them to the github release. Accordingly, we attempted to upload both artifacts and repository contents.

This led to [release build errors like
](https://camunda.slack.com/archives/C06UWQNCU7M/p1717148311917189)

```
Error: Error undefined: Artifact is a directory:zeebe/. Directories can not be uploaded to a release.
```

in the *Github Release* step of the release workflow (see [failed workflow run](https://github.com/camunda/camunda/actions/runs/9315602701)).

All versions from main down to Zeebe 8.2 are affected, so this needs to be backported. This problem impacts our currently ongoing alpha and patch releases.

As a fix, we are downloading the artifacts into a dedicated directory. I also changed the order: First checkout the repository, generate changelog, download the artifacts, upload artifacts/changelog. I think it's clearer if the checkout is the very first step.

Note that I wasn't able to test this as it's the release workflow.

