### PR TITLE
Provide general client REST test infrastructure

### DIFF
--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -62,7 +62,7 @@ import org.apache.hc.core5.util.Timeout;
 
 public class HttpClientFactory {
 
-  private static final String REST_API_PATH = "/v1";
+  private static final String REST_API_PATH = "/v2";
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   private final ZeebeClientConfiguration config;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClientFactory.java
@@ -62,7 +62,9 @@ import org.apache.hc.core5.util.Timeout;
 
 public class HttpClientFactory {
 
-  private static final String REST_API_PATH = "/v2";
+  /** The versioned base REST API context path the client uses for requests */
+  public static final String REST_API_PATH = "/v2";
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   private final ZeebeClientConfiguration config;

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -31,13 +31,13 @@ import io.camunda.zeebe.client.CredentialsProvider.CredentialsApplier;
 import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.client.impl.ZeebeClientCredentials;
-import io.camunda.zeebe.client.impl.http.HttpClientFactory;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsCache;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
 import io.camunda.zeebe.client.protocol.rest.TopologyResponse;
 import io.camunda.zeebe.client.util.RecordingGatewayService;
+import io.camunda.zeebe.client.util.RestGatewayService;
 import io.grpc.Metadata;
 import io.grpc.Metadata.Key;
 import io.grpc.Server;
@@ -91,7 +91,6 @@ public final class OAuthCredentialsProviderTest {
   private static final String ACCESS_TOKEN = "someToken";
   private static final String TOKEN_TYPE = "Bearer";
   private static final String CLIENT_ID = "client";
-  private static final String URL_TOPOLOGY = HttpClientFactory.REST_API_PATH + "/topology";
 
   private final TestCredentialsApplier applier = new TestCredentialsApplier();
   private final WireMockRuntimeInfo wireMockInfo;
@@ -575,7 +574,7 @@ public final class OAuthCredentialsProviderTest {
       wireMockInfo
           .getWireMock()
           .register(
-              WireMock.get(URL_TOPOLOGY)
+              WireMock.get(RestGatewayService.URL_TOPOLOGY)
                   .withHeader("Authorization", WireMock.equalTo(TOKEN_TYPE + " " + ACCESS_TOKEN))
                   .willReturn(
                       WireMock.aResponse()
@@ -596,7 +595,7 @@ public final class OAuthCredentialsProviderTest {
       wireMockInfo
           .getWireMock()
           .register(
-              WireMock.get(URL_TOPOLOGY)
+              WireMock.get(RestGatewayService.URL_TOPOLOGY)
                   .willReturn(
                       WireMock.unauthorized()
                           .withBody(JSON_MAPPER.writeValueAsBytes(new ProblemDetail()))

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.client.CredentialsProvider.CredentialsApplier;
 import io.camunda.zeebe.client.CredentialsProvider.StatusCode;
 import io.camunda.zeebe.client.api.response.Topology;
 import io.camunda.zeebe.client.impl.ZeebeClientCredentials;
+import io.camunda.zeebe.client.impl.http.HttpClientFactory;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsCache;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProvider;
 import io.camunda.zeebe.client.impl.oauth.OAuthCredentialsProviderBuilder;
@@ -78,6 +79,7 @@ import org.junit.jupiter.api.io.TempDir;
 
 @WireMockTest
 public final class OAuthCredentialsProviderTest {
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   private static final Key<String> AUTH_KEY =
       Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
@@ -89,6 +91,7 @@ public final class OAuthCredentialsProviderTest {
   private static final String ACCESS_TOKEN = "someToken";
   private static final String TOKEN_TYPE = "Bearer";
   private static final String CLIENT_ID = "client";
+  private static final String URL_TOPOLOGY = HttpClientFactory.REST_API_PATH + "/topology";
 
   private final TestCredentialsApplier applier = new TestCredentialsApplier();
   private final WireMockRuntimeInfo wireMockInfo;
@@ -572,7 +575,7 @@ public final class OAuthCredentialsProviderTest {
       wireMockInfo
           .getWireMock()
           .register(
-              WireMock.get("/v2/topology")
+              WireMock.get(URL_TOPOLOGY)
                   .withHeader("Authorization", WireMock.equalTo(TOKEN_TYPE + " " + ACCESS_TOKEN))
                   .willReturn(
                       WireMock.aResponse()
@@ -593,7 +596,7 @@ public final class OAuthCredentialsProviderTest {
       wireMockInfo
           .getWireMock()
           .register(
-              WireMock.get("/v2/topology")
+              WireMock.get(URL_TOPOLOGY)
                   .willReturn(
                       WireMock.unauthorized()
                           .withBody(JSON_MAPPER.writeValueAsBytes(new ProblemDetail()))

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/OAuthCredentialsProviderTest.java
@@ -572,7 +572,7 @@ public final class OAuthCredentialsProviderTest {
       wireMockInfo
           .getWireMock()
           .register(
-              WireMock.get("/v1/topology")
+              WireMock.get("/v2/topology")
                   .withHeader("Authorization", WireMock.equalTo(TOKEN_TYPE + " " + ACCESS_TOKEN))
                   .willReturn(
                       WireMock.aResponse()
@@ -593,7 +593,7 @@ public final class OAuthCredentialsProviderTest {
       wireMockInfo
           .getWireMock()
           .register(
-              WireMock.get("/v1/topology")
+              WireMock.get("/v2/topology")
                   .willReturn(
                       WireMock.unauthorized()
                           .withBody(JSON_MAPPER.writeValueAsBytes(new ProblemDetail()))

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
@@ -15,57 +15,60 @@
  */
 package io.camunda.zeebe.client;
 
+import static io.camunda.zeebe.client.protocol.rest.Partition.HealthEnum.DEAD;
+import static io.camunda.zeebe.client.protocol.rest.Partition.HealthEnum.HEALTHY;
+import static io.camunda.zeebe.client.protocol.rest.Partition.HealthEnum.UNHEALTHY;
+import static io.camunda.zeebe.client.protocol.rest.Partition.RoleEnum.FOLLOWER;
+import static io.camunda.zeebe.client.protocol.rest.Partition.RoleEnum.INACTIVE;
+import static io.camunda.zeebe.client.protocol.rest.Partition.RoleEnum.LEADER;
+import static io.camunda.zeebe.client.util.RestGatewayService.broker;
+import static io.camunda.zeebe.client.util.RestGatewayService.partition;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
-import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.zeebe.client.api.response.BrokerInfo;
+import io.camunda.zeebe.client.api.response.PartitionBrokerHealth;
+import io.camunda.zeebe.client.api.response.PartitionBrokerRole;
+import io.camunda.zeebe.client.api.response.PartitionInfo;
 import io.camunda.zeebe.client.api.response.Topology;
-import io.camunda.zeebe.client.impl.response.BrokerInfoImpl;
-import io.camunda.zeebe.client.protocol.rest.BrokerInfo;
-import io.camunda.zeebe.client.protocol.rest.Partition;
-import io.camunda.zeebe.client.protocol.rest.Partition.HealthEnum;
-import io.camunda.zeebe.client.protocol.rest.Partition.RoleEnum;
-import io.camunda.zeebe.client.protocol.rest.TopologyResponse;
-import java.net.URI;
-import java.net.URISyntaxException;
+import io.camunda.zeebe.client.util.ClientRestTest;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.stream.Collectors;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@WireMockTest
-public final class TopologyRequestRestTest {
-  private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-
-  private ZeebeClient client;
-
-  @BeforeEach
-  void beforeEach(final WireMockRuntimeInfo mockInfo) throws URISyntaxException {
-    client = createClient(mockInfo);
-  }
-
-  @AfterEach
-  void afterEach() {
-    if (client != null) {
-      client.close();
-    }
-  }
+public final class TopologyRequestRestTest extends ClientRestTest {
 
   @Test
-  void shouldRequestTopology(final WireMockRuntimeInfo mockInfo)
-      throws JsonProcessingException, ExecutionException, InterruptedException {
+  void shouldRequestTopology() throws ExecutionException, InterruptedException {
     // given
-    final WireMock mock = mockInfo.getWireMock();
-    final TopologyResponse expected = createStubbedTopology();
-    mock.register(
-        WireMock.get("/v1/topology")
-            .willReturn(WireMock.okJson(JSON_MAPPER.writeValueAsString(expected))));
+    gatewayService.onTopologyRequest(
+        2,
+        10,
+        3,
+        "1.22.3-SNAPSHOT",
+        broker(
+            0,
+            "host1",
+            123,
+            "1.22.3-SNAPSHOT",
+            partition(0, LEADER, HEALTHY),
+            partition(1, FOLLOWER, UNHEALTHY)),
+        broker(
+            1,
+            "host2",
+            212,
+            "2.22.3-SNAPSHOT",
+            partition(0, FOLLOWER, HEALTHY),
+            partition(1, LEADER, HEALTHY)),
+        broker(
+            2,
+            "host3",
+            432,
+            "3.22.3-SNAPSHOT",
+            partition(0, FOLLOWER, UNHEALTHY),
+            partition(1, INACTIVE, UNHEALTHY)));
 
     // when
     final Future<Topology> response = client.newTopologyRequest().send();
@@ -73,57 +76,67 @@ public final class TopologyRequestRestTest {
     // then
     assertThat(response).succeedsWithin(Duration.ofSeconds(5));
     final Topology topology = response.get();
-    assertThat(topology.getGatewayVersion()).isEqualTo("1.0.0");
     assertThat(topology.getClusterSize()).isEqualTo(2);
-    assertThat(topology.getReplicationFactor()).isEqualTo(2);
-    assertThat(topology.getPartitionsCount()).isEqualTo(2);
-    assertThat(topology.getBrokers())
-        .containsExactlyInAnyOrderElementsOf(
-            expected.getBrokers().stream().map(BrokerInfoImpl::new).collect(Collectors.toList()));
+    assertThat(topology.getPartitionsCount()).isEqualTo(10);
+    assertThat(topology.getReplicationFactor()).isEqualTo(3);
+    assertThat(topology.getGatewayVersion()).isEqualTo("1.22.3-SNAPSHOT");
+
+    final List<BrokerInfo> brokers = topology.getBrokers();
+    assertThat(brokers).hasSize(3);
+
+    BrokerInfo broker = brokers.get(0);
+    assertThat(broker.getNodeId()).isEqualTo(0);
+    assertThat(broker.getHost()).isEqualTo("host1");
+    assertThat(broker.getPort()).isEqualTo(123);
+    assertThat(broker.getAddress()).isEqualTo("host1:123");
+    assertThat(broker.getVersion()).isEqualTo("1.22.3-SNAPSHOT");
+    assertThat(broker.getPartitions())
+        .extracting(PartitionInfo::getPartitionId, PartitionInfo::getRole, PartitionInfo::getHealth)
+        .containsOnly(
+            tuple(0, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY),
+            tuple(1, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.UNHEALTHY));
+
+    broker = brokers.get(1);
+    assertThat(broker.getNodeId()).isEqualTo(1);
+    assertThat(broker.getHost()).isEqualTo("host2");
+    assertThat(broker.getPort()).isEqualTo(212);
+    assertThat(broker.getAddress()).isEqualTo("host2:212");
+    assertThat(broker.getVersion()).isEqualTo("2.22.3-SNAPSHOT");
+    assertThat(broker.getPartitions())
+        .extracting(PartitionInfo::getPartitionId, PartitionInfo::getRole, PartitionInfo::getHealth)
+        .containsOnly(
+            tuple(0, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.HEALTHY),
+            tuple(1, PartitionBrokerRole.LEADER, PartitionBrokerHealth.HEALTHY));
+
+    broker = brokers.get(2);
+    assertThat(broker.getNodeId()).isEqualTo(2);
+    assertThat(broker.getHost()).isEqualTo("host3");
+    assertThat(broker.getPort()).isEqualTo(432);
+    assertThat(broker.getAddress()).isEqualTo("host3:432");
+    assertThat(broker.getVersion()).isEqualTo("3.22.3-SNAPSHOT");
+    assertThat(broker.getPartitions())
+        .extracting(PartitionInfo::getPartitionId, PartitionInfo::getRole, PartitionInfo::getHealth)
+        .containsOnly(
+            tuple(0, PartitionBrokerRole.FOLLOWER, PartitionBrokerHealth.UNHEALTHY),
+            tuple(1, PartitionBrokerRole.INACTIVE, PartitionBrokerHealth.UNHEALTHY));
   }
 
-  private TopologyResponse createStubbedTopology() {
-    return new TopologyResponse()
-        .gatewayVersion("1.0.0")
-        .clusterSize(2)
-        .replicationFactor(2)
-        .partitionsCount(2)
-        .addBrokersItem(
-            new BrokerInfo()
-                .version("1.0.1")
-                .host("localhost")
-                .port(1025)
-                .nodeId(0)
-                .addPartitionsItem(
-                    new Partition().partitionId(1).health(HealthEnum.HEALTHY).role(RoleEnum.LEADER))
-                .addPartitionsItem(
-                    new Partition()
-                        .partitionId(2)
-                        .role(RoleEnum.FOLLOWER)
-                        .health(HealthEnum.UNHEALTHY)))
-        .addBrokersItem(
-            new BrokerInfo()
-                .version("1.0.3")
-                .host("localhost")
-                .port(1026)
-                .nodeId(1)
-                .addPartitionsItem(
-                    new Partition()
-                        .partitionId(1)
-                        .health(HealthEnum.UNHEALTHY)
-                        .role(RoleEnum.FOLLOWER))
-                .addPartitionsItem(
-                    new Partition()
-                        .partitionId(2)
-                        .role(RoleEnum.LEADER)
-                        .health(HealthEnum.HEALTHY)));
-  }
+  @Test
+  void shouldAcceptDeadPartitions() {
+    // given
+    gatewayService.onTopologyRequest(
+        1,
+        1,
+        1,
+        "1.22.3-SNAPSHOT",
+        broker(0, "host1", 123, "1.22.3-SNAPSHOT", partition(0, LEADER, DEAD)));
 
-  private ZeebeClient createClient(final WireMockRuntimeInfo mockInfo) throws URISyntaxException {
-    return ZeebeClient.newClientBuilder()
-        .usePlaintext()
-        .preferRestOverGrpc(true)
-        .restAddress(new URI(mockInfo.getHttpBaseUrl()))
-        .build();
+    // when
+    final Topology topology = client.newTopologyRequest().send().join();
+
+    // then
+    assertThat(topology.getBrokers().get(0).getPartitions().get(0))
+        .extracting(PartitionInfo::getHealth)
+        .isEqualTo(PartitionBrokerHealth.DEAD);
   }
 }

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
@@ -89,7 +89,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
     final Topology topology = response.get();
     assertThat(topology.getClusterSize()).isEqualTo(3);
     assertThat(topology.getPartitionsCount()).isEqualTo(2);
-    assertThat(topology.getReplicationFactor()).isEqualTo(2);
+    assertThat(topology.getReplicationFactor()).isEqualTo(3);
     assertThat(topology.getGatewayVersion()).isEqualTo("1.22.3-SNAPSHOT");
 
     final List<io.camunda.zeebe.client.api.response.BrokerInfo> brokers = topology.getBrokers();

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/TopologyRequestRestTest.java
@@ -48,7 +48,7 @@ public final class TopologyRequestRestTest extends ClientRestTest {
         new TopologyResponse()
             .gatewayVersion("1.22.3-SNAPSHOT")
             .clusterSize(3)
-            .replicationFactor(2)
+            .replicationFactor(3)
             .partitionsCount(2)
             .addBrokersItem(
                 new BrokerInfo()

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/ClientRestTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/ClientRestTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.util;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import io.camunda.zeebe.client.ZeebeClient;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+@WireMockTest
+public abstract class ClientRestTest {
+
+  public ZeebeClient client;
+  public RestGatewayService gatewayService;
+
+  @BeforeEach
+  void beforeEach(final WireMockRuntimeInfo mockInfo) throws URISyntaxException {
+    client = createClient(mockInfo);
+    gatewayService = new RestGatewayService(mockInfo);
+  }
+
+  @AfterEach
+  void afterEach() {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  private ZeebeClient createClient(final WireMockRuntimeInfo mockInfo) throws URISyntaxException {
+    return ZeebeClient.newClientBuilder()
+        .usePlaintext()
+        .preferRestOverGrpc(true)
+        .restAddress(new URI(mockInfo.getHttpBaseUrl()))
+        .build();
+  }
+}

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import io.camunda.zeebe.client.protocol.rest.BrokerInfo;
+import io.camunda.zeebe.client.protocol.rest.Partition;
+import io.camunda.zeebe.client.protocol.rest.Partition.HealthEnum;
+import io.camunda.zeebe.client.protocol.rest.Partition.RoleEnum;
+import io.camunda.zeebe.client.protocol.rest.TopologyResponse;
+import java.util.Arrays;
+import org.junit.jupiter.api.Assertions;
+
+public class RestGatewayService {
+
+  public static final ObjectMapper JSON_MAPPER = new ObjectMapper();
+
+  private final WireMockRuntimeInfo mockInfo;
+
+  public RestGatewayService(final WireMockRuntimeInfo mockInfo) {
+    this.mockInfo = mockInfo;
+  }
+
+  public void onTopologyRequest(
+      final int clusterSize,
+      final int partitionsCount,
+      final int replicationFactor,
+      final String gatewayVersion,
+      final BrokerInfo... brokers) {
+    try {
+      mockInfo
+          .getWireMock()
+          .register(
+              WireMock.get("/v1/topology")
+                  .willReturn(
+                      WireMock.okJson(
+                          JSON_MAPPER.writeValueAsString(
+                              new TopologyResponse()
+                                  .gatewayVersion(gatewayVersion)
+                                  .clusterSize(clusterSize)
+                                  .replicationFactor(replicationFactor)
+                                  .partitionsCount(partitionsCount)
+                                  .brokers(Arrays.asList(brokers))))));
+    } catch (final JsonProcessingException e) {
+      Assertions.fail("Couldn't register topology request", e);
+    }
+  }
+
+  public static BrokerInfo broker(
+      final int nodeId,
+      final String host,
+      final int port,
+      final String version,
+      final Partition... partitions) {
+    return new BrokerInfo()
+        .nodeId(nodeId)
+        .host(host)
+        .port(port)
+        .version(version)
+        .partitions(Arrays.asList(partitions));
+  }
+
+  public static Partition partition(
+      final int partitionId, final RoleEnum role, final HealthEnum health) {
+    return new Partition().partitionId(partitionId).role(role).health(health);
+  }
+}

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
@@ -47,7 +47,7 @@ public class RestGatewayService {
       mockInfo
           .getWireMock()
           .register(
-              WireMock.get("/v1/topology")
+              WireMock.get("/v2/topology")
                   .willReturn(
                       WireMock.okJson(
                           JSON_MAPPER.writeValueAsString(

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
@@ -45,11 +45,11 @@ public class RestGatewayService {
         .register(WireMock.get(URL_TOPOLOGY).willReturn(WireMock.okJson(toJson(topologyResponse))));
   }
 
-  private static String toJson(final TopologyResponse topologyResponse) {
+  private static String toJson(final Object response) {
     try {
-      return JSON_MAPPER.writeValueAsString(topologyResponse);
+      return JSON_MAPPER.writeValueAsString(response);
     } catch (final JsonProcessingException e) {
-      Assertions.fail("Couldn't serialize request body to JSON", e);
+      Assertions.fail("Couldn't serialize response body to JSON", e);
       return null;
     }
   }

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
@@ -25,8 +25,10 @@ import org.junit.jupiter.api.Assertions;
 
 public class RestGatewayService {
 
+  /** The topology request URL */
+  public static final String URL_TOPOLOGY = HttpClientFactory.REST_API_PATH + "/topology";
+
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
-  private static final String URL_TOPOLOGY = HttpClientFactory.REST_API_PATH + "/topology";
 
   private final WireMockRuntimeInfo mockInfo;
 


### PR DESCRIPTION
## Description

Provides an abstract, Wiremock-based `ClientRestTest` class for Java client REST tests.
This serves as the base class for REST test as `ClientTest` does for client gRPC tests.

The `RestGatewayService` handles request registration and request data creation like
`RecordingGatewayService` does for gRPC tests.

## Related issues

related to #18256 
