### PR TITLE
refactor: redirect old frontend routes to webapp sub-path

### DIFF
--- a/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
+++ b/dist/src/main/java/io/camunda/operate/webapp/controllers/OperateIndexController.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.operate.webapp.controllers;
 
+import static io.camunda.webapps.controllers.WebappsRequestForwardManager.getRequestedUrl;
+
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,5 +34,14 @@ public class OperateIndexController {
   @RequestMapping(value = {"/operate/{regex:[\\w-]+}", "/operate/**/{regex:[\\w-]+}"})
   public String forwardToOperate(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "operate");
+  }
+
+  /**
+   * Redirects the old frontend routes to the /operate sub-path. This can be removed after the
+   * creation of the auto-discovery service.
+   */
+  @GetMapping({"/processes/*", "/decisions", "/decisions/*"})
+  public String redirectOldRoutes(final HttpServletRequest request) {
+    return "redirect:/operate" + getRequestedUrl(request);
   }
 }

--- a/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
+++ b/dist/src/main/java/io/camunda/tasklist/webapp/controllers/TasklistIndexController.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.webapp.controllers;
 
+import static io.camunda.webapps.controllers.WebappsRequestForwardManager.getRequestedUrl;
+
 import io.camunda.webapps.controllers.WebappsRequestForwardManager;
 import jakarta.servlet.ServletContext;
 import jakarta.servlet.http.HttpServletRequest;
@@ -32,5 +34,14 @@ public class TasklistIndexController {
   @RequestMapping(value = {"/tasklist/{regex:[\\w-]+}", "/tasklist/**/{regex:[\\w-]+}"})
   public String forwardToTasklist(final HttpServletRequest request) {
     return webappsRequestForwardManager.forward(request, "tasklist");
+  }
+
+  /**
+   * Redirects the old frontend routes to the /tasklist sub-path. This can be removed after the
+   * creation of the auto-discovery service.
+   */
+  @GetMapping({"/{regex:[\\d]+}", "/processes/*/start"})
+  public String redirectOldRoutes(final HttpServletRequest request) {
+    return "redirect:/tasklist" + getRequestedUrl(request);
   }
 }

--- a/dist/src/main/java/io/camunda/webapps/controllers/IndexController.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/IndexController.java
@@ -7,19 +7,30 @@
  */
 package io.camunda.webapps.controllers;
 
+import static io.camunda.webapps.controllers.WebappsRequestForwardManager.getRequestedUrl;
+
 import io.camunda.webapps.WebappsModuleConfiguration.WebappsProperties;
-import jakarta.servlet.ServletContext;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class IndexController {
-  @Autowired private ServletContext context;
+
   @Autowired private WebappsProperties webappsProperties;
 
   @GetMapping("/index.html")
   public String index() {
     return "redirect:/" + webappsProperties.defaultApp();
+  }
+
+  /**
+   * Redirects the old frontend routes (common tasklist and operate routes) to the default-app
+   * sub-path. This can be removed after the creation of the auto-discovery service.
+   */
+  @GetMapping({"/processes", "/login"})
+  public String redirectOldRoutes(final HttpServletRequest request) {
+    return "redirect:/" + webappsProperties.defaultApp() + getRequestedUrl(request);
   }
 }

--- a/dist/src/main/java/io/camunda/webapps/controllers/WebappsRequestForwardManager.java
+++ b/dist/src/main/java/io/camunda/webapps/controllers/WebappsRequestForwardManager.java
@@ -37,17 +37,22 @@ public class WebappsRequestForwardManager {
   }
 
   private String saveRequestAndRedirectToLogin(final HttpServletRequest request) {
+    final String requestedUrl = getRequestedUrl(request);
+    request.getSession(true).setAttribute(REQUESTED_URL, requestedUrl);
+    LOGGER.warn(
+        "Requested path {}, but not authenticated. Redirect to  {} ",
+        request.getRequestURI().substring(request.getContextPath().length()),
+        LOGIN_RESOURCE);
+    return "forward:" + LOGIN_RESOURCE;
+  }
+
+  public static String getRequestedUrl(final HttpServletRequest request) {
     final String requestedPath =
         request.getRequestURI().substring(request.getContextPath().length());
     final String queryString = request.getQueryString();
     final String requestedUrl =
         StringUtils.isEmpty(queryString) ? requestedPath : requestedPath + "?" + queryString;
-    request.getSession(true).setAttribute(REQUESTED_URL, requestedUrl);
-    LOGGER.warn(
-        "Requested path {}, but not authenticated. Redirect to  {} ",
-        requestedPath,
-        LOGIN_RESOURCE);
-    return "forward:" + LOGIN_RESOURCE;
+    return requestedUrl;
   }
 
   private boolean isNotLoggedIn() {

--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -283,6 +283,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java-api</artifactId>
       <scope>test</scope>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.controllers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.operate.util.apps.nobeans.TestApplicationWithNoBeans;
+import io.camunda.webapps.WebappsModuleConfiguration;
+import io.camunda.webapps.controllers.IndexController;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@SpringBootTest(
+    classes = {
+      TestApplicationWithNoBeans.class,
+      OperateIndexController.class,
+      IndexController.class,
+      WebappsModuleConfiguration.class,
+    },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class OldRoutesRedirectionControllerIT {
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  private String baseUrl() {
+    return "http://localhost:" + port;
+  }
+
+  static Stream<String> redirectionTestDataProvider() {
+    return Stream.of(
+        "", "/processes", "/processes/order", "/login", "/decisions", "/decisions/order");
+  }
+
+  @ParameterizedTest
+  @MethodSource("redirectionTestDataProvider")
+  public void testRedirections(final String path) {
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl() + path, String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    assertThat(response.getHeaders().getLocation().toString())
+        .isEqualTo(baseUrl() + "/operate" + path);
+  }
+
+  static Stream<String> notFoundTestDataProvider() {
+    return Stream.of("/v1/user-tasks", "/process/order/start", "/12345");
+  }
+
+  @ParameterizedTest
+  @MethodSource("notFoundTestDataProvider")
+  public void testNotFound(final String path) {
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl() + path, String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/controllers/OldRoutesRedirectionControllerIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.webapp.controllers;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import io.camunda.tasklist.util.TasklistIntegrationTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class OldRoutesRedirectionControllerIT extends TasklistIntegrationTest {
+
+  @LocalServerPort private int port;
+
+  @Autowired private TestRestTemplate restTemplate;
+
+  private String baseUrl() {
+    return "http://localhost:" + port;
+  }
+
+  static Stream<String> redirectionTestDataProvider() {
+    return Stream.of("", "/processes", "/login", "/123456", "/processes/order/start");
+  }
+
+  @ParameterizedTest
+  @MethodSource("redirectionTestDataProvider")
+  public void testRedirections(final String path) {
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl() + path, String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FOUND);
+    assertThat(response.getHeaders().getLocation().toString())
+        .isEqualTo(baseUrl() + "/tasklist" + path);
+  }
+
+  static Stream<String> notFoundTestDataProvider() {
+    return Stream.of("/v1/user-tasks", "/decisions", "/a12345");
+  }
+
+  @ParameterizedTest
+  @MethodSource("notFoundTestDataProvider")
+  public void testNotFound(final String path) {
+    final ResponseEntity<String> response =
+        restTemplate.getForEntity(baseUrl() + path, String.class);
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+  }
+}


### PR DESCRIPTION
## Description
Redirecting Operate and Tasklist frontend routes, to the paths that are prefixed with `/operate` and `/tasklist`
- Operate frontend routes: https://github.com/camunda/camunda/blob/11d6fd6d1f8194d6a387fdce98af9dd7539b9bc9/operate/client/src/modules/Routes.tsx#L17-L36
- Tasklist frontend routes: https://github.com/camunda/camunda/blob/11d6fd6d1f8194d6a387fdce98af9dd7539b9bc9/tasklist/client/src/modules/routing.tsx#L13-L34

This redirection is necessary to keep working the existing deep links in Camunda applications (Console/WebModeler/Desktop Modeler) working, and any deep links used by customers.

We attempted to update the links with the sub-paths within Camunda applications, but encountered the following issues:
- risky, for example, an update in Console's external service that returns the list of app URLs broke Operate 8.3, causing it to stop returning the c8 links
- It adds logic in the app that we don't want to have, relying on webapps versions (higher or lower than 8.6) to determine if subpaths should be added to the URLs

New routes, such as Tasklist's `/{taskId}/process` introduced in 8.6, are not redirected as the applications or users are expected to use them with the subpaths.

In the mid-term, this redirection should be replaced by an auto-discovery service that returns the (.well-known URLs of the webapps.)[`.well-known` urls of the webapps
](https://github.com/camunda/camunda-modeler/issues/4261#issuecomment-2107116465)
## Related issues

relates to https://github.com/camunda/camunda/issues/18535
