### PR TITLE
fix: create migration plan without using Spring bean factory

### DIFF
--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ReindexIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/elasticsearch/ReindexIT.java
@@ -11,8 +11,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.operate.conditions.DatabaseInfo;
 import io.camunda.operate.schema.SchemaManager;
+import io.camunda.operate.schema.migration.MigrationPlanFactory;
 import io.camunda.operate.schema.migration.Plan;
-import io.camunda.operate.schema.migration.ReindexPlan;
 import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
 import io.camunda.operate.util.searchrepository.TestSearchRepository;
 import java.util.List;
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,7 +30,7 @@ public class ReindexIT extends OperateSearchAbstractIT {
   private String indexPrefix;
   @Autowired private SchemaManager schemaManager;
   @Autowired private TestSearchRepository searchRepository;
-  @Autowired private BeanFactory beanFactory;
+  @Autowired private MigrationPlanFactory migrationPlanFactory;
 
   @Override
   protected void runAdditionalBeforeEachSetup() throws Exception {
@@ -57,8 +56,8 @@ public class ReindexIT extends OperateSearchAbstractIT {
     schemaManager.refresh(idxName("index-*"));
 
     final Plan plan =
-        beanFactory
-            .getBean(ReindexPlan.class)
+        migrationPlanFactory
+            .createReindexPlan()
             .setSrcIndex(idxName("index-1.2.3"))
             .setDstIndex(idxName("index-1.2.4"));
 

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/schema/SchemaStartupIT.java
@@ -20,9 +20,9 @@ import io.camunda.operate.schema.IndexMapping.IndexMappingProperty;
 import io.camunda.operate.schema.elasticsearch.ElasticsearchSchemaManager;
 import io.camunda.operate.schema.indices.MigrationRepositoryIndex;
 import io.camunda.operate.schema.migration.Migrator;
-import io.camunda.operate.schema.migration.elasticsearch.ElasticsearchFillPostImporterQueuePlan;
+import io.camunda.operate.schema.migration.elasticsearch.ElasticsearchMigrationPlanFactory;
 import io.camunda.operate.schema.migration.elasticsearch.ElasticsearchStepsRepository;
-import io.camunda.operate.schema.opensearch.OpensearchFillPostImporterQueuePlan;
+import io.camunda.operate.schema.opensearch.OpensearchMigrationPlanFactory;
 import io.camunda.operate.schema.opensearch.OpensearchSchemaManager;
 import io.camunda.operate.schema.opensearch.OpensearchStepsRepository;
 import io.camunda.operate.schema.templates.IncidentTemplate;
@@ -49,14 +49,14 @@ import org.springframework.test.context.ContextConfiguration;
     classes = {
       IndexSchemaValidator.class,
       Migrator.class,
+      ElasticsearchMigrationPlanFactory.class,
       ElasticsearchStepsRepository.class,
-      ElasticsearchFillPostImporterQueuePlan.class,
       ElasticsearchSchemaManager.class,
       ElasticsearchSchemaTestHelper.class,
       ElasticsearchTaskStore.class,
       TestElasticsearchConnector.class,
+      OpensearchMigrationPlanFactory.class,
       OpensearchStepsRepository.class,
-      OpensearchFillPostImporterQueuePlan.class,
       OpensearchSchemaManager.class,
       OpenSearchSchemaTestHelper.class,
       OpensearchTaskStore.class,

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/MigrationPlanFactory.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/MigrationPlanFactory.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.schema.migration;
+
+public interface MigrationPlanFactory {
+
+  FillPostImporterQueuePlan createFillPostImporterQueuePlan();
+
+  ReindexPlan createReindexPlan();
+
+  ReindexWithQueryAndScriptPlan createReindexWithQueryAndScriptPlan();
+}

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/Migrator.java
@@ -32,7 +32,6 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -65,7 +64,7 @@ public class Migrator {
 
   @Autowired private IndexSchemaValidator indexSchemaValidator;
 
-  @Autowired private BeanFactory beanFactory;
+  @Autowired private MigrationPlanFactory migrationPlanFactory;
 
   @Bean("migrationThreadPoolExecutor")
   public ThreadPoolTaskExecutor getTaskExecutor() {
@@ -263,10 +262,10 @@ public class Migrator {
           "Migration plan contains steps that can't be applied together. Check your upgrade path.");
     }
     if (onlyAffectedVersions.size() == 0) {
-      final ReindexPlan reindexPlan = beanFactory.getBean(ReindexPlan.class);
+      final ReindexPlan reindexPlan = migrationPlanFactory.createReindexPlan();
       return reindexPlan.setSrcIndex(srcIndex).setDstIndex(dstIndex);
     } else if (onlyAffectedVersions.get(0) instanceof ProcessorStep) {
-      final ReindexPlan reindexPlan = beanFactory.getBean(ReindexPlan.class);
+      final ReindexPlan reindexPlan = migrationPlanFactory.createReindexPlan();
       return reindexPlan.setSrcIndex(srcIndex).setDstIndex(dstIndex).setSteps(onlyAffectedVersions);
     } else if (onlyAffectedVersions.get(0) instanceof SetBpmnProcessIdStep
         && onlyAffectedVersions.size() == 1) {
@@ -275,7 +274,7 @@ public class Migrator {
       final String listViewIndexName =
           String.format("%s-%s", indexPrefix, listViewTemplate.getIndexName());
       final ReindexWithQueryAndScriptPlan reindexPlan =
-          beanFactory.getBean(ReindexWithQueryAndScriptPlan.class);
+          migrationPlanFactory.createReindexWithQueryAndScriptPlan();
       return reindexPlan
           .setSrcIndex(srcIndex)
           .setDstIndex(dstIndex)
@@ -284,7 +283,7 @@ public class Migrator {
     } else if (onlyAffectedVersions.get(0) instanceof FillPostImporterQueueStep
         && onlyAffectedVersions.size() == 1) {
       final FillPostImporterQueuePlan fillPostImporterQueuePlan =
-          beanFactory.getBean(FillPostImporterQueuePlan.class);
+          migrationPlanFactory.createFillPostImporterQueuePlan();
       return fillPostImporterQueuePlan
           .setListViewIndexName(
               String.format("%s-%s", indexPrefix, listViewTemplate.getIndexName()))

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchFillPostImporterQueuePlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchFillPostImporterQueuePlan.java
@@ -14,10 +14,8 @@ import static io.camunda.operate.util.ElasticsearchUtil.scroll;
 import static io.camunda.operate.util.LambdaExceptionUtil.rethrowConsumer;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.entities.IncidentEntity;
 import io.camunda.operate.entities.post.PostImporterActionType;
 import io.camunda.operate.entities.post.PostImporterQueueEntity;
@@ -46,29 +44,16 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
-@Component
-@Conditional(ElasticsearchCondition.class)
-@Scope(SCOPE_PROTOTYPE)
 public class ElasticsearchFillPostImporterQueuePlan implements FillPostImporterQueuePlan {
 
   private static final Logger LOGGER =
       LoggerFactory.getLogger(ElasticsearchFillPostImporterQueuePlan.class);
 
-  @Autowired private OperateProperties operateProperties;
-
-  @Autowired private MigrationProperties migrationProperties;
-
-  @Autowired
-  @Qualifier("operateObjectMapper")
-  private ObjectMapper objectMapper;
-
-  @Autowired private RestHighLevelClient esClient;
+  private final OperateProperties operateProperties;
+  private final MigrationProperties migrationProperties;
+  private final ObjectMapper objectMapper;
+  private final RestHighLevelClient esClient;
 
   private Long flowNodesWithIncidentsCount;
   private List<Step> steps;
@@ -76,6 +61,17 @@ public class ElasticsearchFillPostImporterQueuePlan implements FillPostImporterQ
   private String listViewIndexName;
   private String incidentsIndexName;
   private String postImporterQueueIndexName;
+
+  public ElasticsearchFillPostImporterQueuePlan(
+      final OperateProperties operateProperties,
+      final MigrationProperties migrationProperties,
+      final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient) {
+    this.operateProperties = operateProperties;
+    this.migrationProperties = migrationProperties;
+    this.objectMapper = objectMapper;
+    this.esClient = esClient;
+  }
 
   @Override
   public FillPostImporterQueuePlan setListViewIndexName(String listViewIndexName) {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchMigrationPlanFactory.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchMigrationPlanFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.schema.migration.elasticsearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.conditions.ElasticsearchCondition;
+import io.camunda.operate.property.MigrationProperties;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.migration.FillPostImporterQueuePlan;
+import io.camunda.operate.schema.migration.MigrationPlanFactory;
+import io.camunda.operate.schema.migration.ReindexPlan;
+import io.camunda.operate.schema.migration.ReindexWithQueryAndScriptPlan;
+import io.camunda.operate.store.elasticsearch.RetryElasticsearchClient;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(ElasticsearchCondition.class)
+public class ElasticsearchMigrationPlanFactory implements MigrationPlanFactory {
+
+  private final OperateProperties operateProperties;
+  private final MigrationProperties migrationProperties;
+  private final ObjectMapper objectMapper;
+  private final RetryElasticsearchClient retryElasticsearchClient;
+  private final RestHighLevelClient esClient;
+
+  @Autowired
+  public ElasticsearchMigrationPlanFactory(
+      final OperateProperties operateProperties,
+      final MigrationProperties migrationProperties,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
+      final RetryElasticsearchClient retryElasticsearchClient,
+      final RestHighLevelClient esClient) {
+    this.operateProperties = operateProperties;
+    this.migrationProperties = migrationProperties;
+    this.objectMapper = objectMapper;
+    this.retryElasticsearchClient = retryElasticsearchClient;
+    this.esClient = esClient;
+  }
+
+  @Override
+  public FillPostImporterQueuePlan createFillPostImporterQueuePlan() {
+    return new ElasticsearchFillPostImporterQueuePlan(
+        operateProperties, migrationProperties, objectMapper, esClient);
+  }
+
+  @Override
+  public ReindexPlan createReindexPlan() {
+    return new ElasticsearchPipelineReindexPlan(retryElasticsearchClient, migrationProperties);
+  }
+
+  @Override
+  public ReindexWithQueryAndScriptPlan createReindexWithQueryAndScriptPlan() {
+    return new ElasticsearchReindexWithQueryAndScriptPlan(
+        migrationProperties, objectMapper, esClient, retryElasticsearchClient);
+  }
+}

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchPipelineReindexPlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchPipelineReindexPlan.java
@@ -8,9 +8,7 @@
 package io.camunda.operate.schema.migration.elasticsearch;
 
 import static io.camunda.operate.util.CollectionUtil.*;
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
-import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.MigrationException;
 import io.camunda.operate.property.MigrationProperties;
 import io.camunda.operate.schema.SchemaManager;
@@ -24,10 +22,6 @@ import java.util.Optional;
 import org.elasticsearch.index.reindex.ReindexRequest;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptType;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 /**
  * A plan implemented as reindex request in elasticsearch.<br>
@@ -35,9 +29,6 @@ import org.springframework.stereotype.Component;
  * Steps that will be added are elasticsearch ingest processors.<br>
  * The steps will be applied in the order they were added.<br>
  */
-@Component
-@Conditional(ElasticsearchCondition.class)
-@Scope(SCOPE_PROTOTYPE)
 public class ElasticsearchPipelineReindexPlan extends PipelineReindexPlan implements ReindexPlan {
 
   private final RetryElasticsearchClient retryElasticsearchClient;
@@ -45,7 +36,6 @@ public class ElasticsearchPipelineReindexPlan extends PipelineReindexPlan implem
   private final MigrationProperties migrationProperties;
   private Script script;
 
-  @Autowired
   public ElasticsearchPipelineReindexPlan(
       final RetryElasticsearchClient retryElasticsearchClient,
       final MigrationProperties migrationProperties) {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchReindexWithQueryAndScriptPlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchReindexWithQueryAndScriptPlan.java
@@ -14,11 +14,9 @@ import static io.camunda.operate.schema.templates.ListViewTemplate.PROCESS_KEY;
 import static io.camunda.operate.util.ElasticsearchUtil.scroll;
 import static io.camunda.operate.util.LambdaExceptionUtil.rethrowConsumer;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.operate.conditions.ElasticsearchCondition;
 import io.camunda.operate.exceptions.MigrationException;
 import io.camunda.operate.property.MigrationProperties;
 import io.camunda.operate.schema.SchemaManager;
@@ -37,19 +35,11 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
 /**
  * This migration plan scrolls the srcIndex, get additional data from list-view index and reindex
  * the batch of source data combining data from source index and list-view.
  */
-@Component
-@Conditional(ElasticsearchCondition.class)
-@Scope(SCOPE_PROTOTYPE)
 public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQueryAndScriptPlan {
 
   private static final Logger LOGGER =
@@ -58,16 +48,25 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
   private String srcIndex;
   private String dstIndex;
 
-  @Autowired private MigrationProperties migrationProperties;
+  private final MigrationProperties migrationProperties;
   private String listViewIndexName;
 
-  @Autowired
-  @Qualifier("operateObjectMapper")
-  private ObjectMapper objectMapper;
+  private final ObjectMapper objectMapper;
 
-  @Autowired private RestHighLevelClient esClient;
+  private final RestHighLevelClient esClient;
 
-  @Autowired private RetryElasticsearchClient retryElasticsearchClient;
+  private final RetryElasticsearchClient retryElasticsearchClient;
+
+  public ElasticsearchReindexWithQueryAndScriptPlan(
+      final MigrationProperties migrationProperties,
+      final ObjectMapper objectMapper,
+      RestHighLevelClient esClient,
+      final RetryElasticsearchClient retryElasticsearchClient) {
+    this.migrationProperties = migrationProperties;
+    this.objectMapper = objectMapper;
+    this.esClient = esClient;
+    this.retryElasticsearchClient = retryElasticsearchClient;
+  }
 
   @Override
   public ReindexWithQueryAndScriptPlan setSrcIndex(String srcIndex) {

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchFillPostImporterQueuePlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchFillPostImporterQueuePlan.java
@@ -12,10 +12,8 @@ import static io.camunda.operate.schema.templates.ListViewTemplate.JOIN_RELATION
 import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.searchRequestBuilder;
 import static io.camunda.operate.util.LambdaExceptionUtil.rethrowConsumer;
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.entities.IncidentEntity;
 import io.camunda.operate.entities.post.PostImporterActionType;
 import io.camunda.operate.entities.post.PostImporterQueueEntity;
@@ -33,14 +31,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
-@Component
-@Conditional(OpensearchCondition.class)
-@Scope(SCOPE_PROTOTYPE)
 public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueuePlan {
 
   private static final Logger LOGGER =
@@ -61,7 +52,6 @@ public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueu
   private String incidentsIndexName;
   private String postImporterQueueIndexName;
 
-  @Autowired
   public OpensearchFillPostImporterQueuePlan(
       final RichOpenSearchClient richOpenSearchClient,
       final ObjectMapper objectMapper,

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchMigrationPlanFactory.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchMigrationPlanFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.schema.opensearch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.conditions.OpensearchCondition;
+import io.camunda.operate.property.MigrationProperties;
+import io.camunda.operate.property.OperateProperties;
+import io.camunda.operate.schema.migration.FillPostImporterQueuePlan;
+import io.camunda.operate.schema.migration.MigrationPlanFactory;
+import io.camunda.operate.schema.migration.ReindexPlan;
+import io.camunda.operate.schema.migration.ReindexWithQueryAndScriptPlan;
+import io.camunda.operate.store.opensearch.client.sync.RichOpenSearchClient;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.stereotype.Component;
+
+@Component
+@Conditional(OpensearchCondition.class)
+public class OpensearchMigrationPlanFactory implements MigrationPlanFactory {
+
+  private final OperateProperties operateProperties;
+  private final MigrationProperties migrationProperties;
+  private final ObjectMapper objectMapper;
+  private final RichOpenSearchClient richOpenSearchClient;
+
+  @Autowired
+  public OpensearchMigrationPlanFactory(
+      final OperateProperties operateProperties,
+      final MigrationProperties migrationProperties,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
+      final RichOpenSearchClient richOpenSearchClient) {
+    this.operateProperties = operateProperties;
+    this.migrationProperties = migrationProperties;
+    this.objectMapper = objectMapper;
+    this.richOpenSearchClient = richOpenSearchClient;
+  }
+
+  @Override
+  public FillPostImporterQueuePlan createFillPostImporterQueuePlan() {
+    return new OpensearchFillPostImporterQueuePlan(
+        richOpenSearchClient, objectMapper, operateProperties, migrationProperties);
+  }
+
+  @Override
+  public ReindexPlan createReindexPlan() {
+    return new OpensearchPipelineReindexPlan(richOpenSearchClient, migrationProperties);
+  }
+
+  @Override
+  public ReindexWithQueryAndScriptPlan createReindexWithQueryAndScriptPlan() {
+    return new OpensearchReindexWithQueryAndScriptPlan(richOpenSearchClient, migrationProperties);
+  }
+}

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchPipelineReindexPlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchPipelineReindexPlan.java
@@ -8,9 +8,7 @@
 package io.camunda.operate.schema.opensearch;
 
 import static io.camunda.operate.util.CollectionUtil.map;
-import static org.springframework.beans.factory.config.BeanDefinition.SCOPE_PROTOTYPE;
 
-import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.exceptions.MigrationException;
 import io.camunda.operate.property.MigrationProperties;
 import io.camunda.operate.schema.SchemaManager;
@@ -28,25 +26,16 @@ import org.opensearch.client.opensearch._types.Script;
 import org.opensearch.client.opensearch.core.ReindexRequest;
 import org.opensearch.client.opensearch.core.reindex.Destination;
 import org.opensearch.client.opensearch.core.reindex.Source;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
-@Component
-@Conditional(OpensearchCondition.class)
-@Scope(SCOPE_PROTOTYPE)
 public class OpensearchPipelineReindexPlan extends PipelineReindexPlan implements ReindexPlan {
 
   private final RichOpenSearchClient richOpenSearchClient;
   private final MigrationProperties migrationProperties;
   private Script script;
 
-  @Autowired
   public OpensearchPipelineReindexPlan(
       final RichOpenSearchClient richOpenSearchClient,
       final MigrationProperties migrationProperties) {
-    super();
     this.richOpenSearchClient = richOpenSearchClient;
     this.migrationProperties = migrationProperties;
   }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchReindexWithQueryAndScriptPlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchReindexWithQueryAndScriptPlan.java
@@ -15,7 +15,6 @@ import static io.camunda.operate.store.opensearch.dsl.QueryDSL.*;
 import static io.camunda.operate.store.opensearch.dsl.RequestDSL.*;
 import static io.camunda.operate.util.LambdaExceptionUtil.rethrowConsumer;
 
-import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.exceptions.MigrationException;
 import io.camunda.operate.property.MigrationProperties;
 import io.camunda.operate.schema.SchemaManager;
@@ -35,15 +34,7 @@ import org.opensearch.client.opensearch.core.reindex.Source;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.config.BeanDefinition;
-import org.springframework.context.annotation.Conditional;
-import org.springframework.context.annotation.Scope;
-import org.springframework.stereotype.Component;
 
-@Component
-@Conditional(OpensearchCondition.class)
-@Scope(BeanDefinition.SCOPE_PROTOTYPE)
 public class OpensearchReindexWithQueryAndScriptPlan implements ReindexWithQueryAndScriptPlan {
 
   private static final Logger LOGGER =
@@ -55,7 +46,6 @@ public class OpensearchReindexWithQueryAndScriptPlan implements ReindexWithQuery
   private String dstIndex;
   private String listViewIndexName;
 
-  @Autowired
   public OpensearchReindexWithQueryAndScriptPlan(
       final RichOpenSearchClient richOpenSearchClient,
       final MigrationProperties migrationProperties) {


### PR DESCRIPTION
## Description

Based on #19086, the migration procedure might result in a deadlock waiting for a lock which is hold by the `main` thread during Spring bean initialization. With this PR, the migration plans are initiated by migration plan factory instead of using the Spring bean factory. 

## Related issues

closes #
