### PR TITLE
fix: Prevent completed tasks from being included in persistable custom filters search

### DIFF
--- a/tasklist/client/src/modules/utils/getQueryVariables.test.ts
+++ b/tasklist/client/src/modules/utils/getQueryVariables.test.ts
@@ -1,0 +1,409 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import type {TasksSearchBody} from 'modules/types';
+import {getQueryVariables} from './getQueryVariables';
+import {storeStateLocally} from './localStorage';
+
+function mergeWithDefaultQuery(
+  query: Partial<TasksSearchBody>,
+): TasksSearchBody {
+  return {
+    pageSize: undefined,
+    searchAfter: undefined,
+    searchAfterOrEqual: undefined,
+    searchBefore: undefined,
+    searchBeforeOrEqual: undefined,
+    ...query,
+  };
+}
+
+describe('getQueryVariables()', () => {
+  it('should return correct query body for all open tasks filter', () => {
+    expect(
+      getQueryVariables(
+        {
+          filter: 'all-open',
+          sortBy: 'creation',
+          sortOrder: 'asc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'creationTime',
+            order: 'ASC',
+          },
+        ],
+        state: 'CREATED',
+      }),
+    );
+  });
+
+  it('should return correct query body for assigned to me filter', () => {
+    expect(
+      getQueryVariables(
+        {
+          filter: 'assigned-to-me',
+          sortBy: 'creation',
+          sortOrder: 'asc',
+        },
+        {
+          assignee: 'demo',
+        },
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'creationTime',
+            order: 'ASC',
+          },
+        ],
+        assigned: true,
+        assignee: 'demo',
+        state: 'CREATED',
+      }),
+    );
+  });
+
+  it('should return correct query body for unassigned filter', () => {
+    expect(
+      getQueryVariables(
+        {
+          filter: 'unassigned',
+          sortBy: 'creation',
+          sortOrder: 'asc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'creationTime',
+            order: 'ASC',
+          },
+        ],
+        assigned: false,
+        state: 'CREATED',
+      }),
+    );
+  });
+
+  it('should return correct query body for completed filter', () => {
+    expect(
+      getQueryVariables(
+        {
+          filter: 'completed',
+          sortBy: 'creation',
+          sortOrder: 'asc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'creationTime',
+            order: 'ASC',
+          },
+        ],
+        state: 'COMPLETED',
+      }),
+    );
+  });
+
+  it('should return correct query body for custom filter', () => {
+    storeStateLocally('customFilters', {
+      custom: {
+        assignee: 'all',
+        status: 'all',
+        variables: [
+          {
+            name: 'var1',
+            value: 'value1',
+          },
+          {
+            name: 'var2',
+            value: 'value2',
+          },
+        ],
+      },
+    });
+    expect(
+      getQueryVariables(
+        {
+          filter: 'custom',
+          sortBy: 'creation',
+          sortOrder: 'asc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'creationTime',
+            order: 'ASC',
+          },
+        ],
+        taskVariables: [
+          {
+            name: 'var1',
+            value: 'value1',
+            operator: 'eq',
+          },
+          {
+            name: 'var2',
+            value: 'value2',
+            operator: 'eq',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('should return correct query body for persistable custom filter', () => {
+    storeStateLocally('customFilters', {
+      '55283997-c3c1-43c4-9b6d-9a1a3de0b2ac': {
+        assignee: 'all',
+        status: 'all',
+        variables: [
+          {
+            name: 'var1',
+            value: 'value1',
+          },
+          {
+            name: 'var2',
+            value: 'value2',
+          },
+        ],
+      },
+    });
+    expect(
+      getQueryVariables(
+        {
+          filter: '55283997-c3c1-43c4-9b6d-9a1a3de0b2ac',
+          sortBy: 'creation',
+          sortOrder: 'asc',
+        },
+        {
+          assignee: 'demo',
+        },
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'creationTime',
+            order: 'ASC',
+          },
+        ],
+        taskVariables: [
+          {
+            name: 'var1',
+            value: 'value1',
+            operator: 'eq',
+          },
+          {
+            name: 'var2',
+            value: 'value2',
+            operator: 'eq',
+          },
+        ],
+      }),
+    );
+  });
+
+  it('should return correct query body for page params', () => {
+    expect(
+      getQueryVariables(
+        {
+          filter: 'custom',
+          sortBy: 'creation',
+          sortOrder: 'asc',
+        },
+        {
+          searchAfter: [
+            '2023-08-25T15:41:45.322+0300',
+            '2023-08-25T15:41:45.322+0300',
+          ],
+          searchAfterOrEqual: [
+            '2023-08-25T15:41:45.322+0300',
+            '2023-08-25T15:41:45.322+0300',
+          ],
+          searchBefore: [
+            '2023-08-25T15:41:45.322+0300',
+            '2023-08-25T15:41:45.322+0300',
+          ],
+          searchBeforeOrEqual: [
+            '2023-08-25T15:41:45.322+0300',
+            '2023-08-25T15:41:45.322+0300',
+          ],
+          pageSize: 10,
+        },
+      ),
+    ).toStrictEqual({
+      sort: [
+        {
+          field: 'creationTime',
+          order: 'ASC',
+        },
+      ],
+      pageSize: 10,
+      searchAfter: [
+        '2023-08-25T15:41:45.322+0300',
+        '2023-08-25T15:41:45.322+0300',
+      ],
+      searchAfterOrEqual: [
+        '2023-08-25T15:41:45.322+0300',
+        '2023-08-25T15:41:45.322+0300',
+      ],
+      searchBefore: [
+        '2023-08-25T15:41:45.322+0300',
+        '2023-08-25T15:41:45.322+0300',
+      ],
+      searchBeforeOrEqual: [
+        '2023-08-25T15:41:45.322+0300',
+        '2023-08-25T15:41:45.322+0300',
+      ],
+      taskVariables: undefined,
+    });
+  });
+
+  it('should return correct query body for sorting', () => {
+    expect(
+      getQueryVariables(
+        {
+          filter: 'all-open',
+          sortBy: 'due',
+          sortOrder: 'asc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'dueDate',
+            order: 'ASC',
+          },
+        ],
+        state: 'CREATED',
+      }),
+    );
+
+    expect(
+      getQueryVariables(
+        {
+          filter: 'all-open',
+          sortBy: 'due',
+          sortOrder: 'desc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'dueDate',
+            order: 'DESC',
+          },
+        ],
+        state: 'CREATED',
+      }),
+    );
+
+    expect(
+      getQueryVariables(
+        {
+          filter: 'all-open',
+          sortBy: 'follow-up',
+          sortOrder: 'asc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'followUpDate',
+            order: 'ASC',
+          },
+        ],
+        state: 'CREATED',
+      }),
+    );
+
+    expect(
+      getQueryVariables(
+        {
+          filter: 'all-open',
+          sortBy: 'follow-up',
+          sortOrder: 'desc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'followUpDate',
+            order: 'DESC',
+          },
+        ],
+        state: 'CREATED',
+      }),
+    );
+
+    expect(
+      getQueryVariables(
+        {
+          filter: 'all-open',
+          sortBy: 'completion',
+          sortOrder: 'asc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'completionTime',
+            order: 'ASC',
+          },
+        ],
+        state: 'CREATED',
+      }),
+    );
+
+    expect(
+      getQueryVariables(
+        {
+          filter: 'all-open',
+          sortBy: 'completion',
+          sortOrder: 'desc',
+        },
+        {},
+      ),
+    ).toStrictEqual(
+      mergeWithDefaultQuery({
+        sort: [
+          {
+            field: 'completionTime',
+            order: 'DESC',
+          },
+        ],
+        state: 'CREATED',
+      }),
+    );
+  });
+});

--- a/tasklist/client/src/modules/utils/getQueryVariables.tsx
+++ b/tasklist/client/src/modules/utils/getQueryVariables.tsx
@@ -22,11 +22,20 @@ const SORT_BY_FIELD: Record<
 };
 
 const getQueryVariables = (
-  filters: TaskFilters,
+  filters: Omit<
+    TaskFilters,
+    | 'assignee'
+    | 'pageSize'
+    | 'searchBefore'
+    | 'searchBeforeOrEqual'
+    | 'searchAfter'
+    | 'searchAfterOrEqual'
+  >,
   {
     assignee,
     pageSize,
     searchBefore,
+    searchBeforeOrEqual,
     searchAfter,
     searchAfterOrEqual,
   }: Pick<
@@ -34,6 +43,7 @@ const getQueryVariables = (
     | 'assignee'
     | 'pageSize'
     | 'searchBefore'
+    | 'searchBeforeOrEqual'
     | 'searchAfter'
     | 'searchAfterOrEqual'
   >,
@@ -48,6 +58,7 @@ const getQueryVariables = (
     ],
     pageSize,
     searchBefore,
+    searchBeforeOrEqual,
     searchAfter,
     searchAfterOrEqual,
   };
@@ -81,26 +92,20 @@ const getQueryVariables = (
         ...parsedFilters,
       };
     }
-    case 'custom': {
+    case 'all-open': {
+      return {
+        ...BASE_QUERY_VARIABLES,
+        state: 'CREATED',
+        ...parsedFilters,
+      };
+    }
+    case 'custom':
+    default: {
       return {
         ...BASE_QUERY_VARIABLES,
         ...parsedFilters,
         taskVariables,
       };
-    }
-    case 'all-open':
-    default: {
-      return taskVariables === undefined
-        ? {
-            ...BASE_QUERY_VARIABLES,
-            state: 'CREATED',
-            ...parsedFilters,
-          }
-        : {
-            ...BASE_QUERY_VARIABLES,
-            ...parsedFilters,
-            taskVariables,
-          };
     }
   }
 };


### PR DESCRIPTION
## Related issues

closes #18967
