### PR TITLE
test: enable migration test to run

### DIFF
--- a/.github/workflows/operate-test-migrate-elasticsearch-data.yml
+++ b/.github/workflows/operate-test-migrate-elasticsearch-data.yml
@@ -7,5 +7,5 @@ jobs:
   run-migration-tests:
     uses: ./.github/workflows/operate-run-tests.yml
     with:
-      command: mvn -B -pl operate/qa/migration-tests -DskipChecks -DskipTests=false verify
+      command: mvn -B -pl operate/qa/migration-tests/migration-test -DskipChecks -DskipTests=false verify
     secrets: inherit


### PR DESCRIPTION
Currently Migration test nightly workflow in not picking any tests for execution: https://github.com/camunda/camunda/actions/runs/9494006096/job/26163628809