### PR TITLE
fix: filter out dynamic schemas from dynamic update

### DIFF
--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/ProcessIndex.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/indices/ProcessIndex.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 public class ProcessIndex extends AbstractIndexDescriptor implements Prio4Backup {
 
   public static final String INDEX_NAME = "process";
-  public static final String INDEX_VERSION = "8.6.0";
+  public static final String INDEX_VERSION = "8.4.0";
 
   public static final String ID = "id";
   public static final String KEY = "key";

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -77,10 +77,11 @@ public class IndexSchemaValidatorUtil {
       final Map<String, IndexMapping> indexMappings, final IndexDescriptor indexDescriptor) {
     return Maps.filterEntries(
         indexMappings,
-        e ->  STRICT_DYNAMIC_POLICY.equals(e.getValue().getDynamic()) && // filter out dynamic mappings - not supported by schema migration
-                 e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
+        e ->
+            STRICT_DYNAMIC_POLICY.equals(e.getValue().getDynamic())
+                && // filter out dynamic mappings - not supported by schema migration
+                e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
   }
-
 
   public void validateDifferenceAndCollectNewFields(
       final IndexDescriptor indexDescriptor,

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -15,7 +15,6 @@ import io.camunda.tasklist.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.tasklist.schema.IndexMappingDifference;
 import io.camunda.tasklist.schema.SemanticVersion;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
-import io.camunda.tasklist.schema.indices.TasklistWebSessionIndex;
 import io.camunda.tasklist.schema.manager.SchemaManager;
 import java.io.IOException;
 import java.util.HashMap;
@@ -28,7 +27,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.server.session.WebSessionStore;
 
 // TO-DO: This class will replace after a refactor of retryElasticsearchClient  and
 // retryOpenSearchClient

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -76,7 +76,7 @@ public class IndexSchemaValidatorUtil {
       final Map<String, IndexMapping> indexMappings, final IndexDescriptor indexDescriptor) {
     return Maps.filterEntries(
         indexMappings,
-        e ->  "true".equals(e.getValue().getDynamic()) && // filter out dynamic mappings - not supported by schema migration
+        e ->  "strict".equals(e.getValue().getDynamic()) && // filter out dynamic mappings - not supported by schema migration
                  e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -15,6 +15,7 @@ import io.camunda.tasklist.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.tasklist.schema.IndexMappingDifference;
 import io.camunda.tasklist.schema.SemanticVersion;
 import io.camunda.tasklist.schema.indices.IndexDescriptor;
+import io.camunda.tasklist.schema.indices.TasklistWebSessionIndex;
 import io.camunda.tasklist.schema.manager.SchemaManager;
 import java.io.IOException;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.server.session.WebSessionStore;
 
 // TO-DO: This class will replace after a refactor of retryElasticsearchClient  and
 // retryOpenSearchClient
@@ -76,8 +78,10 @@ public class IndexSchemaValidatorUtil {
       final Map<String, IndexMapping> indexMappings, final IndexDescriptor indexDescriptor) {
     return Maps.filterEntries(
         indexMappings,
-        e -> e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
+        e -> e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()) &&
+            "true".equals(e.getValue().getDynamic())); // filter out dynamic mappings - not supported by schema migration
   }
+
 
   public void validateDifferenceAndCollectNewFields(
       final IndexDescriptor indexDescriptor,

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -76,8 +76,8 @@ public class IndexSchemaValidatorUtil {
       final Map<String, IndexMapping> indexMappings, final IndexDescriptor indexDescriptor) {
     return Maps.filterEntries(
         indexMappings,
-        e ->  "true".equals(e.getValue().getDynamic())) && // filter out dynamic mappings - not supported by schema migration 
-                 e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern());
+        e ->  "true".equals(e.getValue().getDynamic()) && // filter out dynamic mappings - not supported by schema migration
+                 e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
   }
 
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -37,6 +37,7 @@ public class IndexSchemaValidatorUtil {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(IndexSchemaValidatorUtil.class);
   private static final Pattern VERSION_PATTERN = Pattern.compile(".*-(\\d+\\.\\d+\\.\\d+.*)_.*");
+  private static final String STRICT_DYNAMIC_POLICY = "strict";
   @Autowired TasklistProperties tasklistProperties;
   @Autowired SchemaManager schemaManager;
 
@@ -76,7 +77,7 @@ public class IndexSchemaValidatorUtil {
       final Map<String, IndexMapping> indexMappings, final IndexDescriptor indexDescriptor) {
     return Maps.filterEntries(
         indexMappings,
-        e ->  "strict".equals(e.getValue().getDynamic()) && // filter out dynamic mappings - not supported by schema migration
+        e ->  STRICT_DYNAMIC_POLICY.equals(e.getValue().getDynamic()) && // filter out dynamic mappings - not supported by schema migration
                  e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()));
   }
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/util/IndexSchemaValidatorUtil.java
@@ -76,8 +76,8 @@ public class IndexSchemaValidatorUtil {
       final Map<String, IndexMapping> indexMappings, final IndexDescriptor indexDescriptor) {
     return Maps.filterEntries(
         indexMappings,
-        e -> e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern()) &&
-            "true".equals(e.getValue().getDynamic())); // filter out dynamic mappings - not supported by schema migration
+        e ->  "true".equals(e.getValue().getDynamic())) && // filter out dynamic mappings - not supported by schema migration 
+                 e.getKey().matches(indexDescriptor.getAllVersionsIndexNameRegexPattern());
   }
 
 

--- a/tasklist/els-schema/src/main/resources/schema/es/change/8.6.0-0_process-bpmnXml.json
+++ b/tasklist/els-schema/src/main/resources/schema/es/change/8.6.0-0_process-bpmnXml.json
@@ -1,8 +1,0 @@
-{
-  "description": "Set JOB_WORKER implementation for 'task' index",
-  "@type": "processorStep",
-  "indexName": "process",
-  "version": "8.6.0",
-  "order": 0,
-  "content": "{\"set\": {\"field\": \"bpmnXml\", \"value\": \"\"}}"
-}

--- a/tasklist/els-schema/src/main/resources/schema/os/change/8.6.0-0_process-bpmnXml.json
+++ b/tasklist/els-schema/src/main/resources/schema/os/change/8.6.0-0_process-bpmnXml.json
@@ -1,8 +1,0 @@
-{
-  "description": "Set JOB_WORKER implementation for 'task' index",
-  "@type": "processorStep",
-  "indexName": "process",
-  "version": "8.6.0",
-  "order": 0,
-  "content": "{\"set\": {\"field\": \"bpmnXml\", \"value\": \"\"}}"
-}


### PR DESCRIPTION
## Description

Dynamic schema is not applicable for Schema Updates, once the schema is update dynamically by the data is inserted

(Only web session index wont be inside of schema updates on dynamic way because the schema is managed over dynamic way on the SaaS)

