### PR TITLE
feat: add support for child instances migration, add relevant tests - 8.5 backport

### DIFF
--- a/operate/client/e2e-playwright/tests/childProcessInstanceMigration.mocks.ts
+++ b/operate/client/e2e-playwright/tests/childProcessInstanceMigration.mocks.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE ("USE"), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * "Licensee" means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+
+import {deployProcess, createInstances} from '../setup-utils';
+
+const setup = async () => {
+  const deployProcessResponse = await deployProcess([
+    'ChildProcessInstanceMigration/callActivityParentProcess.bpmn',
+    'ChildProcessInstanceMigration/childProcess_v_1.bpmn',
+  ]);
+  await deployProcess(['ChildProcessInstanceMigration/childProcess_v_2.bpmn']);
+
+  if (
+    deployProcessResponse.processes[0] === undefined ||
+    deployProcessResponse.processes[1] === undefined
+  ) {
+    throw new Error('Error deploying process');
+  }
+
+  const {
+    version: parentVersion,
+    processDefinitionKey: parentProcessDefinitionKey,
+    bpmnProcessId: parentBpmnProcessId,
+  } = deployProcessResponse.processes[0];
+
+  const {bpmnProcessId: childBpmnProcessId} =
+    deployProcessResponse.processes[1];
+
+  return {
+    processInstances: await createInstances('callActivityParentProcess', 1, 2),
+    parentVersion,
+    parentProcessDefinitionKey,
+    parentBpmnProcessId,
+    childBpmnProcessId,
+  };
+};
+
+export {setup};

--- a/operate/client/e2e-playwright/tests/resources/ChildProcessInstanceMigration/callActivityParentProcess.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ChildProcessInstanceMigration/callActivityParentProcess.bpmn
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13gwn7q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="callActivityParentProcess" name="callActivityParentProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1a3emhl</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1a3emhl" sourceRef="StartEvent_1" targetRef="Activity_13otele" />
+    <bpmn:callActivity id="Activity_13otele" name="Call Activity">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="childProcess" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a3emhl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1j9hrgw</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1p0nsc7">
+      <bpmn:incoming>Flow_1j9hrgw</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1j9hrgw" sourceRef="Activity_13otele" targetRef="Event_1p0nsc7" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="callActivityParentProcess">
+      <bpmndi:BPMNEdge id="Flow_1a3emhl_di" bpmnElement="Flow_1a3emhl">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j9hrgw_di" bpmnElement="Flow_1j9hrgw">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1jff16t_di" bpmnElement="Activity_13otele">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p0nsc7_di" bpmnElement="Event_1p0nsc7">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/e2e-playwright/tests/resources/ChildProcessInstanceMigration/childProcess_v_1.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ChildProcessInstanceMigration/childProcess_v_1.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="childProcess" name="childProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0jj1k9v</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0jj1k9v" sourceRef="StartEvent_1" targetRef="Task" />
+    <bpmn:serviceTask id="Task" name="Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="Task" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jj1k9v</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m49p31</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1shxuko" name="End">
+      <bpmn:incoming>Flow_0m49p31</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0m49p31" sourceRef="Task" targetRef="Event_1shxuko" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="childProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="122" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1b6kzkt_di" bpmnElement="Task">
+        <dc:Bounds x="270" y="57" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1shxuko_di" bpmnElement="Event_1shxuko">
+        <dc:Bounds x="432" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="122" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jj1k9v_di" bpmnElement="Flow_0jj1k9v">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m49p31_di" bpmnElement="Flow_0m49p31">
+        <di:waypoint x="370" y="97" />
+        <di:waypoint x="432" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/e2e-playwright/tests/resources/ChildProcessInstanceMigration/childProcess_v_2.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ChildProcessInstanceMigration/childProcess_v_2.bpmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Zeebe Modeler" exporterVersion="0.6.2">
+  <bpmn:process id="childProcess" name="childProcess" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0jj1k9v</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0jj1k9v" sourceRef="StartEvent_1" targetRef="newTask" />
+    <bpmn:serviceTask id="newTask" name="New Task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="newTask" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0jj1k9v</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m49p31</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:endEvent id="Event_1shxuko" name="End">
+      <bpmn:incoming>Flow_0m49p31</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0m49p31" sourceRef="newTask" targetRef="Event_1shxuko" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="childProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="122" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1b6kzkt_di" bpmnElement="newTask">
+        <dc:Bounds x="270" y="57" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1shxuko_di" bpmnElement="Event_1shxuko">
+        <dc:Bounds x="432" y="79" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="440" y="122" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0jj1k9v_di" bpmnElement="Flow_0jj1k9v">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="270" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m49p31_di" bpmnElement="Flow_0m49p31">
+        <di:waypoint x="370" y="97" />
+        <di:waypoint x="432" y="97" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.test.tsx
@@ -87,7 +87,7 @@ describe('<MigrateAction />', () => {
     expect(screen.getByRole('button', {name: /migrate/i})).toBeEnabled();
   });
 
-  it('should disable migrate button, when selected instances are called by parent', async () => {
+  it('should enable migrate button, when selected instances are called by parent', async () => {
     mockFetchProcessInstances().withSuccess(mockCalledProcessInstances);
 
     const {user} = render(<MigrateAction />, {
@@ -104,7 +104,7 @@ describe('<MigrateAction />', () => {
       processInstancesSelectionStore.selectProcessInstance(instance.id);
     });
 
-    expect(screen.getByRole('button', {name: /migrate/i})).toBeDisabled();
+    expect(screen.getByRole('button', {name: /migrate/i})).toBeEnabled();
   });
 
   it('should disable migrate button, when process XML could not be loaded', async () => {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/Toolbar/MigrateAction/index.tsx
@@ -21,7 +21,6 @@ import {Link, OrderedList, Stack, TableBatchAction} from '@carbon/react';
 import {MigrateAlt} from '@carbon/react/icons';
 import {Restricted} from 'modules/components/Restricted';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
-import {processInstancesStore} from 'modules/stores/processInstances';
 import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
 import {processInstanceMigrationStore} from 'modules/stores/processInstanceMigration';
 import {processXmlStore as processXmlMigrationSourceStore} from 'modules/stores/processXml/processXml.migration.source';
@@ -31,7 +30,6 @@ import {ModalStateManager} from 'modules/components/ModalStateManager';
 import {processStatisticsStore as processStatisticsMigrationSourceStore} from 'modules/stores/processStatistics/processStatistics.migration.source';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
 import {ListItem, Modal} from './styled';
-import isNil from 'lodash/isNil';
 import {tracking} from 'modules/tracking';
 import {batchModificationStore} from 'modules/stores/batchModification';
 
@@ -46,32 +44,12 @@ const MigrateAction: React.FC = observer(() => {
 
   const isVersionSelected = version !== undefined && version !== 'all';
 
-  const isChildProcess = (() => {
-    if (processInstancesSelectionStore.state.isAllChecked) {
-      return processInstancesStore.state.processInstances.some(
-        ({parentInstanceId}) => parentInstanceId !== null,
-      );
-    }
-
-    return processInstancesSelectionStore.state.selectedProcessInstanceIds.some(
-      (processInstanceId) => {
-        const instance = processInstancesStore.state.processInstances.find(
-          ({id}) => {
-            return id === processInstanceId;
-          },
-        );
-        return !isNil(instance?.parentInstanceId);
-      },
-    );
-  })();
-
   const hasXmlError = processXmlStore.state.status === 'error';
 
   const isDisabled =
     batchModificationStore.state.isEnabled ||
     !isVersionSelected ||
     !hasSelectedRunningInstances ||
-    isChildProcess ||
     hasXmlError;
 
   const getTooltipText = () => {
@@ -85,10 +63,6 @@ const MigrateAction: React.FC = observer(() => {
 
     if (!hasSelectedRunningInstances) {
       return 'You can only migrate instances in active or incident state.';
-    }
-
-    if (isChildProcess) {
-      return 'You can only migrate instances which are not called by a parent process';
     }
   };
 


### PR DESCRIPTION
## Description
- Adds support for child process instances migration.
- Adds relevant e2e tests, fix existing integration tests.

## Related issues

relates to #18594 
backport of https://github.com/camunda/camunda/pull/19240
