### PR TITLE
refactor: consolidate job activation handler

### DIFF
--- a/dist/src/main/java/io/camunda/commons/job/JobHandlerConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/job/JobHandlerConfiguration.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.commons.job;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.configuration.LongPollingCfg;
+import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
+import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
+import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
+import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
+import io.camunda.zeebe.gateway.rest.controller.ResponseObserverProvider;
+import io.camunda.zeebe.scheduler.Actor;
+import io.camunda.zeebe.scheduler.ActorScheduler;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(
+    prefix = "zeebe.broker.gateway",
+    name = "enable",
+    havingValue = "true",
+    matchIfMissing = true)
+public class JobHandlerConfiguration {
+
+  private final ActivateJobHandlerConfiguration config;
+  private final BrokerClient brokerClient;
+  private final ActorScheduler scheduler;
+
+  @Autowired
+  public JobHandlerConfiguration(
+      final ActivateJobHandlerConfiguration config,
+      final BrokerClient brokerClient,
+      final ActorScheduler scheduler) {
+    this.config = config;
+    this.brokerClient = brokerClient;
+    this.scheduler = scheduler;
+  }
+
+  @Bean
+  public ResponseObserverProvider responseObserverProvider() {
+    return JobActivationRequestResponseObserver::new;
+  }
+
+  @Bean
+  public ActivateJobsHandler<JobActivationResponse> activateJobsHandler() {
+    final var handler = buildActivateJobsHandler(brokerClient);
+    final var future = new CompletableFuture<ActivateJobsHandler<JobActivationResponse>>();
+    final var actor =
+        Actor.newActor()
+            .name(config.actorName())
+            .actorStartedHandler(handler.andThen(t -> future.complete(handler)))
+            .build();
+    scheduler.submitActor(actor);
+    return handler;
+  }
+
+  private ActivateJobsHandler<JobActivationResponse> buildActivateJobsHandler(
+      final BrokerClient brokerClient) {
+    if (config.longPolling().isEnabled()) {
+      return buildLongPollingHandler(brokerClient);
+    } else {
+      return new RoundRobinActivateJobsHandler<>(
+          brokerClient,
+          config.maxMessageSize().toBytes(),
+          ResponseMapper::toActivateJobsResponse,
+          RuntimeException::new);
+    }
+  }
+
+  private LongPollingActivateJobsHandler<JobActivationResponse> buildLongPollingHandler(
+      final BrokerClient brokerClient) {
+    return LongPollingActivateJobsHandler.<JobActivationResponse>newBuilder()
+        .setBrokerClient(brokerClient)
+        .setMaxMessageSize(config.maxMessageSize().toBytes())
+        .setLongPollingTimeout(config.longPolling().getTimeout())
+        .setProbeTimeoutMillis(config.longPolling().getProbeTimeout())
+        .setMinEmptyResponses(config.longPolling().getMinEmptyResponses())
+        .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
+        .setNoJobsReceivedExceptionProvider(RuntimeException::new)
+        .setRequestCanceledExceptionProvider(RuntimeException::new)
+        .build();
+  }
+
+  public static record ActivateJobHandlerConfiguration(
+      String actorName, LongPollingCfg longPolling, DataSize maxMessageSize) {}
+}

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -12,20 +12,10 @@ import io.camunda.identity.sdk.IdentityConfiguration;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.shared.BrokerConfiguration;
 import io.camunda.zeebe.broker.system.SystemContext;
-import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
-import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
-import io.camunda.zeebe.gateway.impl.job.RoundRobinActivateJobsHandler;
-import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
-import io.camunda.zeebe.gateway.rest.ConditionalOnRestGatewayEnabled;
-import io.camunda.zeebe.gateway.rest.ResponseMapper;
-import io.camunda.zeebe.gateway.rest.controller.JobActivationRequestResponseObserver;
-import io.camunda.zeebe.gateway.rest.controller.ResponseObserverProvider;
-import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
-import java.util.concurrent.CompletableFuture;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
@@ -136,56 +126,6 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     } catch (final IOException e) {
       LOGGER.warn("Failed to delete temporary directory {}", workingDirectory.path());
     }
-  }
-
-  @Bean
-  @ConditionalOnRestGatewayEnabled
-  public ResponseObserverProvider responseObserverProvider() {
-    return JobActivationRequestResponseObserver::new;
-  }
-
-  @Bean
-  @ConditionalOnRestGatewayEnabled
-  public ActivateJobsHandler<JobActivationResponse> activateJobsHandler() {
-    final var handler = buildActivateJobsHandler(brokerClient);
-    final var future = new CompletableFuture<ActivateJobsHandler<JobActivationResponse>>();
-    final var actor =
-        Actor.newActor()
-            .name("ActivateJobsHandlerRest-Broker")
-            .actorStartedHandler(handler.andThen(t -> future.complete(handler)))
-            .build();
-    actorScheduler.submitActor(actor);
-    return handler;
-  }
-
-  private ActivateJobsHandler<JobActivationResponse> buildActivateJobsHandler(
-      final BrokerClient brokerClient) {
-    if (configuration.config().getGateway().getLongPolling().isEnabled()) {
-      return buildLongPollingHandler(brokerClient);
-    } else {
-      return new RoundRobinActivateJobsHandler<>(
-          brokerClient,
-          configuration.config().getGateway().getNetwork().getMaxMessageSize().toBytes(),
-          ResponseMapper::toActivateJobsResponse,
-          RuntimeException::new);
-    }
-  }
-
-  private LongPollingActivateJobsHandler<JobActivationResponse> buildLongPollingHandler(
-      final BrokerClient brokerClient) {
-    return LongPollingActivateJobsHandler.<JobActivationResponse>newBuilder()
-        .setBrokerClient(brokerClient)
-        .setMaxMessageSize(
-            configuration.config().getGateway().getNetwork().getMaxMessageSize().toBytes())
-        .setLongPollingTimeout(configuration.config().getGateway().getLongPolling().getTimeout())
-        .setProbeTimeoutMillis(
-            configuration.config().getGateway().getLongPolling().getProbeTimeout())
-        .setMinEmptyResponses(
-            configuration.config().getGateway().getLongPolling().getMinEmptyResponses())
-        .setActivationResultMapper(ResponseMapper::toActivateJobsResponse)
-        .setNoJobsReceivedExceptionProvider(RuntimeException::new)
-        .setRequestCanceledExceptionProvider(RuntimeException::new)
-        .build();
   }
 
   @Override

--- a/dist/src/main/java/io/camunda/zeebe/broker/shared/BrokerConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/shared/BrokerConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.shared;
 
 import io.camunda.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
 import io.camunda.commons.broker.client.BrokerClientConfiguration.BrokerClientTimeoutConfiguration;
+import io.camunda.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
 import io.camunda.zeebe.broker.shared.BrokerConfiguration.BrokerProperties;
 import io.camunda.zeebe.broker.shared.WorkingDirectoryConfiguration.WorkingDirectory;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
@@ -71,6 +72,14 @@ public final class BrokerConfiguration {
   @Bean
   public RestGatewayDisabled disableRestGateway() {
     return new RestGatewayDisabled();
+  }
+
+  @Bean
+  public ActivateJobHandlerConfiguration activateJobHandlerConfiguration() {
+    return new ActivateJobHandlerConfiguration(
+        "ActivateJobsHandlerRest-Broker",
+        properties.getGateway().getLongPolling(),
+        properties.getGateway().getNetwork().getMaxMessageSize());
   }
 
   public Duration shutdownTimeout() {

--- a/dist/src/main/java/io/camunda/zeebe/gateway/GatewayConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/GatewayConfiguration.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway;
 
 import io.camunda.commons.actor.ActorSchedulerConfiguration.SchedulerConfiguration;
 import io.camunda.commons.broker.client.BrokerClientConfiguration.BrokerClientTimeoutConfiguration;
+import io.camunda.commons.job.JobHandlerConfiguration.ActivateJobHandlerConfiguration;
 import io.camunda.zeebe.gateway.GatewayConfiguration.GatewayProperties;
 import io.camunda.zeebe.gateway.impl.configuration.GatewayCfg;
 import io.camunda.zeebe.gateway.impl.configuration.MultiTenancyCfg;
@@ -41,6 +42,14 @@ public final class GatewayConfiguration {
 
   public Duration shutdownTimeout() {
     return lifecycleProperties.getTimeoutPerShutdownPhase();
+  }
+
+  @Bean
+  public ActivateJobHandlerConfiguration activateJobHandlerConfiguration() {
+    return new ActivateJobHandlerConfiguration(
+        "ActivateJobsHandlerRest-Gateway",
+        config.getLongPolling(),
+        config.getNetwork().getMaxMessageSize());
   }
 
   @Bean


### PR DESCRIPTION
## Description

This PR consolidates the job activation bean declaration to avoid declaring the bean multiple times depending on which profile is used.

This step is a preparation step necessary to make the v2 endpoints (i.e., the endpoints defined in the module `gateway-rest`) available on every node running the REST API. That way, we can avoid implementing another bean declaration logic, for example, when the single application runs only with the profile `operate.`

## Related issues

related to #19076 