### PR TITLE
ci: refactor fake status checks

### DIFF
--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -2,29 +2,22 @@ name: Common CI
 
 on:
   pull_request:
-    paths-ignore:
-      - '.ci/**'
+    paths-ignore: # keep in sync with zeebe-ci.yml trigger
+      - '.ci/docker/test/*'
       - '.github/actions/**'
-      - '.github/workflows/operate-*'
-      - '.github/workflows/tasklist-*'
       - '.github/workflows/zeebe-*'
       - 'Dockerfile'
       - 'bom/*'
       - 'build-tools/**'
       - 'clients/**'
       - 'dist/**'
-      - 'operate.Dockerfile'
-      - 'operate/**'
       - 'parent/*'
       - 'pom.xml'
-      - 'tasklist.Dockerfile'
-      - 'tasklist/**'
-      - 'webapps-common/**'
       - 'zeebe/**'
 
 jobs:
   test-summary:
-    # Dummy job used for pull requests that do not trigger zeebe-ci or operate-ci
+    # Dummy job used for pull requests that do not trigger zeebe-ci
     # This name is hard-coded in the branch rules; remember to update that if this name changes
     name: Test summary
     if: always()

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -83,13 +83,3 @@ jobs:
       command: mvn -f operate/qa/integration-tests verify -P operateItOpensearch,docker-opensearch -B -DskipChecks -Dfailsafe.rerunFailingTestsCount=2
       test-type: Opensearch ITs
       runner-type: gcp-core-32-default
-
-  test-summary:
-    # Used by the merge queue as a dummy instead of the Zeebe CI in case only Operate files got changed:
-    # https://github.com/orgs/community/discussions/26251
-    # This name is hard-coded in the branch rules; remember to update that if this name changes
-    name: Test summary
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -77,13 +77,3 @@ jobs:
     needs: check_changes
     if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
     uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
-
-  test-summary:
-    # Used by the merge queue as a dummy instead of the Zeebe CI in case only Tasklist files got changed:
-    # https://github.com/orgs/community/discussions/26251
-    # This name is hard-coded in the branch rules; remember to update that if this name changes
-    name: Test summary
-    if: always()
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 0

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -21,7 +21,7 @@ on:
       - 'pom.xml'
       - 'zeebe/**'
   pull_request:
-    paths:
+    paths: # keep in sync with common-ci.yml trigger
       - '.ci/docker/test/*'
       - '.github/actions/**'
       - '.github/workflows/zeebe-*'


### PR DESCRIPTION
## Description

The `Test summary` status check is marked as `required` in GitHub and usually produced by [zeebe-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/zeebe-ci.yml). In case that no change related to Zeebe CI happened (meaning it will not run), this status check is still required to allow merging PRs until https://github.com/camunda/camunda/issues/17721 is implemented which is why this workaround of faking (green) status checks exists.

When only the [operate-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/operate-ci.yml) existed it complemented exactly the `zeebe-ci.yml` since there were only those 2 cases. Later [tasklist-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/tasklist-ci.yml) and the SDK got added and made the mix more complex.

Now we have the situation that due to overlapping path filters [operate-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/operate-ci.yml) and [tasklist-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/tasklist-ci.yml) report that fake status check (as green) _even if_ [zeebe-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/zeebe-ci.yml) is running and before results are known. This can happen e.g. if a file in `parent` folder changes which triggers all mentioned GHA workflows.

This PR proposes to resolve that without impacting any other flow by removing the fake status checks completely from Operate CI and Tasklist CI (since they can't know when they run vs when Zeebe CI doesn't run).

Instead, the [common-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/common-ci.yml) gets the exact opposite of the paths triggers (via ignore) of [zeebe-ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/zeebe-ci.yml). This means that if Zeebe CI is not producing the "Test summary" then the Common CI will run and fake it - only those 2 cases exist. Since neither Operate CI nor Tasklist CI are a required status check, they don't need to matter for this issue.

Mid-term this whole faking of status checks will become obsolete with #17721

## Related issues

Related to and should fix #19289
