### PR TITLE
fix flaky test DeploymentClusteredTest.shouldRedistributeDeploymentWhenDeploymentPartitionIsRestarted

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeploymentClusteredTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/DeploymentClusteredTest.java
@@ -123,13 +123,7 @@ public final class DeploymentClusteredTest {
             .addProcessModel(PROCESS, "process.bpmn")
             .send()
             .join();
-    final var processDefinitionKey = deploymentEvent.getKey();
-
-    assertThat(
-            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.ACKNOWLEDGED)
-                .withDistributionPartitionId(3)
-                .findFirst())
-        .isPresent();
+    final var deploymentKey = deploymentEvent.getKey();
 
     clusteringRule.stopBroker(deploymentPartitionLeader);
     adminServiceLeaderTwo.resumeStreamProcessing();
@@ -139,10 +133,11 @@ public final class DeploymentClusteredTest {
     clusteringRule.getClock().addTime(DEPLOYMENT_REDISTRIBUTION_INTERVAL);
 
     // then
-    clientRule.waitUntilDeploymentIsDone(processDefinitionKey);
+    clientRule.waitUntilDeploymentIsDone(deploymentKey);
 
     assertThat(
             RecordingExporter.commandDistributionRecords(CommandDistributionIntent.ACKNOWLEDGED)
+                .withRecordKey(deploymentKey)
                 .withDistributionPartitionId(2)
                 .findFirst())
         .isPresent();


### PR DESCRIPTION
## Description
**Background**
Not receiving an acknowledgement command back from the partition that processed the distributed command is an expected scenario. To resolve that in production, we have a `CommandRedistributor` implemented. Every 10 seconds (with an exponential backoff), re-distributor simply re-tries the distributions that the partition didn't receive an acknowledgement back.

**Flakiness**
The logic explained above is already flaky by its nature. Simply, the partition is sometimes expected **not** to receive an acknowledgement back. This is exactly what happens in the test case. Sometimes, acknowledgement from partition 3 is not retrieved by partition 1 (deployment partition). Since the assertion waits for 5 seconds before failing, the re-distributor cannot retry the distribution in a given timeframe.

**Solution**
As a solution to that, we removed the assertion for `CommandDistributionIntent.ACKNOWLEDGED`. It is because there is already a method called `clientRule.waitUntilDeploymentIsDone()` later in the test, and it verifies if the distribution is completed within (partitionCount * 10L) seconds. Within that time frame the re-distribution can be retried and the distribution can be finished. This solution doesn't eliminate the flakiness as a whole, but it reduces its likelihood. Also, there is no way to reduce flakiness unless we accept to wait forever until the distribution is finished.

In addition, `processDefinitionKey` is renamed to `deploymentKey` as the deployment event's key is a deployment key. That key also added to distribution assertion since we might have other distributions with different keys during the deployment along with deployment distribution in the future.

## Related issues

closes #17303 
