### PR TITLE
fix: exclude draft variable from being serialized in TaskSearchResponse

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/api/rest/v1/controllers/TaskControllerIT.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.JsonPath;
 import io.camunda.tasklist.entities.TaskImplementation;
 import io.camunda.tasklist.entities.TaskState;
 import io.camunda.tasklist.property.IdentityProperties;
@@ -31,6 +32,7 @@ import io.camunda.tasklist.webapp.graphql.entity.VariableInputDTO;
 import io.camunda.tasklist.webapp.security.Permission;
 import io.camunda.tasklist.webapp.security.TasklistURIs;
 import io.camunda.tasklist.webapp.security.identity.IdentityAuthorizationService;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -497,6 +499,13 @@ public class TaskControllerIT extends TasklistZeebeIntegrationTest {
       assertThat(result)
           .hasOkHttpStatus()
           .hasApplicationJsonContentType()
+          .satisfies(
+              payload ->
+                  assertThat(
+                          (List<?>)
+                              JsonPath.parse(payload.getContentAsString(StandardCharsets.UTF_8))
+                                  .read("$.*.variables.*.draft"))
+                      .isEmpty())
           .extractingListContent(objectMapper, TaskSearchResponse.class)
           .hasSize(2)
           .flatExtracting("variables")

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskSearchResponse.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/api/rest/v1/entities/TaskSearchResponse.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.tasklist.webapp.api.rest.v1.entities;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.camunda.tasklist.entities.TaskImplementation;
 import io.camunda.tasklist.entities.TaskState;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -102,6 +103,7 @@ public class TaskSearchResponse {
           @Schema(
               description =
                   "An array of the task's variables. Only variables specified in `TaskSearchRequest.includeVariables` are returned. Note that a variable's draft value is not returned in `TaskSearchResponse`."))
+  @JsonIgnoreProperties("draft")
   private VariableSearchResponse[] variables;
 
   @Schema(description = "The context variable (from modeler) of the task.")


### PR DESCRIPTION
Port of: [tasklist/#4393](https://github.com/camunda/tasklist/issues/4393) 
Related: https://github.com/camunda/tasklist/pull/4954
