### PR TITLE
fix: don't adjust append limit when request limit is exhausted

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/FlowControl.java
@@ -83,7 +83,7 @@ public final class FlowControl implements AppendListener {
     final var requestListener = requestLimiter.acquire(intent).orElse(null);
     if (requestListener == null) {
       metrics.dropped(context);
-      appendListener.onDropped();
+      appendListener.onIgnore();
       return Either.left(new RequestLimitExhausted());
     }
 


### PR DESCRIPTION
Whenever a user request is rejected because the request limit is exhausted, we want to revert the claimed spot in the append limit and not signal that the append was dropped.

This most likely caused weird performance issues where every rejected user command would also lower the append limit, eventually leading to too many rejections and increased workload due to timeouts and retries.