### PR TITLE
[Backport stable/8.4] Make EngineLargeStatePerformanceTest more lenient

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineLargeStatePerformanceTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineLargeStatePerformanceTest.java
@@ -141,6 +141,10 @@ public class EngineLargeStatePerformanceTest {
     final var assertResult = testCase.run();
 
     // then
+<<<<<<< HEAD
     assertResult.isAtLeast(referenceScore, 0.25);
+=======
+    assertResult.isAtLeast(referenceScore, 0.15);
+>>>>>>> 3f0cf01 (test: only allow performance improvements)
   }
 }


### PR DESCRIPTION
# Description
Backport of #19060 to `stable/8.4`.

relates to #14971
original author: @korthout