### PR TITLE
feat: Add completedDate field to Operation

### DIFF
--- a/operate/schema/src/main/java/io/camunda/operate/entities/OperationEntity.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/OperationEntity.java
@@ -39,6 +39,8 @@ public class OperationEntity extends OperateEntity<OperationEntity> {
   private String modifyInstructions;
   private String migrationPlan;
 
+  private OffsetDateTime completedDate;
+
   public Long getProcessInstanceKey() {
     return processInstanceKey;
   }
@@ -197,6 +199,15 @@ public class OperationEntity extends OperateEntity<OperationEntity> {
 
   public OperationEntity setMigrationPlan(final String migrationPlan) {
     this.migrationPlan = migrationPlan;
+    return this;
+  }
+
+  public OffsetDateTime getCompletedDate() {
+    return completedDate;
+  }
+
+  public OperationEntity setCompletedDate(final OffsetDateTime completedDate) {
+    this.completedDate = completedDate;
     return this;
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/OperationTemplate.java
@@ -37,6 +37,7 @@ public class OperationTemplate extends AbstractTemplateDescriptor
   public static final String MIGRATION_PLAN = "migrationPlan";
   public static final String METADATA_AGGREGATION = "metadataAggregation";
   public static final String BATCH_OPERATION_ID_AGGREGATION = "batchOperationIdAggregation";
+  public static final String COMPLETED_DATE = "completedDate";
 
   @Override
   public String getIndexName() {
@@ -45,6 +46,6 @@ public class OperationTemplate extends AbstractTemplateDescriptor
 
   @Override
   public String getVersion() {
-    return "8.4.0";
+    return "8.4.1";
   }
 }

--- a/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-operation.json
+++ b/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-operation.json
@@ -60,7 +60,11 @@
 			},
 			"migrationPlan": {
 				"type": "text"
-			}
-		}
+			},
+      "completedDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      }
+    }
 	}
 }

--- a/operate/schema/src/main/resources/schema/opensearch/create/template/operate-operation.json
+++ b/operate/schema/src/main/resources/schema/opensearch/create/template/operate-operation.json
@@ -60,7 +60,11 @@
 			},
 			"migrationPlan": {
 				"type": "text"
-			}
-		}
+			},
+      "completedDate": {
+        "format": "date_time || epoch_millis",
+        "type": "date"
+      }
+    }
 	}
 }

--- a/operate/schema/src/test/java/io/camunda/operate/enties/OperationEntityTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/enties/OperationEntityTest.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.enties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.entities.OperationEntity;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class OperationEntityTest {
+
+  @Test
+  void shouldHaveCompletedDateField() {
+    final var operation = new OperationEntity();
+    // Default value is null
+    assertThat(operation.getCompletedDate()).isNull();
+    assertThat(operation.setCompletedDate(OffsetDateTime.now()).getCompletedDate())
+        .isInstanceOf(OffsetDateTime.class);
+  }
+}

--- a/operate/schema/src/test/java/io/camunda/operate/schema/templates/OperationTemplateTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/schema/templates/OperationTemplateTest.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.schema.templates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.schema.migration.SemanticVersion;
+import org.junit.jupiter.api.Test;
+
+class OperationTemplateTest {
+
+  @Test
+  void templateShouldHaveCompletedDateFieldAndIncreasedMinorVersion() {
+    assertThat(OperationTemplate.COMPLETED_DATE).isNotNull();
+    assertThat(new SemanticVersion(new OperationTemplate().getVersion()).isNewerThan("8.4.0"));
+  }
+}

--- a/operate/schema/src/test/java/io/camunda/operate/util/OperationsManagerTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/OperationsManagerTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.entities.OperationEntity;
+import io.camunda.operate.exceptions.PersistenceException;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.OperationTemplate;
+import io.camunda.operate.store.BatchRequest;
+import io.camunda.operate.store.OperationStore;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.BeanFactory;
+
+@ExtendWith(MockitoExtension.class)
+class OperationsManagerTest {
+
+  @Mock BeanFactory beanFactory;
+  @Mock BatchOperationTemplate batchOperationTemplate;
+  @Mock OperationTemplate operationTemplate;
+  @Mock OperationStore operationStore;
+
+  @Test
+  void shouldSetCompletedDateToOperationWhenOperationWillComplete() throws PersistenceException {
+    // given
+    when(operationTemplate.getAlias()).thenReturn("operation_alias");
+    final var batchRequest = mock(BatchRequest.class);
+    when(beanFactory.getBean(BatchRequest.class)).thenReturn(batchRequest);
+    // when
+    new OperationsManager(beanFactory, batchOperationTemplate, operationTemplate, operationStore)
+        .completeOperation(new OperationEntity().setId("id"));
+    // then
+    verify(batchRequest)
+        .updateWithScript(
+            any(),
+            anyString(),
+            contains("ctx._source.completedDate = params.now;"),
+            argThat(
+                m -> m.containsKey("now") && m.get("now").getClass().equals(OffsetDateTime.class)));
+  }
+}

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/OperationDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/OperationDto.java
@@ -10,6 +10,7 @@ package io.camunda.operate.webapp.rest.dto;
 import io.camunda.operate.entities.OperationEntity;
 import io.camunda.operate.entities.OperationState;
 import io.camunda.operate.entities.OperationType;
+import java.time.OffsetDateTime;
 import java.util.Objects;
 
 public class OperationDto implements CreatableFromEntity<OperationDto, OperationEntity> {
@@ -23,6 +24,8 @@ public class OperationDto implements CreatableFromEntity<OperationDto, Operation
   private OperationState state;
 
   private String errorMessage;
+
+  private OffsetDateTime completedDate;
 
   public String getId() {
     return id;
@@ -69,19 +72,28 @@ public class OperationDto implements CreatableFromEntity<OperationDto, Operation
     return this;
   }
 
-  @Override
-  public OperationDto fillFrom(final OperationEntity operationEntity) {
-    this.setId(operationEntity.getId())
-        .setType(operationEntity.getType())
-        .setState(operationEntity.getState())
-        .setErrorMessage(operationEntity.getErrorMessage())
-        .setBatchOperationId(operationEntity.getBatchOperationId());
+  public OffsetDateTime getCompletedDate() {
+    return completedDate;
+  }
+
+  public OperationDto setCompletedDate(final OffsetDateTime completedDate) {
+    this.completedDate = completedDate;
     return this;
   }
 
   @Override
+  public OperationDto fillFrom(final OperationEntity operationEntity) {
+    return setId(operationEntity.getId())
+        .setType(operationEntity.getType())
+        .setState(operationEntity.getState())
+        .setErrorMessage(operationEntity.getErrorMessage())
+        .setBatchOperationId(operationEntity.getBatchOperationId())
+        .setCompletedDate(operationEntity.getCompletedDate());
+  }
+
+  @Override
   public int hashCode() {
-    return Objects.hash(id, batchOperationId, type, state, errorMessage);
+    return Objects.hash(id, batchOperationId, type, state, errorMessage, completedDate);
   }
 
   @Override
@@ -97,6 +109,28 @@ public class OperationDto implements CreatableFromEntity<OperationDto, Operation
         && Objects.equals(batchOperationId, that.batchOperationId)
         && type == that.type
         && state == that.state
-        && Objects.equals(errorMessage, that.errorMessage);
+        && Objects.equals(errorMessage, that.errorMessage)
+        && Objects.equals(completedDate, that.completedDate);
+  }
+
+  @Override
+  public String toString() {
+    return "OperationDto{"
+        + "id='"
+        + id
+        + '\''
+        + ", batchOperationId='"
+        + batchOperationId
+        + '\''
+        + ", type="
+        + type
+        + ", state="
+        + state
+        + ", errorMessage='"
+        + errorMessage
+        + '\''
+        + ", completedDate="
+        + completedDate
+        + '}';
   }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/OperationDtoTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/rest/dto/OperationDtoTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.rest.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.operate.entities.OperationEntity;
+import io.camunda.operate.entities.OperationState;
+import io.camunda.operate.entities.OperationType;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.Test;
+
+class OperationDtoTest {
+
+  @Test
+  void shouldHaveCompletedDateField() {
+    final var operation = new OperationDto();
+    // Default value is null
+    assertThat(operation.getCompletedDate()).isNull();
+    operation.setCompletedDate(OffsetDateTime.now());
+    assertThat(operation.getCompletedDate()).isInstanceOf(OffsetDateTime.class);
+  }
+
+  @Test
+  void shouldFillValuesFromOperationEntity() {
+    final var operation =
+        new OperationDto()
+            .fillFrom(
+                new OperationEntity()
+                    .setId("id")
+                    .setType(OperationType.MODIFY_PROCESS_INSTANCE)
+                    .setState(OperationState.COMPLETED)
+                    .setErrorMessage("errorMessage")
+                    .setBatchOperationId("batchOperationId")
+                    .setCompletedDate(OffsetDateTime.now()));
+    assertThat(operation.getId()).isEqualTo("id");
+    assertThat(operation.getType()).isEqualTo(OperationType.MODIFY_PROCESS_INSTANCE);
+    assertThat(operation.getState()).isEqualTo(OperationState.COMPLETED);
+    assertThat(operation.getErrorMessage()).isEqualTo("errorMessage");
+    assertThat(operation.getBatchOperationId()).isEqualTo("batchOperationId");
+    assertThat(operation.getCompletedDate()).isInstanceOf(OffsetDateTime.class);
+  }
+}


### PR DESCRIPTION
## Description

Returns the completed date for `Operation` part in endpoint `GET /api/process-instances/<instanceKey`. By default (old data) the date is `null`

* Add field `completedDate` field in Operation[Entity|Dto] 
  * Update `operation` index schema with field and increased version
* Add unit tests
* Tested migration manually from 8.5.2 

## Related issues

closes #17704 
