### PR TITLE
ci: align artifacts action versions in 8.3

### DIFF
--- a/.github/workflows/zeebe-release.yml
+++ b/.github/workflows/zeebe-release.yml
@@ -166,7 +166,7 @@ jobs:
           cp clients/go/cmd/zbctl/dist/zbctl.darwin "${ARTIFACT_DIR}/"
           echo "dir=${ARTIFACT_DIR}" >> $GITHUB_OUTPUT
       - name: Upload Zeebe Release Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts-${{ inputs.releaseVersion }}
           path: ${{ steps.release-artifacts.outputs.dir }}
@@ -352,7 +352,7 @@ jobs:
           username: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_USR }}
           password: ${{ steps.secrets.outputs.REGISTRY_HUB_DOCKER_COM_PSW }}
       - name: Download Zeebe Release Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: release-artifacts-${{ inputs.releaseVersion }}
       - name: Build Docker Image


### PR DESCRIPTION
## Description

The release workflow in 8.3 used a mix of artifacts action versions which are not compatible with each other. This would lead to failed releases and dry-runs: https://github.com/camunda/camunda/actions/runs/9492627705/job/26160407773 
