### PR TITLE
test: added tests for BatchOperation requests

### DIFF
--- a/operate/qa/integration-tests/pom.xml
+++ b/operate/qa/integration-tests/pom.xml
@@ -268,6 +268,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jetbrains</groupId>
       <artifactId>annotations</artifactId>
       <scope>test</scope>

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/MockMvcManager.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/MockMvcManager.java
@@ -13,7 +13,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.apache.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.test.web.servlet.MockMvc;
@@ -42,7 +41,7 @@ public class MockMvcManager {
         post(url).content(objectMapper.writeValueAsString(dtoRequest)).contentType(jsonContentType);
 
     if (expectedStatus != null) {
-      return mockMvc.perform(ope).andExpect(status().is(HttpStatus.SC_OK)).andReturn();
+      return mockMvc.perform(ope).andExpect(status().is(expectedStatus)).andReturn();
     } else {
       return mockMvc.perform(ope).andReturn();
     }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/util/j5templates/OperateSearchAbstractIT.java
@@ -8,6 +8,7 @@
 package io.camunda.operate.util.j5templates;
 
 import static io.camunda.operate.util.OperateAbstractIT.DEFAULT_USER;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -30,6 +31,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MvcResult;
 
 /**
  * Base definition for a test that requires opensearch/elasticsearch but not zeebe. The test suite
@@ -50,18 +52,14 @@ import org.springframework.test.context.web.WebAppConfiguration;
     TestInstance.Lifecycle
         .PER_CLASS) // Lifecycle required to use BeforeAll and AfterAll in non-static fashion
 public class OperateSearchAbstractIT {
+  public static final String DEFAULT_USER = "testuser";
   // These are mocked so we can bypass authentication issues when connecting to search
   @MockBean protected UserService userService;
   @MockBean protected TenantService tenantService;
-
   @Autowired protected ProcessCache processCache;
-
   @Autowired protected TestSearchRepository testSearchRepository;
-
   @Autowired protected SearchContainerManager searchContainerManager;
-
   @Autowired protected TestResourceManager testResourceManager;
-
   @Autowired protected ObjectMapper objectMapper;
 
   @BeforeAll
@@ -119,4 +117,8 @@ public class OperateSearchAbstractIT {
   }
 
   public void runAdditionalAfterAllTeardown() {}
+
+  protected void assertErrorMessageContains(final MvcResult mvcResult, final String text) {
+    assertThat(mvcResult.getResolvedException().getMessage()).contains(text);
+  }
 }

--- a/operate/webapp/src/test/java/io/camunda/operate/util/BatchOperationTestDataHelper.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/util/BatchOperationTestDataHelper.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import io.camunda.operate.entities.BatchOperationEntity;
+import io.camunda.operate.entities.OperationType;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
+import io.camunda.operate.webapp.rest.dto.operation.OperationTypeDto;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+
+public class BatchOperationTestDataHelper {
+
+  public static final String[] TEST_BATCH_OP_IDS = {
+    "00000000-0000-0000-0000-000000000000",
+    "11111111-1111-1111-1111-111111111111",
+    "22222222-2222-2222-2222-222222222222"
+  };
+  public static final String TEST_USER = "testuser";
+  private static final OffsetDateTime TEST_DATE_TIME =
+      OffsetDateTime.of(2000, 1, 1, 1, 1, 1, 1, ZoneOffset.MIN);
+
+  public static List<BatchOperationEntity> create2TestBatchOperationDtos() {
+    final BatchOperationEntity testEntity1 =
+        new BatchOperationEntity()
+            .setId(TEST_BATCH_OP_IDS[0])
+            .setName("entity1")
+            .setType(OperationType.CANCEL_PROCESS_INSTANCE)
+            .setStartDate(TEST_DATE_TIME)
+            .setEndDate(TEST_DATE_TIME)
+            .setInstancesCount(5)
+            .setOperationsFinishedCount(5)
+            .setUsername(TEST_USER);
+    final BatchOperationEntity testEntity2 =
+        new BatchOperationEntity()
+            .setId(TEST_BATCH_OP_IDS[1])
+            .setName("entity2")
+            .setType(OperationType.MODIFY_PROCESS_INSTANCE)
+            .setStartDate(TEST_DATE_TIME)
+            .setEndDate(TEST_DATE_TIME)
+            .setInstancesCount(3)
+            .setOperationsFinishedCount(3)
+            .setUsername(TEST_USER);
+
+    final List<BatchOperationEntity> testEntities = new ArrayList<>(2);
+    testEntities.add(testEntity1);
+    testEntities.add(testEntity2);
+    return testEntities;
+  }
+
+  public static List<BatchOperationDto> get2DtoBatchRequestExpected() {
+    final BatchOperationDto expectedDto1 =
+        new BatchOperationDto()
+            .setId(TEST_BATCH_OP_IDS[0])
+            .setName("entity1")
+            .setType(OperationTypeDto.CANCEL_PROCESS_INSTANCE)
+            .setStartDate(TEST_DATE_TIME)
+            .setEndDate(TEST_DATE_TIME)
+            .setInstancesCount(5)
+            .setOperationsFinishedCount(5)
+            .setFailedOperationsCount(4)
+            .setCompletedOperationsCount(1);
+    final BatchOperationDto expectedDto2 =
+        new BatchOperationDto()
+            .setId(TEST_BATCH_OP_IDS[1])
+            .setName("entity2")
+            .setType(OperationTypeDto.MODIFY_PROCESS_INSTANCE)
+            .setStartDate(TEST_DATE_TIME)
+            .setEndDate(TEST_DATE_TIME)
+            .setInstancesCount(3)
+            .setOperationsFinishedCount(3)
+            .setFailedOperationsCount(0)
+            .setCompletedOperationsCount(3);
+    return List.of(expectedDto1, expectedDto2);
+  }
+
+  public static List<BatchOperationDto> get2DtoBatchRequestEmptyAggregationsExpected() {
+    final BatchOperationDto expectedDto1 =
+        new BatchOperationDto()
+            .setId(TEST_BATCH_OP_IDS[0])
+            .setName("entity1")
+            .setType(OperationTypeDto.CANCEL_PROCESS_INSTANCE)
+            .setStartDate(TEST_DATE_TIME)
+            .setEndDate(TEST_DATE_TIME)
+            .setInstancesCount(5)
+            .setOperationsFinishedCount(0)
+            .setFailedOperationsCount(0)
+            .setCompletedOperationsCount(0);
+    final BatchOperationDto expectedDto2 =
+        new BatchOperationDto()
+            .setId(TEST_BATCH_OP_IDS[0])
+            .setName("entity2")
+            .setType(OperationTypeDto.MODIFY_PROCESS_INSTANCE)
+            .setStartDate(TEST_DATE_TIME)
+            .setEndDate(TEST_DATE_TIME)
+            .setInstancesCount(3)
+            .setOperationsFinishedCount(0)
+            .setFailedOperationsCount(0)
+            .setCompletedOperationsCount(0);
+    return List.of(expectedDto1, expectedDto2);
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/util/ElasticsearchMocks.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/util/ElasticsearchMocks.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+
+public class ElasticsearchMocks {
+
+  public static final int ELS_PORT = 9200;
+  public static final String ELS_HOST = "localhost";
+  public static final String ELS_SCHEME = "http";
+
+  // create an ElasticSearch SearchResponse from a JSON response String
+  public static SearchResponse getMockResponseFromJSON(final String jsonResponse)
+      throws NoSuchFieldException, IllegalAccessException, IOException {
+    final RestHighLevelClient client =
+        new RestHighLevelClient(RestClient.builder(new HttpHost(ELS_HOST, ELS_PORT, ELS_SCHEME)));
+    final Field registryField = client.getClass().getDeclaredField("registry");
+    registryField.setAccessible(true);
+    final NamedXContentRegistry registry = (NamedXContentRegistry) registryField.get(client);
+
+    final XContentParser parser =
+        XContentFactory.xContent(XContentType.JSON)
+            .createParser(registry, LoggingDeprecationHandler.INSTANCE, jsonResponse);
+    return SearchResponse.fromXContent(parser);
+  }
+
+  public static Terms getMockTermsFromJSONResponse(
+      final String jsonResponse, final String termsAggregationName)
+      throws IOException, NoSuchFieldException, IllegalAccessException {
+    final SearchResponse searchResponse = getMockResponseFromJSON(jsonResponse);
+    return searchResponse.getAggregations().get(termsAggregationName);
+  }
+
+  /*
+   *  Create SearchResponse parts from templates
+   */
+
+  // get a batch operation elasticsearch SearchResponse with two instances and an aggregation as
+  // JSON String
+  public static String batchSearchResponseWithAggregationAsString(
+      final int totalHitCount, final String hits, final String aggregation) {
+    return String.format(
+        "{\"took\":7,\"timed_out\":false,\"_shards\":{\"total\":2,\"successful\":2,\"skipped\":0,\"failed\":0},\"hits\":{\"total\":{\"value\":%s,\"relation\":\"eq\"},\"max_score\":1.0,%s},\"aggregations\":{%s}}",
+        totalHitCount, hits, aggregation);
+  }
+
+  public static String emptyBatchSearchResponseWithAggregationAsString(final String aggregation) {
+    return batchSearchResponseWithAggregationAsString(
+        0, hitsFromTemplate(new String[] {}), aggregation);
+  }
+
+  public static String hitsFromTemplate(final String[] instances) {
+    String hits = "";
+    if (instances != null && instances.length > 0) {
+      hits = String.join(",", instances);
+    }
+    return String.format("\"hits\":[%s]", hits);
+  }
+
+  public static String instanceFromTemplate(
+      final String docId,
+      final String sourceId,
+      final String type,
+      final String batchOperationId,
+      final String username) {
+    return String.format(
+        "{\"_index\":\"operate-operation\",\"_type\":\"_doc\","
+            + "\"_id\":\"%s\",\"_score\":1.0,\"_source\":{\"id\":\"%s\","
+            + "\"processInstanceKey\":1111111111111111,\"processDefinitionKey\":2222222222222222,\"bpmnProcessId\":\"eventBasedGatewayProcess\","
+            + "\"decisionDefinitionKey\":null,\"incidentKey\":null,\"scopeKey\":null,\"variableName\":null,\"variableValue\":null,"
+            + "\"type\":\"%s\",\"lockExpirationTime\":null,\"lockOwner\":null,\"state\":\"COMPLETED\",\"errorMessage\":null,"
+            + "\"batchOperationId\":\"%s\",\"zeebeCommandKey\":null,\"username\":\"%s\",\"modifyInstructions\":null,\"migrationPlan\":null}}",
+        docId, sourceId, type, batchOperationId, username);
+  }
+
+  public static String termsAggregationFromTemplate(
+      final String aggregationName, final String[] termsAggregationSubAggregations) {
+    String subAggregations = "{}";
+    if (termsAggregationSubAggregations != null && termsAggregationSubAggregations.length > 0) {
+      subAggregations = String.join(",", termsAggregationSubAggregations);
+    }
+    return String.format(
+        "\"sterms#%s\":{\"buckets\":[%s],\"doc_count_error_upper_bound\":0,\"sum_other_doc_count\":0}",
+        aggregationName, subAggregations);
+  }
+
+  public static String termsAggregationEmptyFromTemplate(final String aggregationName) {
+    return termsAggregationFromTemplate(aggregationName, null);
+  }
+
+  public static String termsSubaggregationFilterFromTemplate(
+      final int docCount, final String filterAggregation, final String key) {
+    return String.format("{\"doc_count\":%s,%s,\"key\":\"%s\"}", docCount, filterAggregation, key);
+  }
+
+  public static String twoBucketFilterAggregationFromTemplate(
+      final String filterName,
+      final String bucket1Name,
+      final int bucket1DocCount,
+      final String bucket2Name,
+      final int bucket2DocCount) {
+    return String.format(
+        "\"filters#%s\":{\"buckets\":{\"%s\":{\"doc_count\":%s},\"%s\":{\"doc_count\":%s}}}",
+        filterName, bucket1Name, bucket1DocCount, bucket2Name, bucket2DocCount);
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/util/OpensearchMocks.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/util/OpensearchMocks.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.util;
+
+import io.camunda.operate.entities.OperationEntity;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate.Builder;
+import org.opensearch.client.opensearch._types.aggregations.FiltersBucket;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
+import org.opensearch.client.util.ObjectBuilder;
+
+public class OpensearchMocks {
+
+  public static SearchResponse<OperationEntity> getMockResponseOf(
+      final Function<
+              HitsMetadata.Builder<OperationEntity>, ObjectBuilder<HitsMetadata<OperationEntity>>>
+          hits,
+      final String aggregationName,
+      final Function<Builder, ObjectBuilder<Aggregate>> aggregation) {
+    return SearchResponse.searchResponseOf(
+        r ->
+            r.took(3)
+                .timedOut(false)
+                .shards(s -> s.total(1).failed(0).successful(1))
+                .hits(hits)
+                .aggregations(aggregationName, aggregation));
+  }
+
+  public static Function<
+          HitsMetadata.Builder<OperationEntity>, ObjectBuilder<HitsMetadata<OperationEntity>>>
+      mockTwoHits(
+          final OperationEntity mockResponseEntity1, final OperationEntity mockResponseEntity2) {
+    return hits ->
+        hits.total(new TotalHits.Builder().value(2).relation(TotalHitsRelation.Eq).build())
+            .hits(hit -> hit.id("1").index("operate-operations").source(mockResponseEntity1))
+            .hits(hit -> hit.id("2").index("operate-operations").source(mockResponseEntity2));
+  }
+
+  public static Function<Builder, ObjectBuilder<Aggregate>> mockTermsAggregationWithSubaggregations(
+      final String subAggregationName,
+      final Map<String, Function<Builder, ObjectBuilder<Aggregate>>> subAggregations,
+      final long docCount) {
+    final List<StringTermsBucket> termsBuckets = new ArrayList<>();
+    subAggregations.forEach(
+        (aggregationKey, aggregation) -> {
+          final StringTermsBucket bucket =
+              new StringTermsBucket.Builder()
+                  .key(aggregationKey)
+                  .aggregations(subAggregationName, aggregation)
+                  .docCount(docCount)
+                  .build();
+          termsBuckets.add(bucket);
+        });
+    return aggs ->
+        aggs.sterms(
+            t -> t.buckets(buckets -> buckets.array(termsBuckets)).sumOtherDocCount(docCount));
+  }
+
+  public static Function<Builder, ObjectBuilder<Aggregate>> mockTwoFilterAggregation(
+      final String filter1Name,
+      final int filter1DocCount,
+      final String filter2Name,
+      final int filter2DocCount) {
+    return aggs ->
+        aggs.filters(
+            f ->
+                f.buckets(
+                    filtersBucketBuilder ->
+                        filtersBucketBuilder.keyed(
+                            Map.of(
+                                filter1Name,
+                                FiltersBucket.of(bucket -> bucket.docCount(filter1DocCount)),
+                                filter2Name,
+                                FiltersBucket.of(bucket -> bucket.docCount(filter2DocCount))))));
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/transform/ElasticsearchDataAggregatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/elasticsearch/transform/ElasticsearchDataAggregatorTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.elasticsearch.transform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.entities.BatchOperationEntity;
+import io.camunda.operate.entities.OperationType;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.OperationTemplate;
+import io.camunda.operate.util.BatchOperationTestDataHelper;
+import io.camunda.operate.util.ElasticsearchMocks;
+import io.camunda.operate.webapp.elasticsearch.reader.OperationReader;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
+import java.io.IOException;
+import java.util.List;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.bucket.terms.Terms;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ElasticsearchDataAggregatorTest {
+
+  @Mock OperationReader operationReader;
+  @Mock private OperationTemplate operationTemplate;
+  @Mock private ObjectMapper objectMapper;
+  @InjectMocks private ElasticsearchDataAggregator underTest;
+
+  private List<BatchOperationEntity> testEntities;
+
+  @Test
+  public void testEnrichBatchEntitiesWithMetadataSuccess()
+      throws IOException, NoSuchFieldException, IllegalAccessException {
+
+    testEntities = BatchOperationTestDataHelper.create2TestBatchOperationDtos();
+    final List<BatchOperationDto> expectedDtos =
+        BatchOperationTestDataHelper.get2DtoBatchRequestExpected();
+
+    final Terms mockTerms =
+        ElasticsearchMocks.getMockTermsFromJSONResponse(
+            getTestMockJSONResponse(), OperationTemplate.BATCH_OPERATION_ID_AGGREGATION);
+    when(operationReader.getOperationsAggregatedByBatchOperationId(
+            anyList(), any(AggregationBuilder.class)))
+        .thenReturn(mockTerms);
+
+    final List<BatchOperationDto> actualBatchOperationDtos =
+        underTest.enrichBatchEntitiesWithMetadata(testEntities);
+    assertEquals(
+        2,
+        actualBatchOperationDtos.size(),
+        "Two result entities expected but got " + actualBatchOperationDtos.size());
+
+    final BatchOperationDto actual1 = actualBatchOperationDtos.get(0);
+    final BatchOperationDto actual2 = actualBatchOperationDtos.get(1);
+
+    assertEquals(actual1, expectedDtos.get(0), "actual1 is not equal to expected DTO.");
+    assertEquals(actual2, expectedDtos.get(1), "actual2 is not equal to expected DTO.");
+  }
+
+  private String getTestMockJSONResponse() {
+    final String mockESResponseHits =
+        ElasticsearchMocks.hitsFromTemplate(
+            new String[] {
+              // hits content doesn't matter, because entity info is taken from the initially passed
+              // entity
+              ElasticsearchMocks.instanceFromTemplate(
+                  "2",
+                  "2",
+                  OperationType.MODIFY_PROCESS_INSTANCE.name(),
+                  testEntities.get(0).getId(),
+                  BatchOperationTestDataHelper.TEST_USER),
+              ElasticsearchMocks.instanceFromTemplate(
+                  "20",
+                  "20",
+                  OperationType.MODIFY_PROCESS_INSTANCE.name(),
+                  testEntities.get(1).getId(),
+                  BatchOperationTestDataHelper.TEST_USER)
+            });
+
+    final String filterAggregation1 =
+        ElasticsearchMocks.termsSubaggregationFilterFromTemplate(
+            5,
+            ElasticsearchMocks.twoBucketFilterAggregationFromTemplate(
+                OperationTemplate.METADATA_AGGREGATION,
+                BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
+                1,
+                BatchOperationTemplate.FAILED_OPERATIONS_COUNT,
+                4),
+            testEntities.get(0).getId());
+    final String filterAggregation2 =
+        ElasticsearchMocks.termsSubaggregationFilterFromTemplate(
+            3,
+            ElasticsearchMocks.twoBucketFilterAggregationFromTemplate(
+                OperationTemplate.METADATA_AGGREGATION,
+                BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
+                3,
+                BatchOperationTemplate.FAILED_OPERATIONS_COUNT,
+                0),
+            testEntities.get(1).getId());
+
+    final String mockResponse =
+        ElasticsearchMocks.batchSearchResponseWithAggregationAsString(
+            8,
+            mockESResponseHits,
+            ElasticsearchMocks.termsAggregationFromTemplate(
+                OperationTemplate.BATCH_OPERATION_ID_AGGREGATION,
+                new String[] {filterAggregation1, filterAggregation2}));
+    return mockResponse;
+  }
+}

--- a/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregatorTest.java
+++ b/operate/webapp/src/test/java/io/camunda/operate/webapp/opensearch/transform/OpensearchDataAggregatorTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.opensearch.transform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import io.camunda.operate.entities.BatchOperationEntity;
+import io.camunda.operate.entities.OperationEntity;
+import io.camunda.operate.schema.templates.BatchOperationTemplate;
+import io.camunda.operate.schema.templates.OperationTemplate;
+import io.camunda.operate.store.opensearch.client.sync.OpenSearchDocumentOperations;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import io.camunda.operate.util.BatchOperationTestDataHelper;
+import io.camunda.operate.util.OpensearchMocks;
+import io.camunda.operate.webapp.elasticsearch.reader.OperationReader;
+import io.camunda.operate.webapp.rest.dto.operation.BatchOperationDto;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Aggregate.Builder;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.util.ObjectBuilder;
+
+@ExtendWith(MockitoExtension.class)
+public class OpensearchDataAggregatorTest {
+
+  @Mock RichOpenSearchClient richOpenSearchClient;
+  @Mock OpenSearchDocumentOperations openSearchDocumentOperations;
+  @Mock private OperationTemplate operationTemplate;
+  @Mock private BatchOperationTemplate batchOperationTemplate;
+  @Mock private OperationReader operationReader;
+
+  private List<BatchOperationEntity> testEntities;
+  @InjectMocks private OpensearchDataAggregator underTest;
+
+  @Test
+  public void testEnrichBatchEntitiesWithMetadataSuccess() {
+    testEntities = BatchOperationTestDataHelper.create2TestBatchOperationDtos();
+    final List<BatchOperationDto> expectedDtos =
+        BatchOperationTestDataHelper.get2DtoBatchRequestExpected();
+
+    when(richOpenSearchClient.doc()).thenReturn(openSearchDocumentOperations);
+    when(openSearchDocumentOperations.search(any(SearchRequest.Builder.class), any(Class.class)))
+        .thenReturn(mockBasicResponse());
+
+    final List<BatchOperationDto> actualBatchOperationDtos =
+        underTest.enrichBatchEntitiesWithMetadata(testEntities);
+    assertEquals(
+        2,
+        actualBatchOperationDtos.size(),
+        "Two result entities expected but got " + actualBatchOperationDtos.size());
+
+    assertEquals(
+        actualBatchOperationDtos.get(0),
+        expectedDtos.get(0),
+        "actual1 is not equal to expected DTO.");
+    assertEquals(
+        actualBatchOperationDtos.get(1),
+        expectedDtos.get(1),
+        "actual2 is not equal to expected DTO.");
+  }
+
+  private SearchResponse<OperationEntity> mockBasicResponse() {
+    final Map<String, Function<Builder, ObjectBuilder<Aggregate>>> subFilterAggregations =
+        new HashMap<>();
+    subFilterAggregations.put(
+        testEntities.get(0).getId(),
+        OpensearchMocks.mockTwoFilterAggregation(
+            BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
+            1,
+            BatchOperationTemplate.FAILED_OPERATIONS_COUNT,
+            4));
+    subFilterAggregations.put(
+        testEntities.get(1).getId(),
+        OpensearchMocks.mockTwoFilterAggregation(
+            BatchOperationTemplate.COMPLETED_OPERATIONS_COUNT,
+            3,
+            BatchOperationTemplate.FAILED_OPERATIONS_COUNT,
+            0));
+
+    return OpensearchMocks.getMockResponseOf(
+        // hits content doesn't matter, because entity info is taken from the initially passed
+        // entity
+        OpensearchMocks.mockTwoHits(null, null),
+        OperationTemplate.BATCH_OPERATION_ID_AGGREGATION,
+        OpensearchMocks.mockTermsAggregationWithSubaggregations(
+            OperationTemplate.METADATA_AGGREGATION, subFilterAggregations, 8L));
+  }
+}


### PR DESCRIPTION
## Description
Added unit and integration tests to verify the functionality of batch operation requests via the API after the failed/successful operation count was added.

## Related issues

relates to https://github.com/camunda/operate/issues/6294
