### PR TITLE
Use camunda/camunda in `dispatch-release-*` workflows for patches

### DIFF
--- a/.github/workflows/dispatch-release-8-2.yaml
+++ b/.github/workflows/dispatch-release-8-2.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-release:
     name: "Release ${{ github.event.client_payload.releaseVersion }}"
-    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.2
+    uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.2
     secrets: inherit
     with:
       releaseVersion: ${{ github.event.client_payload.releaseVersion }}

--- a/.github/workflows/dispatch-release-8-3.yaml
+++ b/.github/workflows/dispatch-release-8-3.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-release:
     name: "Release ${{ github.event.client_payload.releaseVersion }}"
-    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.3
+    uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.3
     secrets: inherit
     with:
       releaseVersion: ${{ github.event.client_payload.releaseVersion }}

--- a/.github/workflows/dispatch-release-8-4.yaml
+++ b/.github/workflows/dispatch-release-8-4.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-release:
     name: "Release ${{ github.event.client_payload.releaseVersion }}"
-    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.4
+    uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.4
     secrets: inherit
     with:
       releaseVersion: ${{ github.event.client_payload.releaseVersion }}

--- a/.github/workflows/dispatch-release-8-5.yaml
+++ b/.github/workflows/dispatch-release-8-5.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   run-release:
     name: "Release ${{ github.event.client_payload.releaseVersion }}"
-    uses: camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.5
+    uses: camunda/camunda/.github/workflows/zeebe-release.yml@stable/8.5
     secrets: inherit
     with:
       releaseVersion: ${{ github.event.client_payload.releaseVersion }}


### PR DESCRIPTION
## Description

For patch releases, the dispatch-release-* workflows refer to the zeebe-release workflow at a specific branch. This is currently broken, with a parsing error shown:

```
Invalid workflow file: .github/workflows/dispatch-release-8-5.yaml#L13 error parsing called workflow
".github/workflows/dispatch-release-8-5.yaml"
-> "camunda/zeebe/.github/workflows/zeebe-release.yml@stable/8.5" : workflow was not found. See https://docs.github.com/actions/learn-github-actions/reusing-workflows#access-to-reusable-workflows for more information.
```

I think that the reason that the workflow can't be found is the recent repository renaming: camunda/zeebe -> camunda/camunda.

## Related issues

Workflow runs: 
- https://github.com/camunda/camunda/actions/runs/9368078752
- https://github.com/camunda/camunda/actions/runs/9368139396
- https://github.com/camunda/camunda/actions/runs/9368141247
- https://github.com/camunda/camunda/actions/runs/9368143817
