### PR TITLE
refactor: rename Operate CSRF token header

### DIFF
--- a/operate/client/src/modules/request/index.ts
+++ b/operate/client/src/modules/request/index.ts
@@ -19,7 +19,7 @@ type RequestParams = {
 };
 
 async function request({url, method, body, headers, signal}: RequestParams) {
-  const csrfToken = sessionStorage.getItem('OPERATE-X-CSRF-TOKEN');
+  const csrfToken = sessionStorage.getItem('X-CSRF-TOKEN');
   const hasCsrfToken =
     csrfToken !== null &&
     method !== undefined &&
@@ -33,7 +33,7 @@ async function request({url, method, body, headers, signal}: RequestParams) {
       body: typeof body === 'string' ? body : JSON.stringify(body),
       headers: {
         'Content-Type': 'application/json',
-        ...(hasCsrfToken ? {'OPERATE-X-CSRF-TOKEN': csrfToken} : {}),
+        ...(hasCsrfToken ? {'X-CSRF-TOKEN': csrfToken} : {}),
         ...headers,
       },
       mode: 'cors',
@@ -48,9 +48,9 @@ async function request({url, method, body, headers, signal}: RequestParams) {
   if (response.ok) {
     authenticationStore.handleThirdPartySessionSuccess();
 
-    const csrfToken = response.headers.get('OPERATE-X-CSRF-TOKEN');
+    const csrfToken = response.headers.get('X-CSRF-TOKEN');
     if (csrfToken !== null) {
-      sessionStorage.setItem('OPERATE-X-CSRF-TOKEN', csrfToken);
+      sessionStorage.setItem('X-CSRF-TOKEN', csrfToken);
     }
   }
 

--- a/operate/common/src/main/java/io/camunda/operate/util/rest/StatefulRestTemplate.java
+++ b/operate/common/src/main/java/io/camunda/operate/util/rest/StatefulRestTemplate.java
@@ -48,7 +48,7 @@ import org.springframework.web.client.RestTemplate;
 public class StatefulRestTemplate extends RestTemplate {
 
   private static final String LOGIN_URL_PATTERN = "/api/login?username=%s&password=%s";
-  private static final String CSRF_TOKEN_HEADER_NAME = "OPERATE-X-CSRF-TOKEN";
+  private static final String CSRF_TOKEN_HEADER_NAME = "X-CSRF-TOKEN";
 
   private static final String USERNAME_DEFAULT = "demo";
   private static final String PASSWORD_DEFAULT = "demo";

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/OperateURIs.java
@@ -10,7 +10,7 @@ package io.camunda.operate.webapp.security;
 public final class OperateURIs {
 
   public static final String RESPONSE_CHARACTER_ENCODING = "UTF-8";
-  public static final String X_CSRF_TOKEN = "OPERATE-X-CSRF-TOKEN";
+  public static final String X_CSRF_TOKEN = "X-CSRF-TOKEN";
   public static final String ROOT = "/operate";
   public static final String API = "/api/**";
   public static final String PUBLIC_API = "/v*/**";


### PR DESCRIPTION
## Description
Use the standard `X-CSRF-TOKEN` header. The goal is to harmonize it with Tasklist to allow Operate and Tasklist to run in a single application with CSRF prevention enabled

## Related issues

closes #
