### PR TITLE
bug: #18772 opensearch null bpmnxml

### DIFF
--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/ProcessZeebeRecordProcessorElasticSearch.java
@@ -60,7 +60,8 @@ public class ProcessZeebeRecordProcessorElasticSearch {
 
   @Autowired private ProcessDefinitionDeletionProcessor processDefinitionDeletionProcessor;
 
-  public void processDeploymentRecord(Record<DeployedProcessImpl> record, BulkRequest bulkRequest)
+  public void processDeploymentRecord(
+      final Record<DeployedProcessImpl> record, final BulkRequest bulkRequest)
       throws PersistenceException {
     final String intentStr = record.getIntent().name();
     final DeployedProcessImpl recordValue = record.getValue();
@@ -75,7 +76,7 @@ public class ProcessZeebeRecordProcessorElasticSearch {
             try {
               persistForm(
                   processDefinitionKey, formKey, schema, bulkRequest, recordValue.getTenantId());
-            } catch (PersistenceException e) {
+            } catch (final PersistenceException e) {
               exceptions.add(e);
             }
           });
@@ -90,7 +91,9 @@ public class ProcessZeebeRecordProcessorElasticSearch {
   }
 
   private void persistProcess(
-      Process process, BulkRequest bulkRequest, BiConsumer<String, String> userTaskFormCollector)
+      final Process process,
+      final BulkRequest bulkRequest,
+      final BiConsumer<String, String> userTaskFormCollector)
       throws PersistenceException {
 
     final ProcessEntity processEntity = createEntity(process, userTaskFormCollector);
@@ -102,7 +105,7 @@ public class ProcessZeebeRecordProcessorElasticSearch {
               .index(processIndex.getFullQualifiedName())
               .id(toStringOrNull(processEntity.getKey()))
               .source(objectMapper.writeValueAsString(processEntity), XContentType.JSON));
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       throw new PersistenceException(
           String.format("Error preparing the query to insert process [%s]", processEntity.getKey()),
           e);
@@ -110,7 +113,7 @@ public class ProcessZeebeRecordProcessorElasticSearch {
   }
 
   private ProcessEntity createEntity(
-      Process process, BiConsumer<String, String> userTaskFormCollector) {
+      final Process process, final BiConsumer<String, String> userTaskFormCollector) {
     final ProcessEntity processEntity = new ProcessEntity();
 
     processEntity.setId(String.valueOf(process.getProcessDefinitionKey()));
@@ -129,27 +132,24 @@ public class ProcessZeebeRecordProcessorElasticSearch {
         flowNode -> processEntity.getFlowNodes().add(flowNode),
         userTaskFormCollector,
         processEntity::setFormKey,
-        formId -> processEntity.setFormId(formId),
+        processEntity::setFormId,
         processEntity::setStartedByForm);
 
     Optional.ofNullable(processEntity.getFormKey())
         .ifPresent(key -> processEntity.setIsFormEmbedded(true));
 
     Optional.ofNullable(processEntity.getFormId())
-        .ifPresent(
-            id -> {
-              processEntity.setIsFormEmbedded(false);
-            });
+        .ifPresent(id -> processEntity.setIsFormEmbedded(false));
 
     return processEntity;
   }
 
   private void persistForm(
-      String processDefinitionKey,
-      String formKey,
-      String schema,
-      BulkRequest bulkRequest,
-      String tenantId)
+      final String processDefinitionKey,
+      final String formKey,
+      final String schema,
+      final BulkRequest bulkRequest,
+      final String tenantId)
       throws PersistenceException {
     final FormEntity formEntity = new FormEntity(processDefinitionKey, formKey, schema, tenantId);
     LOGGER.debug("Form: key {}", formKey);
@@ -160,7 +160,7 @@ public class ProcessZeebeRecordProcessorElasticSearch {
               .id(toStringOrNull(formEntity.getId()))
               .source(objectMapper.writeValueAsString(formEntity), XContentType.JSON));
 
-    } catch (JsonProcessingException e) {
+    } catch (final JsonProcessingException e) {
       throw new PersistenceException(
           String.format("Error preparing the query to insert task form [%s]", formEntity.getId()),
           e);

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
@@ -121,7 +121,8 @@ public class ProcessZeebeRecordProcessorOpenSearch {
             .setKey(process.getProcessDefinitionKey())
             .setBpmnProcessId(process.getBpmnProcessId())
             .setVersion(process.getVersion())
-            .setTenantId(process.getTenantId());
+            .setTenantId(process.getTenantId())
+            .setBpmnXml(new String(process.getResource()));
 
     final byte[] byteArray = process.getResource();
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
@@ -60,7 +60,7 @@ public class ProcessZeebeRecordProcessorOpenSearch {
   @Autowired private ProcessDefinitionDeletionProcessor processDefinitionDeletionProcessor;
 
   public void processDeploymentRecord(
-      Record<DeployedProcessImpl> record, List<BulkOperation> operations)
+      final Record<DeployedProcessImpl> record, final List<BulkOperation> operations)
       throws PersistenceException {
     final String intentStr = record.getIntent().name();
     final String processDefinitionKey = String.valueOf(record.getValue().getProcessDefinitionKey());
@@ -76,7 +76,7 @@ public class ProcessZeebeRecordProcessorOpenSearch {
             try {
               persistForm(
                   processDefinitionKey, formKey, schema, recordValue.getTenantId(), operations);
-            } catch (PersistenceException e) {
+            } catch (final PersistenceException e) {
               exceptions.add(e);
             }
           });
@@ -95,9 +95,9 @@ public class ProcessZeebeRecordProcessorOpenSearch {
   }
 
   private void persistProcess(
-      Process process,
-      List<BulkOperation> operations,
-      BiConsumer<String, String> userTaskFormCollector) {
+      final Process process,
+      final List<BulkOperation> operations,
+      final BiConsumer<String, String> userTaskFormCollector) {
 
     final ProcessEntity processEntity = createEntity(process, userTaskFormCollector);
     LOGGER.debug("Process: key {}", processEntity.getKey());
@@ -114,7 +114,7 @@ public class ProcessZeebeRecordProcessorOpenSearch {
   }
 
   private ProcessEntity createEntity(
-      Process process, BiConsumer<String, String> userTaskFormCollector) {
+      final Process process, final BiConsumer<String, String> userTaskFormCollector) {
     final ProcessEntity processEntity =
         new ProcessEntity()
             .setId(String.valueOf(process.getProcessDefinitionKey()))
@@ -133,27 +133,24 @@ public class ProcessZeebeRecordProcessorOpenSearch {
         flowNode -> processEntity.getFlowNodes().add(flowNode),
         userTaskFormCollector,
         processEntity::setFormKey,
-        formId -> processEntity.setFormId(formId),
+        processEntity::setFormId,
         processEntity::setStartedByForm);
 
     Optional.ofNullable(processEntity.getFormKey())
         .ifPresent(key -> processEntity.setIsFormEmbedded(true));
 
     Optional.ofNullable(processEntity.getFormId())
-        .ifPresent(
-            id -> {
-              processEntity.setIsFormEmbedded(false);
-            });
+        .ifPresent(id -> processEntity.setIsFormEmbedded(false));
 
     return processEntity;
   }
 
   private void persistForm(
-      String processDefinitionKey,
-      String formKey,
-      String schema,
-      String tenantId,
-      List<BulkOperation> operations)
+      final String processDefinitionKey,
+      final String formKey,
+      final String schema,
+      final String tenantId,
+      final List<BulkOperation> operations)
       throws PersistenceException {
     final FormEntity formEntity = new FormEntity(processDefinitionKey, formKey, schema, tenantId);
     LOGGER.debug("Form: key {}", formKey);

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
@@ -133,17 +133,14 @@ public class ProcessZeebeRecordProcessorOpenSearch {
         flowNode -> processEntity.getFlowNodes().add(flowNode),
         userTaskFormCollector,
         processEntity::setFormKey,
-        formId -> processEntity.setFormId(formId),
+        processEntity::setFormId,
         processEntity::setStartedByForm);
 
     Optional.ofNullable(processEntity.getFormKey())
         .ifPresent(key -> processEntity.setIsFormEmbedded(true));
 
     Optional.ofNullable(processEntity.getFormId())
-        .ifPresent(
-            id -> {
-              processEntity.setIsFormEmbedded(false);
-            });
+        .ifPresent(id -> processEntity.setIsFormEmbedded(false));
 
     return processEntity;
   }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/ProcessZeebeRecordProcessorOpenSearch.java
@@ -121,7 +121,8 @@ public class ProcessZeebeRecordProcessorOpenSearch {
             .setKey(process.getProcessDefinitionKey())
             .setBpmnProcessId(process.getBpmnProcessId())
             .setVersion(process.getVersion())
-            .setTenantId(process.getTenantId());
+            .setTenantId(process.getTenantId())
+            .setBpmnXml(new String(process.getResource()));
 
     final byte[] byteArray = process.getResource();
 


### PR DESCRIPTION
## Description
OpenSearch Importer implementation did not include bpmnXML resource during persist of the ProcessEntity, hence the retrieved data was always null on #18772 

closes #18772 
