### PR TITLE
refactor: Qualified ES and OS clients in Tasklist

### DIFF
--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/AbstractArchiverJobElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/AbstractArchiverJobElasticSearch.java
@@ -15,10 +15,13 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class AbstractArchiverJobElasticSearch extends AbstractArchiverJob {
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   public AbstractArchiverJobElasticSearch(List<Integer> partitionIds) {
     super(partitionIds);

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ArchiverUtilElasticSearch.java
@@ -36,6 +36,7 @@ import org.elasticsearch.index.reindex.ReindexRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -45,7 +46,9 @@ public class ArchiverUtilElasticSearch extends ArchiverUtilAbstract {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverUtilElasticSearch.class);
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   public void setIndexLifeCycle(final String destinationIndexName) {
     try {

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ProcessInstanceArchiverJobElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/ProcessInstanceArchiverJobElasticSearch.java
@@ -41,6 +41,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -66,7 +67,9 @@ public class ProcessInstanceArchiverJobElasticSearch extends AbstractArchiverJob
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/TaskArchiverJobElasticSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/es/TaskArchiverJobElasticSearch.java
@@ -45,6 +45,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -65,7 +66,9 @@ public class TaskArchiverJobElasticSearch extends AbstractArchiverJobElasticSear
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/AbstractArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/AbstractArchiverJobOpenSearch.java
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 public abstract class AbstractArchiverJobOpenSearch extends AbstractArchiverJob {
 
   @Autowired
-  @Qualifier("tasklistOpenSearchAsyncClient")
+  @Qualifier("tasklistOsAsyncClient")
   private OpenSearchAsyncClient osAsyncClient;
 
   public AbstractArchiverJobOpenSearch(List<Integer> partitionIds) {

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/AbstractArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/AbstractArchiverJobOpenSearch.java
@@ -15,10 +15,13 @@ import org.opensearch.client.opensearch.OpenSearchAsyncClient;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class AbstractArchiverJobOpenSearch extends AbstractArchiverJob {
 
-  @Autowired private OpenSearchAsyncClient osAsyncClient;
+  @Autowired
+  @Qualifier("tasklistOpenSearchAsyncClient")
+  private OpenSearchAsyncClient osAsyncClient;
 
   public AbstractArchiverJobOpenSearch(List<Integer> partitionIds) {
     super(partitionIds);

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ArchiverUtilOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ArchiverUtilOpenSearch.java
@@ -37,6 +37,7 @@ import org.opensearch.client.opensearch.core.ReindexResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -46,9 +47,13 @@ public class ArchiverUtilOpenSearch extends ArchiverUtilAbstract {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverUtilOpenSearch.class);
 
-  @Autowired protected RestClient opensearchRestClient;
+  @Autowired
+  @Qualifier("tasklistOpensearchRestClient")
+  private RestClient opensearchRestClient;
 
-  @Autowired private OpenSearchAsyncClient osClient;
+  @Autowired
+  @Qualifier("tasklistOpenSearchAsyncClient")
+  private OpenSearchAsyncClient osClient;
 
   @Override
   public CompletableFuture<Long> deleteDocuments(

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ArchiverUtilOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ArchiverUtilOpenSearch.java
@@ -48,11 +48,11 @@ public class ArchiverUtilOpenSearch extends ArchiverUtilAbstract {
   private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverUtilOpenSearch.class);
 
   @Autowired
-  @Qualifier("tasklistOpensearchRestClient")
+  @Qualifier("tasklistOsRestClient")
   private RestClient opensearchRestClient;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchAsyncClient")
+  @Qualifier("tasklistOsAsyncClient")
   private OpenSearchAsyncClient osClient;
 
   @Override

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearch.java
@@ -66,7 +66,7 @@ public class ProcessInstanceArchiverJobOpenSearch extends AbstractArchiverJobOpe
   @Autowired private TasklistProperties tasklistProperties;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchAsyncClient")
+  @Qualifier("tasklistOsAsyncClient")
   private OpenSearchAsyncClient openSearchAsyncClient;
 
   @Autowired private Metrics metrics;

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/ProcessInstanceArchiverJobOpenSearch.java
@@ -39,6 +39,7 @@ import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
@@ -64,7 +65,9 @@ public class ProcessInstanceArchiverJobOpenSearch extends AbstractArchiverJobOpe
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private OpenSearchAsyncClient openSearchAsyncClient;
+  @Autowired
+  @Qualifier("tasklistOpenSearchAsyncClient")
+  private OpenSearchAsyncClient openSearchAsyncClient;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearch.java
@@ -60,7 +60,7 @@ public class TaskArchiverJobOpenSearch extends AbstractArchiverJobOpenSearch
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearch.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/os/TaskArchiverJobOpenSearch.java
@@ -60,7 +60,7 @@ public class TaskArchiverJobOpenSearch extends AbstractArchiverJobOpenSearch
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/common/src/main/java/io/camunda/tasklist/es/ElasticsearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/es/ElasticsearchConnector.java
@@ -86,7 +86,7 @@ public class ElasticsearchConnector {
   private ElasticsearchClient elasticsearchClient;
 
   @Bean
-  public co.elastic.clients.elasticsearch.ElasticsearchClient elasticsearchClient() {
+  public ElasticsearchClient tasklistElasticsearchClient() {
     LOGGER.debug("Creating ElasticsearchClient ...");
     final ElasticsearchProperties elsConfig = tasklistProperties.getElasticsearch();
     final RestClientBuilder restClientBuilder = RestClient.builder(getHttpHost(elsConfig));
@@ -126,15 +126,15 @@ public class ElasticsearchConnector {
   }
 
   @Bean(destroyMethod = "close")
-  public RestHighLevelClient esClient() {
+  public RestHighLevelClient tasklistEsClient() {
     // some weird error when ELS sets available processors number for Netty - see
     // https://discuss.elastic.co/t/elasticsearch-5-4-1-availableprocessors-is-already-set/88036/3
     System.setProperty("es.set.netty.runtime.available.processors", "false");
     return createEsClient(tasklistProperties.getElasticsearch());
   }
 
-  @Bean(name = "zeebeEsClient", destroyMethod = "close")
-  public RestHighLevelClient zeebeEsClient() {
+  @Bean(destroyMethod = "close")
+  public RestHighLevelClient tasklistZeebeEsClient() {
     // some weird error when ELS sets available processors number for Netty - see
     // https://discuss.elastic.co/t/elasticsearch-5-4-1-availableprocessors-is-already-set/88036/3
     System.setProperty("es.set.netty.runtime.available.processors", "false");

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -90,7 +90,7 @@ public class OpenSearchConnector {
   private ObjectMapper tasklistObjectMapper;
 
   @Bean
-  public OpenSearchClient openSearchClient() {
+  public OpenSearchClient tasklistOpenSearchClient() {
     final OpenSearchClient openSearchClient = createOsClient(tasklistProperties.getOpenSearch());
     try {
       final HealthResponse response = openSearchClient.cluster().health();
@@ -105,7 +105,13 @@ public class OpenSearchConnector {
   }
 
   @Bean
-  public RestClient opensearchRestClient() {
+  public OpenSearchClient tasklistZeebeOsClient() {
+    System.setProperty("es.set.netty.runtime.available.processors", "false");
+    return createOsClient(tasklistProperties.getZeebeOpenSearch());
+  }
+
+  @Bean
+  public RestClient tasklistOpensearchRestClient() {
     final var httpHost = getHttpHost(tasklistProperties.getOpenSearch());
     return RestClient.builder(httpHost)
         .setHttpClientConfigCallback(
@@ -114,16 +120,7 @@ public class OpenSearchConnector {
   }
 
   @Bean
-  public RestClient opensearchZeebeRestClient() {
-    final var httpHost = getHttpHost(tasklistProperties.getZeebeOpenSearch());
-    return RestClient.builder(httpHost)
-        .setHttpClientConfigCallback(
-            b -> configureApacheHttpClient(b, tasklistProperties.getZeebeOpenSearch()))
-        .build();
-  }
-
-  @Bean
-  public OpenSearchAsyncClient openSearchAsyncClient() {
+  public OpenSearchAsyncClient tasklistOpenSearchAsyncClient() {
     final OpenSearchAsyncClient openSearchClient =
         createAsyncOsClient(tasklistProperties.getOpenSearch());
     final CompletableFuture<HealthResponse> healthResponse;
@@ -146,13 +143,7 @@ public class OpenSearchConnector {
     return openSearchClient;
   }
 
-  @Bean("zeebeOsClient")
-  public OpenSearchClient zeebeOsClient() {
-    System.setProperty("es.set.netty.runtime.available.processors", "false");
-    return createOsClient(tasklistProperties.getZeebeOpenSearch());
-  }
-
-  public OpenSearchAsyncClient createAsyncOsClient(final OpenSearchProperties osConfig) {
+  private OpenSearchAsyncClient createAsyncOsClient(final OpenSearchProperties osConfig) {
     LOGGER.debug("Creating Async OpenSearch connection...");
     LOGGER.debug("Creating OpenSearch connection...");
     if (isAws()) {
@@ -207,7 +198,7 @@ public class OpenSearchConnector {
     return openSearchAsyncClient;
   }
 
-  public OpenSearchClient createOsClient(final OpenSearchProperties osConfig) {
+  private OpenSearchClient createOsClient(final OpenSearchProperties osConfig) {
     LOGGER.debug("Creating OpenSearch connection...");
     if (isAws()) {
       return getAwsClient(osConfig);

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -90,7 +90,7 @@ public class OpenSearchConnector {
   private ObjectMapper tasklistObjectMapper;
 
   @Bean
-  public OpenSearchClient tasklistOpenSearchClient() {
+  public OpenSearchClient tasklistOsClient() {
     final OpenSearchClient openSearchClient = createOsClient(tasklistProperties.getOpenSearch());
     try {
       final HealthResponse response = openSearchClient.cluster().health();
@@ -111,7 +111,7 @@ public class OpenSearchConnector {
   }
 
   @Bean
-  public RestClient tasklistOpensearchRestClient() {
+  public RestClient tasklistOsRestClient() {
     final var httpHost = getHttpHost(tasklistProperties.getOpenSearch());
     return RestClient.builder(httpHost)
         .setHttpClientConfigCallback(
@@ -120,7 +120,7 @@ public class OpenSearchConnector {
   }
 
   @Bean
-  public OpenSearchAsyncClient tasklistOpenSearchAsyncClient() {
+  public OpenSearchAsyncClient tasklistOsAsyncClient() {
     final OpenSearchAsyncClient openSearchClient =
         createAsyncOsClient(tasklistProperties.getOpenSearch());
     final CompletableFuture<HealthResponse> healthResponse;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantAwareElasticsearchClient.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantAwareElasticsearchClient.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 public class TenantAwareElasticsearchClient {
 
   @Autowired
-  @Qualifier("esClient")
+  @Qualifier("tasklistEsClient")
   private RestHighLevelClient defaultClient;
 
   @Autowired(required = false)

--- a/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantAwareOpenSearchClient.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantAwareOpenSearchClient.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class TenantAwareOpenSearchClient {
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   private OpenSearchClient defaultClient;
 
   @Autowired(required = false)

--- a/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantAwareOpenSearchClient.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/tenant/TenantAwareOpenSearchClient.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class TenantAwareOpenSearchClient {
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient defaultClient;
 
   @Autowired(required = false)

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/es/DevDataGeneratorElasticSearch.java
@@ -38,10 +38,12 @@ public class DevDataGeneratorElasticSearch extends DevDataGeneratorAbstract
   private static final Logger LOGGER = LoggerFactory.getLogger(DevDataGeneratorElasticSearch.class);
 
   @Autowired
-  @Qualifier("zeebeEsClient")
+  @Qualifier("tasklistZeebeEsClient")
   private RestHighLevelClient zeebeEsClient;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Override
   public void createUser(String username, String firstname, String lastname) {

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
@@ -33,10 +33,10 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
   private static final Logger LOGGER = LoggerFactory.getLogger(DevDataGeneratorOpenSearch.class);
 
   @Autowired
-  @Qualifier("zeebeOsClient")
+  @Qualifier("tasklistZeebeOsClient")
   private OpenSearchClient zeebeOsClient;
 
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/os/DevDataGeneratorOpenSearch.java
@@ -36,7 +36,7 @@ public class DevDataGeneratorOpenSearch extends DevDataGeneratorAbstract impleme
   @Qualifier("tasklistZeebeOsClient")
   private OpenSearchClient zeebeOsClient;
 
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/ElasticsearchInternalTask.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/ElasticsearchInternalTask.java
@@ -58,7 +58,9 @@ public class ElasticsearchInternalTask {
   private static final String TASKS_ENDPOINT = "_tasks";
   private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchInternalTask.class);
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -76,6 +76,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -93,7 +94,9 @@ public class RetryElasticsearchClient {
   public static final int DEFAULT_DELAY_INTERVAL_IN_SECONDS = 2;
   private static final Logger LOGGER = LoggerFactory.getLogger(RetryElasticsearchClient.class);
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private ElasticsearchInternalTask elasticsearchTask;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/OpenSearchInternalTask.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/OpenSearchInternalTask.java
@@ -48,7 +48,7 @@ public class OpenSearchInternalTask {
   public static final String ID = "id";
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient openSearchClient;
 
   public void checkForErrorsOrFailures(final GetTasksResponse tasks) throws IOException {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/OpenSearchInternalTask.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/OpenSearchInternalTask.java
@@ -18,6 +18,7 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.opensearch.client.opensearch.tasks.Status;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -46,7 +47,9 @@ public class OpenSearchInternalTask {
   public static final int MAX_TASKS_ENTRIES = 2_000;
   public static final String ID = "id";
 
-  @Autowired private OpenSearchClient openSearchClient;
+  @Autowired
+  @Qualifier("tasklistOpenSearchClient")
+  private OpenSearchClient openSearchClient;
 
   public void checkForErrorsOrFailures(final GetTasksResponse tasks) throws IOException {
     if (tasks != null) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
@@ -76,11 +76,11 @@ public class RetryOpenSearchClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(RetryOpenSearchClient.class);
 
   @Autowired
-  @Qualifier("tasklistOpensearchRestClient")
+  @Qualifier("tasklistOsRestClient")
   private RestClient opensearchRestClient;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient openSearchClient;
 
   private int numberOfRetries = DEFAULT_NUMBER_OF_RETRIES;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/os/RetryOpenSearchClient.java
@@ -56,6 +56,7 @@ import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
@@ -73,8 +74,15 @@ public class RetryOpenSearchClient {
       30 * 10; // 30*10 with 2 seconds = 10 minutes retry loop
   public static final int DEFAULT_DELAY_INTERVAL_IN_SECONDS = 2;
   private static final Logger LOGGER = LoggerFactory.getLogger(RetryOpenSearchClient.class);
-  @Autowired protected RestClient opensearchRestClient;
-  @Autowired private OpenSearchClient openSearchClient;
+
+  @Autowired
+  @Qualifier("tasklistOpensearchRestClient")
+  private RestClient opensearchRestClient;
+
+  @Autowired
+  @Qualifier("tasklistOpenSearchClient")
+  private OpenSearchClient openSearchClient;
+
   private int numberOfRetries = DEFAULT_NUMBER_OF_RETRIES;
   private int delayIntervalInSeconds = DEFAULT_DELAY_INTERVAL_IN_SECONDS;
   @Autowired private OpenSearchInternalTask openSearchInternalTask;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -55,7 +55,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
   @Autowired protected RetryOpenSearchClient retryOpenSearchClient;
 
   @Autowired
-  @Qualifier("tasklistOpensearchRestClient")
+  @Qualifier("tasklistOsRestClient")
   private RestClient opensearchRestClient;
 
   @Autowired private List<TemplateDescriptor> templateDescriptors;
@@ -63,7 +63,7 @@ public class OpenSearchSchemaManager implements SchemaManager {
   @Autowired private List<AbstractIndexDescriptor> indexDescriptors;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient openSearchClient;
 
   @Override

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -37,6 +37,7 @@ import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplate
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -53,13 +54,17 @@ public class OpenSearchSchemaManager implements SchemaManager {
 
   @Autowired protected RetryOpenSearchClient retryOpenSearchClient;
 
-  @Autowired protected RestClient opensearchRestClient;
+  @Autowired
+  @Qualifier("tasklistOpensearchRestClient")
+  private RestClient opensearchRestClient;
 
   @Autowired private List<TemplateDescriptor> templateDescriptors;
 
   @Autowired private List<AbstractIndexDescriptor> indexDescriptors;
 
-  @Autowired private OpenSearchClient openSearchClient;
+  @Autowired
+  @Qualifier("tasklistOpenSearchClient")
+  private OpenSearchClient openSearchClient;
 
   @Override
   public void createSchema() {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/DraftVariablesStoreElasticSearch.java
@@ -56,7 +56,11 @@ public class DraftVariablesStoreElasticSearch implements DraftVariableStore {
       LoggerFactory.getLogger(DraftVariablesStoreElasticSearch.class);
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
-  @Autowired private RestHighLevelClient esClient;
+
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
+
   @Autowired private DraftTaskVariableTemplate draftTaskVariableTemplate;
 
   @Autowired

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/FormStoreElasticSearch.java
@@ -60,7 +60,9 @@ public class FormStoreElasticSearch implements FormStore {
   @Qualifier("tasklistObjectMapper")
   private ObjectMapper objectMapper;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   public FormEntity getForm(final String id, final String processDefinitionId, final Long version) {
     final FormEntity formEmbedded =

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskMetricsStoreElasticSearch.java
@@ -54,7 +54,10 @@ public class TaskMetricsStoreElasticSearch implements TaskMetricsStore {
   public static final String ASSIGNEE = "assignee";
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskMetricsStoreElasticSearch.class);
   @Autowired private MetricIndex index;
-  @Autowired private RestHighLevelClient esClient;
+
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearch.java
@@ -88,7 +88,9 @@ public class TaskStoreElasticSearch implements TaskStore {
           TaskState.COMPLETED, TaskTemplate.COMPLETION_TIME,
           TaskState.CANCELED, TaskTemplate.COMPLETION_TIME);
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearch.java
@@ -82,7 +82,10 @@ import org.springframework.stereotype.Component;
 public class VariableStoreElasticSearch implements VariableStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableStoreElasticSearch.class);
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
+
   @Autowired private TenantAwareElasticsearchClient tenantAwareClient;
   @Autowired private FlowNodeInstanceIndex flowNodeInstanceIndex;
   @Autowired private VariableIndex variableIndex;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/DraftVariablesStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/DraftVariablesStoreOpenSearch.java
@@ -50,7 +50,7 @@ public class DraftVariablesStoreOpenSearch implements DraftVariableStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(DraftVariablesStoreOpenSearch.class);
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   private OpenSearchClient osClient;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/DraftVariablesStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/DraftVariablesStoreOpenSearch.java
@@ -50,7 +50,7 @@ public class DraftVariablesStoreOpenSearch implements DraftVariableStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(DraftVariablesStoreOpenSearch.class);
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -48,7 +48,7 @@ public class FormStoreOpenSearch implements FormStore {
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   private OpenSearchClient osClient;
 
   public FormEntity getForm(final String id, final String processDefinitionId, final Long version) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/FormStoreOpenSearch.java
@@ -48,7 +48,7 @@ public class FormStoreOpenSearch implements FormStore {
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
   public FormEntity getForm(final String id, final String processDefinitionId, final Long version) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
@@ -54,7 +54,7 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
   @Autowired private MetricIndex index;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient openSearchClient;
 
   @Override

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskMetricsStoreOpenSearch.java
@@ -38,6 +38,7 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 import org.springframework.util.CollectionUtils;
@@ -51,7 +52,10 @@ public class TaskMetricsStoreOpenSearch implements TaskMetricsStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskMetricsStoreOpenSearch.class);
 
   @Autowired private MetricIndex index;
-  @Autowired private OpenSearchClient openSearchClient;
+
+  @Autowired
+  @Qualifier("tasklistOpenSearchClient")
+  private OpenSearchClient openSearchClient;
 
   @Override
   public void registerTaskCompleteEvent(TaskEntity task) {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -83,7 +83,7 @@ public class TaskStoreOpenSearch implements TaskStore {
           TaskState.CANCELED, TaskTemplate.COMPLETION_TIME);
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   private OpenSearchClient osClient;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/TaskStoreOpenSearch.java
@@ -83,7 +83,7 @@ public class TaskStoreOpenSearch implements TaskStore {
           TaskState.CANCELED, TaskTemplate.COMPLETION_TIME);
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -68,7 +68,7 @@ public class VariableStoreOpenSearch implements VariableStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableStoreOpenSearch.class);
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   private OpenSearchClient osClient;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/store/opensearch/VariableStoreOpenSearch.java
@@ -68,7 +68,7 @@ public class VariableStoreOpenSearch implements VariableStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(VariableStoreOpenSearch.class);
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
   @Autowired private TenantAwareOpenSearchClient tenantAwareClient;

--- a/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/es/AbstractImportBatchProcessorElasticSearch.java
+++ b/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/es/AbstractImportBatchProcessorElasticSearch.java
@@ -16,10 +16,13 @@ import java.util.concurrent.Callable;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class AbstractImportBatchProcessorElasticSearch implements ImportBatchProcessor {
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private Metrics metrics;
 

--- a/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/os/AbstractImportBatchProcessorOpenSearch.java
+++ b/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/os/AbstractImportBatchProcessorOpenSearch.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class AbstractImportBatchProcessorOpenSearch implements ImportBatchProcessor {
 
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/os/AbstractImportBatchProcessorOpenSearch.java
+++ b/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/os/AbstractImportBatchProcessorOpenSearch.java
@@ -23,7 +23,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class AbstractImportBatchProcessorOpenSearch implements ImportBatchProcessor {
 
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/CUSTOMCopyProcessesFromOptimize.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/CUSTOMCopyProcessesFromOptimize.java
@@ -47,7 +47,9 @@ public class CUSTOMCopyProcessesFromOptimize {
       LoggerFactory.getLogger(CUSTOMCopyProcessesFromOptimize.class);
   private static final String OPTIMIZE_PROCESS_INDEX = "optimize-process-definition_v6";
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private XMLUtil xmlUtil;
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportJobElasticSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportJobElasticSearch.java
@@ -36,7 +36,7 @@ public class ImportJobElasticSearch extends ImportJobAbstract {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportJobElasticSearch.class);
 
   @Autowired
-  @Qualifier("zeebeEsClient")
+  @Qualifier("tasklistZeebeEsClient")
   private RestHighLevelClient zeebeEsClient;
 
   public ImportJobElasticSearch(ImportBatch importBatch, ImportPositionEntity previousPosition) {

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportPositionHolderElasticSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportPositionHolderElasticSearch.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
@@ -49,7 +50,9 @@ public class ImportPositionHolderElasticSearch extends ImportPositionHolderAbstr
 
   // this is the in-memory only storage
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   public ImportPositionEntity getLatestLoadedPosition(String aliasTemplate, int partitionId)
       throws IOException {

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/RecordsReaderElasticSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/RecordsReaderElasticSearch.java
@@ -58,7 +58,7 @@ public class RecordsReaderElasticSearch extends RecordsReaderAbstract {
   private static final Logger LOGGER = LoggerFactory.getLogger(RecordsReaderElasticSearch.class);
 
   @Autowired
-  @Qualifier("zeebeEsClient")
+  @Qualifier("tasklistZeebeEsClient")
   private RestHighLevelClient zeebeEsClient;
 
   public RecordsReaderElasticSearch(

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportJobOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportJobOpenSearch.java
@@ -35,7 +35,7 @@ public class ImportJobOpenSearch extends ImportJobAbstract {
   private static final Logger LOGGER = LoggerFactory.getLogger(ImportJobOpenSearch.class);
 
   @Autowired
-  @Qualifier("zeebeOsClient")
+  @Qualifier("tasklistZeebeOsClient")
   private OpenSearchClient zeebeOsClient;
 
   public ImportJobOpenSearch(ImportBatch importBatch, ImportPositionEntity previousPosition) {

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
@@ -49,7 +49,7 @@ public class ImportPositionHolderOpenSearch extends ImportPositionHolderAbstract
 
   // this is the in-memory only storage
 
-  @Qualifier("zeebeOsClient")
+  @Qualifier("tasklistZeebeOsClient")
   @Autowired
   private OpenSearchClient osClient;
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/RecordsReaderOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/RecordsReaderOpenSearch.java
@@ -58,7 +58,7 @@ public class RecordsReaderOpenSearch extends RecordsReaderAbstract {
   private static final Logger LOGGER = LoggerFactory.getLogger(RecordsReaderOpenSearch.class);
 
   @Autowired
-  @Qualifier("zeebeOsClient")
+  @Qualifier("tasklistZeebeOsClient")
   private OpenSearchClient zeebeOsClient;
 
   public RecordsReaderOpenSearch(

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestElasticSearch.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestElasticSearch.java
@@ -52,7 +52,7 @@ public class ImportListenerTestElasticSearch extends NoBeansTest {
   @MockBean private ImportPositionHolder importPositionHolder;
 
   @MockBean
-  @Qualifier("zeebeEsClient")
+  @Qualifier("tasklistZeebeEsClient")
   private RestHighLevelClient zeebeEsClient;
 
   @MockBean private RecordsReaderHolder recordsReaderHolder;

--- a/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestOpenSearch.java
+++ b/tasklist/importer/src/test/java/io/camunda/tasklist/zeebeimport/ImportListenerTestOpenSearch.java
@@ -52,7 +52,7 @@ public class ImportListenerTestOpenSearch extends NoBeansTest {
   @MockBean private ImportPositionHolder importPositionHolder;
 
   @MockBean
-  @Qualifier("zeebeOsClient")
+  @Qualifier("tasklistZeebeOsClient")
   private OpenSearchClient zeebeOsClient;
 
   @MockBean private RecordsReaderHolder recordsReaderHolder;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorBasicAuthIT.java
@@ -67,9 +67,9 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
                   ))
           .withExposedPorts(9200);
 
-  @Autowired RestHighLevelClient esClient;
+  @Autowired RestHighLevelClient tasklistEsClient;
 
-  @Autowired RestHighLevelClient zeebeEsClient;
+  @Autowired RestHighLevelClient tasklistZeebeEsClient;
 
   @BeforeAll
   public static void beforeClass() {
@@ -78,8 +78,8 @@ public class ElasticsearchConnectorBasicAuthIT extends TasklistIntegrationTest {
 
   @Test
   public void canConnect() {
-    assertThat(esClient).isNotNull();
-    assertThat(zeebeEsClient).isNotNull();
+    assertThat(tasklistEsClient).isNotNull();
+    assertThat(tasklistZeebeEsClient).isNotNull();
   }
 
   static class ElasticsearchStarter

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/es/ElasticsearchConnectorSSLAuthIT.java
@@ -63,9 +63,9 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
           .withExposedPorts(9200)
           .waitingFor(Wait.forHttps("/").withBasicCredentials("elastic", "elastic"));
 
-  @Autowired RestHighLevelClient esClient;
+  @Autowired RestHighLevelClient tasklistEsClient;
 
-  @Autowired RestHighLevelClient zeebeEsClient;
+  @Autowired RestHighLevelClient tasklistZeebeEsClient;
 
   @BeforeAll
   public static void beforeClass() {
@@ -75,8 +75,8 @@ public class ElasticsearchConnectorSSLAuthIT extends TasklistIntegrationTest {
   @Disabled("Can be tested manually")
   @Test
   public void canConnect() {
-    assertThat(esClient).isNotNull();
-    assertThat(zeebeEsClient).isNotNull();
+    assertThat(tasklistEsClient).isNotNull();
+    assertThat(tasklistZeebeEsClient).isNotNull();
   }
 
   static class ElasticsearchStarter

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/OneNodeArchiverIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/it/OneNodeArchiverIT.java
@@ -53,7 +53,6 @@ public class OneNodeArchiverIT extends TasklistZeebeIntegrationTest {
   @Autowired private ArchiverUtil archiverUtil;
 
   @Autowired private NoSqlHelper noSqlHelper;
-  // @Autowired private RestHighLevelClient esClient;
 
   @Autowired private TaskTemplate taskTemplate;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -70,7 +70,7 @@ public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
               .withExposedPorts(9200, 9200);
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   OpenSearchClient openSearchClient;
 
   @Autowired

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorBasicAuthIT.java
@@ -70,11 +70,11 @@ public class OpenSearchConnectorBasicAuthIT extends TasklistIntegrationTest {
               .withExposedPorts(9200, 9200);
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   OpenSearchClient openSearchClient;
 
   @Autowired
-  @Qualifier("zeebeOsClient")
+  @Qualifier("tasklistZeebeOsClient")
   OpenSearchClient zeebeOsClient;
 
   @BeforeAll

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
@@ -61,11 +61,11 @@ public class OpenSearchConnectorSSLAuthIT extends TasklistIntegrationTest {
               .waitingFor(Wait.forHttps("/").withBasicCredentials("elastic", "elastic"));
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   OpenSearchClient openSearchClient;
 
   @Autowired
-  @Qualifier("zeebeOsClient")
+  @Qualifier("tasklistZeebeOsClient")
   OpenSearchClient zeebeOsClient;
 
   @Disabled("Can be tested manually")

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/os/OpenSearchConnectorSSLAuthIT.java
@@ -61,7 +61,7 @@ public class OpenSearchConnectorSSLAuthIT extends TasklistIntegrationTest {
               .waitingFor(Wait.forHttps("/").withBasicCredentials("elastic", "elastic"));
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   OpenSearchClient openSearchClient;
 
   @Autowired

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchHelper.java
@@ -43,6 +43,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -62,7 +63,9 @@ public class ElasticsearchHelper implements NoSqlHelper {
 
   @Autowired private VariableIndex variableIndex;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private ObjectMapper objectMapper;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/ElasticsearchTestExtension.java
@@ -69,16 +69,18 @@ public class ElasticsearchTestExtension
   private static final String PATH_SEARCH_STATISTICS =
       "/_nodes/stats/indices/search?filter_path=nodes.*.indices.search";
 
-  @Autowired protected RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired
-  @Qualifier("zeebeEsClient")
-  protected RestHighLevelClient zeebeEsClient;
+  @Qualifier("tasklistZeebeEsClient")
+  private RestHighLevelClient zeebeEsClient;
 
-  @Autowired protected TasklistProperties tasklistProperties;
-  @Autowired protected ZeebeImporter zeebeImporter;
-  @Autowired protected RecordsReaderHolder recordsReaderHolder;
-  protected boolean failed = false;
+  @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private ZeebeImporter zeebeImporter;
+  @Autowired private RecordsReaderHolder recordsReaderHolder;
+  private boolean failed = false;
   @Autowired private SchemaManager elasticsearchSchemaManager;
 
   @Autowired private ObjectMapper objectMapper;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchHelper.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchHelper.java
@@ -56,7 +56,7 @@ public class OpenSearchHelper implements NoSqlHelper {
   @Autowired private VariableIndex variableIndex;
 
   @Autowired
-  @Qualifier("openSearchClient")
+  @Qualifier("tasklistOpenSearchClient")
   private OpenSearchClient osClient;
 
   @Autowired private ObjectMapper objectMapper;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchHelper.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchHelper.java
@@ -56,7 +56,7 @@ public class OpenSearchHelper implements NoSqlHelper {
   @Autowired private VariableIndex variableIndex;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
   @Autowired private ObjectMapper objectMapper;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -63,7 +63,7 @@ public class OpenSearchTestExtension
       "/_nodes/stats/indices/search?filter_path=nodes.*.indices.search";
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient osClient;
 
   @Autowired

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/OpenSearchTestExtension.java
@@ -63,17 +63,17 @@ public class OpenSearchTestExtension
       "/_nodes/stats/indices/search?filter_path=nodes.*.indices.search";
 
   @Autowired
-  @Qualifier("openSearchClient")
-  protected OpenSearchClient osClient;
+  @Qualifier("tasklistOpenSearchClient")
+  private OpenSearchClient osClient;
 
   @Autowired
-  @Qualifier("zeebeOsClient")
-  protected OpenSearchClient zeebeOsClient;
+  @Qualifier("tasklistZeebeOsClient")
+  private OpenSearchClient zeebeOsClient;
 
-  @Autowired protected TasklistProperties tasklistProperties;
-  @Autowired protected ZeebeImporter zeebeImporter;
-  @Autowired protected RecordsReaderHolder recordsReaderHolder;
-  protected boolean failed = false;
+  @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private ZeebeImporter zeebeImporter;
+  @Autowired private RecordsReaderHolder recordsReaderHolder;
+  private boolean failed = false;
   @Autowired private SchemaManager schemaManager;
 
   @Autowired private ObjectMapper objectMapper;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionElasticSearch.java
@@ -34,8 +34,8 @@ import org.springframework.stereotype.Component;
 public class TasklistZeebeExtensionElasticSearch extends TasklistZeebeExtension {
 
   @Autowired
-  @Qualifier("zeebeEsClient")
-  protected RestHighLevelClient zeebeEsClient;
+  @Qualifier("tasklistZeebeEsClient")
+  private RestHighLevelClient zeebeEsClient;
 
   @Override
   public void refreshIndices(final Instant instant) {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TasklistZeebeExtensionOpenSearch.java
@@ -29,8 +29,8 @@ import org.springframework.stereotype.Component;
 public class TasklistZeebeExtensionOpenSearch extends TasklistZeebeExtension {
 
   @Autowired
-  @Qualifier("zeebeOsClient")
-  protected OpenSearchClient zeebeOsClient;
+  @Qualifier("tasklistZeebeOsClient")
+  private OpenSearchClient zeebeOsClient;
 
   @Override
   public void refreshIndices(final Instant instant) {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
@@ -87,7 +87,7 @@ public class BackupServiceElasticSearchTest {
   @Mock private SnapshotClient snapshotClient;
 
   @MockBean
-  @Qualifier("esClient")
+  @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
   @SpyBean private TasklistProperties tasklistProperties;

--- a/tasklist/qa/migration-tests/test-fixture-810/src/main/java/io/camunda/tasklist/qa/migration/v810/BasicProcessDataGenerator.java
+++ b/tasklist/qa/migration-tests/test-fixture-810/src/main/java/io/camunda/tasklist/qa/migration/v810/BasicProcessDataGenerator.java
@@ -34,6 +34,7 @@ import org.elasticsearch.script.ScriptType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /** It is considered that Zeebe and Elasticsearch are running. */
@@ -52,7 +53,9 @@ public class BasicProcessDataGenerator {
    */
   private ZeebeClient zeebeClient;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   private final Random random = new Random();
 

--- a/tasklist/qa/migration-tests/test-fixture-810/src/main/java/io/camunda/tasklist/qa/migration/v810/BigVariableProcessDataGenerator.java
+++ b/tasklist/qa/migration-tests/test-fixture-810/src/main/java/io/camunda/tasklist/qa/migration/v810/BigVariableProcessDataGenerator.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /** It is considered that Zeebe and Elasticsearch are running. */
@@ -50,7 +51,9 @@ public class BigVariableProcessDataGenerator {
    */
   private ZeebeClient zeebeClient;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   private final Random random = new Random();
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/internal/DevUtilExternalController.java
@@ -25,6 +25,7 @@ import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -40,7 +41,9 @@ public class DevUtilExternalController {
 
   @Autowired private SchemaManager schemaManager;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private SearchEngineUserDetailsService searchEngineUserDetailsService;
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -81,7 +81,9 @@ public class BackupManagerElasticSearch extends BackupManager {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private RestHighLevelClient esClient;
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -55,6 +55,7 @@ import org.opensearch.client.transport.JsonEndpoint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -72,8 +73,14 @@ public class BackupManagerOpenSearch extends BackupManager {
   private final Queue<CreateSnapshotRequest> requestsQueue = new ConcurrentLinkedQueue<>();
 
   @Autowired private TasklistProperties tasklistProperties;
-  @Autowired private OpenSearchAsyncClient openSearchAsyncClient;
-  @Autowired private OpenSearchClient openSearchClient;
+
+  @Autowired
+  @Qualifier("tasklistOpenSearchAsyncClient")
+  private OpenSearchAsyncClient openSearchAsyncClient;
+
+  @Autowired
+  @Qualifier("tasklistOpenSearchClient")
+  private OpenSearchClient openSearchClient;
 
   @Override
   public void deleteBackup(final Long backupId) {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -75,11 +75,11 @@ public class BackupManagerOpenSearch extends BackupManager {
   @Autowired private TasklistProperties tasklistProperties;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchAsyncClient")
+  @Qualifier("tasklistOsAsyncClient")
   private OpenSearchAsyncClient openSearchAsyncClient;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient openSearchClient;
 
   @Override

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/AssigneeMigratorElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/AssigneeMigratorElasticSearch.java
@@ -26,6 +26,7 @@ import org.elasticsearch.script.ScriptType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,7 +37,10 @@ import org.springframework.stereotype.Component;
 public class AssigneeMigratorElasticSearch implements AssigneeMigrator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AssigneeMigratorElasticSearch.class);
-  @Autowired private RestHighLevelClient esClient;
+
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired private MetricIndex metricIndex;
   @Autowired private TasklistProperties tasklistProperties;

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
@@ -56,7 +56,10 @@ public class UserStoreElasticSearch implements UserStore {
   private static final XContentType XCONTENT_TYPE = XContentType.JSON;
 
   @Autowired private UserIndex userIndex;
-  @Autowired private RestHighLevelClient esClient;
+
+  @Autowired
+  @Qualifier("tasklistEsClient")
+  private RestHighLevelClient esClient;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
@@ -32,6 +32,7 @@ import org.opensearch.client.opensearch.core.SearchResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
@@ -45,7 +46,10 @@ public class UserStoreOpenSearch implements UserStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserStoreOpenSearch.class);
 
   @Autowired private UserIndex userIndex;
-  @Autowired private OpenSearchClient openSearchClient;
+
+  @Autowired
+  @Qualifier("tasklistOpenSearchClient")
+  private OpenSearchClient openSearchClient;
 
   @Override
   public UserEntity getByUserId(String userId) {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
@@ -48,7 +48,7 @@ public class UserStoreOpenSearch implements UserStore {
   @Autowired private UserIndex userIndex;
 
   @Autowired
-  @Qualifier("tasklistOpenSearchClient")
+  @Qualifier("tasklistOsClient")
   private OpenSearchClient openSearchClient;
 
   @Override


### PR DESCRIPTION
## Description
Qualifying ES and OS client beans used by Tasklist
This is required when Tasklist will be run along with Operate, the right ES/OS clients should be autowired in Tasklist components 
Ultimately we should have shared clients builders between Tasklist, Operate and Zeebe but this should be in scope of [Data Layer and Unified Camunda API](https://github.com/camunda/product-hub/issues/2245)

## Related issues

relates to https://github.com/camunda/camunda/issues/18535
