### PR TITLE
feat: Create a Testcontainer runtime for Process Testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,7 @@
     <module>identity</module>
     <module>search</module>
     <module>service</module>
+    <module>testing/camunda-process-test-java</module>
   </modules>
 
   <scm>

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,0 +1,6 @@
+# Testing
+
+Camunda's testing libraries for processes and process applications.
+
+- [Camunda Process Test for Java](camunda-process-test-java)
+

--- a/testing/camunda-process-test-java/README.md
+++ b/testing/camunda-process-test-java/README.md
@@ -1,0 +1,5 @@
+# Camunda-Process-Test-Java
+
+Camunda's new testing library for processes and process applications with Java.
+
+Work in progress!

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -64,6 +64,12 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
@@ -107,6 +113,14 @@
   </dependencies>
 
   <build>
+
+    <!-- Required to access the version as a resource-->
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
 
     <plugins>
 

--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.6.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-process-test-java</artifactId>
+
+  <name>Camunda Process Test Java</name>
+  <description>Camunda's testing library for processes and process applications with Java</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <version.java>8</version.java>
+    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>elasticsearch</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <!--  test scope  -->
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-client-java</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/testing/camunda-process-test-java/revapi.json
+++ b/testing/camunda-process-test-java/revapi.json
@@ -1,0 +1,17 @@
+[
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {
+      "elements": {
+        "exclude": [
+          {
+            "justification": "The implementation package is not meant to be used directly, and as such does not need to maintain any backwards compatibility guarantees.",
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.process\\.test\\.impl(\\..*)?/"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/OperateContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/OperateContainer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.containers;
+
+import io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs;
+import io.camunda.process.test.impl.runtime.ContainerRuntimePorts;
+import java.time.Duration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode;
+import org.testcontainers.utility.DockerImageName;
+
+public class OperateContainer extends GenericContainer<OperateContainer> {
+
+  private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
+  private static final String OPERATE_READY_ENDPOINT = "/actuator/health/readiness";
+
+  public OperateContainer(final DockerImageName dockerImageName) {
+    super(dockerImageName);
+    applyDefaultConfiguration();
+  }
+
+  private void applyDefaultConfiguration() {
+    withNetwork(Network.SHARED)
+        .waitingFor(newDefaultWaitStrategy())
+        .addExposedPorts(ContainerRuntimePorts.OPERATE_REST_API);
+  }
+
+  public OperateContainer withZeebeGrpcApi(final String zeebeGrpcApi) {
+    withEnv(ContainerRuntimeEnvs.OPERATE_ENV_ZEEBE_GATEWAYADDRESS, zeebeGrpcApi);
+    return this;
+  }
+
+  public OperateContainer withElasticsearchUrl(final String elasticsearchUrl) {
+    withEnv(ContainerRuntimeEnvs.OPERATE_ENV_ELASTICSEARCH_URL, elasticsearchUrl);
+    withEnv(ContainerRuntimeEnvs.OPERATE_ENV_ZEEBEELASTICSEARCH_URL, elasticsearchUrl);
+    return this;
+  }
+
+  public static HttpWaitStrategy newDefaultOperateReadyCheck() {
+    return new HttpWaitStrategy()
+        .forPath(OPERATE_READY_ENDPOINT)
+        .forPort(ContainerRuntimePorts.OPERATE_REST_API)
+        .forStatusCodeMatching(status -> status >= 200 && status < 300)
+        .withReadTimeout(Duration.ofSeconds(10));
+  }
+
+  private WaitAllStrategy newDefaultWaitStrategy() {
+    return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
+        .withStrategy(new HostPortWaitStrategy())
+        .withStrategy(newDefaultOperateReadyCheck())
+        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+  }
+
+  public int getRestApiPort() {
+    return getMappedPort(ContainerRuntimePorts.OPERATE_REST_API);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/TasklistContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/TasklistContainer.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.containers;
+
+import io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs;
+import io.camunda.process.test.impl.runtime.ContainerRuntimePorts;
+import java.time.Duration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode;
+import org.testcontainers.utility.DockerImageName;
+
+public class TasklistContainer extends GenericContainer<TasklistContainer> {
+
+  private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
+  private static final String TASKLIST_READY_ENDPOINT = "/actuator/health/readiness";
+
+  public TasklistContainer(final DockerImageName dockerImageName) {
+    super(dockerImageName);
+    applyDefaultConfiguration();
+  }
+
+  private void applyDefaultConfiguration() {
+    withNetwork(Network.SHARED)
+        .waitingFor(newDefaultWaitStrategy())
+        .withEnv(ContainerRuntimeEnvs.TASKLIST_CSRF_PREVENTION_ENABLED, "false")
+        .addExposedPorts(ContainerRuntimePorts.TASKLIST_REST_API);
+  }
+
+  public TasklistContainer withZeebeApi(final String zeebeGrpcApi, final String zeebeRestApi) {
+    withEnv(ContainerRuntimeEnvs.TASKLIST_ENV_ZEEBE_GATEWAYADDRESS, zeebeGrpcApi);
+    withEnv(ContainerRuntimeEnvs.TASKLIST_ENV_ZEEBE_RESTADDRESS, zeebeRestApi);
+    return this;
+  }
+
+  public TasklistContainer withElasticsearchUrl(final String elasticsearchUrl) {
+    withEnv(ContainerRuntimeEnvs.TASKLIST_ENV_ELASTICSEARCH_URL, elasticsearchUrl);
+    withEnv(ContainerRuntimeEnvs.TASKLIST_ENV_ZEEBEELASTICSEARCH_URL, elasticsearchUrl);
+    return this;
+  }
+
+  public static HttpWaitStrategy newDefaultTasklistReadyCheck() {
+    return new HttpWaitStrategy()
+        .forPath(TASKLIST_READY_ENDPOINT)
+        .forPort(ContainerRuntimePorts.TASKLIST_REST_API)
+        .forStatusCodeMatching(status -> status >= 200 && status < 300)
+        .withReadTimeout(Duration.ofSeconds(10));
+  }
+
+  private WaitAllStrategy newDefaultWaitStrategy() {
+    return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
+        .withStrategy(new HostPortWaitStrategy())
+        .withStrategy(newDefaultTasklistReadyCheck())
+        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+  }
+
+  public int getRestApiPort() {
+    return getMappedPort(ContainerRuntimePorts.TASKLIST_REST_API);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ZeebeContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ZeebeContainer.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.containers;
+
+import io.camunda.process.test.impl.runtime.ContainerRuntimeEnvs;
+import io.camunda.process.test.impl.runtime.ContainerRuntimePorts;
+import java.time.Duration;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.HostPortWaitStrategy;
+import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy;
+import org.testcontainers.containers.wait.strategy.WaitAllStrategy.Mode;
+import org.testcontainers.utility.DockerImageName;
+
+public class ZeebeContainer extends GenericContainer<ZeebeContainer> {
+
+  private static final Duration DEFAULT_STARTUP_TIMEOUT = Duration.ofMinutes(1);
+  private static final String ZEEBE_READY_ENDPOINT = "/ready";
+
+  private static final String ZEEBE_ELASTICSEARCH_EXPORTER_CLASSNAME =
+      "io.camunda.zeebe.exporter.ElasticsearchExporter";
+
+  public ZeebeContainer(final DockerImageName dockerImageName) {
+    super(dockerImageName);
+    applyDefaultConfiguration();
+  }
+
+  private void applyDefaultConfiguration() {
+    withNetwork(Network.SHARED)
+        .waitingFor(newDefaultWaitStrategy())
+        .withEnv(ContainerRuntimeEnvs.ZEEBE_ENV_CLOCK_CONTROLLED, "true")
+        .addExposedPorts(
+            ContainerRuntimePorts.ZEEBE_GATEWAY_API,
+            ContainerRuntimePorts.ZEEBE_COMMAND_API,
+            ContainerRuntimePorts.ZEEBE_INTERNAL_API,
+            ContainerRuntimePorts.ZEEBE_MONITORING_API,
+            ContainerRuntimePorts.ZEEBE_REST_API);
+  }
+
+  public ZeebeContainer withElasticsearchExporter(final String url) {
+    withEnv(
+        ContainerRuntimeEnvs.ZEEBE_ENV_ELASTICSEARCH_CLASSNAME,
+        ZEEBE_ELASTICSEARCH_EXPORTER_CLASSNAME);
+    withEnv(ContainerRuntimeEnvs.ZEEBE_ENV_ELASTICSEARCH_ARGS_URL, url);
+    withEnv(ContainerRuntimeEnvs.ZEEBE_ENV_ELASTICSEARCH_ARGS_BULK_SIZE, "1");
+    return this;
+  }
+
+  public static HttpWaitStrategy newDefaultBrokerReadyCheck() {
+    return new HttpWaitStrategy()
+        .forPath(ZEEBE_READY_ENDPOINT)
+        .forPort(ContainerRuntimePorts.ZEEBE_MONITORING_API)
+        .forStatusCodeMatching(status -> status >= 200 && status < 300)
+        .withReadTimeout(Duration.ofSeconds(10));
+  }
+
+  private WaitAllStrategy newDefaultWaitStrategy() {
+    return new WaitAllStrategy(Mode.WITH_OUTER_TIMEOUT)
+        .withStrategy(new HostPortWaitStrategy())
+        .withStrategy(newDefaultBrokerReadyCheck())
+        .withStartupTimeout(DEFAULT_STARTUP_TIMEOUT);
+  }
+
+  public int getGrpcApiPort() {
+    return getMappedPort(ContainerRuntimePorts.ZEEBE_GATEWAY_API);
+  }
+
+  public int getRestApiPort() {
+    return getMappedPort(ContainerRuntimePorts.ZEEBE_REST_API);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntime.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import io.camunda.process.test.impl.containers.OperateContainer;
+import io.camunda.process.test.impl.containers.TasklistContainer;
+import io.camunda.process.test.impl.containers.ZeebeContainer;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class CamundaContainerRuntime implements AutoCloseable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(CamundaContainerRuntime.class);
+
+  private static final String NETWORK_ALIAS_ZEEBE = "zeebe";
+  private static final String NETWORK_ALIAS_ELASTICSEARCH = "elasticsearch";
+  private static final String NETWORK_ALIAS_OPERATE = "operate";
+  private static final String NETWORK_ALIAS_TASKLIST = "tasklist";
+
+  private static final String ELASTICSEARCH_URL =
+      "http://" + NETWORK_ALIAS_ELASTICSEARCH + ":" + ContainerRuntimePorts.ELASTICSEARCH_REST_API;
+
+  private static final String ZEEBE_GRPC_API =
+      NETWORK_ALIAS_ZEEBE + ":" + ContainerRuntimePorts.ZEEBE_GATEWAY_API;
+  private static final String ZEEBE_REST_API =
+      NETWORK_ALIAS_ZEEBE + ":" + ContainerRuntimePorts.ZEEBE_REST_API;
+
+  private final Network network;
+  private final ZeebeContainer zeebeContainer;
+  private final ElasticsearchContainer elasticsearchContainer;
+  private final OperateContainer operateContainer;
+  private final TasklistContainer tasklistContainer;
+
+  CamundaContainerRuntime(final CamundaContainerRuntimeBuilder builder) {
+    network = Network.newNetwork();
+
+    elasticsearchContainer = createElasticsearchContainer(network, builder);
+    zeebeContainer = createZeebeContainer(network, builder);
+    operateContainer = createOperateContainer(network, builder);
+    tasklistContainer = createTasklistContainer(network, builder);
+  }
+
+  private ElasticsearchContainer createElasticsearchContainer(
+      final Network network, final CamundaContainerRuntimeBuilder builder) {
+    final ElasticsearchContainer container =
+        new ElasticsearchContainer(
+                parseDockerImage(
+                    builder.getElasticsearchDockerImageName(),
+                    builder.getElasticsearchDockerImageVersion()))
+            .withLogConsumer(createContainerLogger(builder.getElasticsearchLoggerName()))
+            .withNetwork(network)
+            .withNetworkAliases(NETWORK_ALIAS_ELASTICSEARCH)
+            .withEnv(ContainerRuntimeEnvs.ELASTICSEARCH_ENV_XPACK_SECURITY_ENABLED, "false")
+            .withEnv(builder.getElasticsearchEnvVars());
+
+    builder.getElasticsearchExposedPorts().forEach(container::addExposedPort);
+
+    return container;
+  }
+
+  private ZeebeContainer createZeebeContainer(
+      final Network network, final CamundaContainerRuntimeBuilder builder) {
+    final ZeebeContainer container =
+        new ZeebeContainer(
+                parseDockerImage(
+                    builder.getZeebeDockerImageName(), builder.getZeebeDockerImageVersion()))
+            .withLogConsumer(createContainerLogger(builder.getZeebeLoggerName()))
+            .withNetwork(network)
+            .withNetworkAliases(NETWORK_ALIAS_ZEEBE)
+            .withElasticsearchExporter(ELASTICSEARCH_URL)
+            .withEnv(builder.getZeebeEnvVars());
+
+    builder.getZeebeExposedPorts().forEach(container::addExposedPort);
+
+    return container;
+  }
+
+  private OperateContainer createOperateContainer(
+      final Network network, final CamundaContainerRuntimeBuilder builder) {
+    final OperateContainer container =
+        new OperateContainer(
+                parseDockerImage(
+                    ContainerRuntimeDefaults.OPERATE_DOCKER_IMAGE_NAME,
+                    builder.getOperateDockerImageVersion()))
+            .withLogConsumer(createContainerLogger(builder.getOperateLoggerName()))
+            .withNetwork(network)
+            .withNetworkAliases(NETWORK_ALIAS_OPERATE)
+            .withZeebeGrpcApi(ZEEBE_GRPC_API)
+            .withElasticsearchUrl(ELASTICSEARCH_URL)
+            .withEnv(builder.getOperateEnvVars());
+
+    builder.getOperateExposedPorts().forEach(container::addExposedPort);
+
+    return container;
+  }
+
+  private TasklistContainer createTasklistContainer(
+      final Network network, final CamundaContainerRuntimeBuilder builder) {
+    final TasklistContainer container =
+        new TasklistContainer(
+                parseDockerImage(
+                    ContainerRuntimeDefaults.TASKLIST_DOCKER_IMAGE_NAME,
+                    builder.getTasklistDockerImageVersion()))
+            .withLogConsumer(createContainerLogger(builder.getTasklistLoggerName()))
+            .withNetwork(network)
+            .withNetworkAliases(NETWORK_ALIAS_TASKLIST)
+            .withZeebeApi(ZEEBE_GRPC_API, ZEEBE_REST_API)
+            .withElasticsearchUrl(ELASTICSEARCH_URL)
+            .withEnv(builder.getTasklistEnvVars());
+
+    builder.getTasklistExposedPorts().forEach(container::addExposedPort);
+
+    return container;
+  }
+
+  public void start() {
+    LOGGER.info("Starting Camunda container runtime");
+    final Instant startTime = Instant.now();
+
+    elasticsearchContainer.start();
+    Stream.of(zeebeContainer, operateContainer, tasklistContainer)
+        .parallel()
+        .forEach(GenericContainer::start);
+
+    final Instant endTime = Instant.now();
+    final Duration startupTime = Duration.between(startTime, endTime);
+    LOGGER.info("Camunda container runtime started in {}", startupTime);
+  }
+
+  public ZeebeContainer getZeebeContainer() {
+    return zeebeContainer;
+  }
+
+  public ElasticsearchContainer getElasticsearchContainer() {
+    return elasticsearchContainer;
+  }
+
+  public OperateContainer getOperateContainer() {
+    return operateContainer;
+  }
+
+  public TasklistContainer getTasklistContainer() {
+    return tasklistContainer;
+  }
+
+  @Override
+  public void close() throws Exception {
+    LOGGER.info("Stopping Camunda container runtime");
+    final Instant startTime = Instant.now();
+
+    Stream.of(zeebeContainer, operateContainer, tasklistContainer)
+        .parallel()
+        .forEach(GenericContainer::stop);
+
+    elasticsearchContainer.stop();
+    network.close();
+
+    final Instant endTime = Instant.now();
+    final Duration shutdownTime = Duration.between(startTime, endTime);
+    LOGGER.info("Camunda container runtime stopped in {}", shutdownTime);
+  }
+
+  private static DockerImageName parseDockerImage(
+      final String imageName, final String imageVersion) {
+    return DockerImageName.parse(imageName).withTag(imageVersion);
+  }
+
+  private static Slf4jLogConsumer createContainerLogger(final String name) {
+    final Logger logger = LoggerFactory.getLogger(name);
+    return new Slf4jLogConsumer(logger);
+  }
+
+  public static CamundaContainerRuntimeBuilder newBuilder() {
+    return new CamundaContainerRuntimeBuilder();
+  }
+
+  public static CamundaContainerRuntime newDefaultRuntime() {
+    return newBuilder().build();
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntimeBuilder.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/CamundaContainerRuntimeBuilder.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CamundaContainerRuntimeBuilder {
+
+  private String zeebeDockerImageName = ContainerRuntimeDefaults.ZEEBE_DOCKER_IMAGE_NAME;
+  private String zeebeDockerImageVersion = ContainerRuntimeDefaults.ZEEBE_DOCKER_IMAGE_VERSION;
+
+  private String elasticsearchDockerImageName =
+      ContainerRuntimeDefaults.ELASTICSEARCH_DOCKER_IMAGE_NAME;
+  private String elasticsearchDockerImageVersion =
+      ContainerRuntimeDefaults.ELASTICSEARCH_DOCKER_IMAGE_VERSION;
+
+  private String operateDockerImageVersion = ContainerRuntimeDefaults.OPERATE_DOCKER_IMAGE_VERSION;
+
+  private String tasklistDockerImageVersion =
+      ContainerRuntimeDefaults.TASKLIST_DOCKER_IMAGE_VERSION;
+
+  private final Map<String, String> zeebeEnvVars = new HashMap<>();
+  private final Map<String, String> elasticsearchEnvVars = new HashMap<>();
+  private final Map<String, String> operateEnvVars = new HashMap<>();
+  private final Map<String, String> tasklistEnvVars = new HashMap<>();
+
+  private final List<Integer> zeebeExposedPorts = new ArrayList<>();
+  private final List<Integer> elasticsearchExposedPorts = new ArrayList<>();
+  private final List<Integer> operateExposedPorts = new ArrayList<>();
+  private final List<Integer> tasklistExposedPorts = new ArrayList<>();
+
+  private String zeebeLoggerName = ContainerRuntimeDefaults.ZEEBE_LOGGER_NAME;
+  private String elasticsearchLoggerName = ContainerRuntimeDefaults.ELASTICSEARCH_LOGGER_NAME;
+  private String operateLoggerName = ContainerRuntimeDefaults.OPERATE_LOGGER_NAME;
+  private String tasklistLoggerName = ContainerRuntimeDefaults.TASKLIST_LOGGER_NAME;
+
+  // ============ Configuration options =================
+
+  public CamundaContainerRuntimeBuilder withZeebeDockerImageName(final String dockerImageName) {
+    zeebeDockerImageName = dockerImageName;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withZeebeDockerImageVersion(
+      final String dockerImageVersion) {
+    zeebeDockerImageVersion = dockerImageVersion;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withElasticsearchDockerImageName(
+      final String dockerImageName) {
+    elasticsearchDockerImageName = dockerImageName;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withElasticsearchDockerImageVersion(
+      final String dockerImageVersion) {
+    elasticsearchDockerImageVersion = dockerImageVersion;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withOperateDockerImageVersion(
+      final String dockerImageVersion) {
+    operateDockerImageVersion = dockerImageVersion;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withTasklistDockerImageVersion(
+      final String dockerImageVersion) {
+    tasklistDockerImageVersion = dockerImageVersion;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withZeebeEnv(final Map<String, String> envVars) {
+    zeebeEnvVars.putAll(envVars);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withZeebeEnv(final String name, final String value) {
+    zeebeEnvVars.put(name, value);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withElasticsearchEnv(final Map<String, String> envVars) {
+    elasticsearchEnvVars.putAll(envVars);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withElasticsearchEnv(
+      final String name, final String value) {
+    elasticsearchEnvVars.put(name, value);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withOperateEnv(final Map<String, String> envVars) {
+    operateEnvVars.putAll(envVars);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withOperateEnv(final String name, final String value) {
+    operateEnvVars.put(name, value);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withTasklistEnv(final Map<String, String> envVars) {
+    tasklistEnvVars.putAll(envVars);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withTasklistEnv(final String name, final String value) {
+    tasklistEnvVars.put(name, value);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withZeebeExposedPort(final int port) {
+    zeebeExposedPorts.add(port);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withElasticsearchExposedPort(final int port) {
+    elasticsearchExposedPorts.add(port);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withOperateExposedPort(final int port) {
+    operateExposedPorts.add(port);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withTasklistExposedPort(final int port) {
+    tasklistExposedPorts.add(port);
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withZeebeLogger(final String loggerName) {
+    zeebeLoggerName = loggerName;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withElasticsearchLogger(final String loggerName) {
+    elasticsearchLoggerName = loggerName;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withOperateLogger(final String loggerName) {
+    operateLoggerName = loggerName;
+    return this;
+  }
+
+  public CamundaContainerRuntimeBuilder withTasklistLogger(final String loggerName) {
+    tasklistLoggerName = loggerName;
+    return this;
+  }
+
+  // ============ Build =================
+
+  public CamundaContainerRuntime build() {
+    return new CamundaContainerRuntime(this);
+  }
+
+  // ============ Getters =================
+
+  public String getZeebeDockerImageName() {
+    return zeebeDockerImageName;
+  }
+
+  public String getZeebeDockerImageVersion() {
+    return zeebeDockerImageVersion;
+  }
+
+  public String getElasticsearchDockerImageName() {
+    return elasticsearchDockerImageName;
+  }
+
+  public String getElasticsearchDockerImageVersion() {
+    return elasticsearchDockerImageVersion;
+  }
+
+  public String getOperateDockerImageVersion() {
+    return operateDockerImageVersion;
+  }
+
+  public String getTasklistDockerImageVersion() {
+    return tasklistDockerImageVersion;
+  }
+
+  public Map<String, String> getZeebeEnvVars() {
+    return zeebeEnvVars;
+  }
+
+  public Map<String, String> getElasticsearchEnvVars() {
+    return elasticsearchEnvVars;
+  }
+
+  public Map<String, String> getOperateEnvVars() {
+    return operateEnvVars;
+  }
+
+  public Map<String, String> getTasklistEnvVars() {
+    return tasklistEnvVars;
+  }
+
+  public List<Integer> getZeebeExposedPorts() {
+    return zeebeExposedPorts;
+  }
+
+  public List<Integer> getElasticsearchExposedPorts() {
+    return elasticsearchExposedPorts;
+  }
+
+  public List<Integer> getOperateExposedPorts() {
+    return operateExposedPorts;
+  }
+
+  public List<Integer> getTasklistExposedPorts() {
+    return tasklistExposedPorts;
+  }
+
+  public String getZeebeLoggerName() {
+    return zeebeLoggerName;
+  }
+
+  public String getElasticsearchLoggerName() {
+    return elasticsearchLoggerName;
+  }
+
+  public String getOperateLoggerName() {
+    return operateLoggerName;
+  }
+
+  public String getTasklistLoggerName() {
+    return tasklistLoggerName;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeDefaults.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+public class ContainerRuntimeDefaults {
+
+  // Zeebe
+  public static final String ZEEBE_DOCKER_IMAGE_NAME = "camunda/zeebe";
+  public static final String ZEEBE_DOCKER_IMAGE_VERSION = "SNAPSHOT";
+  public static final String ZEEBE_LOGGER_NAME = "tc.zeebe";
+
+  // Elasticsearch
+  public static final String ELASTICSEARCH_DOCKER_IMAGE_NAME = "elasticsearch";
+  public static final String ELASTICSEARCH_DOCKER_IMAGE_VERSION = "8.13.0";
+  public static final String ELASTICSEARCH_LOGGER_NAME = "tc.elasticsearch";
+
+  // Operate
+  public static final String OPERATE_DOCKER_IMAGE_NAME = "camunda/operate";
+  public static final String OPERATE_DOCKER_IMAGE_VERSION = "SNAPSHOT";
+  public static final String OPERATE_LOGGER_NAME = "tc.operate";
+
+  // Tasklist
+  public static final String TASKLIST_DOCKER_IMAGE_NAME = "camunda/tasklist";
+  public static final String TASKLIST_DOCKER_IMAGE_VERSION = "SNAPSHOT";
+  public static final String TASKLIST_LOGGER_NAME = "tc.tasklist";
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeDefaults.java
@@ -17,23 +17,22 @@ package io.camunda.process.test.impl.runtime;
 
 public class ContainerRuntimeDefaults {
 
-  // Zeebe
-  public static final String ZEEBE_DOCKER_IMAGE_NAME = "camunda/zeebe";
-  public static final String ZEEBE_DOCKER_IMAGE_VERSION = "SNAPSHOT";
-  public static final String ZEEBE_LOGGER_NAME = "tc.zeebe";
-
-  // Elasticsearch
   public static final String ELASTICSEARCH_DOCKER_IMAGE_NAME = "elasticsearch";
-  public static final String ELASTICSEARCH_DOCKER_IMAGE_VERSION = "8.13.0";
-  public static final String ELASTICSEARCH_LOGGER_NAME = "tc.elasticsearch";
-
-  // Operate
+  public static final String ZEEBE_DOCKER_IMAGE_NAME = "camunda/zeebe";
   public static final String OPERATE_DOCKER_IMAGE_NAME = "camunda/operate";
-  public static final String OPERATE_DOCKER_IMAGE_VERSION = "SNAPSHOT";
-  public static final String OPERATE_LOGGER_NAME = "tc.operate";
-
-  // Tasklist
   public static final String TASKLIST_DOCKER_IMAGE_NAME = "camunda/tasklist";
-  public static final String TASKLIST_DOCKER_IMAGE_VERSION = "SNAPSHOT";
+
+  public static final String ELASTICSEARCH_LOGGER_NAME = "tc.elasticsearch";
+  public static final String ZEEBE_LOGGER_NAME = "tc.zeebe";
+  public static final String OPERATE_LOGGER_NAME = "tc.operate";
   public static final String TASKLIST_LOGGER_NAME = "tc.tasklist";
+
+  private static final ContainerRuntimeVersionUtil VERSION_UTIL =
+      ContainerRuntimeVersionUtil.readVersions();
+
+  public static final String ELASTICSEARCH_DOCKER_IMAGE_VERSION =
+      VERSION_UTIL.getElasticsearchVersion();
+  public static final String ZEEBE_DOCKER_IMAGE_VERSION = VERSION_UTIL.getCamundaVersion();
+  public static final String OPERATE_DOCKER_IMAGE_VERSION = VERSION_UTIL.getCamundaVersion();
+  public static final String TASKLIST_DOCKER_IMAGE_VERSION = VERSION_UTIL.getCamundaVersion();
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeEnvs.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeEnvs.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+public class ContainerRuntimeEnvs {
+
+  // Zeebe
+  public static final String ZEEBE_ENV_ELASTICSEARCH_CLASSNAME =
+      "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_CLASSNAME";
+  public static final String ZEEBE_ENV_ELASTICSEARCH_ARGS_URL =
+      "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_URL";
+  public static final String ZEEBE_ENV_ELASTICSEARCH_ARGS_BULK_SIZE =
+      "ZEEBE_BROKER_EXPORTERS_ELASTICSEARCH_ARGS_BULK_SIZE";
+  public static final String ZEEBE_ENV_CLOCK_CONTROLLED = "ZEEBE_CLOCK_CONTROLLED";
+
+  // Elasticsearch
+  public static final String ELASTICSEARCH_ENV_XPACK_SECURITY_ENABLED = "xpack.security.enabled";
+
+  // Operate
+  public static final String OPERATE_ENV_ZEEBE_GATEWAYADDRESS =
+      "CAMUNDA_OPERATE_ZEEBE_GATEWAYADDRESS";
+  public static final String OPERATE_ENV_ELASTICSEARCH_URL = "CAMUNDA_OPERATE_ELASTICSEARCH_URL";
+  public static final String OPERATE_ENV_ZEEBEELASTICSEARCH_URL =
+      "CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL";
+
+  // Tasklist
+  public static final String TASKLIST_ENV_ZEEBE_GATEWAYADDRESS =
+      "CAMUNDA_TASKLIST_ZEEBE_GATEWAYADDRESS";
+  public static final String TASKLIST_ENV_ZEEBE_RESTADDRESS = "CAMUNDA_TASKLIST_ZEEBE_RESTADDRESS";
+  public static final String TASKLIST_ENV_ELASTICSEARCH_URL = "CAMUNDA_TASKLIST_ELASTICSEARCH_URL";
+  public static final String TASKLIST_ENV_ZEEBEELASTICSEARCH_URL =
+      "CAMUNDA_TASKLIST_ZEEBEELASTICSEARCH_URL";
+  public static final String TASKLIST_CSRF_PREVENTION_ENABLED =
+      "CAMUNDA_TASKLIST_CSRFPREVENTIONENABLED";
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePorts.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimePorts.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+public class ContainerRuntimePorts {
+
+  // Zeebe
+  public static final int ZEEBE_COMMAND_API = 26501;
+  public static final int ZEEBE_GATEWAY_API = 26500;
+  public static final int ZEEBE_INTERNAL_API = 26502;
+  public static final int ZEEBE_MONITORING_API = 9600;
+  public static final int ZEEBE_REST_API = 8080;
+
+  // Elasticsearch
+  public static final int ELASTICSEARCH_REST_API = 9200;
+
+  // Operate
+  public static final int OPERATE_REST_API = 8080;
+
+  // Tasklist
+  public static final int TASKLIST_REST_API = 8080;
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeVersionUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeVersionUtil.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.runtime;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ContainerRuntimeVersionUtil {
+
+  public static final Logger LOGGER = LoggerFactory.getLogger(ContainerRuntimeVersionUtil.class);
+
+  public static final String VERSION_PROPERTIES_FILE = "/camunda-container-runtime.properties";
+
+  public static final String PROPERTY_NAME_CAMUNDA_VERSION = "camunda.version";
+  public static final String PROPERTY_NAME_ELASTICSEARCH_VERSION = "elasticsearch.version";
+
+  public static final String CAMUNDA_VERSION_SNAPSHOT = "SNAPSHOT";
+  public static final String ELASTICSEARCH_VERSION_DEFAULT = "8.13.0";
+
+  private static final Pattern SEMANTIC_VERSION_PATTERN =
+      Pattern.compile("(\\d+)\\.(\\d+)\\.(\\d+)(-.*)?");
+
+  private static final String VERSION_FORMAT = "%d.%d.%d";
+
+  private final String camundaVersion;
+  private final String elasticsearchVersion;
+
+  public ContainerRuntimeVersionUtil(final Properties versionProperties) {
+    camundaVersion = resolveCamundaVersion(versionProperties);
+    elasticsearchVersion = resolveElasticsearchVersion(versionProperties);
+  }
+
+  private static String resolveCamundaVersion(final Properties versionProperties) {
+    return Optional.ofNullable(versionProperties.getProperty(PROPERTY_NAME_CAMUNDA_VERSION))
+        .map(SEMANTIC_VERSION_PATTERN::matcher)
+        .filter(Matcher::find)
+        .map(
+            matcher -> {
+              final int major = Integer.parseInt(matcher.group(1));
+              final int minor = Integer.parseInt(matcher.group(2));
+              final int patch = Integer.parseInt(matcher.group(3));
+              final String label = matcher.group(4);
+              return resolveCamundaVersion(major, minor, patch, label);
+            })
+        .orElse(CAMUNDA_VERSION_SNAPSHOT);
+  }
+
+  private static String resolveCamundaVersion(
+      final int major, final int minor, final int patch, final String label) {
+
+    if (label == null) {
+      // release version
+      return String.format(VERSION_FORMAT, major, minor, patch);
+
+    } else if (patch == 0) {
+      // current dev version
+      return CAMUNDA_VERSION_SNAPSHOT;
+
+    } else {
+      // maintenance dev version
+      final int previousPatchVersion = patch - 1;
+      return String.format(VERSION_FORMAT, major, minor, previousPatchVersion);
+    }
+  }
+
+  private String resolveElasticsearchVersion(final Properties versionProperties) {
+    return Optional.ofNullable(versionProperties.getProperty(PROPERTY_NAME_ELASTICSEARCH_VERSION))
+        .filter(version -> SEMANTIC_VERSION_PATTERN.matcher(version).find())
+        .orElse(ELASTICSEARCH_VERSION_DEFAULT);
+  }
+
+  public static ContainerRuntimeVersionUtil readVersions() {
+    return new ContainerRuntimeVersionUtil(readVersionFile());
+  }
+
+  private static Properties readVersionFile() {
+    try (final InputStream versionFileStream =
+        ContainerRuntimeVersionUtil.class.getResourceAsStream(VERSION_PROPERTIES_FILE)) {
+
+      final Properties properties = new Properties();
+      properties.load(versionFileStream);
+      return properties;
+
+    } catch (final IOException e) {
+      LOGGER.warn(String.format("Can't read version file: %s", VERSION_PROPERTIES_FILE), e);
+    }
+    return new Properties();
+  }
+
+  public String getCamundaVersion() {
+    return camundaVersion;
+  }
+
+  public String getElasticsearchVersion() {
+    return elasticsearchVersion;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
+++ b/testing/camunda-process-test-java/src/main/resources/camunda-container-runtime.properties
@@ -1,0 +1,2 @@
+camunda.version=${project.version}
+elasticsearch.version=${version.elasticsearch}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/containers/ContainerIntegrationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/containers/ContainerIntegrationTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.containers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.impl.containers.OperateContainer;
+import io.camunda.process.test.impl.containers.TasklistContainer;
+import io.camunda.process.test.impl.containers.ZeebeContainer;
+import io.camunda.process.test.impl.runtime.CamundaContainerRuntime;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.DeploymentEvent;
+import io.camunda.zeebe.client.api.response.PartitionBrokerHealth;
+import io.camunda.zeebe.client.api.response.PartitionInfo;
+import io.camunda.zeebe.client.api.response.Topology;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.io.IOException;
+import java.net.URI;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.cookie.Cookie;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.HttpEntities;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class ContainerIntegrationTest {
+
+  private static final BpmnModelInstance PROCESS =
+      Bpmn.createExecutableProcess("process")
+          .startEvent()
+          .userTask("A")
+          .zeebeUserTask()
+          .endEvent()
+          .done();
+
+  private static CamundaContainerRuntime runtime;
+
+  @BeforeAll
+  static void startContainerRuntime() {
+    runtime = CamundaContainerRuntime.newBuilder().build();
+    runtime.start();
+  }
+
+  @AfterAll
+  static void closeContainerRuntime() throws Exception {
+    runtime.close();
+  }
+
+  @Test
+  void shouldConnectWithZeebeClient() {
+    // given
+    final ZeebeContainer zeebeContainer = runtime.getZeebeContainer();
+    final URI grpcAddress =
+        URI.create("http://" + zeebeContainer.getHost() + ":" + zeebeContainer.getGrpcApiPort());
+    final URI restAddress =
+        URI.create("http://" + zeebeContainer.getHost() + ":" + zeebeContainer.getRestApiPort());
+
+    // when
+    final ZeebeClient zeebeClient =
+        ZeebeClient.newClientBuilder()
+            .usePlaintext()
+            .grpcAddress(grpcAddress)
+            .restAddress(restAddress)
+            .build();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final Topology topology = zeebeClient.newTopologyRequest().send().join();
+
+              assertThat(topology.getClusterSize()).isEqualTo(1);
+              assertThat(topology.getPartitionsCount()).isEqualTo(1);
+
+              assertThat(topology.getBrokers())
+                  .flatExtracting(BrokerInfo::getPartitions)
+                  .extracting(PartitionInfo::getHealth)
+                  .containsOnly(PartitionBrokerHealth.HEALTHY);
+            });
+  }
+
+  @Test
+  void shouldExportToElasticsearch() {
+    // given
+    final ZeebeClient zeebeClient = createZeebeClient(runtime);
+    zeebeClient.newDeployResourceCommand().addProcessModel(PROCESS, "process.bpmn").send().join();
+
+    // when
+    final String elasticsearchAddress = runtime.getElasticsearchContainer().getHttpHostAddress();
+    final URI elasticsearchIndexStatsEndpoint =
+        URI.create("http://" + elasticsearchAddress + "/_stats");
+
+    final CloseableHttpClient httpClient = HttpClients.createDefault();
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final String responseBody =
+                  sendGetRequest(httpClient, elasticsearchIndexStatsEndpoint);
+              assertThat(responseBody).contains("zeebe-record_deployment");
+            });
+  }
+
+  @Test
+  void shouldFindProcessWithOperateApi() throws IOException {
+    // given
+    final ZeebeClient zeebeClient = createZeebeClient(runtime);
+    final DeploymentEvent deployment =
+        zeebeClient
+            .newDeployResourceCommand()
+            .addProcessModel(PROCESS, "process.bpmn")
+            .send()
+            .join();
+    final long processDefinitionKey = deployment.getProcesses().get(0).getProcessDefinitionKey();
+
+    // when
+    final OperateContainer operateContainer = runtime.getOperateContainer();
+    final String operateRestApi =
+        "http://" + operateContainer.getHost() + ":" + operateContainer.getRestApiPort();
+    final URI operateProcessEndpoint =
+        URI.create(operateRestApi + "/v1/process-definitions/search");
+
+    final BasicCookieStore cookieStore = new BasicCookieStore();
+    final CloseableHttpClient httpClient =
+        HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
+
+    sendLoginRequest(httpClient, operateRestApi);
+    assertThat(cookieStore.getCookies()).extracting(Cookie::getName).contains("OPERATE-SESSION");
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final String responseBody = sendPostRequest(httpClient, operateProcessEndpoint, "{}");
+              assertThat(responseBody).contains("\"key\":" + processDefinitionKey);
+            });
+  }
+
+  @Test
+  void shouldFindUserTaskWithTasklistApi() throws IOException {
+    // given
+    final ZeebeClient zeebeClient = createZeebeClient(runtime);
+    zeebeClient.newDeployResourceCommand().addProcessModel(PROCESS, "process.bpmn").send().join();
+
+    final long processInstanceKey =
+        zeebeClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    // when
+    final TasklistContainer tasklistContainer = runtime.getTasklistContainer();
+    final String tasklistRestApi =
+        "http://" + tasklistContainer.getHost() + ":" + tasklistContainer.getRestApiPort();
+    final URI tasklistSearchTasksEndpoint = URI.create(tasklistRestApi + "/v1/tasks/search");
+    final String searchTasksFilter = "{\n  \"processInstanceKey\": \"" + processInstanceKey + "\"}";
+
+    final BasicCookieStore cookieStore = new BasicCookieStore();
+    final CloseableHttpClient httpClient =
+        HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
+
+    sendLoginRequest(httpClient, tasklistRestApi);
+    assertThat(cookieStore.getCookies()).extracting(Cookie::getName).contains("TASKLIST-SESSION");
+
+    // then
+    Awaitility.await()
+        .untilAsserted(
+            () -> {
+              final String responseBody =
+                  sendPostRequest(httpClient, tasklistSearchTasksEndpoint, searchTasksFilter);
+              assertThat(responseBody)
+                  .contains("\"processInstanceKey\" : \"" + processInstanceKey + "\"");
+            });
+  }
+
+  private static ZeebeClient createZeebeClient(final CamundaContainerRuntime runtime) {
+    final ZeebeContainer zeebeContainer = runtime.getZeebeContainer();
+    final URI grpcAddress =
+        URI.create("http://" + zeebeContainer.getHost() + ":" + zeebeContainer.getGrpcApiPort());
+    final URI restAddress =
+        URI.create("http://" + zeebeContainer.getHost() + ":" + zeebeContainer.getRestApiPort());
+
+    return ZeebeClient.newClientBuilder()
+        .usePlaintext()
+        .grpcAddress(grpcAddress)
+        .restAddress(restAddress)
+        .build();
+  }
+
+  private static void sendLoginRequest(final CloseableHttpClient httpClient, final String apiUrl)
+      throws IOException {
+    httpClient.execute(
+        new HttpPost(apiUrl + "/api/login?username=demo&password=demo"),
+        response -> {
+          assertThat(response.getCode()).isEqualTo(204);
+          return null;
+        });
+  }
+
+  private static String sendGetRequest(final CloseableHttpClient httpClient, final URI uri)
+      throws IOException {
+    return httpClient.execute(
+        new HttpGet(uri),
+        response -> {
+          assertThat(response.getCode()).isEqualTo(200);
+          return EntityUtils.toString(response.getEntity());
+        });
+  }
+
+  private static String sendPostRequest(
+      final CloseableHttpClient httpClient, final URI uri, final String body) throws IOException {
+
+    final HttpPost request = new HttpPost(uri);
+    request.setEntity(HttpEntities.create(body, ContentType.APPLICATION_JSON));
+
+    return httpClient.execute(
+        request,
+        response -> {
+          assertThat(response.getCode()).isEqualTo(200);
+          return EntityUtils.toString(response.getEntity());
+        });
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/runtime/CamundaContainerRuntimeTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/runtime/CamundaContainerRuntimeTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.impl.runtime.CamundaContainerRuntime;
+import org.junit.jupiter.api.Test;
+
+public class CamundaContainerRuntimeTest {
+
+  @Test
+  void shouldCreateContainers() {
+    // given/when
+    final CamundaContainerRuntime runtime = CamundaContainerRuntime.newDefaultRuntime();
+
+    // then
+    assertThat(runtime.getZeebeContainer()).isNotNull();
+    assertThat(runtime.getZeebeContainer().isRunning()).isFalse();
+
+    assertThat(runtime.getElasticsearchContainer()).isNotNull();
+    assertThat(runtime.getElasticsearchContainer().isRunning()).isFalse();
+
+    assertThat(runtime.getOperateContainer()).isNotNull();
+    assertThat(runtime.getOperateContainer().isRunning()).isFalse();
+
+    assertThat(runtime.getTasklistContainer()).isNotNull();
+    assertThat(runtime.getTasklistContainer().isRunning()).isFalse();
+  }
+
+  @Test
+  void shouldStartAndStopContainers() throws Exception {
+    // given
+    final CamundaContainerRuntime runtime = CamundaContainerRuntime.newDefaultRuntime();
+
+    // when
+    runtime.start();
+
+    // then
+    assertThat(runtime.getZeebeContainer()).isNotNull();
+    assertThat(runtime.getZeebeContainer().isRunning()).isTrue();
+
+    assertThat(runtime.getElasticsearchContainer()).isNotNull();
+    assertThat(runtime.getElasticsearchContainer().isRunning()).isTrue();
+
+    assertThat(runtime.getOperateContainer()).isNotNull();
+    assertThat(runtime.getOperateContainer().isRunning()).isTrue();
+
+    assertThat(runtime.getTasklistContainer()).isNotNull();
+    assertThat(runtime.getTasklistContainer().isRunning()).isTrue();
+
+    // and when
+    runtime.close();
+
+    // then
+    assertThat(runtime.getZeebeContainer()).isNotNull();
+    assertThat(runtime.getZeebeContainer().isRunning()).isFalse();
+
+    assertThat(runtime.getElasticsearchContainer()).isNotNull();
+    assertThat(runtime.getElasticsearchContainer().isRunning()).isFalse();
+
+    assertThat(runtime.getOperateContainer()).isNotNull();
+    assertThat(runtime.getOperateContainer().isRunning()).isFalse();
+
+    assertThat(runtime.getTasklistContainer()).isNotNull();
+    assertThat(runtime.getTasklistContainer().isRunning()).isFalse();
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/runtime/ContainerRuntimeVersionUtilTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/runtime/ContainerRuntimeVersionUtilTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.impl.runtime.ContainerRuntimeVersionUtil;
+import java.util.Properties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class ContainerRuntimeVersionUtilTest {
+
+  @Test
+  void shouldReturnDefaults() {
+    // given
+    final Properties versionProperties = new Properties();
+
+    // when
+    final ContainerRuntimeVersionUtil versionUtil =
+        new ContainerRuntimeVersionUtil(versionProperties);
+
+    // then
+    assertThat(versionUtil.getCamundaVersion()).isEqualTo("SNAPSHOT");
+    assertThat(versionUtil.getElasticsearchVersion()).isEqualTo("8.13.0");
+  }
+
+  @Test
+  void shouldReturnDefaultsForDevelopment() {
+    // given
+    final Properties versionProperties = new Properties();
+    versionProperties.put(
+        ContainerRuntimeVersionUtil.PROPERTY_NAME_CAMUNDA_VERSION, "${project.version}");
+    versionProperties.put(
+        ContainerRuntimeVersionUtil.PROPERTY_NAME_ELASTICSEARCH_VERSION,
+        "${version.elasticsearch}");
+
+    // when
+    final ContainerRuntimeVersionUtil versionUtil =
+        new ContainerRuntimeVersionUtil(versionProperties);
+
+    // then
+    assertThat(versionUtil.getCamundaVersion()).isEqualTo("SNAPSHOT");
+    assertThat(versionUtil.getElasticsearchVersion()).isEqualTo("8.13.0");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "8.6.0, 8.6.0",
+    "8.6.1, 8.6.1",
+    "8.6.0-SNAPSHOT, SNAPSHOT",
+    "8.5.2-SNAPSHOT, 8.5.1",
+    "8.5.2-rc1, 8.5.1",
+  })
+  void shouldReturnCamundaVersion(final String propertyVersion, final String expectedVersion) {
+    // given
+    final Properties versionProperties = new Properties();
+    versionProperties.put(
+        ContainerRuntimeVersionUtil.PROPERTY_NAME_CAMUNDA_VERSION, propertyVersion);
+
+    // when
+    final ContainerRuntimeVersionUtil versionUtil =
+        new ContainerRuntimeVersionUtil(versionProperties);
+
+    // then
+    assertThat(versionUtil.getCamundaVersion()).isEqualTo(expectedVersion);
+  }
+
+  @Test
+  void shouldReturnElasticsearchVersion() {
+    // given
+    final Properties versionProperties = new Properties();
+    versionProperties.put(
+        ContainerRuntimeVersionUtil.PROPERTY_NAME_ELASTICSEARCH_VERSION, "8.13.1");
+
+    // when
+    final ContainerRuntimeVersionUtil versionUtil =
+        new ContainerRuntimeVersionUtil(versionProperties);
+
+    // then
+    assertThat(versionUtil.getElasticsearchVersion()).isEqualTo("8.13.1");
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/runtime/RuntimeConfigurationTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/runtime/RuntimeConfigurationTest.java
@@ -1,0 +1,178 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.runtime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.process.test.impl.containers.OperateContainer;
+import io.camunda.process.test.impl.containers.TasklistContainer;
+import io.camunda.process.test.impl.containers.ZeebeContainer;
+import io.camunda.process.test.impl.runtime.CamundaContainerRuntime;
+import io.camunda.process.test.impl.runtime.ContainerRuntimeDefaults;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+
+public class RuntimeConfigurationTest {
+
+  private static final Map<String, String> ENV_VARS;
+
+  static {
+    ENV_VARS = new HashMap<>();
+    ENV_VARS.put("env-1", "test-1");
+    ENV_VARS.put("env-2", "test-2");
+  }
+
+  @Test
+  void shouldUseDefaults() {
+    // given/when
+    final CamundaContainerRuntime runtime = CamundaContainerRuntime.newDefaultRuntime();
+
+    // then
+    assertThat(runtime.getZeebeContainer().getDockerImageName())
+        .isEqualTo(
+            ContainerRuntimeDefaults.ZEEBE_DOCKER_IMAGE_NAME
+                + ":"
+                + ContainerRuntimeDefaults.ZEEBE_DOCKER_IMAGE_VERSION);
+    assertThat(runtime.getElasticsearchContainer().getDockerImageName())
+        .isEqualTo(
+            ContainerRuntimeDefaults.ELASTICSEARCH_DOCKER_IMAGE_NAME
+                + ":"
+                + ContainerRuntimeDefaults.ELASTICSEARCH_DOCKER_IMAGE_VERSION);
+    assertThat(runtime.getOperateContainer().getDockerImageName())
+        .isEqualTo(
+            ContainerRuntimeDefaults.OPERATE_DOCKER_IMAGE_NAME
+                + ":"
+                + ContainerRuntimeDefaults.OPERATE_DOCKER_IMAGE_VERSION);
+    assertThat(runtime.getTasklistContainer().getDockerImageName())
+        .isEqualTo(
+            ContainerRuntimeDefaults.TASKLIST_DOCKER_IMAGE_NAME
+                + ":"
+                + ContainerRuntimeDefaults.TASKLIST_DOCKER_IMAGE_VERSION);
+  }
+
+  @Test
+  void shouldConfigureZeebeContainer() {
+    // given
+    final String zeebeDockerImageName =
+        "ghcr.io/camunda-community-hub/zeebe-with-hazelcast-exporter";
+    final String zeebeDockerImageVersion = "8.5.1";
+
+    // when
+    final CamundaContainerRuntime runtime =
+        CamundaContainerRuntime.newBuilder()
+            .withZeebeDockerImageName(zeebeDockerImageName)
+            .withZeebeDockerImageVersion(zeebeDockerImageVersion)
+            .withZeebeEnv(ENV_VARS)
+            .withZeebeEnv("zeebe-env", "test")
+            .withZeebeExposedPort(5701)
+            .withZeebeLogger("zeebe-test")
+            .build();
+
+    // then
+    final ZeebeContainer zeebeContainer = runtime.getZeebeContainer();
+
+    assertThat(zeebeContainer.getDockerImageName())
+        .isEqualTo(zeebeDockerImageName + ":" + zeebeDockerImageVersion);
+    assertThat(zeebeContainer.getEnvMap())
+        .containsEntry("zeebe-env", "test")
+        .containsAllEntriesOf(ENV_VARS);
+    assertThat(zeebeContainer.getExposedPorts()).contains(5701);
+  }
+
+  @Test
+  void shouldConfigureElasticsearchDockerImage() {
+    // given
+    final String elasticsearchDockerImageName = "docker.elastic.co/elasticsearch/elasticsearch";
+    final String elasticsearchDockerImageVersion = "8.14.0";
+
+    // when
+    final CamundaContainerRuntime runtime =
+        CamundaContainerRuntime.newBuilder()
+            .withElasticsearchDockerImageName(elasticsearchDockerImageName)
+            .withElasticsearchDockerImageVersion(elasticsearchDockerImageVersion)
+            .withElasticsearchEnv(ENV_VARS)
+            .withElasticsearchEnv("es-env", "test")
+            .withElasticsearchExposedPort(9300)
+            .withElasticsearchLogger("es-test")
+            .build();
+
+    // then
+    final ElasticsearchContainer elasticsearchContainer = runtime.getElasticsearchContainer();
+
+    assertThat(elasticsearchContainer.getDockerImageName())
+        .isEqualTo(elasticsearchDockerImageName + ":" + elasticsearchDockerImageVersion);
+    assertThat(elasticsearchContainer.getEnvMap())
+        .containsEntry("es-env", "test")
+        .containsAllEntriesOf(ENV_VARS);
+    assertThat(elasticsearchContainer.getExposedPorts()).contains(9300);
+  }
+
+  @Test
+  void shouldConfigureOperateContainer() {
+    // given
+    final String operateDockerImageVersion = "8.5.1";
+
+    // when
+    final CamundaContainerRuntime runtime =
+        CamundaContainerRuntime.newBuilder()
+            .withOperateDockerImageVersion(operateDockerImageVersion)
+            .withOperateEnv(ENV_VARS)
+            .withOperateEnv("operate-env", "test")
+            .withOperateExposedPort(9600)
+            .withOperateLogger("operate-test")
+            .build();
+
+    // then
+    final OperateContainer operateContainer = runtime.getOperateContainer();
+
+    assertThat(operateContainer.getDockerImageName())
+        .isEqualTo(
+            ContainerRuntimeDefaults.OPERATE_DOCKER_IMAGE_NAME + ":" + operateDockerImageVersion);
+    assertThat(operateContainer.getEnvMap())
+        .containsEntry("operate-env", "test")
+        .containsAllEntriesOf(ENV_VARS);
+    assertThat(operateContainer.getExposedPorts()).contains(9600);
+  }
+
+  @Test
+  void shouldConfigureTasklistContainer() {
+    // given
+    final String tasklistDockerImageVersion = "8.5.1";
+
+    // when
+    final CamundaContainerRuntime runtime =
+        CamundaContainerRuntime.newBuilder()
+            .withTasklistDockerImageVersion(tasklistDockerImageVersion)
+            .withTasklistEnv(ENV_VARS)
+            .withTasklistEnv("tasklist-env", "test")
+            .withTasklistExposedPort(9600)
+            .withTasklistLogger("tasklist-test")
+            .build();
+
+    // then
+    final TasklistContainer tasklistContainer = runtime.getTasklistContainer();
+
+    assertThat(tasklistContainer.getDockerImageName())
+        .isEqualTo(
+            ContainerRuntimeDefaults.TASKLIST_DOCKER_IMAGE_NAME + ":" + tasklistDockerImageVersion);
+    assertThat(tasklistContainer.getEnvMap())
+        .containsEntry("tasklist-env", "test")
+        .containsAllEntriesOf(ENV_VARS);
+    assertThat(tasklistContainer.getExposedPorts()).contains(9600);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
+++ b/testing/camunda-process-test-java/src/test/resources/log4j2-test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+
+    <Root level="info">
+      <AppenderRef ref="Console"/>
+    </Root>
+
+    <Logger name="io.camunda.process.test" level="info"/>
+
+    <!-- Hide default logging from Testcontainers -->
+    <Logger name="org.testcontainers" level="warn"/>
+    <Logger name="tc" level="warn"/>
+
+  </Loggers>
+
+</Configuration>


### PR DESCRIPTION
## Description

- Create a new Maven module for the new Camunda Process Test library for Java: `camunda-process-test-java`
- Create a runtime for process tests based on Docker Testcontainers with containers for:
    - Elasticsearch - used from Testcontainers
    - Zeebe¹
    - Operate¹ 
    - Tasklist¹
- Expose certain configuration options
- Align the Docker image version with the testing library
    - By default, use the same Camunda image version as the testing library 
    - By default, use the same Elasticsearch image version as the Elasticsearch client in Camunda
    - Use a properties file with Maven placeholders to resolve the versions 
- The implementation is inspired by the community project: [zeebe-test-container](https://github.com/camunda-community-hub/zeebe-test-container). :coin: 

¹ These containers will be removed later by a single Camunda image with all components.

## Related issues

closes #18994 
