### PR TITLE
[Backport stable/8.5] Make EngineLargeStatePerformanceTest more lenient

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineLargeStatePerformanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineLargeStatePerformanceTest.java
@@ -141,6 +141,10 @@ public class EngineLargeStatePerformanceTest {
     final var assertResult = testCase.run();
 
     // then
+<<<<<<< HEAD:zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/EngineLargeStatePerformanceTest.java
     assertResult.isAtLeast(referenceScore, 0.25);
+=======
+    assertResult.isAtLeast(referenceScore, 0.15);
+>>>>>>> 3f0cf018 (test: only allow performance improvements):engine/src/test/java/io/camunda/zeebe/engine/perf/EngineLargeStatePerformanceTest.java
   }
 }


### PR DESCRIPTION
# Description
Backport of #19060 to `stable/8.5`.

relates to #14971
original author: @korthout