### PR TITLE
Ensure getGrpcAddress backward compatibility

### DIFF
--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -100,7 +100,7 @@ public class ZeebeClientConfigurationImpl
     return getOrLegacyOrDefault(
         "GrpcAddress",
         () -> camundaClientProperties.getZeebe().getGrpcAddress(),
-        () -> properties.getBroker().getGrpcAddress(),
+        properties::getGrpcAddress,
         DEFAULT.getGrpcAddress(),
         configCache);
   }

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationPropertiesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.spring.client.config;
+
+import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.CONNECTION_MODE_ADDRESS;
+import static io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.CONNECTION_MODE_CLOUD;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
+import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.Broker;
+import io.camunda.zeebe.spring.client.properties.ZeebeClientConfigurationProperties.Cloud;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ZeebeClientConfigurationPropertiesTest {
+
+  private static final String BROKER_GRPC_ADDRESS =
+      "https://cluster-id.cluster-region.base-url:123";
+  private ZeebeClientConfigurationProperties properties;
+
+  @BeforeEach
+  public void setUp() {
+    properties = new ZeebeClientConfigurationProperties(null);
+  }
+
+  @Test
+  public void shouldUseCloudGrpcAddressWhenConnectionModeIsCloud() throws URISyntaxException {
+    properties.setConnectionMode(CONNECTION_MODE_CLOUD);
+    setCloudProperties();
+    setBrokerProperties();
+
+    assertThat(properties.getGrpcAddress())
+        .isEqualTo(new URI("https://cluster-id.cluster-region.base-url:123"));
+  }
+
+  @Test
+  public void shouldUseBrokerGrpcAddressWhenConnectionModeIsAddress() throws URISyntaxException {
+    properties.setConnectionMode(CONNECTION_MODE_ADDRESS);
+    setCloudProperties();
+    setBrokerProperties();
+
+    assertThat(properties.getGrpcAddress()).isEqualTo(new URI(BROKER_GRPC_ADDRESS));
+  }
+
+  @Test
+  public void shouldThrowErrorWhenConnectionModeIsInvalid() throws URISyntaxException {
+    properties.setConnectionMode("CUSTOM");
+
+    final RuntimeException exception =
+        assertThrows(
+            RuntimeException.class,
+            () -> properties.getGrpcAddress(),
+            "Expected getGrpcAddress() to throw, but it didn't");
+
+    assertTrue(exception.getMessage().contains("for ConnectionMode is invalid"));
+  }
+
+  @Test
+  public void shouldUseCloudGrpcAddressFirstWhenNoConnectionMode() throws URISyntaxException {
+    setCloudProperties();
+    setBrokerProperties();
+
+    assertThat(properties.getGrpcAddress())
+        .isEqualTo(new URI("https://cluster-id.cluster-region.base-url:123"));
+  }
+
+  @Test
+  public void shouldUseBrokerGrpcAddressWhenOnlyBrokerConfigAvailable() throws URISyntaxException {
+    setBrokerProperties();
+
+    assertThat(properties.getGrpcAddress()).isEqualTo(new URI(BROKER_GRPC_ADDRESS));
+  }
+
+  private void setCloudProperties() {
+    final Cloud cloud = new Cloud();
+    cloud.setClusterId("cluster-id");
+    cloud.setRegion("cluster-region");
+    cloud.setBaseUrl("base-url");
+    cloud.setPort(123);
+    properties.setCloud(cloud);
+  }
+
+  private void setBrokerProperties() throws URISyntaxException {
+    final Broker broker = new Broker();
+    final URI grpcAddress = new URI(BROKER_GRPC_ADDRESS);
+    broker.setGrpcAddress(grpcAddress);
+    properties.setBroker(broker);
+  }
+}

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -52,7 +52,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 public class ZeebeClientSpringConfigurationPropertiesTest {
 
   @Autowired private ZeebeClientConfigurationProperties properties;
-  @Autowired private JsonMapper jsonMapper;
 
   @Test
   public void hasDeprecatedGatewayAddress() {


### PR DESCRIPTION
## Description

Both `zeebe.client` and `camunda.client` configuration properties should be supported.
Currently there is an issue with SM zeebe.client properties:

```
zeebe.client.cloud.region=bru-2
zeebe.client.cloud.clusterId=<cluster-id>
zeebe.client.cloud.clientId=<client-id>
zeebe.client.cloud.clientSecret=<client-secret>
```

## Related issues

closes #19161
