### PR TITLE
Ensure that stream processor can be closed while writes are rejected

### DIFF
--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -173,7 +173,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       asyncScheduleService =
           new ProcessingScheduleServiceImpl(
               streamProcessorContext::getStreamProcessorPhase, // this is volatile
-              () -> false, // we will just stop the actor in this case, no need to provide this
+              streamProcessorContext.getAbortCondition(),
               logStream::newLogStreamWriter,
               scheduledCommandCache);
       asyncActor = new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);


### PR DESCRIPTION
## Description

This fixes a subtle bug that only recently occurred for the first time because we had a [performance regression](https://github.com/camunda/camunda/pull/19233) that made it more likely that writes were rejected, sometimes permanently.

What would happen is that the async scheduled task actor would try to write results from a task but get rejected by the sequencer. The retry strategy used for the _async_ variant had no proper abort condition because we assumed that we could always just close the actor. This is not correct because the retry strategy constantly submits jobs to the fast lane, starving the queue of externally submitted jobs such as the job initiating the actor closing.

So in effect, the stream processor would fail to close properly because it waits indefinitely on the closing of the async scheduled task actor. This would show up as partition transitions not making progress and Zeebe partitions no longer matching their raft role.

## Related issues

closes #19219