### PR TITLE
github: capture branch protection rules as code via Terraform

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ indent_size = 2
 [*.md]
 indent_size = 2
 
+[*.tf]
+indent_size = 2
+
 [*.yml,*.yaml]
 indent_size = 2

--- a/.github/terraform/.gitignore
+++ b/.github/terraform/.gitignore
@@ -1,0 +1,2 @@
+.terraform*
+*.backup

--- a/.github/terraform/branch-protection.tf
+++ b/.github/terraform/branch-protection.tf
@@ -1,0 +1,151 @@
+
+resource "github_branch_protection" "main" {
+  repository_id = data.github_repository.camunda.node_id
+
+  pattern        = "main"
+  enforce_admins = true
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = [
+      "Test summary",
+      "Operate CI test summary",
+      "Tasklist CI test summary",
+      "SDK test summary",
+    ]
+  }
+
+  # Merge queue cannot be configured via GitHub API yet, for updates see
+  # https://github.com/integrations/terraform-provider-github/issues/1481
+
+  # Require merge queue: YES
+  # Only merge non-failing pull requests: YES
+}
+
+
+################################################################################
+resource "github_branch_protection" "stable85" {
+  repository_id = data.github_repository.camunda.node_id
+
+  pattern        = "stable/8.5"
+  enforce_admins = true
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = [
+      "Test summary",
+      "SDK test summary",
+    ]
+  }
+
+  # Merge queue cannot be configured via GitHub API yet, for updates see
+  # https://github.com/integrations/terraform-provider-github/issues/1481
+
+  # Require merge queue: YES
+  # Only merge non-failing pull requests: YES
+}
+
+resource "github_branch_protection" "stable_operate85" {
+  repository_id = data.github_repository.camunda.node_id
+
+  pattern        = "stable/operate-8.5"
+  enforce_admins = true
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = [
+      "Operate CI test summary",
+    ]
+  }
+
+  # Merge queue cannot be configured via GitHub API yet, for updates see
+  # https://github.com/integrations/terraform-provider-github/issues/1481
+
+  # Require merge queue: YES
+  # Only merge non-failing pull requests: YES
+}
+
+
+
+################################################################################
+resource "github_branch_protection" "stable84" {
+  repository_id = data.github_repository.camunda.node_id
+
+  pattern        = "stable/8.4"
+  enforce_admins = true
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = [
+      "Test summary",
+    ]
+  }
+
+  # Merge queue cannot be configured via GitHub API yet, for updates see
+  # https://github.com/integrations/terraform-provider-github/issues/1481
+
+  # Require merge queue: YES
+  # Only merge non-failing pull requests: YES
+}
+
+
+################################################################################
+resource "github_branch_protection" "stable83" {
+  repository_id = data.github_repository.camunda.node_id
+
+  pattern        = "stable/8.3"
+  enforce_admins = true
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = [
+      "Test summary",
+    ]
+  }
+
+  # Merge queue cannot be configured via GitHub API yet, for updates see
+  # https://github.com/integrations/terraform-provider-github/issues/1481
+
+  # Require merge queue: YES
+  # Only merge non-failing pull requests: YES
+}
+
+
+################################################################################
+resource "github_branch_protection" "stable82" {
+  repository_id = data.github_repository.camunda.node_id
+
+  pattern        = "stable/8.2"
+  enforce_admins = true
+
+  required_pull_request_reviews {
+    required_approving_review_count = 1
+  }
+
+  required_status_checks {
+    contexts = [
+      "Test summary",
+    ]
+  }
+
+  # Merge queue cannot be configured via GitHub API yet, for updates see
+  # https://github.com/integrations/terraform-provider-github/issues/1481
+
+  # Require merge queue: YES
+  # Only merge non-failing pull requests: YES
+}

--- a/.github/terraform/config.tf
+++ b/.github/terraform/config.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = "~> 1.8.0"
+
+  required_providers {
+    github = {
+      source  = "integrations/github"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "github" {
+  owner = "camunda"
+}
+
+data "github_repository" "camunda" {
+  full_name = "camunda/camunda"
+}

--- a/.github/terraform/terraform.tfstate
+++ b/.github/terraform/terraform.tfstate
@@ -1,0 +1,382 @@
+{
+  "version": 4,
+  "terraform_version": "1.8.5",
+  "serial": 14,
+  "lineage": "531b4c88-a4eb-cc5e-dd21-ed1b0f15d2d0",
+  "outputs": {},
+  "resources": [
+    {
+      "mode": "data",
+      "type": "github_repository",
+      "name": "camunda",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 0,
+          "attributes": {
+            "allow_auto_merge": true,
+            "allow_merge_commit": true,
+            "allow_rebase_merge": false,
+            "allow_squash_merge": false,
+            "archived": false,
+            "default_branch": "main",
+            "description": "Distributed Workflow Engine for Microservices Orchestration",
+            "fork": false,
+            "full_name": "camunda/camunda",
+            "git_clone_url": "git://github.com/camunda/camunda.git",
+            "has_discussions": false,
+            "has_downloads": true,
+            "has_issues": true,
+            "has_projects": true,
+            "has_wiki": true,
+            "homepage_url": "https://camunda.com/platform/",
+            "html_url": "https://github.com/camunda/camunda",
+            "http_clone_url": "https://github.com/camunda/camunda.git",
+            "id": "camunda",
+            "is_template": false,
+            "merge_commit_message": "PR_BODY",
+            "merge_commit_title": "PR_TITLE",
+            "name": "camunda",
+            "node_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "pages": [],
+            "primary_language": "Java",
+            "private": false,
+            "repo_id": 54298946,
+            "repository_license": [],
+            "squash_merge_commit_message": "COMMIT_MESSAGES",
+            "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
+            "ssh_clone_url": "git@github.com:camunda/camunda.git",
+            "svn_url": "https://github.com/camunda/camunda",
+            "template": [],
+            "topics": [
+              "bpmn",
+              "golang",
+              "grpc",
+              "hacktoberfest",
+              "java",
+              "microservices",
+              "orchestration-framework",
+              "workflow",
+              "workflow-engine"
+            ],
+            "visibility": "public"
+          },
+          "sensitive_attributes": []
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_branch_protection",
+      "name": "cntest",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "allows_deletions": false,
+            "allows_force_pushes": false,
+            "enforce_admins": false,
+            "force_push_bypassers": null,
+            "id": "BPR_kwDOAzyJQs4DC5cw",
+            "lock_branch": false,
+            "pattern": "cntest",
+            "repository_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "require_conversation_resolution": false,
+            "require_signed_commits": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": [],
+            "required_status_checks": [],
+            "restrict_pushes": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ==",
+          "dependencies": [
+            "data.github_repository.camunda"
+          ]
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_branch_protection",
+      "name": "main",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "allows_deletions": false,
+            "allows_force_pushes": false,
+            "enforce_admins": true,
+            "force_push_bypassers": [],
+            "id": "MDIwOkJyYW5jaFByb3RlY3Rpb25SdWxlMjExMjgwOA==",
+            "lock_branch": false,
+            "pattern": "main",
+            "repository_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "require_conversation_resolution": false,
+            "require_signed_commits": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": [
+              {
+                "dismiss_stale_reviews": false,
+                "dismissal_restrictions": [],
+                "pull_request_bypassers": [],
+                "require_code_owner_reviews": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 1,
+                "restrict_dismissals": false
+              }
+            ],
+            "required_status_checks": [
+              {
+                "contexts": [
+                  "Operate CI test summary",
+                  "SDK test summary",
+                  "Tasklist CI test summary",
+                  "Test summary"
+                ],
+                "strict": false
+              }
+            ],
+            "restrict_pushes": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_branch_protection",
+      "name": "stable82",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "allows_deletions": false,
+            "allows_force_pushes": false,
+            "enforce_admins": true,
+            "force_push_bypassers": [],
+            "id": "BPR_kwDOAzyJQs4Culwk",
+            "lock_branch": false,
+            "pattern": "stable/8.2",
+            "repository_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "require_conversation_resolution": false,
+            "require_signed_commits": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": [
+              {
+                "dismiss_stale_reviews": false,
+                "dismissal_restrictions": [],
+                "pull_request_bypassers": [],
+                "require_code_owner_reviews": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 1,
+                "restrict_dismissals": false
+              }
+            ],
+            "required_status_checks": [
+              {
+                "contexts": [
+                  "Test summary"
+                ],
+                "strict": false
+              }
+            ],
+            "restrict_pushes": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_branch_protection",
+      "name": "stable83",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "allows_deletions": false,
+            "allows_force_pushes": false,
+            "enforce_admins": true,
+            "force_push_bypassers": [],
+            "id": "BPR_kwDOAzyJQs4CulxQ",
+            "lock_branch": false,
+            "pattern": "stable/8.3",
+            "repository_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "require_conversation_resolution": false,
+            "require_signed_commits": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": [
+              {
+                "dismiss_stale_reviews": false,
+                "dismissal_restrictions": [],
+                "pull_request_bypassers": [],
+                "require_code_owner_reviews": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 1,
+                "restrict_dismissals": false
+              }
+            ],
+            "required_status_checks": [
+              {
+                "contexts": [
+                  "Test summary"
+                ],
+                "strict": false
+              }
+            ],
+            "restrict_pushes": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_branch_protection",
+      "name": "stable84",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "allows_deletions": false,
+            "allows_force_pushes": false,
+            "enforce_admins": true,
+            "force_push_bypassers": [],
+            "id": "BPR_kwDOAzyJQs4Culxg",
+            "lock_branch": false,
+            "pattern": "stable/8.4",
+            "repository_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "require_conversation_resolution": false,
+            "require_signed_commits": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": [
+              {
+                "dismiss_stale_reviews": false,
+                "dismissal_restrictions": [],
+                "pull_request_bypassers": [],
+                "require_code_owner_reviews": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 1,
+                "restrict_dismissals": false
+              }
+            ],
+            "required_status_checks": [
+              {
+                "contexts": [
+                  "Test summary"
+                ],
+                "strict": false
+              }
+            ],
+            "restrict_pushes": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_branch_protection",
+      "name": "stable85",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "allows_deletions": false,
+            "allows_force_pushes": false,
+            "enforce_admins": true,
+            "force_push_bypassers": [],
+            "id": "BPR_kwDOAzyJQs4C59rn",
+            "lock_branch": false,
+            "pattern": "stable/8.5",
+            "repository_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "require_conversation_resolution": false,
+            "require_signed_commits": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": [
+              {
+                "dismiss_stale_reviews": false,
+                "dismissal_restrictions": [],
+                "pull_request_bypassers": [],
+                "require_code_owner_reviews": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 1,
+                "restrict_dismissals": false
+              }
+            ],
+            "required_status_checks": [
+              {
+                "contexts": [
+                  "SDK test summary",
+                  "Test summary"
+                ],
+                "strict": false
+              }
+            ],
+            "restrict_pushes": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ=="
+        }
+      ]
+    },
+    {
+      "mode": "managed",
+      "type": "github_branch_protection",
+      "name": "stable_operate85",
+      "provider": "provider[\"registry.terraform.io/integrations/github\"]",
+      "instances": [
+        {
+          "schema_version": 2,
+          "attributes": {
+            "allows_deletions": false,
+            "allows_force_pushes": false,
+            "enforce_admins": true,
+            "force_push_bypassers": [],
+            "id": "BPR_kwDOAzyJQs4C6irE",
+            "lock_branch": false,
+            "pattern": "stable/operate-8.5",
+            "repository_id": "MDEwOlJlcG9zaXRvcnk1NDI5ODk0Ng==",
+            "require_conversation_resolution": false,
+            "require_signed_commits": false,
+            "required_linear_history": false,
+            "required_pull_request_reviews": [
+              {
+                "dismiss_stale_reviews": false,
+                "dismissal_restrictions": [],
+                "pull_request_bypassers": [],
+                "require_code_owner_reviews": false,
+                "require_last_push_approval": false,
+                "required_approving_review_count": 1,
+                "restrict_dismissals": false
+              }
+            ],
+            "required_status_checks": [
+              {
+                "contexts": [
+                  "Operate CI test summary"
+                ],
+                "strict": false
+              }
+            ],
+            "restrict_pushes": []
+          },
+          "sensitive_attributes": [],
+          "private": "eyJzY2hlbWFfdmVyc2lvbiI6IjIifQ=="
+        }
+      ]
+    }
+  ],
+  "check_results": null
+}


### PR DESCRIPTION
## Description

POC PR to test how well suited [Terraform is to capture GitHub branch protection rules](https://registry.terraform.io/providers/integrations/github/latest/docs/resources/branch_protection) of the `camunda/camunda` monorepo. This would help to prevent cases like [this](https://camunda.slack.com/archives/C06HTSPD5AP/p1714461605396099?thread_ts=1714046492.254359&cid=C06HTSPD5AP) where manual changes to settings got overlooked/forgotten or were inconsistent.

The Terraform state is part of this PR since it does not contain any secrets and can help reproduce the POC. Authentication e.g. via personal GitHub token.

Observations so far:

* 🟢 configuration as code is nice to allow reviews and avoid manual mistakes
* 🟢 requires status check settings are working well
* 🔴 merge queue settings are impossible in general due to missing GitHub API support, see https://github.com/integrations/terraform-provider-github/issues/1481 
* 📃 Terraform GitHub provider allows managing even more settings & permissions in the repository