### PR TITLE
fix: AssignUserTaskTest is unstable

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserTaskTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/AssignUserTaskTest.java
@@ -27,17 +27,16 @@ import org.junit.jupiter.api.Test;
 @AutoCloseResources
 class AssignUserTaskTest {
 
-  @TestZeebe
-  private static final TestStandaloneBroker ZEEBE =
-      new TestStandaloneBroker().withRecordingExporter(true);
-
   @AutoCloseResource ZeebeClient client;
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
 
   private long userTaskKey;
 
   @BeforeEach
   void initClientAndInstances() {
-    client = ZEEBE.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
     final ZeebeResourcesHelper resourcesHelper = new ZeebeResourcesHelper(client);
     userTaskKey = resourcesHelper.createSingleUserTask();
   }


### PR DESCRIPTION
## Description

`@TestZeebe` annotation can be used to create an instance of `TestStandaloneBroker` object. When the field is defined as static, the broker instance is created once for all test in the related test class (see zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ ZeebeIntegrationExtension.java). Otherwise, the test broker re-created for every test case.

Even if we reset the exporter before executing each test case, the order of accessing to the exporter is not guaranteed. While running the test in a multi threaded environment this might lead to unordered access to the exporter (see: [ReentrantLock docs](https://docs.oracle.com/javase%2F8%2Fdocs%2Fapi%2F%2F/java/util/concurrent/locks/ReentrantLock.html)) so break the test isolation. We would like to improve the isolation and re-ceate TestStandaloneBroker for each case.

## Related issues

closes #17668 
