### PR TITLE
Not subscribe to new subscription if element is in ACTIVATING state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -297,7 +297,6 @@ public class ProcessInstanceMigrationMigrateProcessor
           targetElementId,
           processInstanceKey,
           elementId);
-      ;
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -289,16 +289,26 @@ public class ProcessInstanceMigrationMigrateProcessor
     if (ProcessInstanceIntent.ELEMENT_ACTIVATING != elementInstance.getState()) {
       // element in ACTIVATING state should not be subscribed into new subscription during migration
       // https://github.com/camunda/camunda/issues/19212
-      migrateCatchEvent(elementInstance, targetProcessDefinition, sourceElementIdToTargetElementId,
-          elementInstanceRecord, targetElementId, processInstanceKey, elementId);;
+      migrateCatchEvent(
+          elementInstance,
+          targetProcessDefinition,
+          sourceElementIdToTargetElementId,
+          elementInstanceRecord,
+          targetElementId,
+          processInstanceKey,
+          elementId);
+      ;
     }
   }
 
-  private void migrateCatchEvent(final ElementInstance elementInstance,
+  private void migrateCatchEvent(
+      final ElementInstance elementInstance,
       final DeployedProcess targetProcessDefinition,
       final Map<String, String> sourceElementIdToTargetElementId,
-      final ProcessInstanceRecord elementInstanceRecord, final String targetElementId,
-      final long processInstanceKey, final String elementId) {
+      final ProcessInstanceRecord elementInstanceRecord,
+      final String targetElementId,
+      final long processInstanceKey,
+      final String elementId) {
     final var context = new BpmnElementContextImpl();
     context.init(elementInstance.getKey(), elementInstanceRecord, elementInstance.getState());
     final var targetElement =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -285,6 +285,12 @@ public class ProcessInstanceMigrationMigrateProcessor
                         .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
                         .setTenantId(elementInstance.getValue().getTenantId())));
 
+    if (ProcessInstanceIntent.ELEMENT_ACTIVATING == elementInstance.getState()) {
+      // element in ACTIVATING state should not be subscribed into new subscription during migration
+      // https://github.com/camunda/camunda/issues/19212
+      return;
+    }
+
     final var context = new BpmnElementContextImpl();
     context.init(elementInstance.getKey(), elementInstanceRecord, elementInstance.getState());
     final var targetElement =

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.variable.VariableRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -285,12 +286,19 @@ public class ProcessInstanceMigrationMigrateProcessor
                         .setBpmnProcessId(targetProcessDefinition.getBpmnProcessId())
                         .setTenantId(elementInstance.getValue().getTenantId())));
 
-    if (ProcessInstanceIntent.ELEMENT_ACTIVATING == elementInstance.getState()) {
+    if (ProcessInstanceIntent.ELEMENT_ACTIVATING != elementInstance.getState()) {
       // element in ACTIVATING state should not be subscribed into new subscription during migration
       // https://github.com/camunda/camunda/issues/19212
-      return;
+      migrateCatchEvent(elementInstance, targetProcessDefinition, sourceElementIdToTargetElementId,
+          elementInstanceRecord, targetElementId, processInstanceKey, elementId);;
     }
+  }
 
+  private void migrateCatchEvent(final ElementInstance elementInstance,
+      final DeployedProcess targetProcessDefinition,
+      final Map<String, String> sourceElementIdToTargetElementId,
+      final ProcessInstanceRecord elementInstanceRecord, final String targetElementId,
+      final long processInstanceKey, final String elementId) {
     final var context = new BpmnElementContextImpl();
     context.init(elementInstance.getKey(), elementInstanceRecord, elementInstance.getState());
     final var targetElement =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRegressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRegressionTest.java
@@ -29,6 +29,7 @@ public class MigrateProcessInstanceRegressionTest {
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
+  // https://github.com/camunda/camunda/issues/19212
   @Test
   public void shouldResolveIncidentAfterMigratingActivatingElementWithMessageBoundaryEvent() {
     // given

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRegressionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRegressionTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateProcessInstanceRegressionTest {
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldResolveIncidentAfterMigratingActivatingElementWithMessageBoundaryEvent() {
+    // given
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .serviceTask("A", t -> t.zeebeJobType("task"))
+                    .boundaryEvent(
+                        "msg",
+                        b ->
+                            b.message(
+                                m -> m.name("msg").zeebeCorrelationKeyExpression("missing_var")))
+                    .endEvent()
+                    .moveToNode("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("B", t -> t.zeebeJobType("task"))
+                    .boundaryEvent(
+                        "msg",
+                        b ->
+                            b.message(
+                                m -> m.name("msg").zeebeCorrelationKeyExpression("existing_var")))
+                    .endEvent()
+                    .moveToNode("B")
+                    .endEvent("target_process_end")
+                    .done())
+            .deploy();
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(sourceProcessId)
+            .withVariable("existing_var", "key")
+            .create();
+
+    final Record<IncidentRecordValue> incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .migrate();
+
+    // then
+    final Record<IncidentRecordValue> incidentRecord =
+        ENGINE.incident().ofInstance(processInstanceKey).withKey(incident.getKey()).resolve();
+
+    assertThat(incidentRecord.getValue())
+        .describedAs("Expect that the incident resolved event contains updated fields")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("B");
+  }
+}


### PR DESCRIPTION
## Description

During PIM (Process Instance Migration) an element shouldn't subscribe into a new subscription if the element state is `ACTIVATING`, due to a previous incident occurred

## Related issues

closes #19212 
