### PR TITLE
feat: process instance search query service

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -776,6 +776,12 @@
 
       <dependency>
         <groupId>io.camunda</groupId>
+        <artifactId>camunda-service</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.camunda</groupId>
         <artifactId>camunda-search-client</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
     <module>tasklist</module>
     <module>identity</module>
     <module>search</module>
+    <module>service</module>
   </modules>
 
   <scm>

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/transformers/query/RangeQueryTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/transformers/query/RangeQueryTransformer.java
@@ -23,20 +23,40 @@ public final class RangeQueryTransformer
   @Override
   public RangeQuery apply(final SearchRangeQuery value) {
     final var field = value.field();
-    final var from = value.from();
-    final var to = value.to();
-    return QueryBuilders.range()
-        .field(field)
-        .gt(of(value.gt()))
-        .gte(of(value.gte()))
-        .lt(of(value.lt()))
-        .lte(of(value.lte()))
-        .from(from)
-        .to(to)
-        .build();
+    final var builder = QueryBuilders.range().field(field);
+
+    if (value.gt() != null) {
+      builder.gt(of(value.gt()));
+    }
+
+    if (value.gte() != null) {
+      builder.gte(of(value.gte()));
+    }
+
+    if (value.lt() != null) {
+      builder.lt(of(value.lt()));
+    }
+
+    if (value.lte() != null) {
+      builder.lte(of(value.lte()));
+    }
+
+    if (value.from() != null) {
+      builder.from(value.from());
+    }
+
+    if (value.to() != null) {
+      builder.to(value.to());
+    }
+
+    if (value.format() != null) {
+      builder.format(value.format());
+    }
+
+    return builder.build();
   }
 
-  private <T> JsonData of(T value) {
+  private <T> JsonData of(final T value) {
     return JsonData.of(value);
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/data/transformers/RangeQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/data/transformers/RangeQueryTransformerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.data.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.clients.query.SearchRangeQuery;
+import io.camunda.search.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class RangeQueryTransformerTest {
+
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<SearchRangeQuery, RangeQuery> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchRangeQuery.class);
+  }
+
+  @Test
+  public void shouldApplyTransformer() {
+    // given
+    final var query = SearchQueryBuilders.range().field("foo").lt(12456L).build();
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isInstanceOf(RangeQuery.class);
+    assertThat(result.lt().to(Long.class)).isEqualTo(12456L);
+  }
+}

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/transformers/query/RangeQueryTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/transformers/query/RangeQueryTransformer.java
@@ -23,21 +23,40 @@ public final class RangeQueryTransformer
   @Override
   public RangeQuery apply(final SearchRangeQuery value) {
     final var field = value.field();
-    final var from = value.from();
-    final var to = value.to();
+    final var builder = QueryBuilders.range().field(field);
 
-    return QueryBuilders.range()
-        .field(field)
-        .gt(of(value.gt()))
-        .gte(of(value.gte()))
-        .lt(of(value.lt()))
-        .lte(of(value.lte()))
-        .from(of(from))
-        .to(of(to))
-        .build();
+    if (value.gt() != null) {
+      builder.gt(of(value.gt()));
+    }
+
+    if (value.gte() != null) {
+      builder.gte(of(value.gte()));
+    }
+
+    if (value.lt() != null) {
+      builder.lt(of(value.lt()));
+    }
+
+    if (value.lte() != null) {
+      builder.lte(of(value.lte()));
+    }
+
+    if (value.from() != null) {
+      builder.from(JsonData.of(value.from()));
+    }
+
+    if (value.to() != null) {
+      builder.to(JsonData.of(value.to()));
+    }
+
+    if (value.format() != null) {
+      builder.format(value.format());
+    }
+
+    return builder.build();
   }
 
-  private <T> JsonData of(T value) {
+  private <T> JsonData of(final T value) {
     return JsonData.of(value);
   }
 }

--- a/search/search-client-opensearch/src/test/java/io/camunda/data/transformers/RangeQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/data/transformers/RangeQueryTransformerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.data.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.clients.query.SearchRangeQuery;
+import io.camunda.search.transformers.OpensearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+
+public class RangeQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchRangeQuery, RangeQuery> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchRangeQuery.class);
+  }
+
+  @Test
+  public void shouldApplyTransformer() {
+    // given
+    final var query = SearchQueryBuilders.range().field("foo").lt(12456L).build();
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isInstanceOf(RangeQuery.class);
+    assertThat(result.lt().to(Long.class)).isEqualTo(12456L);
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -67,7 +67,11 @@ public final class SearchQueryBuilders {
   }
 
   public static SearchQuery not(final List<SearchQuery> queries) {
-    return map(queries, SearchQueryBuilders::mustNot);
+    final var nonNullQueries = withoutNull(queries);
+    if (nonNullQueries != null && !nonNullQueries.isEmpty()) {
+      return SearchQueryBuilders.mustNot(queries);
+    }
+    return null;
   }
 
   public static SearchQuery or(final SearchQuery query, final SearchQuery... queries) {

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchRangeQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchRangeQuery.java
@@ -12,7 +12,14 @@ import java.util.Objects;
 import java.util.function.Function;
 
 public final record SearchRangeQuery(
-    String field, Object gt, Object gte, Object lt, Object lte, String from, String to)
+    String field,
+    Object gt,
+    Object gte,
+    Object lt,
+    Object lte,
+    String from,
+    String to,
+    String format)
     implements SearchQueryOption {
 
   static SearchRangeQuery of(final Function<Builder, ObjectBuilder<SearchRangeQuery>> fn) {
@@ -28,6 +35,7 @@ public final record SearchRangeQuery(
     private Object lte;
     private String from;
     private String to;
+    private String format;
 
     public Builder field(final String field) {
       this.field = field;
@@ -64,9 +72,15 @@ public final record SearchRangeQuery(
       return this;
     }
 
+    public Builder format(final String value) {
+      format = value;
+      return this;
+    }
+
     @Override
     public SearchRangeQuery build() {
-      return new SearchRangeQuery(Objects.requireNonNull(field), gt, gte, lt, lte, from, to);
+      return new SearchRangeQuery(
+          Objects.requireNonNull(field), gt, gte, lt, lte, from, to, format);
     }
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
@@ -31,27 +31,27 @@ public final record SearchTermQuery(String field, TypedValue value, Boolean case
     }
 
     public Builder value(final String value) {
-      this.value = TypedValue.of(value);
-      return this;
+      return value(TypedValue.of(value));
     }
 
     public Builder value(final int value) {
-      this.value = TypedValue.of(value);
-      return this;
+      return value(TypedValue.of(value));
     }
 
     public Builder value(final long value) {
-      this.value = TypedValue.of(value);
-      return this;
+      return value(TypedValue.of(value));
     }
 
     public Builder value(final double value) {
-      this.value = TypedValue.of(value);
-      return this;
+      return value(TypedValue.of(value));
     }
 
     public Builder value(final boolean value) {
-      this.value = TypedValue.of(value);
+      return value(TypedValue.of(value));
+    }
+
+    public Builder value(final TypedValue value) {
+      this.value = value;
       return this;
     }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/types/TypedValue.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/types/TypedValue.java
@@ -99,4 +99,23 @@ public final record TypedValue(ValueType type, Object value) {
       final List<T> values, final Function<T, TypedValue> mapper) {
     return values.stream().map(mapper).collect(Collectors.toList());
   }
+
+  public static TypedValue toTypedValue(final Object value) {
+    if (value == null) {
+      return NULL;
+    } else if (value instanceof TypedValue) {
+      return (TypedValue) value;
+    } else if (String.class.isAssignableFrom(value.getClass())) {
+      return of((String) value);
+    } else if (Integer.class.isAssignableFrom(value.getClass())) {
+      return of((Integer) value);
+    } else if (Long.class.isAssignableFrom(value.getClass())) {
+      return of((Long) value);
+    } else if (Double.class.isAssignableFrom(value.getClass())) {
+      return of((Double) value);
+    } else if (Boolean.class.isAssignableFrom(value.getClass())) {
+      return of((Boolean) value);
+    }
+    throw new IllegalArgumentException("Non-supported type: " + value.getClass());
+  }
 }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.6.0-SNAPSHOT</version>
+    <relativePath>../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-service</artifactId>
+  <name>Camunda Service</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-util</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public abstract class ApiServices<T extends ApiServices<T>> {
+
+  protected final CamundaSearchClient searchClient;
+  protected final Authentication authentication;
+  protected final ServiceTransformers transformers;
+
+  protected ApiServices(
+      final CamundaSearchClient searchClient, final Authentication authentication) {
+    this(searchClient, null, authentication);
+  }
+
+  protected ApiServices(
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    this.searchClient = searchClient;
+    this.authentication = authentication;
+    this.transformers = Objects.requireNonNullElse(transformers, new ServiceTransformers());
+  }
+
+  public abstract T withAuthentication(final Authentication authentication);
+
+  public T withAuthentication(
+      final Function<Authentication.Builder, ObjectBuilder<Authentication>> fn) {
+    return withAuthentication(fn.apply(new Authentication.Builder()).build());
+  }
+}

--- a/service/src/main/java/io/camunda/service/CamundaServiceException.java
+++ b/service/src/main/java/io/camunda/service/CamundaServiceException.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+public class CamundaServiceException extends RuntimeException {
+
+  private static final long serialVersionUID = 1L;
+
+  public CamundaServiceException(String message) {
+    super(message);
+  }
+
+  public CamundaServiceException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public CamundaServiceException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+
+public final class CamundaServices extends ApiServices<CamundaServices> {
+
+  public CamundaServices(final CamundaSearchClient searchClient) {
+    this(searchClient, null, null);
+  }
+
+  public CamundaServices(
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    super(searchClient, transformers, authentication);
+  }
+
+  public ProcessInstanceServices processInstanceServices() {
+    return new ProcessInstanceServices(searchClient, transformers, authentication);
+  }
+
+  @Override
+  public CamundaServices withAuthentication(final Authentication authentication) {
+    return new CamundaServices(searchClient, transformers, authentication);
+  }
+}

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.search.core.SearchQueryService;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.query.SearchQueryBuilders;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public final class ProcessInstanceServices
+    extends SearchQueryService<
+        ProcessInstanceServices, ProcessInstanceQuery, ProcessInstanceEntity> {
+
+  public ProcessInstanceServices(final CamundaSearchClient dataStoreClient) {
+    this(dataStoreClient, null, null);
+  }
+
+  public ProcessInstanceServices(
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    super(searchClient, transformers, authentication);
+  }
+
+  @Override
+  public ProcessInstanceServices withAuthentication(final Authentication authentication) {
+    return new ProcessInstanceServices(searchClient, transformers, authentication);
+  }
+
+  @Override
+  public SearchQueryResult<ProcessInstanceEntity> search(final ProcessInstanceQuery query) {
+    return executor.search(query, ProcessInstanceEntity.class);
+  }
+
+  public SearchQueryResult<ProcessInstanceEntity> search(
+      final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn) {
+    return search(SearchQueryBuilders.processInstanceSearchQuery(fn));
+  }
+}

--- a/service/src/main/java/io/camunda/service/entities/ProcessInstanceEntity.java
+++ b/service/src/main/java/io/camunda/service/entities/ProcessInstanceEntity.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.entities;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public final record ProcessInstanceEntity(
+    String tenantId,
+    Long key,
+    Integer processVersion,
+    String bpmnProcessId,
+    Long parentKey,
+    Long parentFlowNodeInstanceKey,
+    String startDate,
+    String endDate) {}

--- a/service/src/main/java/io/camunda/service/search/core/SearchClientBasedQueryExecutor.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchClientBasedQueryExecutor.java
@@ -75,7 +75,7 @@ public final class SearchClientBasedQueryExecutor {
     return new SearchQueryResultTransformer<R>();
   }
 
-  private RuntimeException rethrowRuntimeException(final Exception e) {
-    return new RuntimeException("something went wrong", e);
+  private SearchQueryExecutionException rethrowRuntimeException(final Exception e) {
+    return new SearchQueryExecutionException("Failed to execute search query", e);
   }
 }

--- a/service/src/main/java/io/camunda/service/search/core/SearchClientBasedQueryExecutor.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchClientBasedQueryExecutor.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.core;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.search.query.TypedSearchQuery;
+import io.camunda.service.search.sort.SortOption;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.service.transformers.filter.AuthenticationTransformer;
+import io.camunda.service.transformers.filter.FilterTransformer;
+import io.camunda.service.transformers.query.SearchQueryResultTransformer;
+import io.camunda.service.transformers.query.TypedSearchQueryTransformer;
+
+public final class SearchClientBasedQueryExecutor {
+
+  private final CamundaSearchClient searchClient;
+  private final ServiceTransformers transformers;
+  private final Authentication authentication;
+
+  public SearchClientBasedQueryExecutor(
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    this.searchClient = searchClient;
+    this.transformers = transformers;
+    this.authentication = authentication;
+  }
+
+  public <T extends FilterBase, S extends SortOption, R> SearchQueryResult<R> search(
+      final TypedSearchQuery<T, S> query, final Class<R> documentClass) {
+    final var authCheck = getAuthenticationCheckIfPresent();
+    final var transformer = getSearchQueryRequestTransformer(query);
+    final var searchRequest = transformer.applyWithAuthentication(query, authCheck);
+
+    final SearchQueryResultTransformer<R> responseTransformer = getSearchResultTransformer();
+    return searchClient
+        .search(searchRequest, documentClass)
+        .fold(
+            responseTransformer::apply,
+            (e) -> {
+              throw rethrowRuntimeException(e);
+            });
+  }
+
+  private SearchQuery getAuthenticationCheckIfPresent() {
+    if (authentication != null) {
+      final var transformer = getAuthenticationTransformer();
+      return transformer.apply(authentication);
+    }
+    return null;
+  }
+
+  private <T extends FilterBase, S extends SortOption>
+      TypedSearchQueryTransformer<T, S> getSearchQueryRequestTransformer(
+          final TypedSearchQuery<T, S> query) {
+    return transformers.getTypedSearchQueryTransformer(query.getClass());
+  }
+
+  private AuthenticationTransformer getAuthenticationTransformer() {
+    final FilterTransformer<Authentication> transformer =
+        transformers.getFilterTransformer(Authentication.class);
+    return (AuthenticationTransformer) transformer;
+  }
+
+  private <R> SearchQueryResultTransformer<R> getSearchResultTransformer() {
+    return new SearchQueryResultTransformer<R>();
+  }
+
+  private RuntimeException rethrowRuntimeException(final Exception e) {
+    return new RuntimeException("something went wrong", e);
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryExecutionException.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryExecutionException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.core;
+
+import io.camunda.service.CamundaServiceException;
+
+public class SearchQueryExecutionException extends CamundaServiceException {
+
+  private static final long serialVersionUID = 1L;
+
+  public SearchQueryExecutionException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.core;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.ApiServices;
+import io.camunda.service.search.query.SearchQueryBase;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+
+public abstract class SearchQueryService<T extends ApiServices<T>, Q extends SearchQueryBase, D>
+    extends ApiServices<T> {
+
+  protected final SearchClientBasedQueryExecutor executor;
+
+  protected SearchQueryService(
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    super(searchClient, transformers, authentication);
+    executor = initiateExecutor();
+  }
+
+  private SearchClientBasedQueryExecutor initiateExecutor() {
+    return new SearchClientBasedQueryExecutor(searchClient, transformers, authentication);
+  }
+
+  public abstract SearchQueryResult<D> search(final Q query);
+}

--- a/service/src/main/java/io/camunda/service/search/filter/DateValueFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/DateValueFilter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public final record DateValueFilter(OffsetDateTime after, OffsetDateTime before)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<DateValueFilter> {
+
+    private OffsetDateTime after;
+    private OffsetDateTime before;
+
+    public Builder after(final OffsetDateTime value) {
+      after = value;
+      return this;
+    }
+
+    public Builder before(final OffsetDateTime value) {
+      before = value;
+      return this;
+    }
+
+    @Override
+    public DateValueFilter build() {
+      Objects.requireNonNullElse(after, before);
+      return new DateValueFilter(after, before);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/filter/FilterBase.java
+++ b/service/src/main/java/io/camunda/service/search/filter/FilterBase.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.filter;
+
+public interface FilterBase {}

--- a/service/src/main/java/io/camunda/service/search/filter/FilterBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/filter/FilterBuilders.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public final class FilterBuilders {
+
+  private FilterBuilders() {}
+
+  public static ProcessInstanceFilter.Builder processInstance() {
+    return new ProcessInstanceFilter.Builder();
+  }
+
+  public static ProcessInstanceFilter processInstance(
+      final Function<ProcessInstanceFilter.Builder, ObjectBuilder<ProcessInstanceFilter>> fn) {
+    return fn.apply(processInstance()).build();
+  }
+
+  public static VariableValueFilter.Builder variableValue() {
+    return new VariableValueFilter.Builder();
+  }
+
+  public static VariableValueFilter variableValue(
+      final Function<VariableValueFilter.Builder, ObjectBuilder<VariableValueFilter>> fn) {
+    return fn.apply(variableValue()).build();
+  }
+
+  public static DateValueFilter.Builder dateValue() {
+    return new DateValueFilter.Builder();
+  }
+
+  public static DateValueFilter dateValue(
+      final Function<DateValueFilter.Builder, ObjectBuilder<DateValueFilter>> fn) {
+    return fn.apply(dateValue()).build();
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/filter/ProcessInstanceFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/ProcessInstanceFilter.java
@@ -125,7 +125,7 @@ public final record ProcessInstanceFilter(
     @Override
     public ProcessInstanceFilter build() {
       return new ProcessInstanceFilter(
-          processInstanceKeys,
+          Objects.requireNonNullElse(processInstanceKeys, Collections.emptyList()),
           running,
           active,
           incidents,

--- a/service/src/main/java/io/camunda/service/search/filter/ProcessInstanceFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/ProcessInstanceFilter.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.filter;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+import static io.camunda.util.CollectionUtil.collectValues;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final record ProcessInstanceFilter(
+    List<Long> processInstanceKeys,
+    boolean running,
+    boolean active,
+    boolean incidents,
+    boolean finished,
+    boolean completed,
+    boolean canceled,
+    boolean retriesLeft,
+    List<VariableValueFilter> variableFilters,
+    DateValueFilter startDateFilter,
+    DateValueFilter endDateFilter)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<ProcessInstanceFilter> {
+
+    private List<Long> processInstanceKeys;
+    private boolean running;
+    private boolean active;
+    private boolean incidents;
+    private boolean finished;
+    private boolean completed;
+    private boolean canceled;
+    private boolean retriesLeft;
+    private List<VariableValueFilter> variableFilters;
+    private DateValueFilter startDateFilter;
+    private DateValueFilter endDateFilter;
+
+    public Builder processInstanceKeys(final Long value, final Long... values) {
+      return processInstanceKeys(collectValues(value, values));
+    }
+
+    public Builder processInstanceKeys(final List<Long> values) {
+      processInstanceKeys = addValuesToList(processInstanceKeys, values);
+      return this;
+    }
+
+    public Builder running() {
+      running = true;
+      return this;
+    }
+
+    public Builder active() {
+      active = true;
+      return this;
+    }
+
+    public Builder incidents() {
+      incidents = true;
+      return this;
+    }
+
+    public Builder finished() {
+      finished = true;
+      return this;
+    }
+
+    public Builder completed() {
+      completed = true;
+      return this;
+    }
+
+    public Builder canceled() {
+      canceled = true;
+      return this;
+    }
+
+    public Builder retriesLeft() {
+      retriesLeft = true;
+      return this;
+    }
+
+    public Builder variable(final List<VariableValueFilter> values) {
+      variableFilters = addValuesToList(variableFilters, values);
+      return this;
+    }
+
+    public Builder variable(final VariableValueFilter value, final VariableValueFilter... values) {
+      return variable(collectValues(value, values));
+    }
+
+    public Builder variable(
+        final Function<VariableValueFilter.Builder, ObjectBuilder<VariableValueFilter>> fn) {
+      return variable(FilterBuilders.variableValue(fn));
+    }
+
+    public Builder startDate(final DateValueFilter value) {
+      startDateFilter = value;
+      return this;
+    }
+
+    public Builder startDate(
+        final Function<DateValueFilter.Builder, ObjectBuilder<DateValueFilter>> fn) {
+      return startDate(FilterBuilders.dateValue(fn));
+    }
+
+    public Builder endDate(final DateValueFilter value) {
+      endDateFilter = value;
+      return this;
+    }
+
+    public Builder endDate(
+        final Function<DateValueFilter.Builder, ObjectBuilder<DateValueFilter>> fn) {
+      return endDate(FilterBuilders.dateValue(fn));
+    }
+
+    @Override
+    public ProcessInstanceFilter build() {
+      return new ProcessInstanceFilter(
+          processInstanceKeys,
+          running,
+          active,
+          incidents,
+          finished,
+          completed,
+          canceled,
+          retriesLeft,
+          Objects.requireNonNullElse(variableFilters, Collections.emptyList()),
+          startDateFilter,
+          endDateFilter);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/filter/VariableValueFilter.java
+++ b/service/src/main/java/io/camunda/service/search/filter/VariableValueFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.filter;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+
+public final record VariableValueFilter(
+    String name, Object eq, Object neq, Object gt, Object gte, Object lt, Object lte)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<VariableValueFilter> {
+
+    private String name;
+    private Object eq;
+    private Object neq;
+    private Object gt;
+    private Object gte;
+    private Object lt;
+    private Object lte;
+
+    public Builder name(final String value) {
+      name = value;
+      return this;
+    }
+
+    public Builder eq(final Object value) {
+      eq = value;
+      return this;
+    }
+
+    public Builder neq(final Object value) {
+      neq = value;
+      return this;
+    }
+
+    public Builder gt(final Object value) {
+      gt = value;
+      return this;
+    }
+
+    public Builder gte(final Object value) {
+      gte = value;
+      return this;
+    }
+
+    public Builder lt(final Object value) {
+      lt = value;
+      return this;
+    }
+
+    public Builder lte(final Object value) {
+      lte = value;
+      return this;
+    }
+
+    @Override
+    public VariableValueFilter build() {
+      return new VariableValueFilter(Objects.requireNonNull(name), eq, neq, gt, gte, lt, lte);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/page/SearchQueryPage.java
+++ b/service/src/main/java/io/camunda/service/search/page/SearchQueryPage.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.page;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public final record SearchQueryPage(
+    Integer from, Integer size, Object[] searchAfter, Object[] searchBefore) {
+
+  public boolean isNextPage() {
+    return searchAfter != null || !isPreviousPage();
+  }
+
+  public boolean isPreviousPage() {
+    return searchBefore != null;
+  }
+
+  public Object[] startNextPageAfter() {
+    if (isNextPage()) {
+      return searchAfter;
+    } else if (isPreviousPage()) {
+      return searchBefore;
+    }
+    return null;
+  }
+
+  public static SearchQueryPage of(final Function<Builder, ObjectBuilder<SearchQueryPage>> fn) {
+    return SearchQueryPageBuilders.page(fn);
+  }
+
+  public static final class Builder implements ObjectBuilder<SearchQueryPage> {
+
+    private Integer from;
+    private Integer size;
+    private Object[] searchAfter;
+    private Object[] searchBefore;
+
+    public Builder from(final Integer value) {
+      from = value;
+      return this;
+    }
+
+    public Builder size(final Integer value) {
+      size = value;
+      return this;
+    }
+
+    public Builder searchAfter(final Object[] value) {
+      searchAfter = value;
+      return this;
+    }
+
+    public Builder searchBefore(final Object[] value) {
+      searchBefore = value;
+      return this;
+    }
+
+    @Override
+    public SearchQueryPage build() {
+      return new SearchQueryPage(from, size, searchAfter, searchBefore);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/page/SearchQueryPageBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/page/SearchQueryPageBuilders.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.page;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public final class SearchQueryPageBuilders {
+
+  public static SearchQueryPage.Builder page() {
+    return new SearchQueryPage.Builder();
+  }
+
+  public static SearchQueryPage page(
+      final Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> fn) {
+    return fn.apply(page()).build();
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/query/ProcessInstanceQuery.java
+++ b/service/src/main/java/io/camunda/service/search/query/ProcessInstanceQuery.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.query;
+
+import io.camunda.service.search.filter.FilterBuilders;
+import io.camunda.service.search.filter.ProcessInstanceFilter;
+import io.camunda.service.search.page.SearchQueryPage;
+import io.camunda.service.search.sort.ProcessInstanceSort;
+import io.camunda.service.search.sort.SortOptionBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final record ProcessInstanceQuery(
+    ProcessInstanceFilter filter, ProcessInstanceSort sort, SearchQueryPage page)
+    implements TypedSearchQuery<ProcessInstanceFilter, ProcessInstanceSort> {
+
+  public static ProcessInstanceQuery of(
+      final Function<Builder, ObjectBuilder<ProcessInstanceQuery>> fn) {
+    return fn.apply(new Builder()).build();
+  }
+
+  public static final class Builder extends SearchQueryBase.AbstractQueryBuilder<Builder>
+      implements ObjectBuilder<ProcessInstanceQuery> {
+
+    private static final ProcessInstanceFilter EMPTY_FILTER =
+        FilterBuilders.processInstance().build();
+    private static final ProcessInstanceSort EMPTY_SORT =
+        SortOptionBuilders.processInstance().build();
+
+    private ProcessInstanceFilter filter;
+    private ProcessInstanceSort sort;
+
+    public Builder filter(final ProcessInstanceFilter value) {
+      filter = value;
+      return this;
+    }
+
+    public Builder filter(
+        final Function<ProcessInstanceFilter.Builder, ObjectBuilder<ProcessInstanceFilter>> fn) {
+      return filter(FilterBuilders.processInstance(fn));
+    }
+
+    public Builder sort(final ProcessInstanceSort value) {
+      sort = value;
+      return this;
+    }
+
+    public Builder sort(
+        final Function<ProcessInstanceSort.Builder, ObjectBuilder<ProcessInstanceSort>> fn) {
+      return sort(SortOptionBuilders.processInstance(fn));
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public ProcessInstanceQuery build() {
+      filter = Objects.requireNonNullElse(filter, EMPTY_FILTER);
+      sort = Objects.requireNonNullElse(sort, EMPTY_SORT);
+      return new ProcessInstanceQuery(filter, sort, page());
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/query/SearchQueryBase.java
+++ b/service/src/main/java/io/camunda/service/search/query/SearchQueryBase.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.query;
+
+import io.camunda.service.search.page.SearchQueryPage;
+import io.camunda.service.search.page.SearchQueryPageBuilders;
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+import java.util.function.Function;
+
+public interface SearchQueryBase {
+
+  SearchQueryPage page();
+
+  public abstract static class AbstractQueryBuilder<T extends AbstractQueryBuilder<T>> {
+
+    private static final SearchQueryPage DEFAULT_PAGE = SearchQueryPage.of((b) -> b);
+
+    private SearchQueryPage page;
+
+    protected abstract T self();
+
+    protected SearchQueryPage page() {
+      return Objects.requireNonNullElse(page, DEFAULT_PAGE);
+    }
+
+    public T page(final SearchQueryPage value) {
+      page = value;
+      return self();
+    }
+
+    public T page(final Function<SearchQueryPage.Builder, ObjectBuilder<SearchQueryPage>> fn) {
+      return page(SearchQueryPageBuilders.page(fn));
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/query/SearchQueryBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/query/SearchQueryBuilders.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.query;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public final class SearchQueryBuilders {
+
+  private SearchQueryBuilders() {}
+
+  public static ProcessInstanceQuery.Builder processInstanceSearchQuery() {
+    return new ProcessInstanceQuery.Builder();
+  }
+
+  public static ProcessInstanceQuery processInstanceSearchQuery(
+      final Function<ProcessInstanceQuery.Builder, ObjectBuilder<ProcessInstanceQuery>> fn) {
+    return fn.apply(processInstanceSearchQuery()).build();
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/query/SearchQueryResult.java
+++ b/service/src/main/java/io/camunda/service/search/query/SearchQueryResult.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.query;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final record SearchQueryResult<T>(long total, List<T> items, Object[] sortValues) {
+
+  public static final class Builder<T> implements ObjectBuilder<SearchQueryResult<T>> {
+
+    private long total;
+    private List<T> items;
+    private Object[] sortValues;
+
+    public Builder<T> total(final long value) {
+      total = value;
+      return this;
+    }
+
+    public Builder<T> items(final List<T> values) {
+      items = values;
+      return this;
+    }
+
+    public Builder<T> sortValues(final Object[] values) {
+      sortValues = values;
+      return this;
+    }
+
+    @Override
+    public SearchQueryResult<T> build() {
+      return new SearchQueryResult<T>(
+          total, Objects.requireNonNullElse(items, Collections.emptyList()), sortValues);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/query/TypedSearchQuery.java
+++ b/service/src/main/java/io/camunda/service/search/query/TypedSearchQuery.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.query;
+
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.search.sort.SortOption;
+
+public interface TypedSearchQuery<F extends FilterBase, S extends SortOption>
+    extends SearchQueryBase {
+
+  F filter();
+
+  S sort();
+}

--- a/service/src/main/java/io/camunda/service/search/sort/ProcessInstanceSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/ProcessInstanceSort.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.sort;
+
+import io.camunda.search.clients.sort.SortOrder;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+import java.util.function.Function;
+
+public final record ProcessInstanceSort(List<FieldSorting> orderings) implements SortOption {
+
+  @Override
+  public List<FieldSorting> getFieldSortings() {
+    return orderings;
+  }
+
+  public static ProcessInstanceSort of(
+      final Function<Builder, ObjectBuilder<ProcessInstanceSort>> fn) {
+    return SortOptionBuilders.processInstance(fn);
+  }
+
+  public static final class Builder extends SortOption.AbstractBuilder<Builder>
+      implements ObjectBuilder<ProcessInstanceSort> {
+
+    public Builder processInstanceKey() {
+      currentOrdering = new FieldSorting("processInstanceKey", null);
+      return this;
+    }
+
+    public Builder startDate() {
+      currentOrdering = new FieldSorting("startDate", null);
+      return this;
+    }
+
+    public Builder endDate() {
+      currentOrdering = new FieldSorting("endDate", null);
+      return this;
+    }
+
+    public Builder asc() {
+      return addOrdering(SortOrder.ASC);
+    }
+
+    public Builder desc() {
+      return addOrdering(SortOrder.DESC);
+    }
+
+    @Override
+    protected Builder self() {
+      return this;
+    }
+
+    @Override
+    public ProcessInstanceSort build() {
+      return new ProcessInstanceSort(orderings);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/search/sort/SortOption.java
+++ b/service/src/main/java/io/camunda/service/search/sort/SortOption.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.sort;
+
+import io.camunda.search.clients.sort.SortOrder;
+import java.util.ArrayList;
+import java.util.List;
+
+public interface SortOption {
+
+  public List<FieldSorting> getFieldSortings();
+
+  public abstract static class AbstractBuilder<T> {
+
+    protected final List<FieldSorting> orderings = new ArrayList<>();
+    protected FieldSorting currentOrdering;
+
+    protected abstract T self();
+
+    protected T addOrdering(final SortOrder value) {
+      if (currentOrdering != null) {
+        final var field = currentOrdering.field();
+        final var newOrdering = new FieldSorting(field, value);
+        orderings.add(newOrdering);
+        currentOrdering = null;
+      }
+      // else if not set, then noop
+
+      return self();
+    }
+  }
+
+  public final record FieldSorting(String field, SortOrder order) {}
+}

--- a/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
+++ b/service/src/main/java/io/camunda/service/search/sort/SortOptionBuilders.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.search.sort;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public final class SortOptionBuilders {
+
+  private SortOptionBuilders() {}
+
+  public static ProcessInstanceSort.Builder processInstance() {
+    return new ProcessInstanceSort.Builder();
+  }
+
+  public static ProcessInstanceSort processInstance(
+      final Function<ProcessInstanceSort.Builder, ObjectBuilder<ProcessInstanceSort>> fn) {
+    return fn.apply(processInstance()).build();
+  }
+}

--- a/service/src/main/java/io/camunda/service/security/auth/Authentication.java
+++ b/service/src/main/java/io/camunda/service/security/auth/Authentication.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.security.auth;
+
+import static io.camunda.util.CollectionUtil.addValuesToList;
+
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.util.ObjectBuilder;
+import java.util.List;
+
+public final record Authentication(
+    String authenticatedUserId,
+    List<String> authenticatedGroupIds,
+    List<String> authenticatedTenantIds)
+    implements FilterBase {
+
+  public static final class Builder implements ObjectBuilder<Authentication> {
+
+    private String user;
+    private List<String> groups;
+    private List<String> tenants;
+
+    public Builder user(final String value) {
+      user = value;
+      return this;
+    }
+
+    public Builder group(final String value) {
+      return groups(List.of(value));
+    }
+
+    public Builder groups(final List<String> values) {
+      groups = addValuesToList(groups, values);
+      return this;
+    }
+
+    public Builder tenant(final String tenant) {
+      return tenants(List.of(tenant));
+    }
+
+    public Builder tenants(final List<String> values) {
+      tenants = addValuesToList(tenants, values);
+      return this;
+    }
+
+    @Override
+    public Authentication build() {
+      return new Authentication(user, groups, tenants);
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/ServiceTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/ServiceTransformer.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers;
+
+public interface ServiceTransformer<T, R> {
+
+  R apply(final T value);
+}

--- a/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
+++ b/service/src/main/java/io/camunda/service/transformers/ServiceTransformers.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers;
+
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.search.filter.DateValueFilter;
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.search.filter.ProcessInstanceFilter;
+import io.camunda.service.search.filter.VariableValueFilter;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.search.query.TypedSearchQuery;
+import io.camunda.service.search.sort.ProcessInstanceSort;
+import io.camunda.service.search.sort.SortOption;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.filter.AuthenticationTransformer;
+import io.camunda.service.transformers.filter.DateValueFilterTransformer;
+import io.camunda.service.transformers.filter.FilterTransformer;
+import io.camunda.service.transformers.filter.ProcessInstanceFilterTransformer;
+import io.camunda.service.transformers.filter.VariableValueFilterTransformer;
+import io.camunda.service.transformers.query.SearchQueryResultTransformer;
+import io.camunda.service.transformers.query.TypedSearchQueryTransformer;
+import io.camunda.service.transformers.sort.FieldSortingTransformer;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class ServiceTransformers {
+
+  private final Map<Class<?>, ServiceTransformer<?, ?>> transformers;
+
+  public ServiceTransformers() {
+    transformers = new HashMap<>();
+    initializeTransformers(this);
+  }
+
+  public <F extends FilterBase, S extends SortOption>
+      TypedSearchQueryTransformer<F, S> getTypedSearchQueryTransformer(final Class<?> cls) {
+    final ServiceTransformer<TypedSearchQuery<F, S>, SearchQueryRequest> transformer =
+        getTransformer(cls);
+    return (TypedSearchQueryTransformer<F, S>) transformer;
+  }
+
+  public <F extends FilterBase> FilterTransformer<F> getFilterTransformer(final Class<?> cls) {
+    final ServiceTransformer<F, SearchQuery> transformer = getTransformer(cls);
+    return (FilterTransformer<F>) transformer;
+  }
+
+  public <T, R> ServiceTransformer<T, R> getTransformer(final Class<?> cls) {
+    return (ServiceTransformer<T, R>) transformers.get(cls);
+  }
+
+  private void put(final Class<?> cls, final ServiceTransformer<?, ?> mapper) {
+    transformers.put(cls, mapper);
+  }
+
+  public static void initializeTransformers(final ServiceTransformers mappers) {
+    // query -> request
+    mappers.put(
+        ProcessInstanceQuery.class,
+        new TypedSearchQueryTransformer<ProcessInstanceFilter, ProcessInstanceSort>(mappers));
+
+    // search query response -> search query result
+    mappers.put(SearchQueryResult.class, new SearchQueryResultTransformer());
+
+    // sorting -> search sort options
+    mappers.put(FieldSortingTransformer.class, new FieldSortingTransformer());
+
+    // filters -> search query
+    mappers.put(Authentication.class, new AuthenticationTransformer());
+    mappers.put(ProcessInstanceFilter.class, new ProcessInstanceFilterTransformer(mappers));
+    mappers.put(VariableValueFilter.class, new VariableValueFilterTransformer());
+    mappers.put(DateValueFilter.class, new DateValueFilterTransformer());
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/filter/AuthenticationTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/AuthenticationTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.stringTerms;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.security.auth.Authentication;
+
+public final class AuthenticationTransformer implements FilterTransformer<Authentication> {
+
+  @Override
+  public SearchQuery toSearchQuery(final Authentication value) {
+    // TODO: intermediate implementation, needs to handle cases where
+    // tenancy is enabled but caller is not assigned to any tenant.
+    // in the best case, such calls are already "rejected" in the
+    // authentication layer.
+    final var authenticatedTenantIds = value.authenticatedTenantIds();
+    if (authenticatedTenantIds != null && !authenticatedTenantIds.isEmpty()) {
+      return stringTerms("tenantId", authenticatedTenantIds);
+    }
+    return null;
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/filter/DateValueFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/DateValueFilterTransformer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.range;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.search.filter.DateValueFilter;
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.transformers.filter.DateValueFilterTransformer.DateFieldFilter;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Objects;
+
+public final class DateValueFilterTransformer implements FilterTransformer<DateFieldFilter> {
+
+  private final DateTimeFormatter dateTimeFormatter =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZZ");
+
+  @Override
+  public SearchQuery toSearchQuery(final DateFieldFilter filter) {
+    final var field = Objects.requireNonNull(filter.field());
+    final var dateFiler = filter.filter();
+    final var after = dateFiler.after();
+    final var before = dateFiler.before();
+
+    final var builder = range().field(field);
+
+    if (after != null) {
+      builder.gte(formatDate(after));
+    }
+
+    if (before != null) {
+      builder.lt(formatDate(before));
+    }
+
+    return builder.format("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").build().toSearchQuery();
+  }
+
+  private String formatDate(final OffsetDateTime date) {
+    return dateTimeFormatter.format(date);
+  }
+
+  public static final record DateFieldFilter(String field, DateValueFilter filter)
+      implements FilterBase {}
+}

--- a/service/src/main/java/io/camunda/service/transformers/filter/FilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/FilterTransformer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.filter;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.transformers.ServiceTransformer;
+import java.util.List;
+
+public interface FilterTransformer<T extends FilterBase>
+    extends ServiceTransformer<T, SearchQuery> {
+
+  default SearchQuery apply(final T filter) {
+    return toSearchQuery(filter);
+  }
+
+  SearchQuery toSearchQuery(final T filter);
+
+  default List<String> toIndices(final T filter) {
+    throw new IllegalArgumentException("Filter does not support indices");
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/filter/ProcessInstanceFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/ProcessInstanceFilterTransformer.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.exists;
+import static io.camunda.search.clients.query.SearchQueryBuilders.hasChildQuery;
+import static io.camunda.search.clients.query.SearchQueryBuilders.longTerms;
+import static io.camunda.search.clients.query.SearchQueryBuilders.matchAll;
+import static io.camunda.search.clients.query.SearchQueryBuilders.not;
+import static io.camunda.search.clients.query.SearchQueryBuilders.or;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.search.filter.DateValueFilter;
+import io.camunda.service.search.filter.ProcessInstanceFilter;
+import io.camunda.service.search.filter.VariableValueFilter;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.service.transformers.filter.DateValueFilterTransformer.DateFieldFilter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class ProcessInstanceFilterTransformer
+    implements FilterTransformer<ProcessInstanceFilter> {
+
+  private final ServiceTransformers transformers;
+
+  public ProcessInstanceFilterTransformer(final ServiceTransformers transformers) {
+    this.transformers = transformers;
+  }
+
+  @Override
+  public SearchQuery toSearchQuery(final ProcessInstanceFilter filter) {
+    final var processInstanceKeys = filter.processInstanceKeys();
+
+    final var joinRelationQuery = term("joinRelation", "processInstance");
+
+    final var processInstanceKeysQuery = getProcessInstanceKeysQuery(processInstanceKeys);
+    final var processInstanceStateQuery = getProcessInstanceStateQuery(filter);
+    final var retriesLeftQuery = getRetriesLeftQuery(filter.retriesLeft());
+    final var variablesQuery = getVariablesQuery(filter.variableFilters());
+    final var startDateQuery = getStartDateQuery(filter.startDateFilter());
+    final var endDateQuery = getEndDateQuery(filter.endDateFilter());
+
+    return and(
+        joinRelationQuery,
+        processInstanceKeysQuery,
+        processInstanceStateQuery,
+        retriesLeftQuery,
+        variablesQuery,
+        startDateQuery,
+        endDateQuery);
+  }
+
+  private SearchQuery getProcessInstanceKeysQuery(final List<Long> processInstanceKeys) {
+    return longTerms("processInstanceKey", processInstanceKeys);
+  }
+
+  private SearchQuery getProcessInstanceStateQuery(final ProcessInstanceFilter filter) {
+    final var running = filter.running();
+    final var finished = filter.finished();
+    final var active = filter.active();
+    final var incidents = filter.incidents();
+    final var completed = filter.completed();
+    final var canceled = filter.canceled();
+
+    if (running && finished && active && incidents && completed && canceled) {
+      // select all
+      return matchAll();
+    }
+
+    SearchQuery runningQuery = null;
+
+    if (running && (active || incidents)) {
+      // running query
+
+      runningQuery = not(exists("endDate"));
+
+      final var activeQuery = getActiveQuery(active);
+      final var incidentsQuery = getIncidentsQuery(incidents);
+
+      runningQuery = and(runningQuery, or(activeQuery, incidentsQuery));
+    }
+
+    SearchQuery finishedQuery = null;
+
+    if (finished && (completed || canceled)) {
+
+      // add finished query
+      finishedQuery = exists("endDate");
+
+      final var completedQuery = getCompletedQuery(completed);
+      final var canceledQuery = getCanceledQuery(canceled);
+
+      finishedQuery = and(finishedQuery, or(completedQuery, canceledQuery));
+    }
+
+    final var processInstanceQuery = or(runningQuery, finishedQuery);
+
+    return processInstanceQuery;
+  }
+
+  private SearchQuery getCanceledQuery(final boolean canceled) {
+    if (canceled) {
+      return term("state", "CANCELED");
+    }
+
+    return null;
+  }
+
+  private SearchQuery getCompletedQuery(final boolean completed) {
+    if (completed) {
+      return term("state", "COMPLETED");
+    }
+
+    return null;
+  }
+
+  private SearchQuery getIncidentsQuery(final boolean incidents) {
+    if (incidents) {
+      return term("incident", true);
+    }
+
+    return null;
+  }
+
+  private SearchQuery getActiveQuery(final boolean active) {
+    if (active) {
+      return term("incident", false);
+    }
+
+    return null;
+  }
+
+  private SearchQuery getRetriesLeftQuery(final boolean retriesLeft) {
+    if (retriesLeft) {
+      final var retriesLeftQuery = term("jobFailedWithRetriesLeft", true);
+      return hasChildQuery("activity", retriesLeftQuery);
+    }
+
+    return null;
+  }
+
+  private SearchQuery getVariablesQuery(final List<VariableValueFilter> variableFilters) {
+    if (variableFilters != null && !variableFilters.isEmpty()) {
+      final var transformer = getVariableValueFilterTransformer();
+      final var queries =
+          variableFilters.stream()
+              .map(transformer::apply)
+              .map((q) -> hasChildQuery("variable", q))
+              .collect(Collectors.toList());
+      return and(queries);
+    }
+    return null;
+  }
+
+  private SearchQuery getStartDateQuery(final DateValueFilter filter) {
+    if (filter != null) {
+      final var transformer = getDateValueFilterTransformer();
+      return transformer.apply(new DateFieldFilter("startDate", filter));
+    }
+    return null;
+  }
+
+  private SearchQuery getEndDateQuery(final DateValueFilter filter) {
+    if (filter != null) {
+      final var transformer = getDateValueFilterTransformer();
+      return transformer.apply(new DateFieldFilter("endDate", filter));
+    }
+    return null;
+  }
+
+  private FilterTransformer<DateFieldFilter> getDateValueFilterTransformer() {
+    return transformers.getFilterTransformer(DateValueFilter.class);
+  }
+
+  private FilterTransformer<VariableValueFilter> getVariableValueFilterTransformer() {
+    return transformers.getFilterTransformer(VariableValueFilter.class);
+  }
+
+  @Override
+  public List<String> toIndices(ProcessInstanceFilter filter) {
+    final var finished = filter.finished();
+    final var completed = filter.completed();
+    final var canceled = filter.canceled();
+
+    if (finished || completed || canceled) {
+      return Arrays.asList("operate-list-view-8.3.0_alias");
+    } else {
+      return Arrays.asList("operate-list-view-8.3.0_");
+    }
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/filter/VariableValueFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/VariableValueFilterTransformer.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.filter;
+
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+import static io.camunda.search.clients.query.SearchQueryBuilders.not;
+import static io.camunda.search.clients.query.SearchQueryBuilders.range;
+import static io.camunda.search.clients.query.SearchQueryBuilders.term;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.clients.types.TypedValue;
+import io.camunda.service.search.filter.VariableValueFilter;
+
+public final class VariableValueFilterTransformer
+    implements FilterTransformer<VariableValueFilter> {
+
+  @Override
+  public SearchQuery toSearchQuery(final VariableValueFilter value) {
+    final var name = value.name();
+    final var eq = value.eq();
+    final var neq = value.neq();
+    final var gt = value.gt();
+    final var gte = value.gte();
+    final var lt = value.lt();
+    final var lte = value.lte();
+
+    final var variableNameQuery = term("varName", name);
+    final SearchQuery variableValueQuery;
+
+    if (eq != null) {
+      variableValueQuery = of(eq);
+    } else if (neq != null) {
+      variableValueQuery = not(of(neq));
+    } else {
+      final var builder = range().field("varValue");
+
+      if (gt != null) {
+        builder.gt(gt);
+      }
+
+      if (gte != null) {
+        builder.gte(gte);
+      }
+
+      if (lt != null) {
+        builder.lt(lt);
+      }
+
+      if (lte != null) {
+        builder.lte(lte);
+      }
+
+      variableValueQuery = builder.build().toSearchQuery();
+    }
+
+    return and(variableNameQuery, variableValueQuery);
+  }
+
+  private SearchQuery of(final Object value) {
+    final var typedValue = TypedValue.toTypedValue(value);
+    return SearchQueryBuilders.term().field("varValue").value(typedValue).build().toSearchQuery();
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/query/SearchQueryResultTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/query/SearchQueryResultTransformer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.query;
+
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.core.SearchQueryResponse;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.search.query.SearchQueryResult.Builder;
+import io.camunda.service.transformers.ServiceTransformer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class SearchQueryResultTransformer<T>
+    implements ServiceTransformer<SearchQueryResponse<T>, SearchQueryResult<T>> {
+
+  @Override
+  public SearchQueryResult<T> apply(final SearchQueryResponse<T> value) {
+    final var hits = value.hits();
+    final var items = of(hits);
+    final var size = hits.size();
+    final Object[] sortValues;
+    if (size > 0) {
+      final var lastItem = hits.get(size - 1);
+      sortValues = lastItem.sortValues();
+    } else {
+      sortValues = null;
+    }
+
+    return new Builder<T>().total(value.totalHits()).sortValues(sortValues).items(items).build();
+  }
+
+  private List<T> of(final List<SearchQueryHit<T>> values) {
+    if (values != null) {
+      return values.stream().map(SearchQueryHit::source).collect(Collectors.toList());
+    }
+    return new ArrayList<>();
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/query/SearchQueryResultTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/query/SearchQueryResultTransformer.java
@@ -12,7 +12,7 @@ import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.transformers.ServiceTransformer;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,6 +39,6 @@ public final class SearchQueryResultTransformer<T>
     if (values != null) {
       return values.stream().map(SearchQueryHit::source).collect(Collectors.toList());
     }
-    return new ArrayList<>();
+    return Collections.emptyList();
   }
 }

--- a/service/src/main/java/io/camunda/service/transformers/query/SearchRequestTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/query/SearchRequestTransformer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.query;
+
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.search.query.TypedSearchQuery;
+import io.camunda.service.search.sort.SortOption;
+import io.camunda.service.transformers.ServiceTransformer;
+
+public interface SearchRequestTransformer<F extends FilterBase, S extends SortOption>
+    extends ServiceTransformer<TypedSearchQuery<F, S>, SearchQueryRequest> {
+
+  default SearchQueryRequest apply(final TypedSearchQuery<F, S> query) {
+    return applyWithAuthentication(query, null);
+  }
+
+  default SearchQueryRequest applyWithAuthentication(
+      final TypedSearchQuery<F, S> value, final SearchQuery authCheck) {
+    return toSearchQueryRequest(value, authCheck);
+  }
+
+  SearchQueryRequest toSearchQueryRequest(
+      final TypedSearchQuery<F, S> query, final SearchQuery authCheck);
+}

--- a/service/src/main/java/io/camunda/service/transformers/query/TypedSearchQueryTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/query/TypedSearchQueryTransformer.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.query;
+
+import static io.camunda.search.clients.core.RequestBuilders.searchRequest;
+import static io.camunda.search.clients.query.SearchQueryBuilders.and;
+
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.sort.SearchSortOptions;
+import io.camunda.service.search.filter.FilterBase;
+import io.camunda.service.search.query.TypedSearchQuery;
+import io.camunda.service.search.sort.SortOption;
+import io.camunda.service.search.sort.SortOption.FieldSorting;
+import io.camunda.service.transformers.ServiceTransformer;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.service.transformers.filter.FilterTransformer;
+import io.camunda.service.transformers.sort.FieldSortingTransformer;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.List;
+
+public final class TypedSearchQueryTransformer<F extends FilterBase, S extends SortOption>
+    implements SearchRequestTransformer<F, S> {
+
+  private final ServiceTransformers transformers;
+
+  public TypedSearchQueryTransformer(final ServiceTransformers transformers) {
+    this.transformers = transformers;
+  }
+
+  @Override
+  public SearchQueryRequest toSearchQueryRequest(
+      final TypedSearchQuery<F, S> query, final SearchQuery authCheck) {
+    final var filter = query.filter();
+    final var searchQueryFilter = toSearchQuery(filter, authCheck);
+    final var indices = toIndices(filter);
+
+    final var page = query.page();
+    final var reverse = !page.isNextPage();
+
+    final var builder =
+        searchRequest().index(indices).query(searchQueryFilter).from(page.from()).size(page.size());
+
+    final var sort = query.sort();
+    final var sorting = toSearchSortOptions(sort, reverse);
+    if (sorting != null && !sorting.isEmpty()) {
+      builder.sort(sorting);
+    }
+
+    final var searchAfter = page.startNextPageAfter();
+    if (searchAfter != null && searchAfter.length > 0) {
+      builder.searchAfter(searchAfter);
+    }
+
+    return builder.build();
+  }
+
+  protected SearchQuery toSearchQuery(final F filter, final SearchQuery authCheck) {
+    final var filterTransformer = getFilterTransformer(filter.getClass());
+    final var transformedQuery = filterTransformer.apply(filter);
+    return and(transformedQuery, authCheck);
+  }
+
+  protected List<String> toIndices(final F filter) {
+    final var filterTransformer = getFilterTransformer(filter.getClass());
+    return filterTransformer.toIndices(filter);
+  }
+
+  protected List<SearchSortOptions> toSearchSortOptions(final S sort, final boolean reverse) {
+    final var orderings = sort.getFieldSortings();
+    final var sortingTransformer = getFieldSortingTransformer();
+    return sortingTransformer.apply(Tuple.of(orderings, reverse));
+  }
+
+  protected FilterTransformer<F> getFilterTransformer(final Class<?> cls) {
+    return transformers.getFilterTransformer(cls);
+  }
+
+  protected FieldSortingTransformer getFieldSortingTransformer() {
+    final ServiceTransformer<Tuple<List<FieldSorting>, Boolean>, List<SearchSortOptions>>
+        transformer = transformers.getTransformer(FieldSortingTransformer.class);
+    return (FieldSortingTransformer) transformer;
+  }
+}

--- a/service/src/main/java/io/camunda/service/transformers/sort/FieldSortingTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/sort/FieldSortingTransformer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.transformers.sort;
+
+import static io.camunda.search.clients.sort.SortOptionsBuilders.reverseOrder;
+import static io.camunda.search.clients.sort.SortOptionsBuilders.sortOptions;
+
+import io.camunda.search.clients.sort.SearchSortOptions;
+import io.camunda.search.clients.sort.SortOrder;
+import io.camunda.service.search.sort.SortOption.FieldSorting;
+import io.camunda.service.transformers.ServiceTransformer;
+import io.camunda.zeebe.util.collection.Tuple;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class FieldSortingTransformer
+    implements ServiceTransformer<Tuple<List<FieldSorting>, Boolean>, List<SearchSortOptions>> {
+
+  private static final SearchSortOptions DEFAULT_SORT_BY_KEY_ASC =
+      sortOptions("key", SortOrder.ASC);
+  private static final SearchSortOptions DEFAULT_SORT_BY_KEY_DESC =
+      sortOptions("key", SortOrder.DESC);
+
+  @Override
+  public List<SearchSortOptions> apply(final Tuple<List<FieldSorting>, Boolean> value) {
+    final var orderings = value.getLeft();
+    final var reverse = value.getRight();
+    final var sorting = map(orderings, reverse);
+    final var defaultSorting = getDefaultSearchSortOption(reverse);
+    sorting.add(defaultSorting);
+    return sorting;
+  }
+
+  private List<SearchSortOptions> map(final List<FieldSorting> orderings, final boolean reverse) {
+    final List<SearchSortOptions> sorting;
+    if (orderings != null && !orderings.isEmpty()) {
+      sorting =
+          orderings.stream()
+              .map((f) -> toSearchSortOption(f, reverse))
+              .collect(Collectors.toList());
+    } else {
+      sorting = new ArrayList<>();
+    }
+    return sorting;
+  }
+
+  private SearchSortOptions toSearchSortOption(final FieldSorting value, final boolean reverse) {
+    final var field = value.field();
+    final var order = value.order();
+    if (!reverse) {
+      return sortOptions(field, order, "_last");
+    } else {
+      return sortOptions(field, reverseOrder(order), "_first");
+    }
+  }
+
+  private SearchSortOptions getDefaultSearchSortOption(final boolean reverse) {
+    if (!reverse) {
+      return DEFAULT_SORT_BY_KEY_ASC;
+    } else {
+      return DEFAULT_SORT_BY_KEY_DESC;
+    }
+  }
+}

--- a/service/src/test/java/io/camunda/service/query/SearchQueryBuilderTest.java
+++ b/service/src/test/java/io/camunda/service/query/SearchQueryBuilderTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.service.search.filter.ProcessInstanceFilter;
+import io.camunda.service.search.page.SearchQueryPage;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.sort.ProcessInstanceSort;
+import org.junit.jupiter.api.Test;
+
+public class SearchQueryBuilderTest {
+
+  @Test
+  public void shouldCreateQuery() {
+    // given
+    final var searchQueryBuilder = new ProcessInstanceQuery.Builder();
+    final var searchQueryPage = new SearchQueryPage.Builder().size(50).build();
+    final var searchQuerySort = ProcessInstanceSort.of(builder -> builder.startDate().asc());
+    final var filter = new ProcessInstanceFilter.Builder().build(); // all
+
+    // when
+    final ProcessInstanceQuery query =
+        searchQueryBuilder.page(searchQueryPage).sort(searchQuerySort).filter(filter).build();
+
+    // when
+    assertThat(query.filter()).isEqualTo(filter);
+    assertThat(query.sort()).isEqualTo(searchQuerySort);
+    assertThat(query.page()).isEqualTo(searchQueryPage);
+  }
+}

--- a/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceFilterTest.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.query.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.query.SearchBoolQuery;
+import io.camunda.search.clients.query.SearchQueryOption;
+import io.camunda.search.clients.query.SearchTermQuery;
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.search.filter.FilterBuilders;
+import io.camunda.service.search.filter.ProcessInstanceFilter.Builder;
+import io.camunda.service.search.filter.VariableValueFilter;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.query.SearchQueryBuilders;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.util.StubbedCamundaSearchClient;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public final class ProcessInstanceFilterTest {
+
+  private ProcessInstanceServices services;
+  private StubbedCamundaSearchClient client;
+
+  @BeforeEach
+  public void before() {
+    client = new StubbedCamundaSearchClient();
+    new ProcessInstanceSearchQueryStub().registerWith(client);
+    services = new ProcessInstanceServices(client);
+  }
+
+  @Test
+  public void shouldQueryOnlyByProcessInstances() {
+    // given
+    final ProcessInstanceQuery searchQuery =
+        SearchQueryBuilders.processInstanceSearchQuery().build();
+
+    // when
+    services.search(searchQuery);
+
+    // then
+
+    // Assert: Transformation from ProcessInstanceQuery to DataStoreSearchRequest
+
+    // a) verify search request
+    // The stubbed client collects all received search requests
+    // that can be used for assertions
+    final SearchQueryRequest searchRequest = client.getSingleSearchRequest();
+
+    // b) verify that the search request has been constructed properly
+    // depending on the actual search query
+    final SearchQueryOption queryVariant = searchRequest.query().queryOption();
+    assertThat((queryVariant))
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            (t) -> {
+              assertThat(t.field()).isEqualTo("joinRelation");
+              assertThat(t.value().stringValue()).isEqualTo("processInstance");
+            });
+  }
+
+  @Test
+  public void shouldReturnProcessInstance() {
+    // given
+    final ProcessInstanceQuery searchQuery =
+        SearchQueryBuilders.processInstanceSearchQuery().build();
+
+    // when
+    final SearchQueryResult<ProcessInstanceEntity> searchQueryResult = services.search(searchQuery);
+
+    // then
+
+    // Assert: Transformation from DataStoreSearchResponse to
+    // SearchQueryResult<ProcessInstanceEntity>
+
+    // a) verify search query result
+    assertThat(searchQueryResult.total()).isEqualTo(1);
+    assertThat(searchQueryResult.items()).hasSize(1);
+
+    // b) assert items
+    final ProcessInstanceEntity item = searchQueryResult.items().get(0);
+    assertThat(item.key()).isEqualTo(123L);
+  }
+
+  @Test
+  public void shouldQueryByProcessInstanceKey() {
+    // given
+    final var processInstanceFilter =
+        FilterBuilders.processInstance((f) -> f.processInstanceKeys(4503599627370497L));
+    final var searchQuery =
+        SearchQueryBuilders.processInstanceSearchQuery((q) -> q.filter(processInstanceFilter));
+
+    // when
+    services.search(searchQuery);
+
+    // then
+    final var searchRequest = client.getSingleSearchRequest();
+
+    final var queryVariant = searchRequest.query().queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(2);
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            (t) -> {
+              assertThat(t.field()).isEqualTo("joinRelation");
+              assertThat(t.value().stringValue()).isEqualTo("processInstance");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(1).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            (t) -> {
+              assertThat(t.field()).isEqualTo("processInstanceKey");
+              assertThat(t.value().longValue()).isEqualTo(4503599627370497L);
+            });
+  }
+
+  @Test
+  public void shouldQueryByVariableValues() {
+    // given
+    final var variableFilter = FilterBuilders.variableValue((v) -> v.name("foo").gt(123));
+    final var filter =
+        FilterBuilders.processInstance(
+            (f) -> f.variable(variableFilter).variable((v) -> v.name("bar").neq(789L)));
+    final var searchQuery = SearchQueryBuilders.processInstanceSearchQuery((b) -> b.filter(filter));
+
+    // when
+    services.search(searchQuery);
+
+    // then
+    final var searchRequest = client.getSingleSearchRequest();
+
+    final var queryVariant = searchRequest.query().queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(2);
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(0).queryOption())
+        .isInstanceOfSatisfying(
+            SearchTermQuery.class,
+            (t) -> {
+              assertThat(t.field()).isEqualTo("joinRelation");
+              assertThat(t.value().stringValue()).isEqualTo("processInstance");
+            });
+
+    assertThat(((SearchBoolQuery) queryVariant).must().get(1).queryOption())
+        .isInstanceOf(SearchBoolQuery.class);
+  }
+
+  @Test
+  public void shouldQueryByStartAndEndDate() {
+    // given
+    final var startDateFilter =
+        FilterBuilders.dateValue((d) -> d.after(OffsetDateTime.now()).before(OffsetDateTime.now()));
+    final var endDateFilter =
+        FilterBuilders.dateValue((d) -> d.after(OffsetDateTime.now()).before(OffsetDateTime.now()));
+    final var searchQuery =
+        SearchQueryBuilders.processInstanceSearchQuery(
+            (b) -> b.filter((f) -> f.startDate(startDateFilter).endDate(endDateFilter)));
+
+    // when
+    services.search(searchQuery);
+
+    // then
+    final var searchRequest = client.getSingleSearchRequest();
+
+    final var queryVariant = searchRequest.query().queryOption();
+    assertThat(queryVariant).isInstanceOf(SearchBoolQuery.class);
+    assertThat(((SearchBoolQuery) queryVariant).must()).hasSize(3);
+  }
+
+  @Test
+  public void shouldCreateDefaultFilter() {
+    // given
+
+    // when
+    final var processInstanceFilter = new Builder().build();
+
+    // then
+    assertThat(processInstanceFilter.processInstanceKeys()).isNull();
+    //    assertThat(processInstanceFilter.index()).contains("operate-list-view-8.3.0_");
+
+    assertThat(processInstanceFilter.active()).isFalse();
+    assertThat(processInstanceFilter.canceled()).isFalse();
+    assertThat(processInstanceFilter.completed()).isFalse();
+    assertThat(processInstanceFilter.finished()).isFalse();
+    assertThat(processInstanceFilter.running()).isFalse();
+    assertThat(processInstanceFilter.retriesLeft()).isFalse();
+  }
+
+  @Test
+  public void shouldSetFilterValues() {
+    // given
+    final var processInstanceFilterBuilder = new Builder();
+
+    // when
+    final var processInstanceFilter =
+        processInstanceFilterBuilder
+            .active()
+            .canceled()
+            .completed()
+            .finished()
+            .retriesLeft()
+            .running()
+            .processInstanceKeys(List.of(1L))
+            .variable(new VariableValueFilter.Builder().name("foo").build())
+            .build();
+
+    // then
+    assertThat(processInstanceFilter.processInstanceKeys()).hasSize(1).contains(1L);
+    //    assertThat(processInstanceFilter.index()).contains("operate-list-view-8.3.0_alias");
+
+    assertThat(processInstanceFilter.active()).isTrue();
+    assertThat(processInstanceFilter.canceled()).isTrue();
+    assertThat(processInstanceFilter.completed()).isTrue();
+    assertThat(processInstanceFilter.finished()).isTrue();
+    assertThat(processInstanceFilter.running()).isTrue();
+    assertThat(processInstanceFilter.retriesLeft()).isTrue();
+  }
+}

--- a/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceSearchQueryStub.java
+++ b/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceSearchQueryStub.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.query.filter;
+
+import io.camunda.search.clients.core.SearchQueryHit;
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.core.SearchQueryResponse;
+import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.util.StubbedCamundaSearchClient;
+import io.camunda.service.util.StubbedCamundaSearchClient.RequestStub;
+import java.util.List;
+
+public class ProcessInstanceSearchQueryStub implements RequestStub<ProcessInstanceEntity> {
+
+  @Override
+  public SearchQueryResponse<ProcessInstanceEntity> handle(final SearchQueryRequest request)
+      throws Exception {
+
+    final var processInstance =
+        new ProcessInstanceEntity("foo", 123L, 1, "bar", null, null, "2020-01-01", "2020-01-02");
+
+    final SearchQueryHit<ProcessInstanceEntity> hit =
+        new SearchQueryHit.Builder<ProcessInstanceEntity>()
+            .id("1234")
+            .source(processInstance)
+            .build();
+
+    final SearchQueryResponse<ProcessInstanceEntity> response =
+        SearchQueryResponse.of(
+            (f) -> {
+              f.totalHits(1).hits(List.of(hit));
+              return f;
+            });
+
+    return response;
+  }
+
+  @Override
+  public void registerWith(final StubbedCamundaSearchClient client) {
+    client.registerHandler(this);
+  }
+}

--- a/service/src/test/java/io/camunda/service/query/filter/VariableValueFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/VariableValueFilterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.query.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.service.search.filter.VariableValueFilter.Builder;
+import org.junit.jupiter.api.Test;
+
+public class VariableValueFilterTest {
+
+  @Test
+  public void shouldCreateDefaultFilter() {
+    // given
+
+    // when
+    final var filter = new Builder().name("foo").build();
+
+    // then
+    assertThat(filter.eq()).isNull();
+    assertThat(filter.gt()).isNull();
+    assertThat(filter.gte()).isNull();
+    assertThat(filter.lt()).isNull();
+    assertThat(filter.lte()).isNull();
+    assertThat(filter.name()).isEqualTo("foo");
+  }
+
+  @Test
+  public void shouldSetFilters() {
+    // given
+    final var filterBuilder = new Builder();
+
+    // when
+    final var filter =
+        filterBuilder
+            .eq("equals")
+            .gt("greaterThen")
+            .gte("greaterThenOrEqual")
+            .lt("lessThen")
+            .lte("lessThenOrEqual")
+            .name("name")
+            .build();
+
+    // then
+    assertThat(filter.eq()).isEqualTo("equals");
+    assertThat(filter.gt()).isEqualTo("greaterThen");
+    assertThat(filter.gte()).isEqualTo("greaterThenOrEqual");
+    assertThat(filter.lt()).isEqualTo("lessThen");
+    assertThat(filter.lte()).isEqualTo("lessThenOrEqual");
+    assertThat(filter.name()).isEqualTo("name");
+  }
+}

--- a/service/src/test/java/io/camunda/service/util/StubbedCamundaSearchClient.java
+++ b/service/src/test/java/io/camunda/service/util/StubbedCamundaSearchClient.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.search.clients.core.SearchQueryResponse;
+import io.camunda.zeebe.util.Either;
+import java.util.ArrayList;
+import java.util.List;
+
+public class StubbedCamundaSearchClient implements CamundaSearchClient {
+
+  private SearchRequestHandler<?> searchRequestHandler;
+  private final List<SearchQueryRequest> searchRequests = new ArrayList<>();
+
+  public StubbedCamundaSearchClient() {}
+
+  @Override
+  public <T> Either<Exception, SearchQueryResponse<T>> search(
+      final SearchQueryRequest searchRequest, final Class<T> documentClass) {
+    searchRequests.add(searchRequest);
+
+    try {
+      final SearchQueryResponse response = searchRequestHandler.handle(searchRequest);
+      return Either.right(response);
+    } catch (final Exception e) {
+      return Either.left(e);
+    }
+  }
+
+  public SearchQueryRequest getSingleSearchRequest() {
+    assertThat(searchRequests).hasSize(1);
+    return searchRequests.get(0);
+  }
+
+  public List<SearchQueryRequest> getSearchRequests() {
+    return searchRequests;
+  }
+
+  public <DocumentT> void registerHandler(
+      final SearchRequestHandler<DocumentT> searchRequestHandler) {
+    this.searchRequestHandler = searchRequestHandler;
+  }
+
+  public interface RequestStub<DocumentT> extends SearchRequestHandler<DocumentT> {
+    void registerWith(final StubbedCamundaSearchClient client);
+  }
+
+  @FunctionalInterface
+  public interface SearchRequestHandler<DocumentT> {
+    SearchQueryResponse<DocumentT> handle(final SearchQueryRequest request) throws Exception;
+  }
+}


### PR DESCRIPTION
## Description

This PR implements the structure for implementing Search Queries in the service layer. Therefore, it provides an opinionated structure based on the Process Instance Query. However, the Process Instance Query filter options are incomplete and subject to change in the upcoming iterations.

## Related issues

related to #19076
