### PR TITLE
Initialize exporter state in dynamic config during first update to 8.6

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -203,11 +203,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
   private static boolean isEnabled(
       final Map<String, ExporterState> exporterConfig,
       final ExporterDescriptor exporterDescriptor) {
-    // TODO: If the exporter is not found in exporterConfig, it should be considered as disabled.
-    // But we can do that only after https://github.com/camunda/zeebe/issues/18296 is implemented.
-    // Until then, we assume if the exporter is not found in the config, it is considered as
-    // enabled. Note that this is a temporary workaround.
-    return !exporterConfig.containsKey(exporterDescriptor.getId())
-        || exporterConfig.get(exporterDescriptor.getId()).state() == State.ENABLED;
+    return exporterConfig.containsKey(exporterDescriptor.getId())
+        && exporterConfig.get(exporterDescriptor.getId()).state() == State.ENABLED;
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -7,10 +7,7 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
-import io.atomix.cluster.ClusterMembershipService;
-import io.atomix.cluster.Member;
 import io.atomix.cluster.MemberId;
-import io.atomix.utils.Version;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.InitializerError.PersistedConfigurationIsBroken;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationUpdateNotifier.ClusterConfigurationUpdateListener;
 import io.camunda.zeebe.dynamic.config.serializer.ClusterConfigurationSerializer;
@@ -21,7 +18,6 @@ import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
-import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.slf4j.Logger;
@@ -360,112 +356,6 @@ public interface ClusterConfigurationInitializer {
       } catch (final Exception e) {
         return CompletableActorFuture.completedExceptionally(e);
       }
-    }
-  }
-
-  /** Initializer that allows rolling update from 8.3.x to 8.4.x */
-  class RollingUpdateAwareInitializerV83ToV84 implements ClusterConfigurationInitializer {
-    private static final Logger LOGGER =
-        LoggerFactory.getLogger(RollingUpdateAwareInitializerV83ToV84.class);
-    private static final Duration RETRY_DELAY = Duration.ofMillis(200);
-    private final ClusterMembershipService membershipService;
-    private final StaticInitializer staticInitializer;
-    private final int staticClusterSize;
-    private final ConcurrencyControl executor;
-    private final CompletableActorFuture<ClusterConfiguration> initializeFuture;
-
-    public RollingUpdateAwareInitializerV83ToV84(
-        final ClusterMembershipService membershipService,
-        final StaticConfiguration staticConfiguration,
-        final ConcurrencyControl executor) {
-      this.membershipService = membershipService;
-      staticInitializer = new StaticInitializer(staticConfiguration);
-      staticClusterSize = staticConfiguration.clusterMembers().size();
-      this.executor = executor;
-      initializeFuture = new CompletableActorFuture<>();
-    }
-
-    @Override
-    public ActorFuture<ClusterConfiguration> initialize() {
-      if (staticClusterSize == 1) {
-        // Cluster will be initialized via normal static initializer
-        initializeFuture.complete(ClusterConfiguration.uninitialized());
-        return initializeFuture;
-      }
-
-      final Version version = membershipService.getLocalMember().version();
-      if (isVersion84(version)) {
-        final boolean knowOtherMembers = hasOtherReachableBrokers(membershipService);
-        if (knowOtherMembers && isRollingUpdate(membershipService)) {
-          LOGGER.debug(
-              "Cluster is doing rolling update. Cannot initialize cluster configuration via gossip. Initializing cluster configuration from static configuration.");
-          staticInitializer.initialize().onComplete(initializeFuture);
-        } else if (!knowOtherMembers) {
-          LOGGER.debug(
-              "No other members are reachable. Cannot initialize configuration. Will retry in {}",
-              RETRY_DELAY);
-          executor.schedule(RETRY_DELAY, this::initialize);
-        } else {
-          // do not initialize. It is not rolling update so initialize via gossip or sync
-          LOGGER.trace(
-              "Cluster is not doing rolling update. Will not initialize cluster configuration.");
-          initializeFuture.complete(ClusterConfiguration.uninitialized());
-        }
-      } else {
-        LOGGER.trace(
-            "Cluster is not doing rolling update. Will not initialize cluster configuration.");
-        initializeFuture.complete(ClusterConfiguration.uninitialized());
-      }
-      return initializeFuture;
-    }
-
-    private boolean hasOtherReachableBrokers(final ClusterMembershipService membershipService) {
-      return membershipService.getMembers().stream()
-          .filter(this::isBroker)
-          .map(Member::id)
-          .anyMatch(memberId -> !memberId.equals(membershipService.getLocalMember().id()));
-    }
-
-    private boolean isRollingUpdate(final ClusterMembershipService membershipService) {
-      final List<Member> otherBrokers =
-          membershipService.getMembers().stream()
-              .filter(this::isBroker)
-              .filter(member -> !member.id().equals(membershipService.getLocalMember().id()))
-              .toList();
-      final var cannotDetermineVersionOfOtherMembers =
-          otherBrokers.stream().map(Member::version).noneMatch(Objects::nonNull);
-      if (cannotDetermineVersionOfOtherMembers) {
-        // This is mainly required for testing, where the DiscoveryMembershipProvider cannot
-        // determine version of remote members.
-        LOGGER.warn(
-            "Cannot determine version of remote members. Assuming this is not rolling update and skip initialization.");
-        return false;
-      }
-      return otherBrokers.stream().map(Member::version).anyMatch(this::isVersion83);
-    }
-
-    private boolean isBroker(final Member member) {
-      try {
-        // hacky way to determine if the other member is a broker
-        return Integer.parseInt(member.id().id()) >= 0;
-      } catch (final NumberFormatException e) {
-        return false;
-      }
-    }
-
-    private boolean isVersion84(final Version version) {
-      if (version == null) {
-        // This is mainly required for testing, where the DiscoveryMembershipProvider cannot
-        // determine version of remote members.
-        LOGGER.warn(
-            "Cannot determine version of local member. Assuming this is not rolling update and skip initialization.");
-        return false;
-      }
-      return version.major() == 8 && version.minor() == 4;
-    }
-
-    private boolean isVersion83(final Version version) {
-      return version.major() == 8 && version.minor() == 3;
     }
   }
 

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -45,6 +45,11 @@ import org.slf4j.LoggerFactory;
  *     static configuration. See {@link StaticInitializer}.
  * <li>When the local configuration is empty, a non-coordinating member waits until it receives a
  *     valid configuration from the coordinator via gossip. See {@link GossipInitializer}.
+ * <li>After initialization, the configuration can be modified using {@link
+ *     ClusterConfigurationModifier}. Currently only {@link
+ *     io.camunda.zeebe.dynamic.config.ClusterConfigurationModifier.ExporterStateInitializer} is
+ *     available. It overwrites the local member's state to keep it in sync with the statically
+ *     configured exporters.
  */
 public interface ClusterConfigurationInitializer {
   Logger LOG = LoggerFactory.getLogger(ClusterConfigurationInitializer.class);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -13,7 +13,6 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.FileInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.GossipInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.InitializerError.PersistedConfigurationIsBroken;
-import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.RollingUpdateAwareInitializerV83ToV84;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.SyncInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
@@ -120,10 +119,6 @@ public final class ClusterConfigurationManagerService
                 otherKnownMembers,
                 managerActor,
                 clusterConfigurationGossiper::queryClusterConfiguration))
-        // Only to support rolling update from 8.3 to 8.4. Should be removed after 8.4 release
-        .orThen(
-            new RollingUpdateAwareInitializerV83ToV84(
-                membershipService, staticConfiguration, managerActor))
         .orThen(
             new GossipInitializer(
                 clusterConfigurationGossiper,
@@ -144,10 +139,6 @@ public final class ClusterConfigurationManagerService
             .filter(m -> !m.equals(staticConfiguration.localMemberId()))
             .toList();
     return new FileInitializer(configurationFile, new ProtoBufSerializer())
-        // Only to support rolling update from 8.3 to 8.4. Should be removed after 8.4 release
-        .orThen(
-            new RollingUpdateAwareInitializerV83ToV84(
-                memberShipService, staticConfiguration, managerActor))
         .orThen(
             new SyncInitializer(
                 clusterConfigurationGossiper,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.RollingUp
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.SyncInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
+import io.camunda.zeebe.dynamic.config.ClusterConfigurationModifier.ExporterStateInitializer;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestsHandler;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestServer;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliersImpl;
@@ -128,6 +129,11 @@ public final class ClusterConfigurationManagerService
                 clusterConfigurationGossiper,
                 persistedClusterConfiguration,
                 clusterConfigurationGossiper::updateClusterConfiguration,
+                managerActor))
+        .andThen(
+            new ExporterStateInitializer(
+                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                staticConfiguration.localMemberId(),
                 managerActor));
   }
 
@@ -148,7 +154,12 @@ public final class ClusterConfigurationManagerService
                 otherKnownMembers,
                 managerActor,
                 clusterConfigurationGossiper::queryClusterConfiguration))
-        .orThen(new StaticInitializer(staticConfiguration));
+        .orThen(new StaticInitializer(staticConfiguration))
+        .andThen(
+            new ExporterStateInitializer(
+                staticConfiguration.partitionConfig().exporting().exporters().keySet(),
+                staticConfiguration.localMemberId(),
+                managerActor));
   }
 
   /** Starts ClusterConfigurationManager which initializes ClusterConfiguration */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Set;
+
+/**
+ * After the configuration is initialized, we can use a {@link ClusterConfigurationModifier} to
+ * update the initialized configuration. This process do not go through the usual process of adding
+ * a {@link io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation} to change the
+ * configuration. Instead, overwrites the configuration immediately after it is initialized. Hence,
+ * this should be used carefully.
+ *
+ * <p>Ideally, a modifier should only update the configuration of the local member to avoid any
+ * concurrent conflicting changes from other members.
+ */
+public interface ClusterConfigurationModifier {
+
+  /**
+   * Modifies the given configuration and returns the modified configuration.
+   *
+   * @param configuration current configuration
+   * @return modified configuration
+   */
+  ActorFuture<ClusterConfiguration> modify(ClusterConfiguration configuration);
+
+  class ExporterStateInitializer implements ClusterConfigurationModifier {
+
+    private final Set<String> configuredExporters;
+    private final MemberId localMemberId;
+    private final ConcurrencyControl executor;
+
+    public ExporterStateInitializer(
+        final Set<String> configuredExporters,
+        final MemberId localMemberId,
+        final ConcurrencyControl executor) {
+      this.configuredExporters = configuredExporters;
+      this.localMemberId = localMemberId;
+      this.executor = executor;
+    }
+
+    @Override
+    public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
+      final ActorFuture<ClusterConfiguration> result = executor.createFuture();
+      if (!configuration.hasMember(localMemberId)) {
+        result.complete(configuration);
+      } else {
+        result.complete(
+            configuration.updateMember(
+                localMemberId, memberState -> updateExporterState(memberState)));
+      }
+      return result;
+    }
+
+    private MemberState updateExporterState(final MemberState memberState) {
+      MemberState updatedMemberState = memberState;
+      for (final var p : memberState.partitions().keySet()) {
+        updatedMemberState =
+            updatedMemberState.updatePartition(
+                p, partitionState -> updateExporterStateInPartition(partitionState));
+      }
+      return updatedMemberState;
+    }
+
+    private PartitionState updateExporterStateInPartition(final PartitionState partitionState) {
+      final var exportersInConfig = partitionState.config().exporting().exporters();
+
+      final var newlyAddedExporters =
+          configuredExporters.stream().filter(id -> !exportersInConfig.containsKey(id)).toList();
+      final var removedExporters =
+          exportersInConfig.keySet().stream()
+              .filter(id -> !configuredExporters.contains(id))
+              .toList();
+
+      return partitionState
+          .updateConfig(c -> c.updateExporting(e -> e.disableExporters(removedExporters)))
+          .updateConfig(c -> c.updateExporting(e -> e.addExporters(newlyAddedExporters)));
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
@@ -36,6 +36,13 @@ public interface ClusterConfigurationModifier {
    */
   ActorFuture<ClusterConfiguration> modify(ClusterConfiguration configuration);
 
+  /**
+   * Updates the exporter state of the local member in the configuration. If a broker restarts with
+   * a changes of exporters in the static configuration, this modifier updates the dynamic config to
+   * reflect that. If new exporter are added to the static configuration, they are added to the
+   * dynamic config with state ENABLED. If existing exporters are removed, they are marked as
+   * disabled. Note that the exporters are not removed from the dynamic config.
+   */
   class ExporterStateInitializer implements ClusterConfigurationModifier {
 
     private final Set<String> configuredExporters;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/DynamicPartitionConfig.java
@@ -12,10 +12,21 @@ import java.util.function.UnaryOperator;
 /** Represents configuration of a partition that can be updated during runtime. */
 public record DynamicPartitionConfig(ExportersConfig exporting) {
 
+  public static DynamicPartitionConfig uninitialized() {
+    // This is temporary until we have a way to initialize this during bootstrap or first update to
+    // the version that added this
+    return new DynamicPartitionConfig(null);
+  }
+
+  // Only used in tests. May be removed.
   public static DynamicPartitionConfig init() {
     // This is temporary until we have a way to initialize this during bootstrap or first update to
     // the version that added this
     return new DynamicPartitionConfig(ExportersConfig.empty());
+  }
+
+  public boolean isInitialized() {
+    return exporting != null;
   }
 
   public DynamicPartitionConfig updateExporting(final ExportersConfig exporter) {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
@@ -113,6 +115,19 @@ final class ClusterConfigurationModifierTest {
               1, partition -> PartitionStateAssert.assertThat(partition).hasConfig(expectedConfig))
           .hasPartitionSatisfying(
               2, partition -> PartitionStateAssert.assertThat(partition).hasConfig(expectedConfig));
+    }
+
+    @Test
+    void shouldNotUpdateMemberStateIfNoExporterChanges() {
+      // when
+      final var newConfiguration =
+          new ClusterConfigurationModifier.ExporterStateInitializer(
+                  Set.of("expA", "expB"), localMemberId, executor)
+              .modify(currentConfiguration)
+              .join();
+
+      // then
+      assertThat(newConfiguration).isEqualTo(currentConfiguration);
     }
 
     public static Stream<Arguments> provideConfigs() {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class ClusterConfigurationModifierTest {
+
+  private final MemberId localMemberId = MemberId.from("0");
+  private final ConcurrencyControl executor = new TestConcurrencyControl();
+  private final DynamicPartitionConfig config =
+      new DynamicPartitionConfig(
+          new ExportersConfig(
+              Map.of(
+                  "expA",
+                  new ExporterState(0, State.ENABLED, Optional.empty()),
+                  "expB",
+                  new ExporterState(0, State.ENABLED, Optional.empty()))));
+
+  final ClusterConfiguration currentConfiguration =
+      ClusterConfiguration.init()
+          .addMember(
+              localMemberId,
+              MemberState.initializeAsActive(
+                  Map.of(
+                      1, PartitionState.active(1, config), 2, PartitionState.active(2, config))));
+
+  @Nested
+  class ExporterStateInitializerTest {
+
+    @ParameterizedTest
+    @MethodSource("provideConfigs")
+    void shouldUpdateExporterConfig(final ExporterConfigParameter parameter) {
+      // given
+      final var exporterStateInitializer =
+          new ClusterConfigurationModifier.ExporterStateInitializer(
+              parameter.configuredExporters(), localMemberId, executor);
+
+      // when
+      final var newConfiguration = exporterStateInitializer.modify(currentConfiguration).join();
+
+      // then
+      ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration)
+          .member(localMemberId)
+          .hasPartitionSatisfying(
+              1,
+              partition ->
+                  PartitionStateAssert.assertThat(partition).hasConfig(parameter.expectedConfig()))
+          .hasPartitionSatisfying(
+              2,
+              partition ->
+                  PartitionStateAssert.assertThat(partition).hasConfig(parameter.expectedConfig()));
+    }
+
+    public static Stream<Arguments> provideConfigs() {
+      return Stream.of(exporterAdded(), exporterRemoved(), exporterAddedAndRemoved());
+    }
+
+    private static Arguments exporterAddedAndRemoved() {
+      final var expectedConfig =
+          new DynamicPartitionConfig(
+              new ExportersConfig(
+                  Map.of(
+                      "expA",
+                      new ExporterState(0, State.ENABLED, Optional.empty()),
+                      "expB",
+                      new ExporterState(0, State.DISABLED, Optional.empty()),
+                      "exporter1",
+                      new ExporterState(0, State.ENABLED, Optional.empty()),
+                      "exporter2",
+                      new ExporterState(0, State.ENABLED, Optional.empty()))));
+
+      return Arguments.of(
+          Named.of(
+              "Exporters Added and Removed",
+              new ExporterConfigParameter(
+                  Set.of("exporter1", "exporter2", "expA"), expectedConfig)));
+    }
+
+    private static Arguments exporterRemoved() {
+      final var expectedConfig =
+          new DynamicPartitionConfig(
+              new ExportersConfig(
+                  Map.of(
+                      "expA",
+                      new ExporterState(0, State.ENABLED, Optional.empty()),
+                      "expB",
+                      new ExporterState(0, State.DISABLED, Optional.empty()))));
+      return Arguments.of(
+          Named.of(
+              "Exporters Removed", new ExporterConfigParameter(Set.of("expA"), expectedConfig)));
+    }
+
+    private static Arguments exporterAdded() {
+      final var expectedConfig =
+          new DynamicPartitionConfig(
+              new ExportersConfig(
+                  Map.of(
+                      "expA",
+                      new ExporterState(0, State.ENABLED, Optional.empty()),
+                      "expB",
+                      new ExporterState(0, State.ENABLED, Optional.empty()),
+                      "exporter1",
+                      new ExporterState(0, State.ENABLED, Optional.empty()),
+                      "exporter2",
+                      new ExporterState(0, State.ENABLED, Optional.empty()))));
+      return Arguments.of(
+          Named.of(
+              "New Exporters Added",
+              new ExporterConfigParameter(
+                  Set.of("expA", "expB", "exporter1", "exporter2"), expectedConfig)));
+    }
+
+    private record ExporterConfigParameter(
+        Set<String> configuredExporters, DynamicPartitionConfig expectedConfig) {}
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -221,7 +221,8 @@ final class ProtoBufSerializerTest {
         topologyWithClusterChangePlanWithMemberOperations(),
         topologyWithExporterState(),
         topologyWithExporterDisableOperation(),
-        topologyWithExporterEnableOperation());
+        topologyWithExporterEnableOperation(),
+        topologyWithUninitializedPartitionConfig());
   }
 
   private static ClusterConfiguration topologyWithOneMemberNoPartitions() {
@@ -360,5 +361,13 @@ final class ProtoBufSerializerTest {
                 // without initialize from another exporter
                 new PartitionEnableExporterOperation(
                     MemberId.from("1"), 1, "expA", Optional.empty())));
+  }
+
+  private static ClusterConfiguration topologyWithUninitializedPartitionConfig() {
+    return ClusterConfiguration.init()
+        .addMember(
+            MemberId.from("0"),
+            MemberState.initializeAsActive(
+                Map.of(1, PartitionState.active(1, DynamicPartitionConfig.uninitialized()))));
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ClusterEndpointResponseIT.java
@@ -20,8 +20,7 @@ import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
 final class ClusterEndpointResponseIT {
-  @TestZeebe
-  static TestStandaloneBroker broker = new TestStandaloneBroker().withRecordingExporter(true);
+  @TestZeebe static TestStandaloneBroker broker = new TestStandaloneBroker();
 
   @Test
   void shouldMatchExpectedSerialization() throws IOException, InterruptedException {
@@ -47,12 +46,7 @@ final class ClusterEndpointResponseIT {
                                   "priority": 1,
                                   "config":{
                                      "exporting": {
-                                        "exporters": [
-                                          {
-                                            "id": "recordingExporter",
-                                            "state": "ENABLED"
-                                          }
-                                        ]
+                                        "exporters": []
                                      }
                                   }
                                 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDynamicConfigTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDynamicConfigTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.exporter;
+
+import static org.hamcrest.Matchers.greaterThan;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class ExporterDynamicConfigTest {
+
+  @TestZeebe private final TestStandaloneBroker zeebe = new TestStandaloneBroker();
+  @AutoCloseResource private ZeebeClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = zeebe.newClientBuilder().build();
+  }
+
+  @Test
+  void shouldEnableExporterByDefaultOnStartup() {
+    // given -- when start with no exporter
+    zeebe.stop();
+
+    // when -- restart with new exporter
+    zeebe.withRecordingExporter(true).start().awaitCompleteTopology();
+    client.newPublishMessageCommand().messageName("test").correlationKey("test").send().join();
+
+    // then
+    Awaitility.await("Exporter is enabled")
+        .until(() -> RecordingExporter.getRecords().size(), greaterThan(0));
+  }
+}


### PR DESCRIPTION
## Description

This PR introduces the following changes:
- When a broker is restarted, and if it has configured new exporters, they are enabled by default and added to the dynamic config.
- When a broker is restarted and if it has removed an existing exporter from the static configuration, then it is marked as disabled in the dynamic config. It is not removed from the dynamic config because if it is re-enabled, it would be necessary to keep track of the metadata version.
- During rolling update from 8.5 to 8.6, the existing exporter are added to the dynamic config in `ClusterConfiguration`. The merge logic ensures that cluster configuration from 8.5 and 8.6 are merged correctly without losing the valid exporter state.
- Removes the RollingUpdateInitializer83to84 that was required to support rolling update from 8.3 to 8.4

## Related issues

closes #18296 
