### PR TITLE
Support job activation over REST in Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/ActivateJobsCommandStep1.java
@@ -19,7 +19,8 @@ import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import java.time.Duration;
 import java.util.List;
 
-public interface ActivateJobsCommandStep1 {
+public interface ActivateJobsCommandStep1
+    extends CommandWithCommunicationApiStep<ActivateJobsCommandStep1> {
 
   /**
    * Set the type of jobs to work on.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -472,12 +472,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
 
   private JobClient newJobClient() {
     return new JobClientImpl(
-        asyncStub,
-        httpClient,
-        config,
-        jsonMapper,
-        credentialsProvider::shouldRetryRequest,
-        config.preferRestOverGrpc());
+        asyncStub, httpClient, config, jsonMapper, credentialsProvider::shouldRetryRequest);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -472,7 +472,12 @@ public final class ZeebeClientImpl implements ZeebeClient {
 
   private JobClient newJobClient() {
     return new JobClientImpl(
-        asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
+        asyncStub,
+        httpClient,
+        config,
+        jsonMapper,
+        credentialsProvider::shouldRetryRequest,
+        config.preferRestOverGrpc());
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -25,78 +25,111 @@ import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobs
 import io.camunda.zeebe.client.api.command.FinalCommandStep;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.impl.RetriableStreamingFutureImpl;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.camunda.zeebe.client.impl.response.ActivateJobsResponseImpl;
+import io.camunda.zeebe.client.protocol.rest.JobActivationRequest;
+import io.camunda.zeebe.client.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ActivateJobsRequest.Builder;
 import io.grpc.stub.StreamObserver;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
+import org.apache.hc.client5.http.config.RequestConfig;
 
 public final class ActivateJobsCommandImpl
     implements ActivateJobsCommandStep1, ActivateJobsCommandStep2, ActivateJobsCommandStep3 {
 
   private static final Duration DEADLINE_OFFSET = Duration.ofSeconds(10);
   private final GatewayStub asyncStub;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
   private final JsonMapper jsonMapper;
   private final Predicate<StatusCode> retryPredicate;
-  private final Builder builder;
+  private final Builder grpcRequestObjectBuilder;
+  private final JobActivationRequest httpRequestObject;
   private Duration requestTimeout;
+  private boolean useRest;
 
   private final Set<String> defaultTenantIds;
   private final Set<String> customTenantIds;
 
   public ActivateJobsCommandImpl(
       final GatewayStub asyncStub,
+      final HttpClient httpClient,
       final ZeebeClientConfiguration config,
       final JsonMapper jsonMapper,
-      final Predicate<StatusCode> retryPredicate) {
+      final Predicate<StatusCode> retryPredicate,
+      final boolean useRest) {
     this.asyncStub = asyncStub;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
     this.jsonMapper = jsonMapper;
     this.retryPredicate = retryPredicate;
-    builder = ActivateJobsRequest.newBuilder();
+    grpcRequestObjectBuilder = ActivateJobsRequest.newBuilder();
+    httpRequestObject = new JobActivationRequest();
     requestTimeout(config.getDefaultRequestTimeout());
     timeout(config.getDefaultJobTimeout());
     workerName(config.getDefaultJobWorkerName());
+    this.useRest = useRest;
     defaultTenantIds = new HashSet<>(config.getDefaultJobWorkerTenantIds());
     customTenantIds = new HashSet<>();
   }
 
   @Override
+  public ActivateJobsCommandStep1 useRest() {
+    useRest = true;
+    return this;
+  }
+
+  @Override
+  public ActivateJobsCommandStep1 useGrpc() {
+    useRest = false;
+    return this;
+  }
+
+  @Override
   public ActivateJobsCommandStep2 jobType(final String jobType) {
-    builder.setType(jobType);
+    grpcRequestObjectBuilder.setType(jobType);
+    httpRequestObject.setType(jobType);
     return this;
   }
 
   @Override
   public ActivateJobsCommandStep3 maxJobsToActivate(final int maxJobsToActivate) {
-    builder.setMaxJobsToActivate(maxJobsToActivate);
+    grpcRequestObjectBuilder.setMaxJobsToActivate(maxJobsToActivate);
+    httpRequestObject.setMaxJobsToActivate(maxJobsToActivate);
     return this;
   }
 
   @Override
   public ActivateJobsCommandStep3 timeout(final Duration timeout) {
-    builder.setTimeout(timeout.toMillis());
+    grpcRequestObjectBuilder.setTimeout(timeout.toMillis());
+    httpRequestObject.setTimeout(timeout.toMillis());
     return this;
   }
 
   @Override
   public ActivateJobsCommandStep3 workerName(final String workerName) {
     if (workerName != null) {
-      builder.setWorker(workerName);
+      grpcRequestObjectBuilder.setWorker(workerName);
+      httpRequestObject.setWorker(workerName);
     }
     return this;
   }
 
   @Override
   public ActivateJobsCommandStep3 fetchVariables(final List<String> fetchVariables) {
-    builder.addAllFetchVariable(fetchVariables);
+    grpcRequestObjectBuilder.addAllFetchVariable(fetchVariables);
+    httpRequestObject.fetchVariable(fetchVariables);
     return this;
   }
 
@@ -107,21 +140,47 @@ public final class ActivateJobsCommandImpl
 
   @Override
   public FinalCommandStep<ActivateJobsResponse> requestTimeout(final Duration requestTimeout) {
-    builder.setRequestTimeout(requestTimeout.toMillis());
+    grpcRequestObjectBuilder.setRequestTimeout(requestTimeout.toMillis());
+    httpRequestObject.setRequestTimeout(requestTimeout.toMillis());
     this.requestTimeout = requestTimeout;
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
     return this;
   }
 
   @Override
   public ZeebeFuture<ActivateJobsResponse> send() {
-    builder.clearTenantIds();
+    grpcRequestObjectBuilder.clearTenantIds();
+    httpRequestObject.setTenantIds(new ArrayList<>());
     if (customTenantIds.isEmpty()) {
-      builder.addAllTenantIds(defaultTenantIds);
+      grpcRequestObjectBuilder.addAllTenantIds(defaultTenantIds);
+      httpRequestObject.setTenantIds(new ArrayList<>(defaultTenantIds));
     } else {
-      builder.addAllTenantIds(customTenantIds);
+      grpcRequestObjectBuilder.addAllTenantIds(customTenantIds);
+      httpRequestObject.setTenantIds(new ArrayList<>(customTenantIds));
     }
 
-    final ActivateJobsRequest request = builder.build();
+    if (useRest) {
+      return sendRestRequest();
+    } else {
+      return sendGrpcRequest();
+    }
+  }
+
+  private ZeebeFuture<ActivateJobsResponse> sendRestRequest() {
+    final HttpZeebeFuture<ActivateJobsResponse> result = new HttpZeebeFuture<>();
+    final ActivateJobsResponseImpl response = new ActivateJobsResponseImpl(jsonMapper);
+    httpClient.post(
+        "/jobs/activation",
+        jsonMapper.toJson(httpRequestObject),
+        httpRequestConfig.build(),
+        JobActivationResponse.class,
+        response::addResponse,
+        result);
+    return result;
+  }
+
+  private ZeebeFuture<ActivateJobsResponse> sendGrpcRequest() {
+    final ActivateJobsRequest request = grpcRequestObjectBuilder.build();
 
     final ActivateJobsResponseImpl response = new ActivateJobsResponseImpl(jsonMapper);
     final RetriableStreamingFutureImpl<ActivateJobsResponse, GatewayOuterClass.ActivateJobsResponse>
@@ -130,13 +189,13 @@ public final class ActivateJobsCommandImpl
                 response,
                 response::addResponse,
                 retryPredicate,
-                streamObserver -> send(request, streamObserver));
+                streamObserver -> sendGrpc(request, streamObserver));
 
-    send(request, future);
+    sendGrpc(request, future);
     return future;
   }
 
-  private void send(
+  private void sendGrpc(
       final ActivateJobsRequest request,
       final StreamObserver<GatewayOuterClass.ActivateJobsResponse> future) {
     asyncStub

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/ActivateJobsCommandImpl.java
@@ -67,8 +67,7 @@ public final class ActivateJobsCommandImpl
       final HttpClient httpClient,
       final ZeebeClientConfiguration config,
       final JsonMapper jsonMapper,
-      final Predicate<StatusCode> retryPredicate,
-      final boolean useRest) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.httpClient = httpClient;
     httpRequestConfig = httpClient.newRequestConfig();
@@ -79,7 +78,7 @@ public final class ActivateJobsCommandImpl
     requestTimeout(config.getDefaultRequestTimeout());
     timeout(config.getDefaultJobTimeout());
     workerName(config.getDefaultJobWorkerName());
-    this.useRest = useRest;
+    useRest = config.preferRestOverGrpc();
     defaultTenantIds = new HashSet<>(config.getDefaultJobWorkerTenantIds());
     customTenantIds = new HashSet<>();
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivateJobsResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivateJobsResponseImpl.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.client.impl.response;
 import io.camunda.zeebe.client.api.JsonMapper;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.protocol.rest.JobActivationResponse;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -36,6 +37,15 @@ public final class ActivateJobsResponseImpl implements ActivateJobsResponse {
     activateJobsResponse.getJobsList().stream()
         .map(r -> new ActivatedJobImpl(jsonMapper, r))
         .forEach(jobs::add);
+  }
+
+  public ActivateJobsResponseImpl addResponse(final JobActivationResponse activateJobsResponse) {
+    final List<io.camunda.zeebe.client.protocol.rest.ActivatedJob> activatedJobs =
+        activateJobsResponse.getJobs();
+    if (activatedJobs != null) {
+      activatedJobs.stream().map(r -> new ActivatedJobImpl(jsonMapper, r)).forEach(jobs::add);
+    }
+    return this;
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 public final class ActivatedJobImpl implements ActivatedJob {
@@ -79,7 +80,13 @@ public final class ActivatedJobImpl implements ActivatedJob {
         job.getCustomHeaders() == null
             ? new HashMap<>()
             : job.getCustomHeaders().entrySet().stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, jsonMapper::toJson));
+                .collect(
+                    Collectors.toMap(
+                        Entry::getKey,
+                        e ->
+                            (e.getValue() instanceof String)
+                                ? (String) e.getValue()
+                                : jsonMapper.toJson(e.getValue())));
     worker = getOrEmpty(job.getWorker());
     retries = getOrEmpty(job.getRetries());
     deadline = getOrEmpty(job.getDeadline());

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/ActivatedJobImpl.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public final class ActivatedJobImpl implements ActivatedJob {
 
@@ -66,6 +67,31 @@ public final class ActivatedJobImpl implements ActivatedJob {
     elementId = job.getElementId();
     elementInstanceKey = job.getElementInstanceKey();
     tenantId = job.getTenantId();
+  }
+
+  public ActivatedJobImpl(
+      final JsonMapper jsonMapper, final io.camunda.zeebe.client.protocol.rest.ActivatedJob job) {
+    this.jsonMapper = jsonMapper;
+
+    key = getOrEmpty(job.getKey());
+    type = getOrEmpty(job.getType());
+    customHeaders =
+        job.getCustomHeaders() == null
+            ? new HashMap<>()
+            : job.getCustomHeaders().entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, jsonMapper::toJson));
+    worker = getOrEmpty(job.getWorker());
+    retries = getOrEmpty(job.getRetries());
+    deadline = getOrEmpty(job.getDeadline());
+    variablesAsMap = job.getVariables() == null ? new HashMap<>() : job.getVariables();
+    variables = jsonMapper.toJson(variablesAsMap);
+    processInstanceKey = getOrEmpty(job.getProcessInstanceKey());
+    bpmnProcessId = getOrEmpty(job.getBpmnProcessId());
+    processDefinitionVersion = getOrEmpty(job.getProcessDefinitionVersion());
+    processDefinitionKey = getOrEmpty(job.getProcessDefinitionKey());
+    elementId = getOrEmpty(job.getElementId());
+    elementInstanceKey = getOrEmpty(job.getElementInstanceKey());
+    tenantId = getOrEmpty(job.getTenantId());
   }
 
   @Override
@@ -168,5 +194,17 @@ public final class ActivatedJobImpl implements ActivatedJob {
   @Override
   public String toString() {
     return toJson();
+  }
+
+  private static String getOrEmpty(final String value) {
+    return value == null ? "" : value;
+  }
+
+  private static Long getOrEmpty(final Long value) {
+    return value == null ? -1L : value;
+  }
+
+  private static Integer getOrEmpty(final Integer value) {
+    return value == null ? -1 : value;
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
@@ -30,25 +30,40 @@ import io.camunda.zeebe.client.impl.command.CompleteJobCommandImpl;
 import io.camunda.zeebe.client.impl.command.FailJobCommandImpl;
 import io.camunda.zeebe.client.impl.command.StreamJobsCommandImpl;
 import io.camunda.zeebe.client.impl.command.ThrowErrorCommandImpl;
+import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayStub;
 import java.util.function.Predicate;
 
 public final class JobClientImpl implements JobClient {
 
   private final GatewayStub asyncStub;
+  private final HttpClient httpClient;
   private final ZeebeClientConfiguration config;
   private final JsonMapper jsonMapper;
   private final Predicate<StatusCode> retryPredicate;
+  private final boolean useRest;
 
   public JobClientImpl(
       final GatewayStub asyncStub,
       final ZeebeClientConfiguration config,
       final JsonMapper jsonMapper,
       final Predicate<StatusCode> retryPredicate) {
+    this(asyncStub, null, config, jsonMapper, retryPredicate, false);
+  }
+
+  public JobClientImpl(
+      final GatewayStub asyncStub,
+      final HttpClient httpClient,
+      final ZeebeClientConfiguration config,
+      final JsonMapper jsonMapper,
+      final Predicate<StatusCode> retryPredicate,
+      final boolean useRest) {
     this.asyncStub = asyncStub;
+    this.httpClient = httpClient;
     this.config = config;
     this.jsonMapper = jsonMapper;
     this.retryPredicate = retryPredicate;
+    this.useRest = useRest;
   }
 
   @Override
@@ -86,7 +101,8 @@ public final class JobClientImpl implements JobClient {
 
   @Override
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
-    return new ActivateJobsCommandImpl(asyncStub, config, jsonMapper, retryPredicate);
+    return new ActivateJobsCommandImpl(
+        asyncStub, httpClient, config, jsonMapper, retryPredicate, useRest);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobClientImpl.java
@@ -41,29 +41,18 @@ public final class JobClientImpl implements JobClient {
   private final ZeebeClientConfiguration config;
   private final JsonMapper jsonMapper;
   private final Predicate<StatusCode> retryPredicate;
-  private final boolean useRest;
-
-  public JobClientImpl(
-      final GatewayStub asyncStub,
-      final ZeebeClientConfiguration config,
-      final JsonMapper jsonMapper,
-      final Predicate<StatusCode> retryPredicate) {
-    this(asyncStub, null, config, jsonMapper, retryPredicate, false);
-  }
 
   public JobClientImpl(
       final GatewayStub asyncStub,
       final HttpClient httpClient,
       final ZeebeClientConfiguration config,
       final JsonMapper jsonMapper,
-      final Predicate<StatusCode> retryPredicate,
-      final boolean useRest) {
+      final Predicate<StatusCode> retryPredicate) {
     this.asyncStub = asyncStub;
     this.httpClient = httpClient;
     this.config = config;
     this.jsonMapper = jsonMapper;
     this.retryPredicate = retryPredicate;
-    this.useRest = useRest;
   }
 
   @Override
@@ -101,8 +90,7 @@ public final class JobClientImpl implements JobClient {
 
   @Override
   public ActivateJobsCommandStep1 newActivateJobsCommand() {
-    return new ActivateJobsCommandImpl(
-        asyncStub, httpClient, config, jsonMapper, retryPredicate, useRest);
+    return new ActivateJobsCommandImpl(asyncStub, httpClient, config, jsonMapper, retryPredicate);
   }
 
   @Override

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
@@ -73,7 +73,11 @@ final class JobStreamImplTest {
         InProcessServerBuilder.forName(name).directExecutor().addService(service).build().start());
     client =
         new JobClientImpl(
-            asyncStub, new ZeebeClientBuilderImpl(), new ZeebeObjectMapper(), ignored -> false);
+            asyncStub,
+            null,
+            new ZeebeClientBuilderImpl(),
+            new ZeebeObjectMapper(),
+            ignored -> false);
     jobStreamer = createStreamer();
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobStreamImplTest.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.util.JsonUtil;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc;
 import io.camunda.zeebe.gateway.protocol.GatewayGrpc.GatewayImplBase;
@@ -50,6 +51,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.migrationsupport.rules.ExternalResourceSupport;
+import org.mockito.Mockito;
 
 @ExtendWith(ExternalResourceSupport.class)
 final class JobStreamImplTest {
@@ -74,7 +76,7 @@ final class JobStreamImplTest {
     client =
         new JobClientImpl(
             asyncStub,
-            null,
+            Mockito.mock(HttpClient.class),
             new ZeebeClientBuilderImpl(),
             new ZeebeObjectMapper(),
             ignored -> false);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/job/ActivateJobsRestTest.java
@@ -1,0 +1,438 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.job;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1.ActivateJobsCommandStep3;
+import io.camunda.zeebe.client.api.command.ClientException;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
+import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import io.camunda.zeebe.client.impl.response.ActivatedJobImpl;
+import io.camunda.zeebe.client.protocol.rest.ActivatedJob;
+import io.camunda.zeebe.client.protocol.rest.JobActivationRequest;
+import io.camunda.zeebe.client.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+public final class ActivateJobsRestTest extends ClientRestTest {
+
+  @Test
+  void shouldActivateJobs() {
+    // given
+    final ActivatedJob activatedJob1 =
+        new ActivatedJob()
+            .key(12L)
+            .type("foo")
+            .processInstanceKey(123L)
+            .bpmnProcessId("test1")
+            .processDefinitionVersion(2)
+            .processDefinitionKey(23L)
+            .elementId("foo")
+            .elementInstanceKey(23213L)
+            .customHeaders(singletonMap("version", "1"))
+            .worker("worker1")
+            .retries(34)
+            .deadline(1231L)
+            .variables(singletonMap("key", "val"))
+            .tenantId("test-tenant-1");
+
+    final ActivatedJob activatedJob2 =
+        new ActivatedJob()
+            .key(42L)
+            .type("foo")
+            .processInstanceKey(333L)
+            .bpmnProcessId("test3")
+            .processDefinitionVersion(23)
+            .processDefinitionKey(11L)
+            .elementId("bar")
+            .elementInstanceKey(111L)
+            .customHeaders(singletonMap("key", "value"))
+            .worker("worker1")
+            .retries(334)
+            .deadline(3131L)
+            .variables(singletonMap("bar", 3))
+            .tenantId("test-tenant-2");
+
+    gatewayService.onActivateJobsRequest(
+        new JobActivationResponse().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
+
+    // when
+    final ActivateJobsResponse response =
+        client
+            .newActivateJobsCommand()
+            .jobType("foo")
+            .maxJobsToActivate(3)
+            .timeout(Duration.ofMillis(1000))
+            .workerName("worker1")
+            .tenantIds("test-tenant-1", "test-tenant-2")
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getJobs()).hasSize(2);
+
+    io.camunda.zeebe.client.api.response.ActivatedJob job = response.getJobs().get(0);
+    assertThat(job.getKey()).isEqualTo(activatedJob1.getKey());
+    assertThat(job.getType()).isEqualTo(activatedJob1.getType());
+    assertThat(job.getBpmnProcessId()).isEqualTo(activatedJob1.getBpmnProcessId());
+    assertThat(job.getElementId()).isEqualTo(activatedJob1.getElementId());
+    assertThat(job.getElementInstanceKey()).isEqualTo(activatedJob1.getElementInstanceKey());
+    assertThat(job.getProcessDefinitionVersion())
+        .isEqualTo(activatedJob1.getProcessDefinitionVersion());
+    assertThat(job.getProcessDefinitionKey()).isEqualTo(activatedJob1.getProcessDefinitionKey());
+    assertThat(job.getProcessInstanceKey()).isEqualTo(activatedJob1.getProcessInstanceKey());
+    assertThat(job.getCustomHeaders()).isEqualTo(activatedJob1.getCustomHeaders());
+    assertThat(job.getWorker()).isEqualTo(activatedJob1.getWorker());
+    assertThat(job.getRetries()).isEqualTo(activatedJob1.getRetries());
+    assertThat(job.getDeadline()).isEqualTo(activatedJob1.getDeadline());
+    assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob1.getVariables());
+    assertThat(job.getTenantId()).isEqualTo(activatedJob1.getTenantId());
+
+    job = response.getJobs().get(1);
+    assertThat(job.getKey()).isEqualTo(activatedJob2.getKey());
+    assertThat(job.getType()).isEqualTo(activatedJob2.getType());
+    assertThat(job.getBpmnProcessId()).isEqualTo(activatedJob2.getBpmnProcessId());
+    assertThat(job.getElementId()).isEqualTo(activatedJob2.getElementId());
+    assertThat(job.getElementInstanceKey()).isEqualTo(activatedJob2.getElementInstanceKey());
+    assertThat(job.getProcessDefinitionVersion())
+        .isEqualTo(activatedJob2.getProcessDefinitionVersion());
+    assertThat(job.getProcessDefinitionKey()).isEqualTo(activatedJob2.getProcessDefinitionKey());
+    assertThat(job.getProcessInstanceKey()).isEqualTo(activatedJob2.getProcessInstanceKey());
+    assertThat(job.getCustomHeaders()).isEqualTo(activatedJob2.getCustomHeaders());
+    assertThat(job.getWorker()).isEqualTo(activatedJob2.getWorker());
+    assertThat(job.getRetries()).isEqualTo(activatedJob2.getRetries());
+    assertThat(job.getDeadline()).isEqualTo(activatedJob2.getDeadline());
+    assertThat(job.getVariablesAsMap()).isEqualTo(activatedJob2.getVariables());
+    assertThat(job.getTenantId()).isEqualTo(activatedJob2.getTenantId());
+
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+    assertThat(request.getType()).isEqualTo("foo");
+    assertThat(request.getMaxJobsToActivate()).isEqualTo(3);
+    assertThat(request.getTimeout()).isEqualTo(1000);
+    assertThat(request.getWorker()).isEqualTo("worker1");
+  }
+
+  @Test
+  void shouldSetTimeoutFromDuration() {
+    // given
+    final Duration timeout = Duration.ofMinutes(2);
+
+    // when
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .timeout(timeout)
+        .send()
+        .join();
+
+    // then
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+    assertThat(request.getTimeout()).isEqualTo(timeout.toMillis());
+  }
+
+  @Test
+  void shouldSetFetchVariables() {
+    // given
+    final List<String> fetchVariables = Arrays.asList("foo", "bar", "baz");
+
+    // when
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .fetchVariables(fetchVariables)
+        .send()
+        .join();
+
+    // then
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+
+    assertThat(request.getFetchVariable()).containsExactlyInAnyOrderElementsOf(fetchVariables);
+  }
+
+  @Test
+  void shouldSetFetchVariablesAsVargs() {
+    // given
+    final String[] fetchVariables = new String[] {"foo", "bar", "baz"};
+
+    // when
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .fetchVariables(fetchVariables)
+        .send()
+        .join();
+
+    // then
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+    assertThat(request.getFetchVariable()).containsExactlyInAnyOrder(fetchVariables);
+  }
+
+  @Test
+  void shouldSetDefaultValues() {
+    // when
+    client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
+
+    // then
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+    assertThat(request.getTimeout())
+        .isEqualTo(client.getConfiguration().getDefaultJobTimeout().toMillis());
+
+    assertThat(request.getWorker()).isEqualTo(client.getConfiguration().getDefaultJobWorkerName());
+    assertThat(request.getRequestTimeout())
+        .isEqualTo(client.getConfiguration().getDefaultRequestTimeout().toMillis());
+  }
+
+  @Test
+  void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        RestGatewayService.URL_JOB_ACTIVATION,
+        () -> new ProblemDetail().title("Invalid request").status(400));
+
+    // when
+    assertThatThrownBy(
+            () -> client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join())
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("Invalid request");
+  }
+
+  @Test
+  void shouldSetRequestTimeout() {
+    // given
+    final Duration requestTimeout = Duration.ofHours(124);
+
+    // when
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .requestTimeout(requestTimeout)
+        .send()
+        .join();
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+
+    // then
+    assertThat(request.getRequestTimeout()).isEqualTo(requestTimeout.toMillis());
+  }
+
+  @Test
+  void shouldDeserializePartiallyToPojo() {
+    // given
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("a", 1);
+    variables.put("b", 2);
+    final ActivatedJobImpl activatedJob =
+        new ActivatedJobImpl(
+            new ZeebeObjectMapper(),
+            new ActivatedJob().customHeaders(new HashMap<>()).variables(variables));
+
+    // when
+    final VariablesPojo variablesPojo = activatedJob.getVariablesAsType(VariablesPojo.class);
+
+    // then
+    assertThat(variablesPojo.getA()).isEqualTo(1);
+  }
+
+  @Test
+  void shouldAllowSpecifyingTenantIdsAsList() {
+    // given
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .tenantIds(Arrays.asList("tenant1", "tenant2"))
+        .send()
+        .join();
+
+    // when
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+
+    // then
+    assertThat(request.getTenantIds()).containsExactlyInAnyOrder("tenant1", "tenant2");
+  }
+
+  @Test
+  void shouldAllowSpecifyingTenantIdsAsVarArgs() {
+    // given
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .tenantIds("tenant1", "tenant2")
+        .send()
+        .join();
+
+    // when
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+
+    // then
+    assertThat(request.getTenantIds()).containsExactlyInAnyOrder("tenant1", "tenant2");
+  }
+
+  @Test
+  void shouldAllowSpecifyingTenantIds() {
+    // given
+    client
+        .newActivateJobsCommand()
+        .jobType("foo")
+        .maxJobsToActivate(3)
+        .tenantId("tenant1")
+        .tenantId("tenant2")
+        .tenantId("tenant2")
+        .send()
+        .join();
+
+    // when
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+
+    // then
+    assertThat(request.getTenantIds()).containsExactlyInAnyOrder("tenant1", "tenant2");
+  }
+
+  // Regression: https://github.com/camunda/zeebe/issues/17513
+  @Test
+  void shouldNotAccumulateTenantsOnSuccessiveOpen() {
+    // given
+    final ActivateJobsCommandStep3 command =
+        client
+            .newActivateJobsCommand()
+            .jobType("foo")
+            .maxJobsToActivate(3)
+            .tenantId("tenant1")
+            .tenantId("tenant2")
+            .tenantId("tenant2");
+
+    // when
+    command.send().join();
+    command.send().join();
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+
+    // then
+    assertThat(request.getTenantIds()).containsExactlyInAnyOrder("tenant1", "tenant2");
+  }
+
+  @Test
+  void shouldGetSingleVariable() {
+    // given
+    final Map<String, Object> variablesJob1 = new HashMap<>();
+    variablesJob1.put("key", "val");
+    variablesJob1.put("foo", "bar");
+    variablesJob1.put("joe", "doe");
+    final Map<String, Object> variablesJob2 = new HashMap<>();
+    variablesJob2.put("key", "val2");
+    variablesJob2.put("foo", "bar2");
+    variablesJob2.put("joe", "doe2");
+
+    final ActivatedJob activatedJob1 = new ActivatedJob().variables(variablesJob1);
+    final ActivatedJob activatedJob2 = new ActivatedJob().variables(variablesJob2);
+
+    gatewayService.onActivateJobsRequest(
+        new JobActivationResponse().addJobsItem(activatedJob1).addJobsItem(activatedJob2));
+
+    // when
+    final ActivateJobsResponse response =
+        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
+
+    assertThat(response.getJobs()).hasSize(2);
+
+    final io.camunda.zeebe.client.api.response.ActivatedJob job1 = response.getJobs().get(0);
+    assertThat(job1.getVariable("key")).isEqualTo("val");
+    assertThat(job1.getVariable("foo")).isEqualTo("bar");
+    assertThat(job1.getVariable("joe")).isEqualTo("doe");
+
+    final io.camunda.zeebe.client.api.response.ActivatedJob job2 = response.getJobs().get(1);
+    assertThat(job2.getVariable("key")).isEqualTo("val2");
+    assertThat(job2.getVariable("foo")).isEqualTo("bar2");
+    assertThat(job2.getVariable("joe")).isEqualTo("doe2");
+  }
+
+  @Test
+  void shouldThrowAnErrorIfVariableNameIsNotPresent() {
+    // given
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("key", "val");
+    variables.put("foo", "bar");
+    variables.put("joe", "doe");
+    final ActivatedJob activatedJob1 = new ActivatedJob().variables(variables);
+
+    gatewayService.onActivateJobsRequest(new JobActivationResponse().addJobsItem(activatedJob1));
+
+    // when
+    final ActivateJobsResponse response =
+        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
+
+    assertThat(response.getJobs()).hasSize(1);
+
+    assertThatThrownBy(() -> response.getJobs().get(0).getVariable("notPresentName"))
+        .isInstanceOf(ClientException.class);
+  }
+
+  @Test
+  void shouldReturnNullIfVariableValueIsNull() {
+    final Map<String, Object> variables = singletonMap("key", null);
+    // given
+    final ActivatedJob activatedJob1 = new ActivatedJob().variables(variables);
+
+    gatewayService.onActivateJobsRequest(new JobActivationResponse().addJobsItem(activatedJob1));
+
+    // when
+    final ActivateJobsResponse response =
+        client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(3).send().join();
+
+    assertThat(response.getJobs()).hasSize(1);
+
+    assertThat(response.getJobs().get(0).getVariable("key")).isNull();
+  }
+
+  @Test
+  void shouldSetDefaultWorkerNameWhenMissingInCommand() {
+    // when
+    client.newActivateJobsCommand().jobType("foo").maxJobsToActivate(1).send().join();
+
+    // then
+    final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
+    assertThat(request.getWorker()).isEqualTo(ZeebeClientBuilderImpl.DEFAULT_JOB_WORKER_NAME);
+  }
+
+  private static final class VariablesPojo {
+
+    int a;
+
+    public int getA() {
+      return a;
+    }
+
+    public VariablesPojo setA(final int a) {
+      this.a = a;
+      return this;
+    }
+  }
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -39,8 +39,7 @@ paths:
         - Job
       summary: Activate jobs
       description: |
-        Iterate through all known partitions and activate up to the requested maximum and
-        stream them back to the client as they are activated.
+        Iterate through all known partitions and activate jobs up to the requested maximum.
       requestBody:
         required: true
         content:

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/ActivateJobsTest.java
@@ -9,72 +9,73 @@ package io.camunda.zeebe.it.client.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
+import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
-import io.camunda.zeebe.it.util.GrpcClientRule;
-import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
-public final class ActivateJobsTest {
+@ZeebeIntegration
+@AutoCloseResources
+class ActivateJobsTest {
 
-  private static final EmbeddedBrokerRule BROKER_RULE =
-      new EmbeddedBrokerRule(ActivateJobsTest::disableLongPolling);
-  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+  @AutoCloseResource ZeebeClient client;
 
-  @ClassRule
-  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+  @TestZeebe
+  final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withGatewayConfig(c -> c.getLongPolling().setEnabled(false));
 
-  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  ZeebeResourcesHelper resourcesHelper;
 
-  private String jobType;
-
-  private static void disableLongPolling(final BrokerCfg config) {
-    config.getGateway().getLongPolling().setEnabled(false);
+  @BeforeEach
+  void initClientAndInstances() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
   }
 
-  @Before
-  public void init() {
-    jobType = helper.getJobType();
-  }
-
-  @Test(timeout = 5000)
-  public void shouldRespondActivatedJobsWhenJobsAreAvailable() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldRespondActivatedJobsWhenJobsAreAvailable(
+      final boolean useRest, final TestInfo testInfo) {
     // given
-    CLIENT_RULE.createJobs(jobType, 2);
+    final String jobType = "job-" + testInfo.getDisplayName();
+    resourcesHelper.createJobs(jobType, 2);
 
     // when
     final ZeebeFuture<ActivateJobsResponse> responseFuture =
-        CLIENT_RULE
-            .getClient()
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(2)
-            .send();
+        getCommand(client, useRest).jobType(jobType).maxJobsToActivate(2).send();
 
     // then
     final ActivateJobsResponse response = responseFuture.join();
     assertThat(response.getJobs()).hasSize(2);
   }
 
-  @Test(timeout = 5000)
-  public void shouldRespondNoActivatedJobsWhenNoJobsAvailable() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldRespondNoActivatedJobsWhenNoJobsAvailable(final boolean useRest) {
     // when
     final ZeebeFuture<ActivateJobsResponse> responseFuture =
-        CLIENT_RULE
-            .getClient()
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(1)
-            .send();
+        getCommand(client, useRest).jobType("notExisting").maxJobsToActivate(1).send();
 
     // then
     final ActivateJobsResponse response = responseFuture.join();
     assertThat(response.getJobs()).isEmpty();
+  }
+
+  private ActivateJobsCommandStep1 getCommand(final ZeebeClient client, final boolean useRest) {
+    final ActivateJobsCommandStep1 activateJobsCommandStep1 = client.newActivateJobsCommand();
+    return useRest ? activateJobsCommandStep1.useRest() : activateJobsCommandStep1.useGrpc();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -65,8 +65,10 @@ public class LongPollingActivateJobsTest {
     assertThat(response.getJobs()).hasSize(activateJobs);
   }
 
+  // TODO: the REST use case is currently not working, see
+  // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
+  @ValueSource(booleans = {false})
   public void shouldActivateJobsIfBatchIsTruncated(final boolean useRest, final TestInfo testInfo) {
     // given
     final int availableJobs = 10;
@@ -105,8 +107,10 @@ public class LongPollingActivateJobsTest {
     assertThat(response.getJobs()).hasSize(expectedJobsCount);
   }
 
+  // TODO: the REST use case is currently not working, see
+  // https://github.com/camunda/camunda/issues/19883
   @ParameterizedTest
-  @ValueSource(booleans = {true, false})
+  @ValueSource(booleans = {false})
   public void shouldActivateJobForOpenRequest(final boolean useRest, final TestInfo testInfo)
       throws InterruptedException {
     // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/LongPollingActivateJobsTest.java
@@ -9,154 +9,142 @@ package io.camunda.zeebe.it.client.command;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
-import io.camunda.zeebe.broker.test.EmbeddedBrokerRule;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.ActivateJobsCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivateJobsResponse;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
-import io.camunda.zeebe.it.util.GrpcClientRule;
-import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
-import io.netty.util.NetUtil;
-import org.junit.Before;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.RuleChain;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+@ZeebeIntegration
+@AutoCloseResources
 public class LongPollingActivateJobsTest {
 
-  private static final EmbeddedBrokerRule BROKER_RULE =
-      new EmbeddedBrokerRule(LongPollingActivateJobsTest::enableLongPolling);
-  private static final GrpcClientRule CLIENT_RULE = new GrpcClientRule(BROKER_RULE);
+  @AutoCloseResource ZeebeClient client;
 
-  @ClassRule
-  public static RuleChain ruleChain = RuleChain.outerRule(BROKER_RULE).around(CLIENT_RULE);
+  @TestZeebe
+  final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker()
+          .withRecordingExporter(true)
+          .withGatewayConfig(c -> c.getLongPolling().setEnabled(true));
 
-  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+  ZeebeResourcesHelper resourcesHelper;
 
-  private String jobType;
-
-  private static void enableLongPolling(final BrokerCfg config) {
-    config.getGateway().getLongPolling().setEnabled(true);
+  @BeforeEach
+  void initClientAndInstances() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
   }
 
-  @Before
-  public void init() {
-    jobType = helper.getJobType();
-  }
-
-  @Test
-  public void shouldActivateJobsRespectingAmountLimit() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldActivateJobsRespectingAmountLimit(
+      final boolean useRest, final TestInfo testInfo) {
     // given
     final int availableJobs = 3;
     final int activateJobs = 2;
 
-    CLIENT_RULE.createJobs(jobType, availableJobs);
+    final String jobType = "job-" + testInfo.getDisplayName();
+    resourcesHelper.createJobs(jobType, availableJobs);
 
     // when
     final ActivateJobsResponse response =
-        CLIENT_RULE
-            .getClient()
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(activateJobs)
-            .send()
-            .join();
+        getCommand(client, useRest).jobType(jobType).maxJobsToActivate(activateJobs).send().join();
 
     // then
     assertThat(response.getJobs()).hasSize(activateJobs);
   }
 
-  @Test
-  public void shouldActivateJobsIfBatchIsTruncated() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldActivateJobsIfBatchIsTruncated(final boolean useRest, final TestInfo testInfo) {
     // given
     final int availableJobs = 10;
 
-    final int maxMessageSize =
-        (int) BROKER_RULE.getBrokerCfg().getNetwork().getMaxMessageSizeInBytes();
+    final int maxMessageSize = (int) zeebe.brokerConfig().getNetwork().getMaxMessageSizeInBytes();
     final var largeVariableValue = "x".repeat(maxMessageSize / 4);
     final String variablesJson = String.format("{\"variablesJson\":\"%s\"}", largeVariableValue);
 
-    CLIENT_RULE.createJobs(jobType, b -> {}, variablesJson, availableJobs);
+    final String jobType = "job-" + testInfo.getDisplayName();
+    resourcesHelper.createJobs(jobType, b -> {}, variablesJson, availableJobs);
 
     // when
     final var response =
-        CLIENT_RULE
-            .getClient()
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(availableJobs)
-            .send()
-            .join();
+        getCommand(client, useRest).jobType(jobType).maxJobsToActivate(availableJobs).send().join();
 
     // then
     assertThat(response.getJobs()).hasSize(availableJobs);
   }
 
-  @Test
-  public void shouldWaitUntilJobsAvailable() {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldWaitUntilJobsAvailable(final boolean useRest, final TestInfo testInfo) {
     // given
     final int expectedJobsCount = 1;
 
+    final String jobType = "job-" + testInfo.getDisplayName();
+
     final ZeebeFuture<ActivateJobsResponse> responseFuture =
-        CLIENT_RULE
-            .getClient()
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(expectedJobsCount)
-            .send();
+        getCommand(client, useRest).jobType(jobType).maxJobsToActivate(expectedJobsCount).send();
 
     // when
-    CLIENT_RULE.createSingleJob(jobType);
+    resourcesHelper.createSingleJob(jobType);
 
     // then
     final ActivateJobsResponse response = responseFuture.join();
     assertThat(response.getJobs()).hasSize(expectedJobsCount);
   }
 
-  @Test
-  public void shouldActivatedJobForOpenRequest() throws InterruptedException {
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void shouldActivateJobForOpenRequest(final boolean useRest, final TestInfo testInfo)
+      throws InterruptedException {
     // given
-    sendActivateRequestsAndClose(jobType, 3);
+    final String jobType = "job-" + testInfo.getDisplayName();
+
+    sendActivateRequestsAndClose(useRest, jobType);
 
     final var activateJobsResponse =
-        CLIENT_RULE
-            .getClient()
-            .newActivateJobsCommand()
-            .jobType(jobType)
-            .maxJobsToActivate(5)
-            .workerName("open")
-            .send();
+        getCommand(client, useRest).jobType(jobType).maxJobsToActivate(5).workerName("open").send();
 
-    sendActivateRequestsAndClose(jobType, 3);
+    sendActivateRequestsAndClose(useRest, jobType);
 
     // when
-    CLIENT_RULE.createSingleJob(jobType);
+    resourcesHelper.createSingleJob(jobType);
 
     // then
     final var jobs = activateJobsResponse.join().getJobs();
     assertThat(jobs).hasSize(1).extracting(ActivatedJob::getWorker).contains("open");
   }
 
-  private void sendActivateRequestsAndClose(final String jobType, final int count)
-      throws InterruptedException {
-    for (int i = 0; i < count; i++) {
-      final ZeebeClient client =
-          ZeebeClient.newClientBuilder()
-              .gatewayAddress(NetUtil.toSocketAddressString(BROKER_RULE.getGatewayAddress()))
-              .usePlaintext()
-              .build();
+  private ActivateJobsCommandStep1 getCommand(final ZeebeClient client, final boolean useRest) {
+    final ActivateJobsCommandStep1 activateJobsCommandStep1 = client.newActivateJobsCommand();
+    return useRest ? activateJobsCommandStep1.useRest() : activateJobsCommandStep1.useGrpc();
+  }
 
-      client
-          .newActivateJobsCommand()
+  private void sendActivateRequestsAndClose(final boolean useRest, final String jobType)
+      throws InterruptedException {
+    for (int i = 0; i < 3; i++) {
+      final ZeebeClient tempClient = zeebe.newClientBuilder().usePlaintext().build();
+
+      getCommand(tempClient, useRest)
           .jobType(jobType)
           .maxJobsToActivate(5)
           .workerName("closed-" + i)
           .send();
 
       Thread.sleep(100);
-      client.close();
+      tempClient.close();
     }
   }
 }


### PR DESCRIPTION
## Description

The Java client's job activation command supports sending requests over REST, additionally
to sending it over gRPC. By default, it's sent over gRPC unless either the client is configured
to prefer REST over gRPC in general or the command is explicitly sent over REST by calling `useRest`.

## Related issues

closes #18256 
