### PR TITLE
fix: update pre-selected target process

### DIFF
--- a/operate/client/e2e-playwright/tests/processInstanceMigration.mocks.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceMigration.mocks.ts
@@ -23,26 +23,22 @@ const setup = async () => {
     throw new Error('Error deploying process');
   }
 
-  await deployProcess([
+  const deploymentV3 = await deployProcess([
     'ProcessInstanceMigration/orderProcessMigration_v_3.bpmn',
   ]);
-
-  const {
-    version: sourceVersion,
-    processDefinitionKey,
-    bpmnProcessId,
-  } = deploymentV1.processes[0];
+  if (deploymentV3.processes[0] === undefined) {
+    throw new Error('Error deploying process');
+  }
 
   return {
-    processInstances: await createInstances(
+    processV1Instances: await createInstances(
       'orderProcessMigration',
-      sourceVersion,
+      deploymentV1.processes[0].version,
       10,
     ),
-    processDefinitionKey,
-    bpmnProcessId,
-    sourceVersion: sourceVersion,
-    targetVersion: deploymentV2.processes[0].version,
+    processV1: deploymentV1.processes[0],
+    processV2: deploymentV2.processes[0],
+    processV3: deploymentV3.processes[0],
   };
 };
 

--- a/operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceMigration.spec.ts
@@ -13,16 +13,9 @@ import {SETUP_WAITING_TIME} from './constants';
 import {config} from '../config';
 
 let initialData: Awaited<ReturnType<typeof setup>>;
-let sourceVersion: string;
-let targetVersion: string;
-let sourceBpmnProcessId: string;
 
 test.beforeAll(async ({request}) => {
   initialData = await setup();
-  const {processDefinitionKey} = initialData;
-  sourceVersion = initialData.sourceVersion.toString();
-  targetVersion = initialData.targetVersion.toString();
-  sourceBpmnProcessId = initialData.bpmnProcessId;
 
   await expect
     .poll(
@@ -32,7 +25,8 @@ test.beforeAll(async ({request}) => {
           {
             data: {
               filter: {
-                processDefinitionKey,
+                processDefinitionKey:
+                  initialData.processV1.processDefinitionKey,
               },
             },
           },
@@ -45,14 +39,26 @@ test.beforeAll(async ({request}) => {
     .toHaveProperty('total', 10);
 });
 
-test.describe.serial('Process Instance Migration @roundtrip', () => {
-  test('Migrate Process Instances', async ({
+test.describe.serial('Process Instance Migration', () => {
+  /**
+   * Migrate from ProcessV1 to ProcessV2
+   * ProcessV1 and ProcessV2 have identical bpmnProcess id and flow node names,
+   * so the target process will be preselected and flow nodes will be auto-mapped
+   */
+  test('Auto Mapping @roundtrip', async ({
     processesPage,
     processesPage: {filtersPanel},
     migrationView,
     commonPage,
+    page,
   }) => {
     test.slow();
+
+    const sourceVersion = initialData.processV1.version.toString();
+    const sourceBpmnProcessId = initialData.processV1.bpmnProcessId;
+    const targetVersion = initialData.processV2.version.toString();
+    const targetBpmnProcessId = initialData.processV2.bpmnProcessId;
+
     await processesPage.navigateToProcesses({searchParams: {active: 'true'}});
 
     await filtersPanel.selectProcess(sourceBpmnProcessId);
@@ -60,7 +66,7 @@ test.describe.serial('Process Instance Migration @roundtrip', () => {
 
     await expect(
       processesPage.processInstancesTable.getByRole('heading'),
-    ).toContainText(/10 results/i);
+    ).toContainText(/results/i);
 
     // select 6 process instances for migration
     await processesPage.getNthProcessInstanceCheckbox(0).click();
@@ -73,29 +79,40 @@ test.describe.serial('Process Instance Migration @roundtrip', () => {
     await processesPage.migrateButton.click();
     await processesPage.migrationModal.confirmButton.click();
 
-    await migrationView.selectTargetVersion(targetVersion);
+    // Expect auto mapping for each flow node
+    await expect(page.getByLabel(/target flow node for/i)).toHaveCount(3);
+    await expect(
+      page.getByLabel(/target flow node for check payment/i),
+    ).toHaveValue('checkPayment');
+    await expect(
+      page.getByLabel(/target flow node for ship articles/i),
+    ).toHaveValue('shipArticles');
+    await expect(
+      page.getByLabel(/target flow node for request for payment/i),
+    ).toHaveValue('requestForPayment');
 
-    await migrationView.mapFlowNode({
-      sourceFlowNodeName: 'Check payment',
-      targetFlowNodeName: 'Ship Articles',
-    });
+    // Expect pre-selected process and version
+    await expect(migrationView.targetProcessComboBox).toHaveValue(
+      targetBpmnProcessId,
+    );
+    await expect(migrationView.targetVersionDropdown).toHaveText(
+      targetVersion,
+      {useInnerText: true},
+    );
 
     await migrationView.nextButton.click();
 
     await expect(migrationView.summaryNotification).toContainText(
-      `You are about to migrate 6 process instances from the process definition: ${sourceBpmnProcessId} - version ${sourceVersion} to the process definition: ${sourceBpmnProcessId} - version ${targetVersion}`,
+      `You are about to migrate 6 process instances from the process definition: ${sourceBpmnProcessId} - version ${sourceVersion} to the process definition: ${targetBpmnProcessId} - version ${targetVersion}`,
     );
 
     await migrationView.confirmButton.click();
-
     await expect(commonPage.operationsList).toBeVisible();
 
     const migrateOperationEntry = commonPage.operationsList
       .getByRole('listitem')
       .first();
-
     await expect(migrateOperationEntry).toContainText('Migrate');
-
     await expect(migrateOperationEntry.getByRole('progressbar')).toBeVisible();
 
     // wait for migrate operation to finish
@@ -104,7 +121,7 @@ test.describe.serial('Process Instance Migration @roundtrip', () => {
     ).not.toBeVisible({timeout: 60000});
 
     await expect(filtersPanel.processNameFilter).toHaveValue(
-      sourceBpmnProcessId,
+      targetBpmnProcessId,
     );
     expect(await filtersPanel.processVersionFilter.innerText()).toBe(
       targetVersion,
@@ -144,11 +161,120 @@ test.describe.serial('Process Instance Migration @roundtrip', () => {
     await commonPage.collapseOperationsPanel();
   });
 
+  /**
+   * Migrate from ProcessV2 to ProcessV3
+   * ProcessV3 has a different bpmn process id and different flow node names,
+   * so no flow node auto-mapping or pre-selected processes are available.
+   */
+  test('Manual Mapping @roundtrip', async ({
+    processesPage,
+    processesPage: {filtersPanel},
+    migrationView,
+    commonPage,
+  }) => {
+    test.slow();
+
+    const sourceVersion = initialData.processV2.version.toString();
+    const sourceBpmnProcessId = initialData.processV2.bpmnProcessId;
+    const targetVersion = initialData.processV3.version.toString();
+    const targetBpmnProcessId = initialData.processV3.bpmnProcessId;
+
+    await processesPage.navigateToProcesses({searchParams: {active: 'true'}});
+
+    await filtersPanel.selectProcess(sourceBpmnProcessId);
+    await filtersPanel.selectVersion(sourceVersion);
+
+    await expect(
+      processesPage.processInstancesTable.getByRole('heading'),
+    ).toContainText(/results/i);
+
+    // select 3 process instances for migration
+    await processesPage.getNthProcessInstanceCheckbox(0).click();
+    await processesPage.getNthProcessInstanceCheckbox(1).click();
+    await processesPage.getNthProcessInstanceCheckbox(2).click();
+
+    await processesPage.migrateButton.click();
+    await processesPage.migrationModal.confirmButton.click();
+
+    await migrationView.selectTargetProcess(targetBpmnProcessId);
+    await migrationView.selectTargetVersion(targetVersion);
+
+    await migrationView.mapFlowNode({
+      sourceFlowNodeName: 'Check payment',
+      targetFlowNodeName: 'Ship Articles 2',
+    });
+
+    await migrationView.nextButton.click();
+
+    await expect(migrationView.summaryNotification).toContainText(
+      `You are about to migrate 3 process instances from the process definition: ${sourceBpmnProcessId} - version ${sourceVersion} to the process definition: ${targetBpmnProcessId} - version ${targetVersion}`,
+    );
+
+    await migrationView.confirmButton.click();
+
+    await expect(commonPage.operationsList).toBeVisible();
+
+    const migrateOperationEntry = commonPage.operationsList
+      .getByRole('listitem')
+      .first();
+
+    await expect(migrateOperationEntry).toContainText('Migrate');
+    await expect(migrateOperationEntry.getByRole('progressbar')).toBeVisible();
+
+    // wait for migrate operation to finish
+    await expect(
+      migrateOperationEntry.getByRole('progressbar'),
+    ).not.toBeVisible({timeout: 60000});
+
+    await expect(filtersPanel.processNameFilter).toHaveValue(
+      targetBpmnProcessId,
+    );
+    expect(await filtersPanel.processVersionFilter.innerText()).toBe(
+      targetVersion,
+    );
+
+    await migrateOperationEntry.getByRole('link').click();
+
+    await expect(
+      processesPage.processInstancesTable.getByRole('heading'),
+    ).toContainText(/3 results/i);
+
+    // expect 3 process instances to be migrated to target version
+    await expect(
+      processesPage.processInstancesTable.getByRole('cell', {
+        name: targetVersion,
+        exact: true,
+      }),
+    ).toHaveCount(3);
+
+    // expect no process instances for source version
+    await expect(
+      processesPage.processInstancesTable.getByRole('cell', {
+        name: sourceVersion,
+        exact: true,
+      }),
+    ).not.toBeVisible();
+
+    await filtersPanel.removeOptionalFilter('Operation Id');
+
+    // expect 3 process instances for source version
+    await filtersPanel.selectProcess(sourceBpmnProcessId);
+    await filtersPanel.selectVersion(sourceVersion);
+    await expect(
+      processesPage.processInstancesTable.getByRole('heading'),
+    ).toContainText(/3 results/i);
+
+    await commonPage.collapseOperationsPanel();
+  });
+
   test('Migrated date tag', async ({processesPage, processInstancePage}) => {
+    const targetBpmnProcessId = initialData.processV3.bpmnProcessId;
+    const targetVersion = initialData.processV3.version.toString();
+
     await processesPage.navigateToProcesses({
       searchParams: {
         active: 'true',
-        process: sourceBpmnProcessId,
+        process: targetBpmnProcessId,
         version: targetVersion,
       },
     });

--- a/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/ProcessInstanceMigration/orderProcessMigration_v_3.bpmn
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.12.0">
-  <bpmn:process id="orderProcessMigration" name="orderProcessMigration" isExecutable="true">
-    <bpmn:startEvent id="StartEvent_1" name="Order received">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0">
+  <bpmn:process id="newOrderProcessMigration" name="newOrderProcessMigration" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_2" name="Order received 2">
       <bpmn:outgoing>SequenceFlow_0j6tsnn</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_1" targetRef="checkPayment" />
-    <bpmn:serviceTask id="checkPayment" name="Check payment">
+    <bpmn:sequenceFlow id="SequenceFlow_0j6tsnn" sourceRef="StartEvent_2" targetRef="checkPayment2" />
+    <bpmn:serviceTask id="checkPayment2" name="Check payment 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="checkPayment" />
       </bpmn:extensionElements>
@@ -21,39 +21,39 @@
       <bpmn:outgoing>SequenceFlow_0jzbqu1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1dq2rqw</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment" targetRef="ExclusiveGateway_1qqmrb8" />
-    <bpmn:serviceTask id="requestForPayment" name="Request for payment">
+    <bpmn:sequenceFlow id="SequenceFlow_1s6g17c" sourceRef="checkPayment2" targetRef="ExclusiveGateway_1qqmrb8" />
+    <bpmn:serviceTask id="requestForPayment2" name="Request for payment 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="requestPayment" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0jzbqu1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q6ade7</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment">
+    <bpmn:sequenceFlow id="SequenceFlow_0jzbqu1" name="Not paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="requestForPayment2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = false</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment" targetRef="checkPayment" />
-    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles">
+    <bpmn:sequenceFlow id="SequenceFlow_1q6ade7" sourceRef="requestForPayment2" targetRef="checkPayment2" />
+    <bpmn:sequenceFlow id="SequenceFlow_1dq2rqw" name="paid" sourceRef="ExclusiveGateway_1qqmrb8" targetRef="shipArticles2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">=paid = true</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="shipArticles" name="Ship Articles">
+    <bpmn:serviceTask id="shipArticles2" name="Ship Articles 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="shipArticles" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1dq2rqw</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19klrd3</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles" targetRef="Activity_0ae6k1y" />
-    <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="Activity_0ae6k1y" targetRef="Activity_0fjvqbt" />
-    <bpmn:serviceTask id="Activity_0ae6k1y" name="Notify Customer">
+    <bpmn:sequenceFlow id="SequenceFlow_19klrd3" sourceRef="shipArticles2" targetRef="notifyCustomer2" />
+    <bpmn:sequenceFlow id="Flow_0zx0zzd" sourceRef="notifyCustomer2" targetRef="checkDeliveryState2" />
+    <bpmn:serviceTask id="notifyCustomer2" name="Notify Customer 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="notifyCustomer" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_19klrd3</bpmn:incoming>
       <bpmn:outgoing>Flow_0zx0zzd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0hxjz3q" sourceRef="Activity_0fjvqbt" targetRef="EndEvent_042s0oc" />
-    <bpmn:serviceTask id="Activity_0fjvqbt" name="Check delivery state">
+    <bpmn:sequenceFlow id="Flow_0hxjz3q" sourceRef="checkDeliveryState2" targetRef="EndEvent_042s0oc" />
+    <bpmn:serviceTask id="checkDeliveryState2" name="Check delivery state 2">
       <bpmn:extensionElements>
         <zeebe:taskDefinition type="checkDelivery" />
       </bpmn:extensionElements>
@@ -62,30 +62,16 @@
     </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="orderProcessMigration">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="newOrderProcessMigration">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_2">
         <dc:Bounds x="175" y="120" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="157" y="156" width="73" height="14" />
+          <dc:Bounds x="153" y="156" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment">
+      <bpmndi:BPMNShape id="ServiceTask_0c3g2sx_di" bpmnElement="checkPayment2">
         <dc:Bounds x="300" y="98" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
-        <dc:Bounds x="469" y="113" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="460" y="85" width="69" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment">
-        <dc:Bounds x="444" y="260" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles">
-        <dc:Bounds x="590" y="98" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="Activity_0ae6k1y">
-        <dc:Bounds x="740" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_042s0oc_di" bpmnElement="EndEvent_042s0oc">
         <dc:Bounds x="1032" y="120" width="36" height="36" />
@@ -93,8 +79,27 @@
           <dc:Bounds x="385" y="270" width="90" height="12" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1qx12ic_di" bpmnElement="Activity_0fjvqbt">
+      <bpmndi:BPMNShape id="ExclusiveGateway_1qqmrb8_di" bpmnElement="ExclusiveGateway_1qqmrb8" isMarkerVisible="true">
+        <dc:Bounds x="469" y="113" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="460" y="85" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="requestForPayment_di" bpmnElement="requestForPayment2">
+        <dc:Bounds x="444" y="260" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0k2efs8_di" bpmnElement="shipArticles2">
+        <dc:Bounds x="590" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02f6gwz_di" bpmnElement="notifyCustomer2">
+        <dc:Bounds x="740" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1qx12ic_di" bpmnElement="checkDeliveryState2">
         <dc:Bounds x="890" y="98" width="100" height="80" />
+        <bpmndi:BPMNLabel />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0j6tsnn_di" bpmnElement="SequenceFlow_0j6tsnn">
         <di:waypoint x="211" y="138" />

--- a/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/BottomPanel/index.test.tsx
@@ -55,11 +55,14 @@ const Wrapper = ({children}: Props) => {
   processInstanceMigrationStore.enable();
 
   useEffect(() => {
-    processInstanceMigrationStore.reset();
-    processXmlMigrationSourceStore.reset();
-    processXmlMigrationTargetStore.reset();
-    processStatisticsStore.reset();
-  });
+    return () => {
+      processInstanceMigrationStore.reset();
+      processXmlMigrationSourceStore.reset();
+      processXmlMigrationTargetStore.reset();
+      processStatisticsStore.reset();
+    };
+  }, []);
+
   return (
     <>
       {children}

--- a/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
+++ b/operate/client/src/App/Processes/MigrationView/Footer/index.test.tsx
@@ -21,7 +21,7 @@ const Wrapper = ({children}: Props) => {
   useEffect(() => {
     processInstanceMigrationStore.setCurrentStep('elementMapping');
     return processInstanceMigrationStore.reset;
-  });
+  }, []);
   return (
     <MemoryRouter>
       {children}

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/TargetDiagram.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/TargetDiagram.tsx
@@ -41,6 +41,9 @@ const TargetDiagram: React.FC = observer(() => {
     } else {
       processXmlStore.reset();
     }
+    processInstanceMigrationStore.setTargetProcessDefinitionKey(
+      selectedTargetProcessId ?? null,
+    );
   }, [selectedTargetProcessId]);
 
   const getStatus = () => {

--- a/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/TargetVersionField.tsx
+++ b/operate/client/src/App/Processes/MigrationView/TopPanel/Diagrams/TargetVersionField.tsx
@@ -32,9 +32,6 @@ const TargetVersionField: React.FC = observer(() => {
           if (!isNil(selectedItem)) {
             processInstanceMigrationStore.resetFlowNodeMapping();
             processesStore.setSelectedTargetVersion(selectedItem);
-            processInstanceMigrationStore.setTargetProcessDefinitionKey(
-              processesStore.selectedTargetProcessId ?? null,
-            );
           }
         }}
         disabled={

--- a/operate/client/src/modules/stores/processes/processes.migration.test.ts
+++ b/operate/client/src/modules/stores/processes/processes.migration.test.ts
@@ -308,7 +308,7 @@ describe('processes.migration store', () => {
     expect(processesStore.latestProcessVersion).toEqual(3);
   });
 
-  it('should not pre-set target process version', async () => {
+  it('should pre-set latest previous target process version', async () => {
     // given: demoProcess version 3 (latest version) as source process
     locationSpy.mockImplementation(() => ({
       ...originalWindow.location,


### PR DESCRIPTION
## Description

- Move setTargetProcessDefinitionKey call from onChange to useEffect to ensure it is called every time selectedTargetProcessId changes
- Refactor e2e test setup
- Add e2e test for auto-mapping

### Code review hints 

The flow is now the following:

#### Manual target selection
- The user selects a process and version using the combobox/dropdown :arrow_right: process and version are set in `processes.migration` store
- This updates the `selectedTargetProcessId` computed value in `processes.migration` store
- This triggers the useEffect in `TargetDiagram` which calls `processInstanceMigrationStore.setTargetProcessDefinitionKey`

#### Pre-selection
- The migration mode is entered
- This triggers version selection autorun in `processes.migration` store
- This calls setSelectedTargetProcess and setSelectedTargetVersion actions in `processes.migration` store
- This updates the `selectedTargetProcessId` computed value in `processes.migration` store
- This triggers the useEffect in `TargetDiagram` which calls `processInstanceMigrationStore.setTargetProcessDefinitionKey`

## Related issues

closes #19171 
