### PR TITLE
refactor: move RequestIdGenerator instantiation to be a broker startup step

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import java.time.Duration;
 import java.util.List;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 
 /**
  * Context that is utilized during broker startup and shutdown process. It contains dependencies
@@ -112,4 +113,8 @@ public interface BrokerStartupContext {
   BrokerClient getBrokerClient();
 
   Duration getShutdownTimeout();
+
+  SnowflakeIdGenerator getRequestIdGenerator();
+
+  void setRequestIdGenerator(SnowflakeIdGenerator requestIdGenerator);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContextImpl.java
@@ -36,6 +36,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 
 public final class BrokerStartupContextImpl implements BrokerStartupContext {
 
@@ -55,6 +56,7 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   private ConcurrencyControl concurrencyControl;
   private DiskSpaceUsageMonitor diskSpaceUsageMonitor;
   private AtomixServerTransport gatewayBrokerTransport;
+  private SnowflakeIdGenerator requestIdGenerator;
   private ManagedMessagingService commandApiMessagingService;
   private CommandApiServiceImpl commandApiService;
   private AdminApiRequestHandler adminApiService;
@@ -309,5 +311,15 @@ public final class BrokerStartupContextImpl implements BrokerStartupContext {
   @Override
   public Duration getShutdownTimeout() {
     return shutdownTimeout;
+  }
+
+  @Override
+  public SnowflakeIdGenerator getRequestIdGenerator() {
+    return requestIdGenerator;
+  }
+
+  @Override
+  public void setRequestIdGenerator(final SnowflakeIdGenerator requestIdGenerator) {
+    this.requestIdGenerator = requestIdGenerator;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupProcess.java
@@ -55,6 +55,7 @@ public final class BrokerStartupProcess {
     result.add(new MonitoringServerStep());
 
     result.add(new ApiMessagingServiceStep());
+    result.add(new RequestIdGeneratorStep());
     result.add(new GatewayBrokerTransportStep());
     result.add(new CommandApiServiceStep());
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/GatewayBrokerTransportStep.java
@@ -40,12 +40,12 @@ final class GatewayBrokerTransportStep extends AbstractBrokerStartupStep {
       final ActorFuture<BrokerStartupContext> startupFuture) {
 
     final var concurrencyControl = brokerStartupContext.getConcurrencyControl();
-    final var brokerInfo = brokerStartupContext.getBrokerInfo();
     final var schedulingService = brokerStartupContext.getActorSchedulingService();
     final var messagingService = brokerStartupContext.getApiMessagingService();
+    final var requestIdGenerator = brokerStartupContext.getRequestIdGenerator();
 
     final var atomixServerTransport =
-        new AtomixServerTransport(messagingService, brokerInfo.getNodeId());
+        new AtomixServerTransport(messagingService, requestIdGenerator);
 
     concurrencyControl.runOnCompletion(
         schedulingService.submitActor(atomixServerTransport),

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStep.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.bootstrap;
+
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.startup.StartupStep;
+import org.agrona.concurrent.SnowflakeIdGenerator;
+import org.agrona.concurrent.SystemEpochClock;
+
+public class RequestIdGeneratorStep implements StartupStep<BrokerStartupContext> {
+  // Unix epoch time for January 1, 2023 1:00:00 AM GMT+01:00
+  private static final long TIMESTAMP_OFFSET_2023 = 1672531200000L;
+
+  @Override
+  public String getName() {
+    return "Request Id Generator";
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> startup(
+      final BrokerStartupContext brokerStartupContext) {
+    final ActorFuture<BrokerStartupContext> started =
+        brokerStartupContext.getConcurrencyControl().createFuture();
+
+    final var brokerInfo = brokerStartupContext.getBrokerInfo();
+
+    final var requestIdGenerator =
+        new SnowflakeIdGenerator(
+            SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
+            SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
+            brokerInfo.getNodeId(),
+            TIMESTAMP_OFFSET_2023,
+            SystemEpochClock.INSTANCE);
+
+    brokerStartupContext.setRequestIdGenerator(requestIdGenerator);
+    started.complete(brokerStartupContext);
+    return started;
+  }
+
+  @Override
+  public ActorFuture<BrokerStartupContext> shutdown(
+      final BrokerStartupContext brokerStartupContext) {
+    final ActorFuture<BrokerStartupContext> stopFuture =
+        brokerStartupContext.getConcurrencyControl().createFuture();
+
+    brokerStartupContext.setRequestIdGenerator(null);
+
+    stopFuture.complete(brokerStartupContext);
+    return stopFuture;
+  }
+}

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/bootstrap/RequestIdGeneratorStepTest.java
@@ -9,10 +9,9 @@ package io.camunda.zeebe.broker.bootstrap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import io.camunda.zeebe.broker.SpringBrokerBridge;
@@ -25,45 +24,40 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
-import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.Random;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class GatewayBrokerTransportStepTest {
+class RequestIdGeneratorStepTest {
   private static final Duration TEST_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
-  private static final TestConcurrencyControl CONCURRENCY_CONTROL = new TestConcurrencyControl();
   private static final BrokerCfg TEST_BROKER_CONFIG = new BrokerCfg();
   private static final Duration TIME_OUT = Duration.ofSeconds(10);
-
-  private final ActorScheduler mockActorSchedulingService = mock(ActorScheduler.class);
-
   private BrokerStartupContextImpl testBrokerStartupContext;
   private final BrokerInfo mockBrokerInfo = mock(BrokerInfo.class);
+  private final TestConcurrencyControl spyConcurrencyControl = spy(new TestConcurrencyControl());
 
-  private final GatewayBrokerTransportStep sut = new GatewayBrokerTransportStep();
+  private final RequestIdGeneratorStep sut = new RequestIdGeneratorStep();
 
   @BeforeEach
   void setUp() {
-    when(mockActorSchedulingService.submitActor(any()))
-        .thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
 
     testBrokerStartupContext =
         new BrokerStartupContextImpl(
             mockBrokerInfo,
             TEST_BROKER_CONFIG,
             mock(SpringBrokerBridge.class),
-            mockActorSchedulingService,
+            mock(ActorScheduler.class),
             mock(BrokerHealthCheckService.class),
             mock(ExporterRepository.class),
             mock(ClusterServicesImpl.class, RETURNS_DEEP_STUBS),
             mock(BrokerClient.class),
             Collections.emptyList(),
             TEST_SHUTDOWN_TIMEOUT);
-    testBrokerStartupContext.setConcurrencyControl(CONCURRENCY_CONTROL);
+    testBrokerStartupContext.setConcurrencyControl(spyConcurrencyControl);
   }
 
   @Test
@@ -72,7 +66,7 @@ class GatewayBrokerTransportStepTest {
     final var actual = sut.getName();
 
     // then
-    assertThat(actual).isSameAs("Broker Transport");
+    assertThat(actual).isSameAs("Request Id Generator");
   }
 
   @Nested
@@ -82,13 +76,14 @@ class GatewayBrokerTransportStepTest {
 
     @BeforeEach
     void setUp() {
-      startupFuture = CONCURRENCY_CONTROL.createFuture();
+      startupFuture = spyConcurrencyControl.createFuture();
+      when(spyConcurrencyControl.<BrokerStartupContext>createFuture()).thenReturn(startupFuture);
     }
 
     @Test
     void shouldCompleteFuture() {
       // when
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      sut.startup(testBrokerStartupContext);
 
       // then
       assertThat(startupFuture).succeedsWithin(TIME_OUT);
@@ -96,55 +91,49 @@ class GatewayBrokerTransportStepTest {
     }
 
     @Test
-    void shouldStartAndInstallTransport() {
+    void shouldStartAndInstallRequestIdGenerator() {
       // when
       final int randomNodeId = new Random().nextInt(10);
       when(mockBrokerInfo.getNodeId()).thenReturn(randomNodeId);
-      sut.startupInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, startupFuture);
+      sut.startup(testBrokerStartupContext);
       await().until(startupFuture::isDone);
 
       // then
-      final var transport = testBrokerStartupContext.getGatewayBrokerTransport();
+      final var requestIdGenerator = testBrokerStartupContext.getRequestIdGenerator();
 
-      assertThat(transport).isNotNull();
-      verify(mockActorSchedulingService).submitActor(transport);
+      assertThat(requestIdGenerator).isNotNull();
+      assertThat(requestIdGenerator.nodeId()).isEqualTo(randomNodeId);
     }
   }
 
   @Nested
   class ShutdownBehavior {
 
-    private AtomixServerTransport mockTransport;
-
     private ActorFuture<BrokerStartupContext> shutdownFuture;
 
     @BeforeEach
     void setUp() {
-
-      mockTransport = mock(AtomixServerTransport.class);
-      when(mockTransport.closeAsync()).thenReturn(CONCURRENCY_CONTROL.completedFuture(null));
-
-      testBrokerStartupContext.setGatewayBrokerTransport(mockTransport);
-
-      shutdownFuture = CONCURRENCY_CONTROL.createFuture();
+      final var mockIdGenerator = mock(SnowflakeIdGenerator.class);
+      testBrokerStartupContext.setRequestIdGenerator(mockIdGenerator);
+      shutdownFuture = spyConcurrencyControl.createFuture();
+      when(spyConcurrencyControl.<BrokerStartupContext>createFuture()).thenReturn(shutdownFuture);
     }
 
     @Test
-    void shouldStopAndUninstallServerTransport() {
+    void shouldStopAndUninstallRequestIdGenerator() {
       // when
-      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      sut.shutdown(testBrokerStartupContext);
       await().until(shutdownFuture::isDone);
 
       // then
-      verify(mockTransport).closeAsync();
-      final var serverTransport = testBrokerStartupContext.getGatewayBrokerTransport();
-      assertThat(serverTransport).isNull();
+      final var requestIdGenerator = testBrokerStartupContext.getRequestIdGenerator();
+      assertThat(requestIdGenerator).isNull();
     }
 
     @Test
     void shouldCompleteFuture() {
       // when
-      sut.shutdownInternal(testBrokerStartupContext, CONCURRENCY_CONTROL, shutdownFuture);
+      sut.shutdown(testBrokerStartupContext);
 
       // then
       assertThat(shutdownFuture).succeedsWithin(TIME_OUT);

--- a/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
+++ b/zeebe/protocol-test-util/src/main/java/io/camunda/zeebe/test/broker/protocol/brokerapi/StubBroker.java
@@ -26,6 +26,7 @@ import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 
 public final class StubBroker implements AutoCloseable {
 
@@ -90,7 +91,9 @@ public final class StubBroker implements AutoCloseable {
     cluster.start().join();
 
     final var transportFactory = new TransportFactory(scheduler);
-    serverTransport = transportFactory.createServerTransport(nodeId, cluster.getMessagingService());
+    final var requestIdGenerator = new SnowflakeIdGenerator(nodeId);
+    serverTransport =
+        transportFactory.createServerTransport(cluster.getMessagingService(), requestIdGenerator);
 
     channelHandler = new StubRequestHandler(msgPackHelper);
     serverTransport.subscribe(partitionId, RequestType.COMMAND, channelHandler);

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/TransportFactory.java
@@ -26,6 +26,7 @@ import io.camunda.zeebe.transport.stream.impl.RemoteStreamerImpl;
 import io.camunda.zeebe.util.buffer.BufferWriter;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
+import org.agrona.concurrent.IdGenerator;
 
 public final class TransportFactory {
 
@@ -36,8 +37,10 @@ public final class TransportFactory {
   }
 
   public ServerTransport createServerTransport(
-      final int nodeId, final MessagingService messagingService) {
-    final var atomixServerTransport = new AtomixServerTransport(messagingService, nodeId);
+      final MessagingService messagingService, final IdGenerator requestIdGenerator) {
+
+    final var atomixServerTransport =
+        new AtomixServerTransport(messagingService, requestIdGenerator);
     actorSchedulingService.submitActor(atomixServerTransport);
     return atomixServerTransport;
   }

--- a/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
+++ b/zeebe/transport/src/main/java/io/camunda/zeebe/transport/impl/AtomixServerTransport.java
@@ -19,8 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import org.agrona.collections.Int2ObjectHashMap;
 import org.agrona.collections.Long2ObjectHashMap;
 import org.agrona.concurrent.IdGenerator;
-import org.agrona.concurrent.SnowflakeIdGenerator;
-import org.agrona.concurrent.SystemEpochClock;
 import org.agrona.concurrent.UnsafeBuffer;
 import org.slf4j.Logger;
 
@@ -28,8 +26,6 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
 
   private static final Logger LOG = Loggers.TRANSPORT_LOGGER;
   private static final String API_TOPIC_FORMAT = "%s-api-%d";
-  // Unix epoch time for January 1, 2023 1:00:00 AM GMT+01:00
-  private static final long TIMESTAMP_OFFSET_2023 = 1672531200000L;
   private static final String ERROR_MSG_MISSING_PARTITON_MAP =
       "Node already unsubscribed from partition %d, this can only happen when atomix does not cleanly remove its handlers.";
 
@@ -37,18 +33,13 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
       partitionsRequestMap;
   private final MessagingService messagingService;
 
-  private final IdGenerator idGenerator;
+  private final IdGenerator requestIdGenerator;
 
-  public AtomixServerTransport(final MessagingService messagingService, final int nodeId) {
+  public AtomixServerTransport(
+      final MessagingService messagingService, final IdGenerator requestIdGenerator) {
     this.messagingService = messagingService;
+    this.requestIdGenerator = requestIdGenerator;
     partitionsRequestMap = new Int2ObjectHashMap<>();
-    this.idGenerator =
-        new SnowflakeIdGenerator(
-            SnowflakeIdGenerator.NODE_ID_BITS_DEFAULT,
-            SnowflakeIdGenerator.SEQUENCE_BITS_DEFAULT,
-            nodeId,
-            TIMESTAMP_OFFSET_2023,
-            SystemEpochClock.INSTANCE);
   }
 
   @Override
@@ -114,7 +105,7 @@ public class AtomixServerTransport extends Actor implements ServerTransport {
     final var completableFuture = new CompletableFuture<byte[]>();
     actor.call(
         () -> {
-          final long requestId = idGenerator.nextId();
+          final long requestId = requestIdGenerator.nextId();
           final var requestMap = partitionsRequestMap.get(partitionId);
           if (requestMap == null) {
             final var errorMsg = String.format(ERROR_MSG_MISSING_PARTITON_MAP, partitionId);

--- a/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
+++ b/zeebe/transport/src/test/java/io/camunda/zeebe/transport/impl/AtomixTransportTest.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import org.agrona.DirectBuffer;
 import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.SnowflakeIdGenerator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -80,6 +81,7 @@ public class AtomixTransportTest {
 
   @Parameters(name = "{0}")
   public static Collection<Object[]> data() {
+    final SnowflakeIdGenerator requestIdGenerator = new SnowflakeIdGenerator(0);
     return Arrays.asList(
         new Object[][] {
           {
@@ -92,7 +94,8 @@ public class AtomixTransportTest {
             (Function<AtomixCluster, ServerTransport>)
                 (cluster) -> {
                   final var messagingService = cluster.getMessagingService();
-                  return transportFactory.createServerTransport(0, messagingService);
+                  return transportFactory.createServerTransport(
+                      messagingService, requestIdGenerator);
                 }
           },
           {
@@ -115,7 +118,8 @@ public class AtomixTransportTest {
                     nettyMessagingService.start().join();
                   }
 
-                  return transportFactory.createServerTransport(0, nettyMessagingService);
+                  return transportFactory.createServerTransport(
+                      nettyMessagingService, requestIdGenerator);
                 }
           }
         });
@@ -426,7 +430,7 @@ public class AtomixTransportTest {
     private ServerResponseImpl serverResponse;
 
     DirectlyResponder() {
-      this.requestConsumer = (bytes -> {});
+      requestConsumer = (bytes -> {});
     }
 
     DirectlyResponder(final Consumer<byte[]> requestConsumer) {


### PR DESCRIPTION
## Description
Move RequestIdGenerator instantiation to be a broker startup step
- this way the request id generation is not an implementation detail anymore, rather an explicit part of the engine
- we can then ensure we have only one id generator per broker and hence the requestId is unique per cluster

## Related issues

closes #19339
