### PR TITLE
refactor: qualifying Tasklist conflicting beans

### DIFF
--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/AbstractArchiverJob.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/AbstractArchiverJob.java
@@ -27,7 +27,7 @@ public abstract class AbstractArchiverJob implements Runnable {
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractArchiverJob.class);
 
   @Autowired
-  @Qualifier("archiverThreadPoolExecutor")
+  @Qualifier("tasklistArchiverThreadPoolExecutor")
   protected ThreadPoolTaskScheduler archiverExecutor;
 
   @Autowired protected ArchiverUtil archiverUtil;
@@ -36,7 +36,7 @@ public abstract class AbstractArchiverJob implements Runnable {
   private final BackoffIdleStrategy errorStrategy;
 
   private boolean shutdown = false;
-  private List<Integer> partitionIds;
+  private final List<Integer> partitionIds;
 
   @Autowired private TasklistProperties tasklistProperties;
 

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/ArchiverConfigurator.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/ArchiverConfigurator.java
@@ -18,7 +18,7 @@ public class ArchiverConfigurator {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Bean("archiverThreadPoolExecutor")
+  @Bean("tasklistArchiverThreadPoolExecutor")
   public ThreadPoolTaskScheduler getTaskScheduler() {
     final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
     scheduler.setPoolSize(tasklistProperties.getArchiver().getThreadsCount());

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/ArchiverStarter.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/ArchiverStarter.java
@@ -22,13 +22,13 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Component;
 
 @Component
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 public class ArchiverStarter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverStarter.class);
 
   @Autowired
-  @Qualifier("archiverThreadPoolExecutor")
+  @Qualifier("tasklistArchiverThreadPoolExecutor")
   public ThreadPoolTaskScheduler taskScheduler;
 
   @Autowired private BeanFactory beanFactory;

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/ArchiverUtilAbstract.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/ArchiverUtilAbstract.java
@@ -20,7 +20,7 @@ public abstract class ArchiverUtilAbstract implements ArchiverUtil {
   private static final String INDEX_NAME_PATTERN = "%s%s";
 
   @Autowired
-  @Qualifier("archiverThreadPoolExecutor")
+  @Qualifier("tasklistArchiverThreadPoolExecutor")
   protected ThreadPoolTaskScheduler archiverExecutor;
 
   @Autowired protected Metrics metrics;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/PartitionHolder.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/PartitionHolder.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -35,7 +36,9 @@ public class PartitionHolder {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Autowired private ZeebeClient zeebeClient;
+  @Autowired
+  @Qualifier("tasklistZeebeClient")
+  private ZeebeClient zeebeClient;
 
   @Autowired(required = false)
   private ApplicationShutdownService applicationShutdownService;

--- a/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/zeebe/ZeebeConnector.java
@@ -29,7 +29,7 @@ public class ZeebeConnector {
   @Autowired private TasklistProperties tasklistProperties;
 
   @Bean // will be closed automatically
-  public ZeebeClient zeebeClient() {
+  public ZeebeClient tasklistZeebeClient() {
     return newZeebeClient(tasklistProperties.getZeebe());
   }
 

--- a/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
+++ b/tasklist/data-generator/src/main/java/io/camunda/tasklist/data/DevDataGeneratorAbstract.java
@@ -34,7 +34,7 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 public abstract class DevDataGeneratorAbstract implements DataGenerator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DevDataGeneratorAbstract.class);
@@ -43,7 +43,9 @@ public abstract class DevDataGeneratorAbstract implements DataGenerator {
   @Autowired protected UserIndex userIndex;
   protected PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-  @Autowired private ZeebeClient zeebeClient;
+  @Autowired
+  @Qualifier("tasklistZeebeClient")
+  private ZeebeClient zeebeClient;
 
   @Autowired private FormIndex formIndex;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/SchemaStartup.java
@@ -24,7 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Component("schemaStartup")
+@Component("tasklistSchemaStartup")
 @Profile("!test")
 public class SchemaStartup {
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -56,7 +56,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
 
-@Component("schemaManager")
+@Component("tasklistSchemaManager")
 @Profile("!test")
 @Conditional(ElasticSearchCondition.class)
 public class ElasticsearchSchemaManager implements SchemaManager {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -61,7 +61,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StreamUtils;
 
-@Component("schemaManager")
+@Component("tasklistSchemaManager")
 @Profile("!test")
 @Conditional(OpenSearchCondition.class)
 public class OpenSearchSchemaManager implements SchemaManager {

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/migration/es/ElasticSearchMigrator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/migration/es/ElasticSearchMigrator.java
@@ -63,7 +63,7 @@ public class ElasticSearchMigrator implements Migrator {
 
   @Autowired private IndexSchemaValidator indexSchemaValidator;
 
-  @Bean("migrationThreadPoolExecutor")
+  @Bean("tasklistMigrationThreadPoolExecutor")
   public ThreadPoolTaskExecutor getTaskExecutor() {
     final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(migrationProperties.getThreadsCount());

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/migration/os/OpenSearchMigrator.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/migration/os/OpenSearchMigrator.java
@@ -63,7 +63,7 @@ public class OpenSearchMigrator implements Migrator {
 
   @Autowired private IndexSchemaValidator indexSchemaValidator;
 
-  @Bean("migrationThreadPoolExecutor")
+  @Bean("tasklistMigrationThreadPoolExecutor")
   public ThreadPoolTaskExecutor getTaskExecutor() {
     final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(migrationProperties.getThreadsCount());

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportConfig.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportConfig.java
@@ -19,7 +19,7 @@ public class ImportConfig {
 
   @Autowired private TasklistProperties tasklistProperties;
 
-  @Bean("importThreadPoolExecutor")
+  @Bean("tasklistImportThreadPoolExecutor")
   public ThreadPoolTaskExecutor getTaskExecutor() {
     final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(tasklistProperties.getImporter().getThreadsCount());
@@ -29,7 +29,7 @@ public class ImportConfig {
     return executor;
   }
 
-  @Bean("recordsReaderThreadPoolExecutor")
+  @Bean("tasklistRecordsReaderThreadPoolExecutor")
   public ThreadPoolTaskScheduler getRecordsReaderTaskExecutor() {
     final var executor = new ThreadPoolTaskScheduler();
     executor.setPoolSize(tasklistProperties.getImporter().getReaderThreadsCount());
@@ -38,7 +38,7 @@ public class ImportConfig {
     return executor;
   }
 
-  @Bean("importPositionUpdateThreadPoolExecutor")
+  @Bean("tasklistImportPositionUpdateThreadPoolExecutor")
   public ThreadPoolTaskScheduler getImportPositionUpdateTaskExecutor() {
     final var executor = new ThreadPoolTaskScheduler();
     executor.setPoolSize(1);

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolderAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolderAbstract.java
@@ -48,7 +48,7 @@ public abstract class ImportPositionHolderAbstract implements ImportPositionHold
   @Autowired protected Metrics metrics;
 
   @Autowired
-  @Qualifier("importPositionUpdateThreadPoolExecutor")
+  @Qualifier("tasklistImportPositionUpdateThreadPoolExecutor")
   protected ThreadPoolTaskScheduler importPositionUpdateExecutor;
 
   @PostConstruct

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/RecordsReaderAbstract.java
@@ -50,11 +50,11 @@ public abstract class RecordsReaderAbstract implements RecordsReader, Runnable {
   @Autowired private BeanFactory beanFactory;
 
   @Autowired
-  @Qualifier("recordsReaderThreadPoolExecutor")
+  @Qualifier("tasklistRecordsReaderThreadPoolExecutor")
   private ThreadPoolTaskScheduler readersExecutor;
 
   @Autowired
-  @Qualifier("importThreadPoolExecutor")
+  @Qualifier("tasklistImportThreadPoolExecutor")
   private ThreadPoolTaskExecutor importExecutor;
 
   private ImportJob pendingImportJob;

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ZeebeImporter.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ZeebeImporter.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Configuration
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 public class ZeebeImporter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ZeebeImporter.class);
@@ -32,7 +32,7 @@ public class ZeebeImporter {
   @Autowired private RecordsReaderHolder recordsReaderHolder;
 
   @Autowired
-  @Qualifier("recordsReaderThreadPoolExecutor")
+  @Qualifier("tasklistRecordsReaderThreadPoolExecutor")
   private ThreadPoolTaskScheduler readersExecutor;
 
   @PostConstruct
@@ -48,9 +48,9 @@ public class ZeebeImporter {
     allRecordsReaders.forEach(recordsReader -> readersExecutor.submit(recordsReader));
   }
 
-  public int performOneRoundOfImportFor(Collection<RecordsReader> readers) {
+  public int performOneRoundOfImportFor(final Collection<RecordsReader> readers) {
     int countRecords = 0;
-    for (RecordsReader recordsReaderElasticSearch : readers) {
+    for (final RecordsReader recordsReaderElasticSearch : readers) {
       countRecords += importOneBatch(recordsReaderElasticSearch, false);
     }
     return countRecords;
@@ -60,7 +60,7 @@ public class ZeebeImporter {
     return performOneRoundOfImportFor(recordsReaderHolder.getAllRecordsReaders());
   }
 
-  public int importOneBatch(RecordsReader recordsReader, final boolean autoContinue) {
+  public int importOneBatch(final RecordsReader recordsReader, final boolean autoContinue) {
     return recordsReader.readAndScheduleNextBatch(autoContinue);
   }
 }

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportPositionHolderElasticSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/es/ImportPositionHolderElasticSearch.java
@@ -40,7 +40,7 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 @Component
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 @Conditional(ElasticSearchCondition.class)
 public class ImportPositionHolderElasticSearch extends ImportPositionHolderAbstract
     implements ImportPositionHolder {

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/os/ImportPositionHolderOpenSearch.java
@@ -39,7 +39,7 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 
 @Component
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 @Conditional(OpenSearchCondition.class)
 public class ImportPositionHolderOpenSearch extends ImportPositionHolderAbstract
     implements ImportPositionHolder {

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestElasticsearchSchemaManager.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestElasticsearchSchemaManager.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Component("schemaManager")
+@Component("tasklistSchemaManager")
 @Profile({"test"})
 @Conditional(ElasticSearchCondition.class)
 public class TestElasticsearchSchemaManager extends ElasticsearchSchemaManager

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestOpenSearchSchemaManager.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestOpenSearchSchemaManager.java
@@ -15,7 +15,7 @@ import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Component("schemaManager")
+@Component("tasklistSchemaManager")
 @Profile("test")
 @Conditional(OpenSearchCondition.class)
 public class TestOpenSearchSchemaManager extends OpenSearchSchemaManager

--- a/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestSchemaStartup.java
+++ b/tasklist/qa/util/src/main/java/io/camunda/tasklist/qa/util/TestSchemaStartup.java
@@ -14,7 +14,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Component("schemaStartup")
+@Component("tasklistSchemaStartup")
 @Profile("test")
 public class TestSchemaStartup extends SchemaStartup {
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/StartupBean.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/StartupBean.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Component
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 @Profile("!test")
 public class StartupBean {
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/es/BackupManagerElasticSearch.java
@@ -450,7 +450,7 @@ public class BackupManagerElasticSearch extends BackupManager {
     }
   }
 
-  @Bean("backupThreadPoolExecutor")
+  @Bean("tasklistBackupThreadPoolExecutor")
   public ThreadPoolTaskExecutor getTaskExecutor() {
     final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(1);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/es/backup/os/BackupManagerOpenSearch.java
@@ -500,7 +500,7 @@ public class BackupManagerOpenSearch extends BackupManager {
         .setVersion(jsonDataMap.get("version").to(String.class));
   }
 
-  @Bean("backupThreadPoolExecutor")
+  @Bean("tasklistBackupThreadPoolExecutor")
   public ThreadPoolTaskExecutor getTaskExecutor() {
     final ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
     executor.setCorePoolSize(1);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreElasticSearch.java
@@ -48,7 +48,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("!" + SSO_AUTH_PROFILE + " & !" + IDENTITY_AUTH_PROFILE)
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 @Conditional(ElasticSearchCondition.class)
 public class UserStoreElasticSearch implements UserStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserStoreElasticSearch.class);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/store/UserStoreOpenSearch.java
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Profile("!" + SSO_AUTH_PROFILE + " & !" + IDENTITY_AUTH_PROFILE)
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 @Conditional(OpenSearchCondition.class)
 public class UserStoreOpenSearch implements UserStore {
   private static final Logger LOGGER = LoggerFactory.getLogger(UserStoreOpenSearch.class);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ILMService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ILMService.java
@@ -18,7 +18,7 @@ import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Service;
 
 @Service
-@DependsOn("schemaStartup")
+@DependsOn("tasklistSchemaStartup")
 public class ILMService {
   private static final Logger LOGGER = LoggerFactory.getLogger(ILMService.class);
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/ProcessService.java
@@ -41,7 +41,9 @@ import org.springframework.stereotype.Component;
 public class ProcessService {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessService.class);
 
-  @Autowired private ZeebeClient zeebeClient;
+  @Autowired
+  @Qualifier("tasklistZeebeClient")
+  private ZeebeClient zeebeClient;
 
   @Autowired
   @Qualifier("tasklistObjectMapper")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/service/TaskService.java
@@ -48,7 +48,11 @@ public class TaskService {
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskService.class);
 
   @Autowired private UserReader userReader;
-  @Autowired private ZeebeClient zeebeClient;
+
+  @Autowired
+  @Qualifier("tasklistZeebeClient")
+  private ZeebeClient zeebeClient;
+
   @Autowired private TaskStore taskStore;
   @Autowired private VariableService variableService;
 


### PR DESCRIPTION
## Description
Qualifying Tasklist beans that conflicts with Operate's beans.
Same goal as in https://github.com/camunda/camunda/pull/19078, for the sake of having small pull requests, before adding Tasklist into `StandaloneCamunda`

Ultimately, we should have a shared `ZeebeClient`, but this will handled later
## Related issues

relates to https://github.com/camunda/camunda/issues/18535
