### PR TITLE
Add endpoint to enable exporter

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -8,7 +8,9 @@
 package io.camunda.zeebe.shared.management;
 
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
+import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
@@ -16,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Component
@@ -38,4 +41,19 @@ public class ExportersEndpoint {
         .disableExporter(new ExporterDisableRequest(exporterId, dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
+
+  @PostMapping(path = "/{exporterId}/enable")
+  public CompletableFuture<ResponseEntity<?>> enableExporter(
+      @PathVariable("exporterId") final String exporterId,
+      @RequestBody(required = false) final InitializationInfo initializeInfo,
+      @RequestParam(defaultValue = "false") final boolean dryRun) {
+
+    final var initializeFrom = initializeInfo != null ? initializeInfo.initializeFrom() : null;
+    return requestSender
+        .enableExporter(
+            new ExporterEnableRequest(exporterId, Optional.ofNullable(initializeFrom), dryRun))
+        .handle(ClusterApiUtils::mapOperationResponse);
+  }
+
+  private record InitializationInfo(String initializeFrom) {}
 }

--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -47,11 +47,12 @@ public class ExportersEndpoint {
       @PathVariable("exporterId") final String exporterId,
       @RequestBody(required = false) final InitializationInfo initializeInfo,
       @RequestParam(defaultValue = "false") final boolean dryRun) {
-
-    final var initializeFrom = initializeInfo != null ? initializeInfo.initializeFrom() : null;
     return requestSender
         .enableExporter(
-            new ExporterEnableRequest(exporterId, Optional.ofNullable(initializeFrom), dryRun))
+            new ExporterEnableRequest(
+                exporterId,
+                Optional.ofNullable(initializeInfo).map(InitializationInfo::initializeFrom),
+                dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -284,7 +284,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
     }
     // initializes metadata and position in the runtime state
     container.initMetadata();
-    container.openExporter();
+    if (exporterMode == ExporterMode.ACTIVE) {
+      container.openExporter();
+    }
     containers.add(container);
     LOG.debug("Exporter '{}' is enabled.", exporterId);
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorPauseTest.java
@@ -22,7 +22,6 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import java.util.List;
 import java.util.Map;
-import org.awaitility.Awaitility;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -160,14 +159,6 @@ public final class ExporterDirectorPauseTest {
   public void canPauseAndResumeWithoutAnyExporter() {
     // given
     activeExporter.startExporterDirector(List.of());
-
-    // when -- exporter is closed
-    // Wait for exporter to properly close before submitting pause/resume jobs.
-    // Needed to prevent flaky test https://github.com/camunda/camunda/issues/10439
-    Awaitility.await()
-        .alias("Exporter is closed")
-        .ignoreExceptions() // joining can still throw if actor is closed after `getPhase` is called
-        .until(() -> activeExporter.getDirector().getPhase().join() == ExporterPhase.CLOSED);
 
     // then
     assertThatCode(() -> activeExporter.getDirector().pauseExporting().join())

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDisableTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDisableTest.java
@@ -122,19 +122,4 @@ public class ExporterDisableTest {
     assertThat(rule.getDirector().disableExporter(EXPORTER_ID_1))
         .succeedsWithin(Duration.ofMillis(100));
   }
-
-  @Test
-  public void shouldCloseExporterDirectorWhenAllExportersAreDisabled() {
-    // given
-    rule.startExporterDirector(exporterDescriptors);
-
-    // when
-    rule.getDirector().disableExporter(EXPORTER_ID_1).join();
-    rule.getDirector().disableExporter(EXPORTER_ID_2).join();
-
-    // then
-    Awaitility.await("ExporterDirector is closed")
-        .untilAsserted(
-            () -> assertThat(rule.getDirector().getPhase().join()).isEqualTo(ExporterPhase.CLOSED));
-  }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterEnableTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterEnableTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.exporter;
+
+import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.shared.BrokerConfiguration.BrokerProperties;
+import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.qa.util.actuator.ExportersActuator;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.qa.util.topology.ClusterActuatorAssert;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.IntStream;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+@Timeout(2 * 60) // 2 minutes
+@ZeebeIntegration
+@AutoCloseResources
+final class ExporterEnableTest {
+  private static final int PARTITIONS_COUNT = 2;
+  private static final String EXPORTER_ID_1 = "exporter-1";
+  private static final String EXPORTER_ID_2 = "exporter-2";
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withBrokersCount(3)
+          .withPartitionsCount(PARTITIONS_COUNT)
+          .withReplicationFactor(3)
+          .withEmbeddedGateway(false)
+          // We have to restart brokers in the test. So use standalone gateway to avoid potentially
+          // accessing an unavailable broker
+          .withGatewaysCount(1)
+          .withBrokerConfig(b -> withCustomerExporters(b.brokerConfig()))
+          .build();
+
+  @AutoCloseResource private ZeebeClient client;
+  private ExportersActuator actuator;
+
+  private void withCustomerExporters(final BrokerProperties brokerConfig) {
+    final ExporterCfg exporterCfg = new ExporterCfg();
+    exporterCfg.setClassName(TestExporter.class.getName());
+    brokerConfig.setExporters(Map.of(EXPORTER_ID_1, exporterCfg, EXPORTER_ID_2, exporterCfg));
+  }
+
+  @BeforeEach
+  void setup() {
+    client = cluster.newClientBuilder().build();
+    actuator = ExportersActuator.of(cluster.availableGateway());
+  }
+
+  @Test
+  void shouldEnableExporterOnAllPartitions() {
+    // given
+    waitUntilOperationCompleted(actuator.disableExporter(EXPORTER_ID_2));
+    TestExporter.RECORDS.get(EXPORTER_ID_2).clear();
+    TestExporter.METADATA.get(EXPORTER_ID_2).clear();
+
+    // when
+    waitUntilOperationCompleted(actuator.enableExporter(EXPORTER_ID_2));
+    createDeploymentOnAllPartitions("process-1");
+
+    // then
+    final var recordsAfterEnable =
+        Awaitility.await()
+            .atMost(Duration.ofSeconds(30))
+            .during(Duration.ofSeconds(5))
+            .until(TestExporter.RECORDS.get(EXPORTER_ID_2)::size, hasStableValue());
+
+    assertThat(recordsAfterEnable).isNotZero();
+    IntStream.rangeClosed(1, PARTITIONS_COUNT)
+        .forEach(
+            p ->
+                assertThat(TestExporter.METADATA.get(EXPORTER_ID_2).get(p))
+                    .describedAs("Exporter has exported from all partitions.")
+                    .isGreaterThan(0L));
+  }
+
+  @Test
+  void shouldEnableExporterOnAllPartitionsAndInitializeMetadata() {
+    // given
+    waitUntilOperationCompleted(actuator.disableExporter(EXPORTER_ID_2));
+    TestExporter.RECORDS.get(EXPORTER_ID_2).clear();
+    TestExporter.METADATA.get(EXPORTER_ID_2).clear();
+
+    createDeploymentOnAllPartitions("process-1");
+    Awaitility.await("Exporter 1 has exported all records")
+        .atMost(Duration.ofSeconds(30))
+        .during(Duration.ofSeconds(10))
+        .until(TestExporter.RECORDS.get(EXPORTER_ID_1)::size, hasStableValue());
+
+    // when
+    final var response = actuator.enableExporter(EXPORTER_ID_2, EXPORTER_ID_1);
+    waitUntilOperationCompleted(response);
+    createDeploymentOnAllPartitions("process-2");
+
+    // then
+    Awaitility.await("Exporter 1 has exported all records")
+        .atMost(Duration.ofSeconds(30))
+        .during(Duration.ofSeconds(10))
+        .until(TestExporter.RECORDS.get(EXPORTER_ID_1)::size, hasStableValue());
+    Awaitility.await("Exporter 2 has exported all records")
+        .atMost(Duration.ofSeconds(30))
+        .during(Duration.ofSeconds(10))
+        .until(TestExporter.RECORDS.get(EXPORTER_ID_1)::size, hasStableValue());
+
+    IntStream.rangeClosed(1, PARTITIONS_COUNT)
+        .forEach(
+            p ->
+                assertThat(TestExporter.METADATA.get(EXPORTER_ID_2).get(p))
+                    .describedAs(
+                        "Exporter 2 has same sequence position as Exporter 1 in partition %d", p)
+                    .isEqualTo(TestExporter.METADATA.get(EXPORTER_ID_1).get(p)));
+  }
+
+  private void waitUntilOperationCompleted(final PlannedOperationsResponse disableResponse) {
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(30))
+        .untilAsserted(
+            () -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(disableResponse));
+  }
+
+  private void createDeploymentOnAllPartitions(final String processId) {
+    // Deployment will be distributed to other partitions as well, ensuring all partitions have some
+    // records to export.
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId).startEvent().endEvent().done(), "process.bpmn")
+        .send()
+        .join();
+  }
+
+  public static class TestExporter implements Exporter {
+    static final Map<String, List<Record<?>>> RECORDS = new ConcurrentHashMap<>();
+    static final Map<String, Map<Integer, Long>> METADATA = new ConcurrentHashMap<>();
+    private Controller controller;
+    private String exporterId;
+    private int partitionId;
+
+    @Override
+    public void configure(final Context context) throws Exception {
+      exporterId = context.getConfiguration().getId();
+      partitionId = context.getPartitionId();
+    }
+
+    @Override
+    public void open(final Controller controller) {
+      this.controller = controller;
+      final var metadata =
+          controller.readMetadata().map(b -> ByteBuffer.wrap(b).getLong()).orElse(0L);
+      METADATA.putIfAbsent(exporterId, new ConcurrentHashMap<>());
+      METADATA.get(exporterId).put(partitionId, metadata);
+      RECORDS.putIfAbsent(exporterId, new CopyOnWriteArrayList<>());
+    }
+
+    @Override
+    public void export(final Record<?> record) {
+      RECORDS.get(exporterId).add(record.copyOf());
+      final var newSeqPos = METADATA.get(exporterId).compute(partitionId, (p, pos) -> pos + 1);
+      controller.updateLastExportedRecordPosition(
+          record.getPosition(), ByteBuffer.allocate(8).putLong(newSeqPos).array());
+    }
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterEnableTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterEnableTest.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.it.exporter;
 import static io.camunda.zeebe.test.StableValuePredicate.hasStableValue;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.broker.shared.BrokerConfiguration.BrokerProperties;
-import io.camunda.zeebe.broker.system.configuration.ExporterCfg;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
@@ -58,17 +56,18 @@ final class ExporterEnableTest {
           // We have to restart brokers in the test. So use standalone gateway to avoid potentially
           // accessing an unavailable broker
           .withGatewaysCount(1)
-          .withBrokerConfig(b -> withCustomerExporters(b.brokerConfig()))
+          .withBrokerConfig(
+              b ->
+                  b.withExporter(
+                          EXPORTER_ID_1,
+                          config -> config.setClassName(TestExporter.class.getName()))
+                      .withExporter(
+                          EXPORTER_ID_2,
+                          config -> config.setClassName(TestExporter.class.getName())))
           .build();
 
   @AutoCloseResource private ZeebeClient client;
   private ExportersActuator actuator;
-
-  private void withCustomerExporters(final BrokerProperties brokerConfig) {
-    final ExporterCfg exporterCfg = new ExporterCfg();
-    exporterCfg.setClassName(TestExporter.class.getName());
-    brokerConfig.setExporters(Map.of(EXPORTER_ID_1, exporterCfg, EXPORTER_ID_2, exporterCfg));
-  }
 
   @BeforeEach
   void setup() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportersEndpointIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/management/ExportersEndpointIT.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.management.cluster.BrokerState;
 import io.camunda.zeebe.management.cluster.ExporterStateCode;
 import io.camunda.zeebe.management.cluster.Operation.OperationEnum;
+import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.actuator.ExportersActuator;
 import io.camunda.zeebe.qa.util.cluster.TestCluster;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
@@ -75,9 +76,7 @@ final class ExportersEndpointIT {
     assertThat(response.getExpectedTopology().stream().allMatch(this::hasExporterDisabled))
         .isTrue();
 
-    Awaitility.await()
-        .timeout(Duration.ofSeconds(30))
-        .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
+    waitUntilOperationIsApplied(response);
 
     // write more events
     client.newPublishMessageCommand().messageName("test2").correlationKey("key2").send().join();
@@ -111,5 +110,32 @@ final class ExportersEndpointIT {
         .asInstanceOf(InstanceOfAssertFactories.type(FeignException.class))
         .extracting(FeignException::status)
         .isEqualTo(400);
+  }
+
+  @Test
+  void shouldEnableExporter() {
+    // given
+    final var messageName = "enable-exporter-test";
+    final var response =
+        ExportersActuator.of(cluster.anyGateway()).disableExporter("recordingExporter");
+    waitUntilOperationIsApplied(response);
+
+    // when
+    final var enableResponse =
+        ExportersActuator.of(cluster.anyGateway()).enableExporter("recordingExporter");
+    waitUntilOperationIsApplied(enableResponse);
+
+    client.newPublishMessageCommand().messageName(messageName).correlationKey("key2").send().join();
+
+    // then
+    Awaitility.await("Record is exported")
+        .until(
+            () -> RecordingExporter.messageRecords().withName(messageName).findFirst().isPresent());
+  }
+
+  private void waitUntilOperationIsApplied(final PlannedOperationsResponse response) {
+    Awaitility.await()
+        .timeout(Duration.ofSeconds(30))
+        .untilAsserted(() -> ClusterActuatorAssert.assertThat(cluster).hasAppliedChanges(response));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceWithOutExporterTest.java
@@ -39,7 +39,7 @@ public class BrokerAdminServiceWithOutExporterTest {
     assertThat(partitionStatus.snapshotId()).isNull();
     assertThat(partitionStatus.processedPositionInSnapshot()).isNull();
     assertThat(partitionStatus.streamProcessorPhase()).isEqualTo(Phase.PROCESSING);
-    assertThat(partitionStatus.exporterPhase()).isEqualTo(ExporterPhase.CLOSED);
+    assertThat(partitionStatus.exporterPhase()).isEqualTo(ExporterPhase.EXPORTING);
     assertThat(partitionStatus.exportedPosition()).isEqualTo(-1);
   }
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
@@ -7,6 +7,9 @@
  */
 package io.camunda.zeebe.qa.util.actuator;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.Feign;
@@ -19,6 +22,7 @@ import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.zeebe.containers.ZeebeNode;
 import java.util.List;
 
@@ -78,4 +82,27 @@ public interface ExportersActuator {
   @RequestLine("POST /{exporterId}/disable")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PlannedOperationsResponse disableExporter(@Param final String exporterId);
+
+  /**
+   * Request to enable an exporter
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("POST /{exporterId}/enable")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse enableExporter(
+      @Param final String exporterId, @RequestBody final InitializationInfo initializeFrom);
+
+  default PlannedOperationsResponse enableExporter(
+      final String exporterId, final String initializeFrom) {
+    return enableExporter(exporterId, new InitializationInfo(initializeFrom));
+  }
+
+  @RequestLine("POST /{exporterId}/enable")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  PlannedOperationsResponse enableExporter(@Param final String exporterId);
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonInclude(Include.NON_EMPTY)
+  record InitializationInfo(String initializeFrom) {}
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestCluster.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
+import io.camunda.zeebe.client.api.response.BrokerInfo;
 import io.camunda.zeebe.test.util.asserts.TopologyAssert;
 import io.camunda.zeebe.util.CloseableSilently;
 import java.time.Duration;
@@ -357,6 +358,30 @@ public final class TestCluster implements CloseableSilently {
         .atMost(timeout)
         .untilAsserted(() -> assertThat(nodes).allSatisfy(node -> assertProbe(node, probe)));
     return this;
+  }
+
+  /**
+   * returns the broker which is the leader for given partitionId according to the topology response
+   *
+   * @param partitionId id of the partition
+   * @return the broker which is the leader for given partitionId
+   * @throws NoSuchElementException if no leader is found for the partition
+   */
+  public TestStandaloneBroker leaderForPartition(final int partitionId) {
+    try (final var client = newClientBuilder().build()) {
+      final var leaderOfPartition2 =
+          client.newTopologyRequest().send().join().getBrokers().stream()
+              .filter(
+                  b ->
+                      b.getPartitions().stream()
+                          .anyMatch(p -> p.getPartitionId() == partitionId && p.isLeader()))
+              .map(BrokerInfo::getNodeId)
+              .findFirst()
+              .orElseThrow(
+                  () -> new NoSuchElementException("No leader found for partition " + partitionId));
+
+      return brokers().get(MemberId.from(String.valueOf(leaderOfPartition2)));
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR combines two things
1. `ExporterDirector` does not close itself when no exporters are configured. Instead it goes to an idle state, where the actor is still running, but it is not actively doing any tasks. When a new exporter is enabled, it will become active again and starts all necessary services to resume exporting.
2. Added endpoint in the gateway for enabling exporter. The endpoint allows to enable an exporter with and without another exporter to initialize from.

## Related issues

closes #19022 
closes #18752
