### PR TITLE
refactor: Tasklist part of C8 single application

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -126,12 +126,6 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>operate-webapp</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
 
     <dependency>
@@ -163,12 +157,21 @@
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>tasklist-webapp</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-common</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-archiver</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>tasklist-importer</artifactId>
     </dependency>
 
     <dependency>
@@ -615,12 +618,10 @@
             <!-- Needed for configuring the Identity SDK by providing an IdentityConfiguration bean -->
             <dependency>io.camunda:identity-spring-boot-autoconfigure</dependency>
 
-            <dependency>io.camunda:operate-webapp</dependency>
             <dependency>io.camunda:operate-data-generator</dependency>
             <dependency>io.camunda:operate-archiver</dependency>
             <dependency>io.camunda:operate-importer</dependency>
 
-            <dependency>io.camunda:tasklist-webapp</dependency>
             <dependency>io.camunda:tasklist-data-generator</dependency>
 
             <!-- Used to parse PKCS1 certificates -->

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -14,7 +14,6 @@ import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.application.sources.DefaultObjectMapperConfiguration;
-import io.camunda.application.sources.TasklistSecurityStubsConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
 import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
@@ -42,7 +41,6 @@ public class StandaloneCamunda {
             .sources(
                 OperateModuleConfiguration.class,
                 TasklistModuleConfiguration.class,
-                TasklistSecurityStubsConfiguration.class,
                 WebappsModuleConfiguration.class,
                 BrokerModuleConfiguration.class,
                 GatewayModuleConfiguration.class,

--- a/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneCamunda.java
@@ -13,7 +13,10 @@ import io.camunda.application.initializers.DefaultAuthenticationInitializer;
 import io.camunda.application.initializers.HealthConfigurationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
+import io.camunda.application.sources.DefaultObjectMapperConfiguration;
+import io.camunda.application.sources.TasklistSecurityStubsConfiguration;
 import io.camunda.operate.OperateModuleConfiguration;
+import io.camunda.tasklist.TasklistModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import io.camunda.zeebe.broker.BrokerModuleConfiguration;
 import io.camunda.zeebe.gateway.GatewayModuleConfiguration;
@@ -26,7 +29,7 @@ public class StandaloneCamunda {
 
   private static final String SPRING_PROFILES_ACTIVE_PROPERTY = ACTIVE_PROFILES_PROPERTY_NAME;
   private static final String DEFAULT_CAMUNDA_PROFILES =
-      String.format("%s,%s", Profile.OPERATE.getId(), Profile.BROKER.getId());
+      String.join(",", Profile.OPERATE.getId(), Profile.TASKLIST.getId(), Profile.BROKER.getId());
 
   public static void main(final String[] args) {
     MainSupport.setDefaultGlobalConfiguration();
@@ -38,9 +41,12 @@ public class StandaloneCamunda {
         MainSupport.createDefaultApplicationBuilder()
             .sources(
                 OperateModuleConfiguration.class,
+                TasklistModuleConfiguration.class,
+                TasklistSecurityStubsConfiguration.class,
                 WebappsModuleConfiguration.class,
                 BrokerModuleConfiguration.class,
-                GatewayModuleConfiguration.class)
+                GatewayModuleConfiguration.class,
+                DefaultObjectMapperConfiguration.class)
             .properties(defaultActiveProfiles)
             .initializers(
                 new DefaultAuthenticationInitializer(),

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -51,13 +51,8 @@ public class StandaloneOperate {
 
   private static Map<String, Object> getDefaultProperties() {
     final Map<String, Object> defaultsProperties = new HashMap<>();
-    defaultsProperties.putAll(getWebProperties());
     defaultsProperties.putAll(getManagementProperties());
     return defaultsProperties;
-  }
-
-  private static Map<String, Object> getWebProperties() {
-    return Map.of("server.servlet.session.cookie.name", "OPERATE-SESSION");
   }
 
   public static Map<String, Object> getManagementProperties() {

--- a/dist/src/main/java/io/camunda/application/StandaloneOperate.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneOperate.java
@@ -57,13 +57,7 @@ public class StandaloneOperate {
   }
 
   private static Map<String, Object> getWebProperties() {
-    return Map.of(
-        "server.servlet.session.cookie.name",
-        "OPERATE-SESSION",
-        // Return error messages for all endpoints by default, except for Internal API.
-        // Internal API error handling is defined in InternalAPIErrorController.
-        "server.error.include-message",
-        "always");
+    return Map.of("server.servlet.session.cookie.name", "OPERATE-SESSION");
   }
 
   public static Map<String, Object> getManagementProperties() {

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -46,13 +46,8 @@ public class StandaloneTasklist {
 
   private static Map<String, Object> getDefaultProperties() {
     final Map<String, Object> defaultsProperties = new HashMap<>();
-    defaultsProperties.putAll(getWebProperties());
     defaultsProperties.putAll(getManagementProperties());
     return defaultsProperties;
-  }
-
-  private static Map<String, Object> getWebProperties() {
-    return Map.of("server.servlet.session.cookie.name", "TASKLIST-SESSION");
   }
 
   public static Map<String, Object> getManagementProperties() {

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -11,7 +11,13 @@ import io.camunda.application.initializers.DefaultAuthenticationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.tasklist.TasklistModuleConfiguration;
+import io.camunda.tasklist.archiver.security.ArchiverSecurityModuleConfiguration;
+import io.camunda.tasklist.webapp.management.WebappManagementModuleConfiguration;
+import io.camunda.tasklist.webapp.security.WebappSecurityModuleConfiguration;
+import io.camunda.tasklist.zeebeimport.security.ImporterSecurityModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.boot.SpringBootConfiguration;
 
 @SpringBootConfiguration(proxyBeanMethods = false)
@@ -30,14 +36,53 @@ public class StandaloneTasklist {
 
     final var standaloneTasklistApplication =
         MainSupport.createDefaultApplicationBuilder()
-            .sources(TasklistModuleConfiguration.class, WebappsModuleConfiguration.class)
+            .sources(
+                TasklistModuleConfiguration.class,
+                WebappSecurityModuleConfiguration.class,
+                ArchiverSecurityModuleConfiguration.class,
+                ImporterSecurityModuleConfiguration.class,
+                WebappManagementModuleConfiguration.class,
+                WebappsModuleConfiguration.class)
             .profiles(Profile.TASKLIST.getId(), Profile.STANDALONE.getId())
             .addCommandLineProperties(true)
+            .properties(getDefaultProperties())
             .initializers(
                 new DefaultAuthenticationInitializer(), new WebappsConfigurationInitializer())
             .listeners(new ApplicationErrorListener())
             .build(args);
 
     standaloneTasklistApplication.run(args);
+  }
+
+  private static Map<String, Object> getDefaultProperties() {
+    final Map<String, Object> defaultsProperties = new HashMap<>();
+    defaultsProperties.putAll(getWebProperties());
+    defaultsProperties.putAll(getManagementProperties());
+    return defaultsProperties;
+  }
+
+  private static Map<String, Object> getWebProperties() {
+    return Map.of("server.servlet.session.cookie.name", "TASKLIST-SESSION");
+  }
+
+  public static Map<String, Object> getManagementProperties() {
+    return Map.of(
+        // disable default health indicators:
+        // https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-health-indicators
+        "management.health.defaults.enabled",
+        false,
+
+        // enable Kubernetes health groups:
+        // https://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-features.html#production-ready-kubernetes-probes
+        "management.endpoint.health.probes.enabled",
+        true,
+
+        // enable health check and metrics endpoints
+        "management.endpoints.web.exposure.include",
+        "health, prometheus, loggers, usage-metrics, backups",
+
+        // add custom check to standard readiness check
+        "management.endpoint.health.group.readiness.include",
+        "readinessState, searchEngineCheck");
   }
 }

--- a/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
+++ b/dist/src/main/java/io/camunda/application/StandaloneTasklist.java
@@ -11,10 +11,6 @@ import io.camunda.application.initializers.DefaultAuthenticationInitializer;
 import io.camunda.application.initializers.WebappsConfigurationInitializer;
 import io.camunda.application.listeners.ApplicationErrorListener;
 import io.camunda.tasklist.TasklistModuleConfiguration;
-import io.camunda.tasklist.archiver.security.ArchiverSecurityModuleConfiguration;
-import io.camunda.tasklist.webapp.management.WebappManagementModuleConfiguration;
-import io.camunda.tasklist.webapp.security.WebappSecurityModuleConfiguration;
-import io.camunda.tasklist.zeebeimport.security.ImporterSecurityModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import java.util.HashMap;
 import java.util.Map;
@@ -36,13 +32,7 @@ public class StandaloneTasklist {
 
     final var standaloneTasklistApplication =
         MainSupport.createDefaultApplicationBuilder()
-            .sources(
-                TasklistModuleConfiguration.class,
-                WebappSecurityModuleConfiguration.class,
-                ArchiverSecurityModuleConfiguration.class,
-                ImporterSecurityModuleConfiguration.class,
-                WebappManagementModuleConfiguration.class,
-                WebappsModuleConfiguration.class)
+            .sources(TasklistModuleConfiguration.class, WebappsModuleConfiguration.class)
             .profiles(Profile.TASKLIST.getId(), Profile.STANDALONE.getId())
             .addCommandLineProperties(true)
             .properties(getDefaultProperties())

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -12,6 +12,8 @@ import static io.camunda.application.Profile.OPERATE;
 import static io.camunda.application.Profile.SSO_AUTH;
 import static io.camunda.application.Profile.TASKLIST;
 
+import io.camunda.operate.webapp.security.OperateURIs;
+import io.camunda.tasklist.webapp.security.TasklistURIs;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Set;
@@ -26,7 +28,8 @@ public class WebappsConfigurationInitializer
   private static final String CAMUNDA_WEBAPPS_DEFAULT_APP_PROPERTY = "camunda.webapps.default-app";
   private static final String CAMUNDA_WEBAPPS_LOGIN_DELEGATED_PROPERTY =
       "camunda.webapps.login-delegated";
-
+  private static final String SERVER_SERVLET_SESSION_COOKIE_NAME_PROPERTY =
+      "server.servlet.session.cookie.name";
   private static final Set<String> WEBAPPS_PROFILES = Set.of(OPERATE.getId(), TASKLIST.getId());
   private static final Set<String> LOGIN_DELEGATED_PROFILES =
       Set.of(IDENTITY_AUTH.getId(), SSO_AUTH.getId());
@@ -42,8 +45,14 @@ public class WebappsConfigurationInitializer
       propertyMap.put(CAMUNDA_WEBAPPS_ENABLED_PROPERTY, true);
       if (activeProfiles.contains(OPERATE.getId())) {
         propertyMap.put(CAMUNDA_WEBAPPS_DEFAULT_APP_PROPERTY, OPERATE.getId());
+        // When Operate and Tasklist are run in a single C8 application, the session cookie name of
+        // Operate is used, as currently, we only utilize Operate's security package for this single
+        // app configuration.
+        propertyMap.put(SERVER_SERVLET_SESSION_COOKIE_NAME_PROPERTY, OperateURIs.COOKIE_JSESSIONID);
       } else if (activeProfiles.contains(TASKLIST.getId())) {
         propertyMap.put(CAMUNDA_WEBAPPS_DEFAULT_APP_PROPERTY, TASKLIST.getId());
+        propertyMap.put(
+            SERVER_SERVLET_SESSION_COOKIE_NAME_PROPERTY, TasklistURIs.COOKIE_JSESSIONID);
       }
       propertyMap.put(
           CAMUNDA_WEBAPPS_LOGIN_DELEGATED_PROPERTY,

--- a/dist/src/main/java/io/camunda/application/sources/DefaultObjectMapperConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/sources/DefaultObjectMapperConfiguration.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.sources;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+/**
+ * Configuration that provides a default ObjectMapper bean to be used when multiple custom
+ * ObjectMappers are present in the application context: operateObjectMapper, tasklistObjectMapper.
+ *
+ * <p>To be removed once, custom object mappers are unified.
+ *
+ * <p>Example of places where this default object mapper is used:
+ * <li>- {@link io.camunda.zeebe.shared.security.ProblemAuthFailureHandler}
+ * <li>- {@link io.camunda.authentication.handler.AuthFailureHandler}
+ * <li>- {@link
+ *     org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointAutoConfiguration}
+ */
+@Configuration
+public class DefaultObjectMapperConfiguration {
+  @Bean
+  @Primary
+  @ConditionalOnBean(name = {"operateObjectMapper", "tasklistObjectMapper"})
+  public ObjectMapper defaultObjectMapper() {
+    return Jackson2ObjectMapperBuilder.json().build();
+  }
+}

--- a/dist/src/main/java/io/camunda/application/sources/DefaultObjectMapperConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/sources/DefaultObjectMapperConfiguration.java
@@ -26,7 +26,7 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
  * <li>- {@link
  *     org.springframework.boot.actuate.autoconfigure.endpoint.jmx.JmxEndpointAutoConfiguration}
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 public class DefaultObjectMapperConfiguration {
   @Bean
   @Primary

--- a/dist/src/main/java/io/camunda/application/sources/TasklistSecurityStubsConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/sources/TasklistSecurityStubsConfiguration.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.application.sources;
+
+import io.camunda.operate.webapp.security.UserService;
+import io.camunda.tasklist.property.IdentityProperties;
+import io.camunda.tasklist.webapp.graphql.entity.UserDTO;
+import io.camunda.tasklist.webapp.security.AssigneeMigrator;
+import io.camunda.tasklist.webapp.security.AssigneeMigratorNoImpl;
+import io.camunda.tasklist.webapp.security.Permission;
+import io.camunda.tasklist.webapp.security.TasklistProfileService;
+import io.camunda.tasklist.webapp.security.UserReader;
+import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
+import io.camunda.tasklist.webapp.security.tenant.TenantService;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Temporary configuration required to start Tasklist as part of C8 single application.
+ *
+ * <p>Tasklist security package is excluded from the configuration of C8 single application to avoid
+ * the conflicts with the existing Operate WebSecurity configuration. This will be solved after the
+ * creation of a common Security layer.
+ *
+ * <p>For now, only default AUTH authentication is supported for Tasklist when run in C8 single
+ * application.
+ *
+ * <p>TasklistSecurityStubsConfiguration provides the security related bean stubs required by the
+ * service layer of Tasklist.
+ */
+@Configuration
+@Profile("tasklist")
+public class TasklistSecurityStubsConfiguration {
+
+  /** UserReader that gets user details using Operate's UserService */
+  @Bean
+  public UserReader stubUserReader(final UserService userService) {
+    return new UserReader() {
+
+      @Override
+      public UserDTO getCurrentUser() {
+        final var operateUserDto = userService.getCurrentUser();
+        return new UserDTO()
+            .setUserId(operateUserDto.getUserId())
+            .setDisplayName(operateUserDto.getDisplayName())
+            .setPermissions(List.of(Permission.READ, Permission.WRITE));
+      }
+
+      @Override
+      public Optional<UserDTO> getCurrentUserBy(final Authentication authentication) {
+        return Optional.empty();
+      }
+
+      @Override
+      public String getCurrentOrganizationId() {
+        return DEFAULT_ORGANIZATION;
+      }
+
+      @Override
+      public String getCurrentUserId() {
+        return getCurrentUser().getUserId();
+      }
+
+      /** used for GraphQL only */
+      @Override
+      public List<UserDTO> getUsersByUsernames(final List<String> usernames) {
+        return List.of();
+      }
+
+      /** used in SSO only */
+      @Override
+      public Optional<String> getUserToken(final Authentication authentication) {
+        return Optional.empty();
+      }
+    };
+  }
+
+  @Bean
+  public TenantService stubTenantService() {
+    return new TenantService() {
+      @Override
+      public AuthenticatedTenants getAuthenticatedTenants() {
+        return AuthenticatedTenants.allTenants();
+      }
+
+      @Override
+      public boolean isTenantValid(final String tenantId) {
+        return true;
+      }
+
+      @Override
+      public boolean isMultiTenancyEnabled() {
+        return false;
+      }
+    };
+  }
+
+  @Bean
+  public AssigneeMigrator stubAssigneeMigrator() {
+    return new AssigneeMigratorNoImpl();
+  }
+
+  /** stub to IdentityAuthorizationService that provides full access to user */
+  @Bean
+  public IdentityAuthorizationService stubIdentityAuthorizationService() {
+    return new IdentityAuthorizationService() {
+
+      @Override
+      public List<String> getUserGroups() {
+        return List.of(IdentityProperties.FULL_GROUP_ACCESS);
+      }
+
+      @Override
+      public boolean isAllowedToStartProcess(final String processDefinitionKey) {
+        return true;
+      }
+
+      @Override
+      public List<String> getProcessReadFromAuthorization() {
+        return List.of(IdentityProperties.ALL_RESOURCES);
+      }
+
+      @Override
+      public List<String> getProcessDefinitionsFromAuthorization() {
+        return List.of(IdentityProperties.ALL_RESOURCES);
+      }
+    };
+  }
+
+  @Bean
+  public TasklistProfileService stubTasklistProfileService() {
+    return new TasklistProfileService() {
+
+      @Override
+      public String getMessageByProfileFor(final Exception exception) {
+        return "";
+      }
+
+      @Override
+      public boolean currentProfileCanLogout() {
+        return true;
+      }
+
+      @Override
+      public boolean isLoginDelegated() {
+        return false;
+      }
+    };
+  }
+}

--- a/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
@@ -8,6 +8,10 @@
 package io.camunda.tasklist;
 
 import graphql.kickstart.autoconfigure.annotations.GraphQLAnnotationsAutoConfiguration;
+import io.camunda.tasklist.archiver.security.ArchiverSecurityModuleConfiguration;
+import io.camunda.tasklist.webapp.management.WebappManagementModuleConfiguration;
+import io.camunda.tasklist.webapp.security.WebappSecurityModuleConfiguration;
+import io.camunda.tasklist.zeebeimport.security.ImporterSecurityModuleConfiguration;
 import io.camunda.zeebe.broker.Broker;
 import io.camunda.zeebe.gateway.Gateway;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -17,6 +21,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
+import org.springframework.context.annotation.Import;
 import org.springframework.context.annotation.Profile;
 
 /**
@@ -65,4 +70,18 @@ public class TasklistModuleConfiguration {
     this.broker = broker;
     this.gateway = gateway;
   }
+
+  @Configuration(proxyBeanMethods = false)
+  @Import({
+    WebappSecurityModuleConfiguration.class,
+    ArchiverSecurityModuleConfiguration.class,
+    ImporterSecurityModuleConfiguration.class
+  })
+  @Profile("!operate")
+  public static class TasklistSecurityModulesConfiguration {}
+
+  @Configuration(proxyBeanMethods = false)
+  @Import(WebappManagementModuleConfiguration.class)
+  @Profile("!operate")
+  public static class TasklistManagementModulesConfiguration {}
 }

--- a/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/tasklist/TasklistModuleConfiguration.java
@@ -8,6 +8,9 @@
 package io.camunda.tasklist;
 
 import graphql.kickstart.autoconfigure.annotations.GraphQLAnnotationsAutoConfiguration;
+import io.camunda.zeebe.broker.Broker;
+import io.camunda.zeebe.gateway.Gateway;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.elasticsearch.ElasticsearchClientAutoConfiguration;
 import org.springframework.context.annotation.ComponentScan;
@@ -47,4 +50,19 @@ import org.springframework.context.annotation.Profile;
       GraphQLAnnotationsAutoConfiguration.class
     })
 @Profile("tasklist")
-public class TasklistModuleConfiguration {}
+public class TasklistModuleConfiguration {
+  // if present, then it will ensure
+  // that the broker is started first
+  private final Broker broker;
+
+  // if present, then it will ensure
+  // that the gateway is started first
+  private final Gateway gateway;
+
+  public TasklistModuleConfiguration(
+      @Autowired(required = false) final Broker broker,
+      @Autowired(required = false) final Gateway gateway) {
+    this.broker = broker;
+    this.gateway = gateway;
+  }
+}

--- a/dist/src/main/java/io/camunda/tasklist/TasklistSecurityStubsConfiguration.java
+++ b/dist/src/main/java/io/camunda/tasklist/TasklistSecurityStubsConfiguration.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.application.sources;
+package io.camunda.tasklist;
 
 import io.camunda.operate.webapp.security.UserService;
 import io.camunda.tasklist.property.IdentityProperties;
@@ -37,8 +37,8 @@ import org.springframework.security.core.Authentication;
  * <p>TasklistSecurityStubsConfiguration provides the security related bean stubs required by the
  * service layer of Tasklist.
  */
-@Configuration
-@Profile("tasklist")
+@Configuration(proxyBeanMethods = false)
+@Profile("tasklist && operate")
 public class TasklistSecurityStubsConfiguration {
 
   /** UserReader that gets user details using Operate's UserService */

--- a/dist/src/main/resources/application-operate.properties
+++ b/dist/src/main/resources/application-operate.properties
@@ -1,5 +1,3 @@
-server.servlet.session.cookie.name=OPERATE-SESSION
-
 # allow static resource mappings
 spring.web.resources.add-mappings=true
 spring.web.resources.static-locations=classpath:/META-INF/resources/operate/

--- a/dist/src/main/resources/application-tasklist.properties
+++ b/dist/src/main/resources/application-tasklist.properties
@@ -1,19 +1,12 @@
+# allow static resource mappings
 spring.web.resources.add-mappings=true
 spring.web.resources.static-locations=classpath:/META-INF/resources/tasklist/
+
 # configure thymeleaf used by index.html
 spring.thymeleaf.check-template-location=true
 spring.thymeleaf.prefix=classpath:/META-INF/resources/
 
-server.servlet.session.cookie.name=TASKLIST-SESSION
-# Return error messages for all endpoints by default, except for Internal API.
-# Internal API error handling is defined in InternalAPIErrorController.
-server.error.include-message=always
-
-management.health.defaults.enabled=false
-management.endpoint.health.probes.enabled=true
-management.endpoints.web.exposure.include=health,prometheus,loggers,usage-metrics,backups
-management.endpoint.health.group.readiness.include=readinessState,searchEngineCheck
-
+# graphql configuration
 graphql.playground.enabled=false
 graphql.servlet.exception-handlers-enabled=true
 graphql.extended-scalars=DateTime

--- a/operate/common/src/main/java/io/camunda/operate/JacksonConfig.java
+++ b/operate/common/src/main/java/io/camunda/operate/JacksonConfig.java
@@ -22,9 +22,11 @@ import io.camunda.operate.connect.OperateDateTimeFormatter;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 
 @Configuration
 public class JacksonConfig {
@@ -65,5 +67,11 @@ public class JacksonConfig {
   @Bean
   public DateTimeFormatter dateTimeFormatter(final OperateDateTimeFormatter dateTimeFormatter) {
     return dateTimeFormatter.getGeneralDateTimeFormatter();
+  }
+
+  @Bean
+  public MappingJackson2HttpMessageConverter mappingJackson2HttpMessageConverter(
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
+    return new MappingJackson2HttpMessageConverter(objectMapper);
   }
 }

--- a/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
+++ b/operate/data-generator/src/main/java/io/camunda/operate/data/AbstractDataGenerator.java
@@ -25,13 +25,18 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.DependsOn;
 
 @DependsOn("schemaStartup")
 public abstract class AbstractDataGenerator implements DataGenerator {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractDataGenerator.class);
-  @Autowired protected ZeebeClient client;
+
+  @Autowired
+  @Qualifier("zeebeClient")
+  protected ZeebeClient client;
+
   @Autowired protected OperateProperties operateProperties;
   protected boolean manuallyCalled = false;
   protected ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(3);

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/UserTaskZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/v8_5/processors/UserTaskZeebeRecordProcessor.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -56,7 +57,8 @@ public class UserTaskZeebeRecordProcessor {
           this::getCanceledFields);
 
   public UserTaskZeebeRecordProcessor(
-      final UserTaskTemplate userTaskTemplate, final ObjectMapper objectMapper) {
+      final UserTaskTemplate userTaskTemplate,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.userTaskTemplate = userTaskTemplate;
     this.objectMapper = objectMapper;
   }

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/UserTaskZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/UserTaskZeebeRecordProcessor.java
@@ -25,6 +25,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -56,7 +57,8 @@ public class UserTaskZeebeRecordProcessor {
           this::getCanceledFields);
 
   public UserTaskZeebeRecordProcessor(
-      final UserTaskTemplate userTaskTemplate, final ObjectMapper objectMapper) {
+      final UserTaskTemplate userTaskTemplate,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.userTaskTemplate = userTaskTemplate;
     this.objectMapper = objectMapper;
   }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -60,7 +61,10 @@ public class OperateSearchAbstractIT {
   @Autowired protected TestSearchRepository testSearchRepository;
   @Autowired protected SearchContainerManager searchContainerManager;
   @Autowired protected TestResourceManager testResourceManager;
-  @Autowired protected ObjectMapper objectMapper;
+
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  protected ObjectMapper objectMapper;
 
   @BeforeAll
   public void beforeAllSetup() throws Exception {

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestElasticSearchRepository.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/searchrepository/TestElasticSearchRepository.java
@@ -73,7 +73,9 @@ public class TestElasticSearchRepository implements TestSearchRepository {
   @Qualifier("zeebeEsClient")
   private RestHighLevelClient zeebeEsClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public boolean isConnected() {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchProcessStore.java
@@ -89,6 +89,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
@@ -124,7 +125,7 @@ public class ElasticsearchProcessStore implements ProcessStore {
       ProcessIndex processIndex,
       ListViewTemplate listViewTemplate,
       List<ProcessInstanceDependant> processInstanceDependantTemplates,
-      ObjectMapper objectMapper,
+      @Qualifier("operateObjectMapper") ObjectMapper objectMapper,
       OperateProperties operateProperties,
       RestHighLevelClient esClient,
       TenantAwareElasticsearchClient tenantAwareClient) {

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchUserStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchUserStore.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
@@ -52,7 +53,9 @@ public class ElasticsearchUserStore implements UserStore {
 
   @Autowired protected RestHighLevelClient esClient;
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  protected ObjectMapper objectMapper;
 
   @Autowired private UserIndex userIndex;
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/dao/UsageMetricDAO.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/dao/UsageMetricDAO.java
@@ -13,6 +13,7 @@ import io.camunda.operate.entities.MetricEntity;
 import io.camunda.operate.schema.indices.MetricIndex;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -21,7 +22,9 @@ import org.springframework.stereotype.Component;
 public class UsageMetricDAO extends GenericDAO<MetricEntity, MetricIndex> {
   @Autowired
   public UsageMetricDAO(
-      ObjectMapper objectMapper, MetricIndex index, RestHighLevelClient esClient) {
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
+      final MetricIndex index,
+      final RestHighLevelClient esClient) {
     super(objectMapper, index, esClient);
   }
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDao.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/api/v1/dao/elasticsearch/ElasticsearchDao.java
@@ -42,7 +42,9 @@ public abstract class ElasticsearchDao<T> {
 
   @Autowired protected TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  protected ObjectMapper objectMapper;
 
   @Autowired protected OperateDateTimeFormatter dateTimeFormatter;
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/AbstractReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/AbstractReader.java
@@ -19,6 +19,7 @@ import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.aggregations.Aggregations;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class AbstractReader {
 
@@ -26,7 +27,9 @@ public abstract class AbstractReader {
 
   @Autowired protected TenantAwareElasticsearchClient tenantAwareClient;
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  protected ObjectMapper objectMapper;
 
   protected <T extends OperateEntity> List<T> scroll(SearchRequest searchRequest, Class<T> clazz)
       throws IOException {

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/EventReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/EventReader.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -40,7 +41,7 @@ public class EventReader implements io.camunda.operate.webapp.reader.EventReader
   public EventReader(
       final EventTemplate eventTemplate,
       final TenantAwareElasticsearchClient tenantAwareClient,
-      final ObjectMapper objectMapper) {
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.eventTemplate = eventTemplate;
     this.tenantAwareClient = tenantAwareClient;
     this.objectMapper = objectMapper;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/elasticsearch/reader/ProcessInstanceReader.java
@@ -22,6 +22,7 @@ import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -29,7 +30,10 @@ public class ProcessInstanceReader {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ProcessInstanceReader.class);
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  protected ObjectMapper objectMapper;
+
   @Autowired private ListViewTemplate listViewTemplate;
 
   @Autowired private ProcessStore processStore;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/transform/DataAggregator.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/transform/DataAggregator.java
@@ -15,10 +15,13 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.collections4.CollectionUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class DataAggregator {
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  protected ObjectMapper objectMapper;
 
   public abstract Map<String, BatchOperationDto> requestAndAddMetadata(
       Map<String, BatchOperationDto> resultDtos, List<String> ids);

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/writer/PersistOperationHelper.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /**
@@ -54,7 +55,7 @@ public class PersistOperationHelper {
       final ListViewTemplate listViewTemplate,
       final IncidentReader incidentReader,
       final UserService userService,
-      final ObjectMapper objectMapper) {
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.operationStore = operationStore;
     this.incidentReader = incidentReader;
     this.listViewStore = listViewStore;

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/MigrateProcessInstanceHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/zeebe/operation/MigrateProcessInstanceHandler.java
@@ -18,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 /** Operation handler to migrate process instances */
@@ -29,7 +30,8 @@ public class MigrateProcessInstanceHandler extends AbstractOperationHandler
 
   private final ObjectMapper objectMapper;
 
-  public MigrateProcessInstanceHandler(final ObjectMapper objectMapper) {
+  public MigrateProcessInstanceHandler(
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.objectMapper = objectMapper;
   }
 

--- a/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/security/ArchiverSecurityModuleConfiguration.java
+++ b/tasklist/archiver/src/main/java/io/camunda/tasklist/archiver/security/ArchiverSecurityModuleConfiguration.java
@@ -5,36 +5,19 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.tasklist;
+package io.camunda.tasklist.archiver.security;
 
-import jakarta.annotation.PostConstruct;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 
 @Configuration
 @ComponentScan(
-    basePackages = "io.camunda.tasklist.archiver",
-    excludeFilters = {
-      @ComponentScan.Filter(
-          type = FilterType.REGEX,
-          pattern = "io\\.camunda\\.tasklist\\.archiver\\.security\\..*")
-    },
+    basePackages = "io.camunda.tasklist.archiver.security",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
     name = "camunda.tasklist.archiverEnabled",
     havingValue = "true",
     matchIfMissing = true)
-public class ArchiverModuleConfiguration {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverModuleConfiguration.class);
-
-  @PostConstruct
-  public void logModule() {
-    LOGGER.info("Starting module: archiver");
-  }
-}
+public class ArchiverSecurityModuleConfiguration {}

--- a/tasklist/common/src/main/java/io/camunda/tasklist/JacksonConfig.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/JacksonConfig.java
@@ -56,13 +56,11 @@ public class JacksonConfig {
         .build();
   }
 
-  @Bean
-  public DateTimeFormatter dateTimeFormatter() {
+  private DateTimeFormatter dateTimeFormatter() {
     return DateTimeFormatter.ofPattern(tasklistProperties.getElasticsearch().getDateFormat());
   }
 
-  @Bean
-  public DateTimeFormatter localDateFormatter() {
+  private DateTimeFormatter localDateFormatter() {
     return DateTimeFormatter.ofPattern(tasklistProperties.getZeebeElasticsearch().getDateFormat());
   }
 }

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/es/RetryElasticsearchClient.java
@@ -102,7 +102,9 @@ public class RetryElasticsearchClient {
   @Qualifier("tasklistEsClient")
   private RestHighLevelClient esClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private ElasticsearchInternalTask elasticsearchTask;
 

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/ElasticsearchSchemaManager.java
@@ -51,6 +51,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -74,7 +75,9 @@ public class ElasticsearchSchemaManager implements SchemaManager {
 
   @Autowired protected TasklistProperties tasklistProperties;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Autowired private List<AbstractIndexDescriptor> indexDescriptors;
 

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/common/UserTaskRecordToTaskEntityMapper.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/common/UserTaskRecordToTaskEntityMapper.java
@@ -24,6 +24,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -44,7 +45,9 @@ public class UserTaskRecordToTaskEntityMapper {
 
   private final ObjectMapper objectMapper;
 
-  public UserTaskRecordToTaskEntityMapper(ObjectMapper objectMapper, FormStore formStore) {
+  public UserTaskRecordToTaskEntityMapper(
+      @Qualifier("tasklistObjectMapper") final ObjectMapper objectMapper,
+      final FormStore formStore) {
     this.objectMapper = objectMapper;
     this.formStore = formStore;
   }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToTaskEntityMapper.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/common/UserTaskRecordToTaskEntityMapper.java
@@ -24,6 +24,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -45,7 +46,8 @@ public class UserTaskRecordToTaskEntityMapper {
   private final ObjectMapper objectMapper;
 
   public UserTaskRecordToTaskEntityMapper(
-      final ObjectMapper objectMapper, final FormStore formStore) {
+      @Qualifier("tasklistObjectMapper") final ObjectMapper objectMapper,
+      final FormStore formStore) {
     this.objectMapper = objectMapper;
     this.formStore = formStore;
   }

--- a/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/util/XMLUtil.java
+++ b/tasklist/importer-common/src/main/java/io/camunda/tasklist/zeebeimport/util/XMLUtil.java
@@ -18,21 +18,17 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParserFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.stereotype.Component;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
 @Component
-@Configuration
 public class XMLUtil {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(XMLUtil.class);
 
-  @Bean
-  public SAXParserFactory getSAXParserFactory() {
+  private SAXParserFactory getSAXParserFactory() {
     final SAXParserFactory saxParserFactory = SAXParserFactory.newInstance();
     saxParserFactory.setNamespaceAware(true);
     try {

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/ImportModuleConfiguration.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/ImportModuleConfiguration.java
@@ -13,11 +13,17 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 
 @Configuration
 @ComponentScan(
     basePackages = "io.camunda.tasklist.zeebeimport",
+    excludeFilters = {
+      @ComponentScan.Filter(
+          type = FilterType.REGEX,
+          pattern = "io\\.camunda\\.tasklist\\.zeebeimport\\.security\\..*")
+    },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
     name = "camunda.tasklist.importerEnabled",

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolderAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportPositionHolderAbstract.java
@@ -41,7 +41,9 @@ public abstract class ImportPositionHolderAbstract implements ImportPositionHold
 
   @Autowired protected ImportPositionIndex importPositionType;
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  protected ObjectMapper objectMapper;
 
   @Autowired protected TasklistProperties tasklistProperties;
 

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/ImporterSecurityModuleConfiguration.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/security/ImporterSecurityModuleConfiguration.java
@@ -5,36 +5,19 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.tasklist;
+package io.camunda.tasklist.zeebeimport.security;
 
-import jakarta.annotation.PostConstruct;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 
 @Configuration
 @ComponentScan(
-    basePackages = "io.camunda.tasklist.archiver",
-    excludeFilters = {
-      @ComponentScan.Filter(
-          type = FilterType.REGEX,
-          pattern = "io\\.camunda\\.tasklist\\.archiver\\.security\\..*")
-    },
+    basePackages = "io.camunda.tasklist.zeebeimport.security",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.tasklist.archiverEnabled",
+    name = "camunda.tasklist.importerEnabled",
     havingValue = "true",
     matchIfMissing = true)
-public class ArchiverModuleConfiguration {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverModuleConfiguration.class);
-
-  @PostConstruct
-  public void logModule() {
-    LOGGER.info("Starting module: archiver");
-  }
-}
+public class ImporterSecurityModuleConfiguration {}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/management/HealthCheckAuthenticationIT.java
@@ -21,7 +21,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.TestUtil;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
 import io.camunda.tasklist.webapp.security.ElasticsearchSessionRepository;
-import io.camunda.tasklist.webapp.security.TasklistProfileService;
+import io.camunda.tasklist.webapp.security.TasklistProfileServiceImpl;
 import io.camunda.tasklist.webapp.security.WebSecurityConfig;
 import io.camunda.tasklist.webapp.security.oauth.OAuth2WebConfigurer;
 import org.junit.jupiter.api.BeforeAll;
@@ -47,7 +47,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       TestApplicationWithNoBeans.class,
       SearchEngineHealthIndicator.class,
       WebSecurityConfig.class,
-      TasklistProfileService.class,
+      TasklistProfileServiceImpl.class,
       ElasticsearchSessionRepository.class,
       RetryElasticsearchClient.class,
       ElasticsearchInternalTask.class,

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -33,7 +33,7 @@ import org.springframework.context.annotation.Import;
           value = TasklistModuleConfiguration.class),
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@Import(WebappsModuleConfiguration.class)
+@Import({WebappsModuleConfiguration.class})
 public class TestApplication {
 
   public static void main(final String[] args) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
@@ -8,11 +8,15 @@
 package io.camunda.tasklist.util.apps.modules;
 
 import io.camunda.tasklist.TasklistModuleConfiguration;
+import io.camunda.tasklist.archiver.security.ArchiverSecurityModuleConfiguration;
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.es.DevDataGeneratorElasticSearch;
 import io.camunda.tasklist.data.os.DevDataGeneratorOpenSearch;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
+import io.camunda.tasklist.webapp.management.WebappManagementModuleConfiguration;
+import io.camunda.tasklist.webapp.security.WebappSecurityModuleConfiguration;
+import io.camunda.tasklist.zeebeimport.security.ImporterSecurityModuleConfiguration;
 import io.camunda.webapps.WebappsModuleConfiguration;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -49,7 +53,13 @@ import org.springframework.context.annotation.Import;
           value = TasklistModuleConfiguration.class)
     },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
-@Import(WebappsModuleConfiguration.class)
+@Import({
+  WebappsModuleConfiguration.class,
+  WebappSecurityModuleConfiguration.class,
+  ArchiverSecurityModuleConfiguration.class,
+  ImporterSecurityModuleConfiguration.class,
+  WebappManagementModuleConfiguration.class,
+})
 public class ModulesTestApplication {
 
   public static void main(final String[] args) throws Exception {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
@@ -39,7 +39,7 @@ import io.camunda.tasklist.webapp.management.dto.GetBackupStateResponseDto;
 import io.camunda.tasklist.webapp.management.dto.TakeBackupRequestDto;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
-import io.camunda.tasklist.webapp.security.TasklistProfileService;
+import io.camunda.tasklist.webapp.security.TasklistProfileServiceImpl;
 import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -77,7 +77,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       TestConfig.class,
       JacksonConfig.class,
       BackupService.class,
-      TasklistProfileService.class
+      TasklistProfileServiceImpl.class,
     })
 @ActiveProfiles({"test", "backend-test"})
 public class BackupServiceElasticSearchTest {
@@ -756,7 +756,7 @@ public class BackupServiceElasticSearchTest {
   }
 
   private void assertBackupDetails(
-      List<SnapshotInfo> snapshotInfos, GetBackupStateResponseDto backupState) {
+      final List<SnapshotInfo> snapshotInfos, final GetBackupStateResponseDto backupState) {
     assertThat(backupState.getDetails()).hasSize(snapshotInfos.size());
     assertThat(backupState.getDetails())
         .extracting(GetBackupStateResponseDetailDto::getSnapshotName)
@@ -772,26 +772,31 @@ public class BackupServiceElasticSearchTest {
             snapshotInfos.stream().map(SnapshotInfo::startTime).toArray(Long[]::new));
   }
 
-  private SnapshotInfo createSnapshotInfoMock(String name, String uuid, SnapshotState state) {
+  private SnapshotInfo createSnapshotInfoMock(
+      final String name, final String uuid, final SnapshotState state) {
     return createSnapshotInfoMock(null, name, uuid, state, null);
   }
 
-  private SnapshotInfo createSnapshotInfoMock(Metadata metadata, String uuid, SnapshotState state) {
+  private SnapshotInfo createSnapshotInfoMock(
+      final Metadata metadata, final String uuid, final SnapshotState state) {
     return createSnapshotInfoMock(metadata, null, uuid, state, null);
   }
 
   private SnapshotInfo createSnapshotInfoMock(
-      String name, String uuid, SnapshotState state, List<SnapshotShardFailure> failures) {
+      final String name,
+      final String uuid,
+      final SnapshotState state,
+      final List<SnapshotShardFailure> failures) {
     return createSnapshotInfoMock(null, name, uuid, state, failures);
   }
 
   @NotNull
   private SnapshotInfo createSnapshotInfoMock(
-      Metadata metadata,
-      String name,
-      String uuid,
-      SnapshotState state,
-      List<SnapshotShardFailure> failures) {
+      final Metadata metadata,
+      final String name,
+      final String uuid,
+      final SnapshotState state,
+      final List<SnapshotShardFailure> failures) {
     final SnapshotInfo snapshotInfo = mock(SnapshotInfo.class);
     if (metadata != null) {
       when(snapshotInfo.snapshotId())

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/BackupServiceElasticSearchTest.java
@@ -79,7 +79,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       BackupService.class,
       TasklistProfileServiceImpl.class,
     })
-@ActiveProfiles({"test", "backend-test"})
+@ActiveProfiles({"test", "backend-test", "standalone"})
 public class BackupServiceElasticSearchTest {
 
   @SpyBean private BackupManagerElasticSearch backupManager;

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/identity/IdentityAuthenticationIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/identity/IdentityAuthenticationIT.java
@@ -54,6 +54,7 @@ import org.springframework.test.util.ReflectionTestUtils;
     },
     properties = {
       "camunda.tasklist.identity.issuerUrl=http://localhost:18080/auth/realms/camunda-platform",
+      "management.endpoint.health.group.readiness.include=readinessState"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ActiveProfiles({IDENTITY_AUTH_PROFILE, "test"})

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/rest/ClientConfigRestServiceIT.java
@@ -14,7 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.util.apps.nobeans.TestApplicationWithNoBeans;
-import io.camunda.tasklist.webapp.security.TasklistProfileService;
+import io.camunda.tasklist.webapp.security.TasklistProfileServiceImpl;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,7 +31,7 @@ import org.springframework.web.context.WebApplicationContext;
 @SpringBootTest(
     classes = {
       TestApplicationWithNoBeans.class,
-      TasklistProfileService.class,
+      TasklistProfileServiceImpl.class,
       ClientConfig.class,
       ClientConfigRestService.class,
       TasklistProperties.class
@@ -43,7 +43,8 @@ import org.springframework.web.context.WebApplicationContext;
       // CAMUNDA_TASKLIST_CLOUD_CLUSTERID=clusterId  -- leave out to test for null values
       "CAMUNDA_TASKLIST_CLOUD_STAGE=stage",
       "CAMUNDA_TASKLIST_CLOUD_MIXPANELTOKEN=i-am-a-token",
-      "CAMUNDA_TASKLIST_CLOUD_MIXPANELAPIHOST=https://fake.mixpanel.com"
+      "CAMUNDA_TASKLIST_CLOUD_MIXPANELAPIHOST=https://fake.mixpanel.com",
+      "management.endpoint.health.group.readiness.include=readinessState"
     },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class ClientConfigRestServiceIT {

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityJwt2AuthenticationTokenConverterTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityJwt2AuthenticationTokenConverterTest.java
@@ -56,6 +56,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
     },
     properties = {
       TasklistProperties.PREFIX + ".identity.issuerUrl = http://some.issuer.url",
+      "management.endpoint.health.group.readiness.include=readinessState"
     })
 @ActiveProfiles({IDENTITY_AUTH_PROFILE, "test"})
 public class IdentityJwt2AuthenticationTokenConverterTest {

--- a/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
+++ b/tasklist/qa/integration-tests/src/test/resources/config/application-test.yml
@@ -32,6 +32,12 @@ spring:
       static-locations: classpath:/test-static/tasklist/
   thymeleaf:
     prefix: classpath:/test-static/
+server.servlet.session.cookie.name: TASKLIST-SESSION
+server.error.include-message: always
+management.health.defaults.enabled: false
+management.endpoint.health.probes.enabled: true
+management.endpoints.web.exposure.include: health,prometheus,loggers,usage-metrics,backups
+management.endpoint.health.group.readiness.include: readinessState,searchEngineCheck
 ---
 spring.config.activate.on-profile: identity-auth, sso-auth
 camunda.webapps.login-delegated: true

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/WebappModuleConfiguration.java
@@ -14,12 +14,21 @@ import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 import org.springframework.context.annotation.Import;
 
 @Configuration
 @ComponentScan(
     basePackages = "io.camunda.tasklist.webapp",
+    excludeFilters = {
+      @ComponentScan.Filter(
+          type = FilterType.REGEX,
+          pattern = "io\\.camunda\\.tasklist\\.webapp\\.security\\..*"),
+      @ComponentScan.Filter(
+          type = FilterType.REGEX,
+          pattern = "io\\.camunda\\.tasklist\\.webapp\\.management\\..*")
+    },
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
     name = "camunda.tasklist.webappEnabled",

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskController.java
@@ -113,9 +113,9 @@ public class TaskController extends ApiErrorController {
 
     if (tasklistProperties.getIdentity() != null
         && tasklistProperties.getIdentity().isUserAccessRestrictionsEnabled()) {
-      final String userName = userReader.getCurrentUser().getUserId();
       final List<String> listOfUserGroups = identityAuthorizationService.getUserGroups();
       if (!listOfUserGroups.contains(IdentityProperties.FULL_GROUP_ACCESS)) {
+        final String userName = userReader.getCurrentUser().getUserId();
         final TaskByCandidateUserOrGroup taskByCandidateUserOrGroup =
             new TaskByCandidateUserOrGroup();
         taskByCandidateUserOrGroup.setUserGroups(listOfUserGroups.toArray(String[]::new));

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/graphql/TasklistGraphQLConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/graphql/TasklistGraphQLConfiguration.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.graphql;
+
+import com.fasterxml.jackson.databind.InjectableValues;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import graphql.kickstart.execution.config.ObjectMapperProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TasklistGraphQLConfiguration {
+
+  @Bean
+  public ObjectMapperProvider objectMapperProvider(
+      @Qualifier("tasklistObjectMapper") final ObjectMapper objectMapper) {
+    final InjectableValues.Std injectableValues = new InjectableValues.Std();
+    injectableValues.addValue(ObjectMapper.class, objectMapper);
+    objectMapper.setInjectableValues(injectableValues);
+    return () -> objectMapper;
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/BackupService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/BackupService.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Component
 @RestControllerEndpoint(id = "backups")
+@Profile("standalone")
 public class BackupService extends ManagementAPIErrorController {
 
   @Autowired private BackupManager backupManager;
@@ -40,7 +42,7 @@ public class BackupService extends ManagementAPIErrorController {
   private final Pattern pattern = Pattern.compile("((?![A-Z \"*\\\\<|,>\\/?_]).){0,3996}$");
 
   @PostMapping(produces = {MediaType.APPLICATION_JSON_VALUE})
-  public TakeBackupResponseDto takeBackup(@RequestBody TakeBackupRequestDto request) {
+  public TakeBackupResponseDto takeBackup(@RequestBody final TakeBackupRequestDto request) {
     validateRequest(request);
     validateRepositoryNameIsConfigured();
     return backupManager.takeBackup(request);
@@ -54,7 +56,7 @@ public class BackupService extends ManagementAPIErrorController {
   }
 
   @GetMapping("/{backupId}")
-  public GetBackupStateResponseDto getBackupState(@PathVariable Long backupId) {
+  public GetBackupStateResponseDto getBackupState(@PathVariable final Long backupId) {
     validateBackupId(backupId);
     validateRepositoryNameIsConfigured();
     return backupManager.getBackupState(backupId);
@@ -68,20 +70,20 @@ public class BackupService extends ManagementAPIErrorController {
 
   @DeleteMapping("/{backupId}")
   @ResponseStatus(HttpStatus.NO_CONTENT)
-  public void deleteBackup(@PathVariable Long backupId) {
+  public void deleteBackup(@PathVariable final Long backupId) {
     validateBackupId(backupId);
     validateRepositoryNameIsConfigured();
     backupManager.deleteBackup(backupId);
   }
 
-  private void validateRequest(TakeBackupRequestDto request) {
+  private void validateRequest(final TakeBackupRequestDto request) {
     if (request.getBackupId() == null) {
       throw new InvalidRequestException("BackupId must be provided");
     }
     validateBackupId(request.getBackupId());
   }
 
-  private void validateBackupId(Long backupId) {
+  private void validateBackupId(final Long backupId) {
     if (backupId < 0) {
       throw new InvalidRequestException(
           "BackupId must be a non-negative Long. Received value: " + backupId);

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/UsageMetricsService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/UsageMetricsService.java
@@ -35,7 +35,7 @@ public class UsageMetricsService extends InternalAPIErrorController {
   @GetMapping(
       value = "/assignees",
       produces = {MediaType.APPLICATION_JSON_VALUE})
-  public UsageMetricDTO retrieveUniqueAssignedUsers(UsageMetricQueryDTO query) {
+  public UsageMetricDTO retrieveUniqueAssignedUsers(final UsageMetricQueryDTO query) {
     final List<String> assignees =
         taskMetricsStore.retrieveDistinctAssigneesBetweenDates(
             query.getStartTime(), query.getEndTime());

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/WebappManagementModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/management/WebappManagementModuleConfiguration.java
@@ -5,36 +5,19 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.tasklist;
+package io.camunda.tasklist.webapp.management;
 
-import jakarta.annotation.PostConstruct;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 
 @Configuration
 @ComponentScan(
-    basePackages = "io.camunda.tasklist.archiver",
-    excludeFilters = {
-      @ComponentScan.Filter(
-          type = FilterType.REGEX,
-          pattern = "io\\.camunda\\.tasklist\\.archiver\\.security\\..*")
-    },
+    basePackages = "io.camunda.tasklist.webapp.management",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.tasklist.archiverEnabled",
+    name = "camunda.tasklist.webappEnabled",
     havingValue = "true",
     matchIfMissing = true)
-public class ArchiverModuleConfiguration {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverModuleConfiguration.class);
-
-  @PostConstruct
-  public void logModule() {
-    LOGGER.info("Starting module: archiver");
-  }
-}
+public class WebappManagementModuleConfiguration {}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileService.java
@@ -7,53 +7,21 @@
  */
 package io.camunda.tasklist.webapp.security;
 
-import java.util.Arrays;
-import java.util.List;
 import java.util.Set;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.env.Environment;
-import org.springframework.stereotype.Component;
 
-@Component
-public class TasklistProfileService {
+public interface TasklistProfileService {
 
-  public static final String SSO_AUTH_PROFILE = "sso-auth";
-  public static final String IDENTITY_AUTH_PROFILE = "identity-auth";
-  public static final String AUTH_PROFILE = "auth";
-  public static final String DEFAULT_AUTH = AUTH_PROFILE;
-  public static final String LDAP_AUTH_PROFILE = "ldap-auth";
-  public static final Set<String> AUTH_PROFILES =
+  String SSO_AUTH_PROFILE = "sso-auth";
+  String IDENTITY_AUTH_PROFILE = "identity-auth";
+  String AUTH_PROFILE = "auth";
+  String DEFAULT_AUTH = AUTH_PROFILE;
+  String LDAP_AUTH_PROFILE = "ldap-auth";
+  Set<String> AUTH_PROFILES =
       Set.of(AUTH_PROFILE, LDAP_AUTH_PROFILE, SSO_AUTH_PROFILE, IDENTITY_AUTH_PROFILE);
 
-  private static final Set<String> CANT_LOGOUT_AUTH_PROFILES = Set.of(SSO_AUTH_PROFILE);
+  String getMessageByProfileFor(Exception exception);
 
-  @Autowired private Environment environment;
+  boolean currentProfileCanLogout();
 
-  public String getMessageByProfileFor(final Exception exception) {
-    if (isDevelopmentProfileActive()) {
-      return exception.getMessage();
-    }
-    return "";
-  }
-
-  public boolean currentProfileCanLogout() {
-    return Arrays.stream(environment.getActiveProfiles())
-        .noneMatch(CANT_LOGOUT_AUTH_PROFILES::contains);
-  }
-
-  public boolean isDevelopmentProfileActive() {
-    return List.of(environment.getActiveProfiles()).contains("dev");
-  }
-
-  public boolean isSSOProfile() {
-    return Arrays.asList(environment.getActiveProfiles()).contains(SSO_AUTH_PROFILE);
-  }
-
-  public boolean isIdentityProfile() {
-    return Arrays.asList(environment.getActiveProfiles()).contains(IDENTITY_AUTH_PROFILE);
-  }
-
-  public boolean isLoginDelegated() {
-    return isIdentityProfile() || isSSOProfile();
-  }
+  boolean isLoginDelegated();
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileServiceImpl.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileServiceImpl.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.security;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TasklistProfileServiceImpl implements TasklistProfileService {
+
+  private static final Set<String> CANT_LOGOUT_AUTH_PROFILES = Set.of(SSO_AUTH_PROFILE);
+
+  @Autowired private Environment environment;
+
+  @Override
+  public String getMessageByProfileFor(final Exception exception) {
+    if (isDevelopmentProfileActive()) {
+      return exception.getMessage();
+    }
+    return "";
+  }
+
+  @Override
+  public boolean currentProfileCanLogout() {
+    return Arrays.stream(environment.getActiveProfiles())
+        .noneMatch(CANT_LOGOUT_AUTH_PROFILES::contains);
+  }
+
+  @Override
+  public boolean isLoginDelegated() {
+    return isIdentityProfile() || isSSOProfile();
+  }
+
+  private boolean isDevelopmentProfileActive() {
+    return List.of(environment.getActiveProfiles()).contains("dev");
+  }
+
+  private boolean isSSOProfile() {
+    return Arrays.asList(environment.getActiveProfiles()).contains(SSO_AUTH_PROFILE);
+  }
+
+  private boolean isIdentityProfile() {
+    return Arrays.asList(environment.getActiveProfiles()).contains(IDENTITY_AUTH_PROFILE);
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/WebappSecurityModuleConfiguration.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/WebappSecurityModuleConfiguration.java
@@ -5,36 +5,19 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.tasklist;
+package io.camunda.tasklist.webapp.security;
 
-import jakarta.annotation.PostConstruct;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.FullyQualifiedAnnotationBeanNameGenerator;
 
 @Configuration
 @ComponentScan(
-    basePackages = "io.camunda.tasklist.archiver",
-    excludeFilters = {
-      @ComponentScan.Filter(
-          type = FilterType.REGEX,
-          pattern = "io\\.camunda\\.tasklist\\.archiver\\.security\\..*")
-    },
+    basePackages = "io.camunda.tasklist.webapp.security",
     nameGenerator = FullyQualifiedAnnotationBeanNameGenerator.class)
 @ConditionalOnProperty(
-    name = "camunda.tasklist.archiverEnabled",
+    name = "camunda.tasklist.webappEnabled",
     havingValue = "true",
     matchIfMissing = true)
-public class ArchiverModuleConfiguration {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(ArchiverModuleConfiguration.class);
-
-  @PostConstruct
-  public void logModule() {
-    LOGGER.info("Starting module: archiver");
-  }
-}
+public class WebappSecurityModuleConfiguration {}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationService.java
@@ -7,119 +7,14 @@
  */
 package io.camunda.tasklist.webapp.security.identity;
 
-import io.camunda.identity.sdk.Identity;
-import io.camunda.tasklist.property.IdentityProperties;
-import io.camunda.tasklist.property.TasklistProperties;
-import io.camunda.tasklist.util.SpringContextHolder;
-import io.camunda.tasklist.webapp.security.sso.TokenAuthentication;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.stereotype.Component;
-import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
-@Component
-public class IdentityAuthorizationService {
+public interface IdentityAuthorizationService {
+  List<String> getUserGroups();
 
-  private final Logger logger = LoggerFactory.getLogger(IdentityAuthorizationService.class);
+  boolean isAllowedToStartProcess(final String processDefinitionKey);
 
-  @Autowired private TasklistProperties tasklistProperties;
-  @Autowired private LocalValidatorFactoryBean defaultValidator;
+  List<String> getProcessReadFromAuthorization();
 
-  public List<String> getUserGroups() {
-    final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    String accessToken = null;
-
-    final Identity identity = SpringContextHolder.getBean(Identity.class);
-    // Extract access token based on authentication type
-    if (authentication instanceof IdentityAuthentication) {
-      accessToken = ((IdentityAuthentication) authentication).getTokens().getAccessToken();
-      return identity.authentication().getGroups(accessToken);
-    } else if (authentication instanceof TokenAuthentication) {
-      accessToken = ((TokenAuthentication) authentication).getAccessToken();
-      final String organization = ((TokenAuthentication) authentication).getOrganization();
-      // Sending explicit the audience null to get the groups in the organization
-      // Method getGroups is not used because it returns the groups of the user without consider
-      // organization
-      return identity.authentication().getGroupsInOrganization(accessToken, null, organization);
-    }
-
-    // Fallback groups if authentication type is unrecognized or access token is null
-    final List<String> defaultGroups = new ArrayList<>();
-    defaultGroups.add(IdentityProperties.FULL_GROUP_ACCESS);
-    return defaultGroups;
-  }
-
-  public boolean isAllowedToStartProcess(final String processDefinitionKey) {
-    return !Collections.disjoint(
-        getProcessDefinitionsFromAuthorization(),
-        Set.of(IdentityProperties.ALL_RESOURCES, processDefinitionKey));
-  }
-
-  public List<String> getProcessReadFromAuthorization() {
-    return getFromAuthorization(IdentityAuthorization.PROCESS_PERMISSION_READ);
-  }
-
-  public List<String> getProcessDefinitionsFromAuthorization() {
-    return getFromAuthorization(IdentityAuthorization.PROCESS_PERMISSION_START);
-  }
-
-  private Optional<IdentityAuthorization> getIdentityAuthorization() {
-    if (!tasklistProperties.getIdentity().isResourcePermissionsEnabled()
-        || tasklistProperties.getIdentity().getBaseUrl() == null) {
-      return Optional.empty();
-    }
-
-    final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-
-    return switch (authentication) {
-      case final IdentityAuthentication identityAuthentication ->
-          Optional.of(identityAuthentication.getAuthorizations());
-      case final JwtAuthenticationToken jwtAuthenticationToken -> {
-        final Identity identity = SpringContextHolder.getBean(Identity.class);
-        yield Optional.of(
-            new IdentityAuthorization(
-                identity
-                    .authorizations()
-                    .forToken(jwtAuthenticationToken.getToken().getTokenValue())));
-      }
-
-      case final TokenAuthentication tokenAuthentication -> {
-        final Identity identity = SpringContextHolder.getBean(Identity.class);
-        yield Optional.of(
-            new IdentityAuthorization(
-                identity
-                    .authorizations()
-                    .forToken(
-                        tokenAuthentication.getAccessToken(),
-                        tokenAuthentication.getOrganization())));
-      }
-      default -> Optional.empty();
-    };
-  }
-
-  private List<String> getFromAuthorization(final String type) {
-    final Optional<IdentityAuthorization> optIdentityAuthorization = getIdentityAuthorization();
-    if (optIdentityAuthorization.isEmpty()) {
-      return Collections.singletonList(IdentityProperties.ALL_RESOURCES);
-    }
-
-    final IdentityAuthorization identityAuthorization = optIdentityAuthorization.get();
-
-    return switch (type) {
-      case IdentityAuthorization.PROCESS_PERMISSION_READ ->
-          identityAuthorization.getProcessesAllowedToRead();
-      case IdentityAuthorization.PROCESS_PERMISSION_START ->
-          identityAuthorization.getProcessesAllowedToStart();
-      default -> Collections.emptyList();
-    };
-  }
+  List<String> getProcessDefinitionsFromAuthorization();
 }

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationServiceImpl.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityAuthorizationServiceImpl.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.security.identity;
+
+import io.camunda.identity.sdk.Identity;
+import io.camunda.tasklist.property.IdentityProperties;
+import io.camunda.tasklist.property.TasklistProperties;
+import io.camunda.tasklist.util.SpringContextHolder;
+import io.camunda.tasklist.webapp.security.sso.TokenAuthentication;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
+@Component
+public class IdentityAuthorizationServiceImpl implements IdentityAuthorizationService {
+
+  private final Logger logger = LoggerFactory.getLogger(IdentityAuthorizationServiceImpl.class);
+
+  @Autowired private TasklistProperties tasklistProperties;
+  @Autowired private LocalValidatorFactoryBean defaultValidator;
+
+  @Override
+  public List<String> getUserGroups() {
+    final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+    String accessToken = null;
+
+    final Identity identity = SpringContextHolder.getBean(Identity.class);
+    // Extract access token based on authentication type
+    if (authentication instanceof IdentityAuthentication) {
+      accessToken = ((IdentityAuthentication) authentication).getTokens().getAccessToken();
+      return identity.authentication().getGroups(accessToken);
+    } else if (authentication instanceof TokenAuthentication) {
+      accessToken = ((TokenAuthentication) authentication).getAccessToken();
+      final String organization = ((TokenAuthentication) authentication).getOrganization();
+      // Sending explicit the audience null to get the groups in the organization
+      // Method getGroups is not used because it returns the groups of the user without consider
+      // organization
+      return identity.authentication().getGroupsInOrganization(accessToken, null, organization);
+    }
+
+    // Fallback groups if authentication type is unrecognized or access token is null
+    final List<String> defaultGroups = new ArrayList<>();
+    defaultGroups.add(IdentityProperties.FULL_GROUP_ACCESS);
+    return defaultGroups;
+  }
+
+  @Override
+  public boolean isAllowedToStartProcess(final String processDefinitionKey) {
+    return !Collections.disjoint(
+        getProcessDefinitionsFromAuthorization(),
+        Set.of(IdentityProperties.ALL_RESOURCES, processDefinitionKey));
+  }
+
+  @Override
+  public List<String> getProcessReadFromAuthorization() {
+    return getFromAuthorization(IdentityAuthorization.PROCESS_PERMISSION_READ);
+  }
+
+  @Override
+  public List<String> getProcessDefinitionsFromAuthorization() {
+    return getFromAuthorization(IdentityAuthorization.PROCESS_PERMISSION_START);
+  }
+
+  private Optional<IdentityAuthorization> getIdentityAuthorization() {
+    if (!tasklistProperties.getIdentity().isResourcePermissionsEnabled()
+        || tasklistProperties.getIdentity().getBaseUrl() == null) {
+      return Optional.empty();
+    }
+
+    final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+    return switch (authentication) {
+      case final IdentityAuthentication identityAuthentication ->
+          Optional.of(identityAuthentication.getAuthorizations());
+      case final JwtAuthenticationToken jwtAuthenticationToken -> {
+        final Identity identity = SpringContextHolder.getBean(Identity.class);
+        yield Optional.of(
+            new IdentityAuthorization(
+                identity
+                    .authorizations()
+                    .forToken(jwtAuthenticationToken.getToken().getTokenValue())));
+      }
+
+      case final TokenAuthentication tokenAuthentication -> {
+        final Identity identity = SpringContextHolder.getBean(Identity.class);
+        yield Optional.of(
+            new IdentityAuthorization(
+                identity
+                    .authorizations()
+                    .forToken(
+                        tokenAuthentication.getAccessToken(),
+                        tokenAuthentication.getOrganization())));
+      }
+      default -> Optional.empty();
+    };
+  }
+
+  private List<String> getFromAuthorization(final String type) {
+    final Optional<IdentityAuthorization> optIdentityAuthorization = getIdentityAuthorization();
+    if (optIdentityAuthorization.isEmpty()) {
+      return Collections.singletonList(IdentityProperties.ALL_RESOURCES);
+    }
+
+    final IdentityAuthorization identityAuthorization = optIdentityAuthorization.get();
+
+    return switch (type) {
+      case IdentityAuthorization.PROCESS_PERMISSION_READ ->
+          identityAuthorization.getProcessesAllowedToRead();
+      case IdentityAuthorization.PROCESS_PERMISSION_START ->
+          identityAuthorization.getProcessesAllowedToStart();
+      default -> Collections.emptyList();
+    };
+  }
+}

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/tenant/TenantService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/tenant/TenantService.java
@@ -9,100 +9,19 @@ package io.camunda.tasklist.webapp.security.tenant;
 
 import static java.util.Collections.emptyList;
 
-import io.camunda.tasklist.exceptions.TasklistRuntimeException;
-import io.camunda.tasklist.property.TasklistProperties;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.stream.Collectors;
-import org.apache.commons.collections4.CollectionUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
-public class TenantService {
+public interface TenantService {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(TenantService.class);
+  AuthenticatedTenants getAuthenticatedTenants();
 
-  @Autowired private TasklistProperties tasklistProperties;
+  boolean isTenantValid(final String tenantId);
 
-  public AuthenticatedTenants getAuthenticatedTenants() {
-    if (!isMultiTenancyEnabled()) {
-      // disabled means no tenant check necessary.
-      // thus, the user/app has access to all tenants.
-      return AuthenticatedTenants.allTenants();
-    }
+  boolean isMultiTenancyEnabled();
 
-    final var authentication = getCurrentTenantAwareAuthentication();
-    final var tenants = getTenantsFromAuthentication(authentication);
-
-    if (CollectionUtils.isNotEmpty(tenants)) {
-      return AuthenticatedTenants.assignedTenants(tenants);
-    } else {
-      return AuthenticatedTenants.noTenantsAssigned();
-    }
-  }
-
-  public Boolean isTenantValid(final String tenantId) {
-    if (isMultiTenancyEnabled()) {
-      return getAuthenticatedTenants().contains(tenantId);
-    } else {
-      return true;
-    }
-  }
-
-  private TenantAwareAuthentication getCurrentTenantAwareAuthentication() {
-    final var authentication = SecurityContextHolder.getContext().getAuthentication();
-    final TenantAwareAuthentication currentAuthentication;
-
-    if (authentication instanceof TenantAwareAuthentication tenantAwareAuthentication) {
-      currentAuthentication = tenantAwareAuthentication;
-    } else {
-      currentAuthentication = null;
-      // log error message for visibility
-      final var message =
-          String.format(
-              "Multi Tenancy is not supported with current authentication type %s",
-              authentication.getClass());
-      LOGGER.error(message, new TasklistRuntimeException());
-    }
-
-    return currentAuthentication;
-  }
-
-  private List<String> getTenantsFromAuthentication(
-      final TenantAwareAuthentication authentication) {
-    final var authenticatedTenants = new ArrayList<String>();
-
-    if (authentication != null) {
-      final var tenants = authentication.getTenants();
-      if (tenants != null && !tenants.isEmpty()) {
-        tenants.stream()
-            .map(TasklistTenant::getId)
-            .collect(Collectors.toCollection(() -> authenticatedTenants));
-      }
-    }
-
-    return authenticatedTenants;
-  }
-
-  public boolean isMultiTenancyEnabled() {
-    return tasklistProperties.getMultiTenancy().isEnabled()
-        && SecurityContextHolder.getContext().getAuthentication() != null;
-  }
-
-  public static class AuthenticatedTenants {
-
-    private final TenantAccessType tenantAccessType;
-    private final List<String> ids;
-
-    AuthenticatedTenants(final TenantAccessType tenantAccessType, final List<String> ids) {
-      this.tenantAccessType = tenantAccessType;
-      this.ids = ids;
-    }
+  record AuthenticatedTenants(TenantAccessType tenantAccessType, List<String> ids) {
 
     public TenantAccessType getTenantAccessType() {
       return tenantAccessType;
@@ -112,7 +31,7 @@ public class TenantService {
       return ids;
     }
 
-    public boolean contains(String tenantId) {
+    public boolean contains(final String tenantId) {
       return ids.contains(tenantId);
     }
 
@@ -124,29 +43,12 @@ public class TenantService {
       return new AuthenticatedTenants(TenantAccessType.TENANT_ACCESS_NONE, emptyList());
     }
 
-    public static AuthenticatedTenants assignedTenants(List<String> tenants) {
+    public static AuthenticatedTenants assignedTenants(final List<String> tenants) {
       return new AuthenticatedTenants(TenantAccessType.TENANT_ACCESS_ASSIGNED, tenants);
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      final AuthenticatedTenants that = (AuthenticatedTenants) o;
-      return tenantAccessType == that.tenantAccessType && Objects.equals(ids, that.ids);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(tenantAccessType, ids);
     }
   }
 
-  public static enum TenantAccessType {
+  enum TenantAccessType {
     TENANT_ACCESS_ALL,
     TENANT_ACCESS_ASSIGNED,
     TENANT_ACCESS_NONE

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/tenant/TenantServiceImpl.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/tenant/TenantServiceImpl.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.security.tenant;
+
+import io.camunda.tasklist.exceptions.TasklistRuntimeException;
+import io.camunda.tasklist.property.TasklistProperties;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.commons.collections4.CollectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TenantServiceImpl implements TenantService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TenantServiceImpl.class);
+
+  @Autowired private TasklistProperties tasklistProperties;
+
+  @Override
+  public AuthenticatedTenants getAuthenticatedTenants() {
+    if (!isMultiTenancyEnabled()) {
+      // disabled means no tenant check necessary.
+      // thus, the user/app has access to all tenants.
+      return AuthenticatedTenants.allTenants();
+    }
+
+    final var authentication = getCurrentTenantAwareAuthentication();
+    final var tenants = getTenantsFromAuthentication(authentication);
+
+    if (CollectionUtils.isNotEmpty(tenants)) {
+      return AuthenticatedTenants.assignedTenants(tenants);
+    } else {
+      return AuthenticatedTenants.noTenantsAssigned();
+    }
+  }
+
+  @Override
+  public boolean isTenantValid(final String tenantId) {
+    if (isMultiTenancyEnabled()) {
+      return getAuthenticatedTenants().contains(tenantId);
+    } else {
+      return true;
+    }
+  }
+
+  @Override
+  public boolean isMultiTenancyEnabled() {
+    return tasklistProperties.getMultiTenancy().isEnabled()
+        && SecurityContextHolder.getContext().getAuthentication() != null;
+  }
+
+  private TenantAwareAuthentication getCurrentTenantAwareAuthentication() {
+    final var authentication = SecurityContextHolder.getContext().getAuthentication();
+    final TenantAwareAuthentication currentAuthentication;
+
+    if (authentication instanceof final TenantAwareAuthentication tenantAwareAuthentication) {
+      currentAuthentication = tenantAwareAuthentication;
+    } else {
+      currentAuthentication = null;
+      // log error message for visibility
+      final var message =
+          String.format(
+              "Multi Tenancy is not supported with current authentication type %s",
+              authentication.getClass());
+      LOGGER.error(message, new TasklistRuntimeException());
+    }
+
+    return currentAuthentication;
+  }
+
+  private List<String> getTenantsFromAuthentication(
+      final TenantAwareAuthentication authentication) {
+    final var authenticatedTenants = new ArrayList<String>();
+
+    if (authentication != null) {
+      final var tenants = authentication.getTenants();
+      if (tenants != null && !tenants.isEmpty()) {
+        tenants.stream()
+            .map(TasklistTenant::getId)
+            .collect(Collectors.toCollection(() -> authenticatedTenants));
+      }
+    }
+
+    return authenticatedTenants;
+  }
+}

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreElasticSearchTest.java
@@ -33,7 +33,7 @@ import io.camunda.tasklist.util.ElasticsearchUtil;
 import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthentication;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorization;
-import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
+import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationServiceImpl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,7 +65,7 @@ class ProcessStoreElasticSearchTest {
   @Mock private ProcessIndex processIndex;
   @Mock private TenantAwareElasticsearchClient tenantAwareClient;
   @InjectMocks private ProcessStoreElasticSearch processStore;
-  @InjectMocks private IdentityAuthorizationService identityService;
+  @InjectMocks private IdentityAuthorizationServiceImpl identityService;
   @Mock private ObjectMapper objectMapper;
   @InjectMocks private SpringContextHolder springContextHolder;
   @Mock private TasklistProperties tasklistProperties;

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/es/cache/ProcessStoreOpenSearchTest.java
@@ -35,7 +35,7 @@ import io.camunda.tasklist.util.OpenSearchUtil;
 import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthentication;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorization;
-import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
+import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationServiceImpl;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -65,7 +65,7 @@ class ProcessStoreOpenSearchTest {
   @Mock private ProcessIndex processIndex;
   @Mock private TenantAwareOpenSearchClient tenantAwareClient;
   @InjectMocks private ProcessStoreOpenSearch processStore;
-  @InjectMocks private IdentityAuthorizationService identityService;
+  @InjectMocks private IdentityAuthorizationServiceImpl identityService;
   @Mock private ObjectMapper objectMapper;
   @InjectMocks private SpringContextHolder springContextHolder;
   @Mock private TasklistProperties tasklistProperties;

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/ProcessServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/service/ProcessServiceTest.java
@@ -19,6 +19,7 @@ import io.camunda.tasklist.webapp.rest.exception.ForbiddenActionException;
 import io.camunda.tasklist.webapp.rest.exception.InvalidRequestException;
 import io.camunda.tasklist.webapp.rest.exception.NotFoundApiException;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
+import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationServiceImpl;
 import io.camunda.tasklist.webapp.security.tenant.TenantService;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.ClientStatusException;
@@ -49,7 +50,7 @@ public class ProcessServiceTest {
 
   @Spy
   private IdentityAuthorizationService identityAuthorizationService =
-      new IdentityAuthorizationService();
+      new IdentityAuthorizationServiceImpl();
 
   @InjectMocks private ProcessService instance;
 

--- a/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/tenant/TenantServiceTest.java
+++ b/tasklist/webapp/src/test/java/io/camunda/tasklist/webapp/tenant/TenantServiceTest.java
@@ -13,6 +13,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.webapp.security.tenant.TasklistTenant;
 import io.camunda.tasklist.webapp.security.tenant.TenantAwareAuthentication;
 import io.camunda.tasklist.webapp.security.tenant.TenantService;
+import io.camunda.tasklist.webapp.security.tenant.TenantServiceImpl;
 import java.util.ArrayList;
 import java.util.List;
 import org.assertj.core.api.Assertions;
@@ -29,7 +30,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 public class TenantServiceTest {
 
   @Spy private TasklistProperties tasklistProperties;
-  @InjectMocks private TenantService instance;
+  @InjectMocks private TenantServiceImpl instance;
 
   @Test
   void getAuthenticatedTenantsWhenMultiTenancyIsOff() {


### PR DESCRIPTION
## Description

With this pull request, a Single Application (containing Tasklist, Operate and/or Zeebe) can be started via a `camunda.sh` script. By default, tasklist, operate and zeebe-broker profiles are applied.

Only basic authentication (`AUTH` profile) is supported.

## Related issues

relates to https://github.com/camunda/camunda/issues/18535
