### PR TITLE
Update cached test executions periodically to avoid losing work

### DIFF
--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
@@ -239,7 +239,7 @@ public final class CachedTestResultsExtension
       }
     }
 
-    void snapshot() {
+    synchronized void snapshot() {
       try (final var writer = Files.newBufferedWriter(path)) {
         for (final var version : cached) {
           writer.write(version.toLine());

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
@@ -215,7 +215,7 @@ public final class CachedTestResultsExtension
     void confirm(final String id) {
       final var invocation = staged.remove(id);
       if (invocation == null) {
-        throw new IllegalArgumentException("No staged invocation with id " + id + " found.");
+        return;
       }
       if (!cached.add(invocation)) {
         throw new IllegalStateException("Invocation " + invocation + "is already cached.");

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/junit/CachedTestResultsExtension.java
@@ -18,6 +18,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.SortedSet;
+import java.util.Timer;
+import java.util.TimerTask;
 import java.util.TreeSet;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -56,6 +58,7 @@ public final class CachedTestResultsExtension
     implements TestWatcher, AfterAllCallback, BeforeAllCallback, InvocationInterceptor {
   public static final String CACHE_KEY = "cache";
   public static final String SHUTDOWN_HOOK_KEY = "shutdownHook";
+  public static final String PERIODIC_SAVE_KEY = "periodicSave";
   private final Path cachePath;
 
   /**
@@ -101,12 +104,26 @@ public final class CachedTestResultsExtension
             .getOrComputeIfAbsent(
                 SHUTDOWN_HOOK_KEY, key -> new Thread(cache::snapshot), Thread.class);
     Runtime.getRuntime().addShutdownHook(hook);
+
+    final var timer =
+        getStore(context)
+            .getOrComputeIfAbsent(PERIODIC_SAVE_KEY, key -> new Timer(true), Timer.class);
+    timer.scheduleAtFixedRate(
+        new TimerTask() {
+          @Override
+          public void run() {
+            cache.snapshot();
+          }
+        },
+        30_000,
+        30_000);
   }
 
   @Override
   public void afterAll(final ExtensionContext context) {
     final var shutdownHook = getStore(context).remove(SHUTDOWN_HOOK_KEY, Thread.class);
     Runtime.getRuntime().removeShutdownHook(shutdownHook);
+    getStore(context).remove(PERIODIC_SAVE_KEY, Timer.class).cancel();
     getCache(context).snapshot();
   }
 


### PR DESCRIPTION
## Description

This adds a periodic task to update the file containing successful test executions every 30 seconds. This is to prevent losing work when the test was interrupted non-gracefully such that the shutdown hook didn't get a chance to run. This is exactly what happens when GHA jobs run into timeouts.

## Related issues

closes #19026
