### PR TITLE
feat: add group's detail in identity UI

### DIFF
--- a/identity/client/src/pages/groups/List.tsx
+++ b/identity/client/src/pages/groups/List.tsx
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import { FC, useState } from "react";
+import useTranslate from "src/utility/localization";
+import { useApi } from "src/utility/api/hooks";
+import Page from "src/components/layout/Page";
+import EntityList, {
+  DocumentationDescription,
+} from "src/components/entityList";
+import { DocumentationLink } from "src/components/documentation";
+import { getGroups, Group } from "src/utility/api/groups";
+import { useNavigate } from "react-router";
+import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+
+const List: FC = () => {
+  const { t, Translate } = useTranslate();
+  const navigate = useNavigate();
+  const [, setSearch] = useState("");
+
+  const { data: groups, loading, reload, success } = useApi(getGroups);
+
+  const showDetails = ({ id }: Group) => navigate(`${id}`);
+
+  return (
+    <Page>
+      <EntityList
+        title={t("Groups")}
+        data={groups}
+        headers={[{ header: t("name"), key: "name" }]}
+        sortProperty="name"
+        onEntityClick={showDetails}
+        onSearch={setSearch}
+        loading={loading}
+      />
+      {success && (
+        <DocumentationDescription>
+          <Translate>Learn more about groups in our</Translate>{" "}
+          <DocumentationLink path="/concepts/access-control/groups" />.
+        </DocumentationDescription>
+      )}
+      {!loading && !success && (
+        <TranslatedErrorInlineNotification
+          title="The list of groups could not be loaded."
+          actionButton={{ label: "Retry", onClick: reload }}
+        />
+      )}
+    </Page>
+  );
+};
+
+export default List;

--- a/identity/client/src/pages/groups/detail/index.tsx
+++ b/identity/client/src/pages/groups/detail/index.tsx
@@ -19,7 +19,6 @@ import Flex from "src/components/layout/Flex";
 import PageHeadline from "src/components/layout/PageHeadline";
 import Tabs from "src/components/tabs";
 import { getGroupDetails } from "src/utility/api/groups";
-import UserDetails from "src/pages/users/detail/UserDetailsTab";
 import Members from "src/pages/groups/detail/members";
 
 const Details: FC = () => {
@@ -55,28 +54,26 @@ const Details: FC = () => {
             </Flex>
           )}
         </Stack>
-        <Section>
-          <Tabs
-            tabs={[
-              ...(group
-                ? [
-                    {
-                      key: "members",
-                      label: t("Members"),
-                      content: <Members groupId={group?.id} />,
-                    },
-                  ]
-                : []),
-              {
-                key: "roles",
-                label: t("Roles"),
-                content: t("Roles"),
-              },
-            ]}
-            selectedTabKey={tab}
-            path={`../${id}`}
-          />
-        </Section>
+        {group && (
+          <Section>
+            <Tabs
+              tabs={[
+                {
+                  key: "members",
+                  label: t("Members"),
+                  content: <Members groupId={group?.id} />,
+                },
+                {
+                  key: "roles",
+                  label: t("Roles"),
+                  content: t("Roles"),
+                },
+              ]}
+              selectedTabKey={tab}
+              path={`../${id}`}
+            />
+          </Section>
+        )}
       </>
     </StackPage>
   );

--- a/identity/client/src/pages/groups/detail/index.tsx
+++ b/identity/client/src/pages/groups/detail/index.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { useParams } from "react-router";
+import { OverflowMenu, OverflowMenuItem, Section, Stack } from "@carbon/react";
+import { spacing02 } from "@carbon/themes";
+import useTranslate from "src/utility/localization";
+import { useApi } from "src/utility/api/hooks";
+import NotFound from "src/pages/not-found";
+import { Breadcrumbs, StackPage } from "src/components/layout/Page";
+import { DetailPageHeaderFallback } from "src/components/fallbacks";
+import Flex from "src/components/layout/Flex";
+import PageHeadline from "src/components/layout/PageHeadline";
+import Tabs from "src/components/tabs";
+import { getGroupDetails } from "src/utility/api/groups";
+import UserDetails from "src/pages/users/detail/UserDetailsTab";
+import Members from "src/pages/groups/detail/members";
+
+const Details: FC = () => {
+  const { t } = useTranslate();
+  const { id = "", tab = "members" } = useParams<{
+    id: string;
+    tab: string;
+  }>();
+
+  const { data: group, loading } = useApi(getGroupDetails, { id });
+
+  if (!loading && !group) return <NotFound />;
+
+  return (
+    <StackPage>
+      <>
+        <Stack gap={spacing02}>
+          <Breadcrumbs items={[{ href: "/groups", title: t("Groups") }]} />
+          {loading && !group ? (
+            <DetailPageHeaderFallback />
+          ) : (
+            <Flex>
+              {group && (
+                <>
+                  <PageHeadline>{group.name}</PageHeadline>
+
+                  <OverflowMenu ariaLabel={t("Open group context menu")}>
+                    <OverflowMenuItem itemText={t("Rename")} />
+                    <OverflowMenuItem itemText={t("Delete")} isDelete />
+                  </OverflowMenu>
+                </>
+              )}
+            </Flex>
+          )}
+        </Stack>
+        <Section>
+          <Tabs
+            tabs={[
+              ...(group
+                ? [
+                    {
+                      key: "members",
+                      label: t("Members"),
+                      content: <Members groupId={group?.id} />,
+                    },
+                  ]
+                : []),
+              {
+                key: "roles",
+                label: t("Roles"),
+                content: t("Roles"),
+              },
+            ]}
+            selectedTabKey={tab}
+            path={`../${id}`}
+          />
+        </Section>
+      </>
+    </StackPage>
+  );
+};
+
+export default Details;

--- a/identity/client/src/pages/groups/detail/members/index.tsx
+++ b/identity/client/src/pages/groups/detail/members/index.tsx
@@ -56,6 +56,7 @@ const Members: FC<MembersProps> = ({ groupId }) => {
           )}
           button={{
             label: t("Assign members"),
+            onClick: () => null,
           }}
           link={{
             label: t("Learn more about groups"),
@@ -71,11 +72,10 @@ const Members: FC<MembersProps> = ({ groupId }) => {
         title={t("Assigned members")}
         data={users}
         headers={[
-          { header: t("Full name"), key: "name" },
           { header: t("Username"), key: "username" },
           { header: t("Email"), key: "email" },
         ]}
-        sortProperty="name"
+        sortProperty="username"
         loading={loading}
         addEntityLabel={t("Assign members")}
         menuItems={[

--- a/identity/client/src/pages/groups/detail/members/index.tsx
+++ b/identity/client/src/pages/groups/detail/members/index.tsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import { FC } from "react";
+import { C3EmptyState } from "@camunda/camunda-composite-components";
+import useTranslate from "src/utility/localization";
+import { useApi } from "src/utility/api/hooks";
+import { getGroupUsers } from "src/utility/api/groups";
+import EntityList, {
+  DocumentationDescription,
+} from "src/components/entityList";
+import { DocumentationLink } from "src/components/documentation";
+import { TrashCan } from "@carbon/react/icons";
+
+type MembersProps = {
+  groupId: string;
+};
+
+const Members: FC<MembersProps> = ({ groupId }) => {
+  const { t, Translate } = useTranslate();
+
+  const {
+    data: users,
+    loading,
+    success,
+    reload,
+  } = useApi(getGroupUsers, {
+    id: groupId,
+  });
+
+  const areNoUsersAssigned = !users || users.length === 0;
+
+  if (!loading && !success)
+    return (
+      <C3EmptyState
+        heading={t("Something's wrong")}
+        description={t(
+          'We were unable to load the members. Click "Retry" to try again.',
+        )}
+        button={{ label: t("Retry"), onClick: reload }}
+      />
+    );
+
+  if (success && areNoUsersAssigned)
+    return (
+      <>
+        <C3EmptyState
+          heading={t("Assign members to this group")}
+          description={t(
+            "Members of this group will be given access and roles that are assigned to this group.",
+          )}
+          button={{
+            label: t("Assign members"),
+          }}
+          link={{
+            label: t("Learn more about groups"),
+            href: `/identity/concepts/access-control/groups`,
+          }}
+        />
+      </>
+    );
+
+  return (
+    <>
+      <EntityList
+        title={t("Assigned members")}
+        data={users}
+        headers={[
+          { header: t("Full name"), key: "name" },
+          { header: t("Username"), key: "username" },
+          { header: t("Email"), key: "email" },
+        ]}
+        sortProperty="name"
+        loading={loading}
+        addEntityLabel={t("Assign members")}
+        menuItems={[
+          {
+            label: t("Remove"),
+            icon: TrashCan,
+            isDangerous: true,
+            onClick: () => {},
+          },
+        ]}
+      />
+      {success && !areNoUsersAssigned && (
+        <DocumentationDescription>
+          <Translate>To learn more, visit our</Translate>{" "}
+          <DocumentationLink path="/concepts/access-control/groups">
+            {t("groups documentation")}
+          </DocumentationLink>
+          .
+        </DocumentationDescription>
+      )}
+    </>
+  );
+};
+
+export default Members;

--- a/identity/client/src/pages/groups/index.tsx
+++ b/identity/client/src/pages/groups/index.tsx
@@ -7,15 +7,13 @@
  */
 import { FC } from "react";
 import Lazy from "src/components/router/Lazy";
-import { DetailPageFallback } from "src/components/fallbacks";
 import PageRoutes from "src/components/router/PageRoutes";
+import Detail from "./detail";
 
 const Groups: FC = () => (
   <PageRoutes
     indexElement={<Lazy load={() => import("./List")} />}
-    detailElement={
-      <Lazy load={() => import("./detail")} fallback={<DetailPageFallback />} />
-    }
+    detailElement={<Detail />}
   />
 );
 

--- a/identity/client/src/pages/groups/index.tsx
+++ b/identity/client/src/pages/groups/index.tsx
@@ -1,49 +1,22 @@
-import { FC, useState } from "react";
-import useTranslate from "src/utility/localization";
-import { useApi } from "src/utility/api/hooks";
-import Page from "src/components/layout/Page";
-import EntityList, {
-  DocumentationDescription,
-} from "src/components/entityList";
-import { DocumentationLink } from "src/components/documentation";
-import { getGroups, Group } from "src/utility/api/groups";
-import { useNavigate } from "react-router";
-import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import { FC } from "react";
+import Lazy from "src/components/router/Lazy";
+import { DetailPageFallback } from "src/components/fallbacks";
+import PageRoutes from "src/components/router/PageRoutes";
 
-const List: FC = () => {
-  const { t, Translate } = useTranslate();
-  const navigate = useNavigate();
-  const [, setSearch] = useState("");
+const Groups: FC = () => (
+  <PageRoutes
+    indexElement={<Lazy load={() => import("./List")} />}
+    detailElement={
+      <Lazy load={() => import("./detail")} fallback={<DetailPageFallback />} />
+    }
+  />
+);
 
-  const { data: groups, loading, reload, success } = useApi(getGroups);
-
-  const showDetails = ({ id }: Group) => navigate(`${id}`);
-
-  return (
-    <Page>
-      <EntityList
-        title={t("Groups")}
-        data={groups}
-        headers={[{ header: t("name"), key: "name" }]}
-        sortProperty="name"
-        onEntityClick={showDetails}
-        onSearch={setSearch}
-        loading={loading}
-      />
-      {success && (
-        <DocumentationDescription>
-          <Translate>Learn more about groups in our</Translate>{" "}
-          <DocumentationLink path="/concepts/access-control/groups" />.
-        </DocumentationDescription>
-      )}
-      {!loading && !success && (
-        <TranslatedErrorInlineNotification
-          title="The list of groups could not be loaded."
-          actionButton={{ label: "Retry", onClick: reload }}
-        />
-      )}
-    </Page>
-  );
-};
-
-export default List;
+export default Groups;

--- a/identity/client/src/pages/users/index.tsx
+++ b/identity/client/src/pages/users/index.tsx
@@ -7,15 +7,13 @@
  */
 import { FC } from "react";
 import Lazy from "src/components/router/Lazy";
-import { DetailPageFallback } from "src/components/fallbacks";
 import PageRoutes from "src/components/router/PageRoutes";
+import Detail from "src/pages/users/detail";
 
 const Users: FC = () => (
   <PageRoutes
     indexElement={<Lazy load={() => import("./List")} />}
-    detailElement={
-      <Lazy load={() => import("./detail")} fallback={<DetailPageFallback />} />
-    }
+    detailElement={<Detail />}
   />
 );
 

--- a/identity/client/src/utility/api/groups/index.ts
+++ b/identity/client/src/utility/api/groups/index.ts
@@ -1,4 +1,12 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
 import { ApiDefinition, apiGet } from "../request";
+import { User } from "src/utility/api/users";
 
 export const GROUPS_ENDPOINT = "/groups";
 
@@ -8,3 +16,18 @@ export type Group = {
 };
 
 export const getGroups: ApiDefinition<Group[]> = () => apiGet(GROUPS_ENDPOINT);
+
+export type GetGroupParams = {
+  id: string;
+};
+
+export const getGroupDetails: ApiDefinition<Group, GetGroupParams> = ({ id }) =>
+  apiGet(`${GROUPS_ENDPOINT}/${id}`);
+
+export type GetGroupUsersParams = {
+  id: string;
+};
+
+export const getGroupUsers: ApiDefinition<User[], GetGroupUsersParams> = ({
+  id,
+}) => apiGet(`${GROUPS_ENDPOINT}/${id}/users`);

--- a/identity/common/src/main/java/io/camunda/identity/usermanagement/CamundaUser.java
+++ b/identity/common/src/main/java/io/camunda/identity/usermanagement/CamundaUser.java
@@ -13,7 +13,7 @@ public class CamundaUser {
   private Long id;
   private String username;
   private String email;
-  private boolean enabled;
+  private boolean enabled = true;
 
   public CamundaUser() {}
 


### PR DESCRIPTION
## Description
Add a page to show the name of a group which also display members of a group.

## Related issues

Part of identity issues [#2819](https://github.com/camunda-cloud/identity/issues/2819) and [#2944](https://github.com/camunda-cloud/identity/issues/2944)
