### PR TITLE
transfer snapshot files in chunks

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallResponse.java
@@ -29,7 +29,7 @@ import io.atomix.raft.RaftError;
  */
 public class InstallResponse extends AbstractRaftResponse {
 
-  public static final int DEFAULT_CHUNK_SIZE = 1024 * 1024;
+  public static final int DEFAULT_CHUNK_SIZE = Integer.MAX_VALUE;
   protected int preferredChunkSize;
 
   public InstallResponse(final Status status, final RaftError error, final int preferredChunkSize) {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallResponse.java
@@ -52,7 +52,7 @@ public class InstallResponse extends AbstractRaftResponse {
 
   /** Install response builder. */
   public static class Builder extends AbstractRaftResponse.Builder<Builder, InstallResponse> {
-    protected int preferredChunkSize;
+    protected int preferredChunkSize = DEFAULT_CHUNK_SIZE;
 
     @Override
     public InstallResponse build() {

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallResponse.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/protocol/InstallResponse.java
@@ -16,6 +16,8 @@
  */
 package io.atomix.raft.protocol;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import io.atomix.raft.RaftError;
 
 /**
@@ -27,8 +29,16 @@ import io.atomix.raft.RaftError;
  */
 public class InstallResponse extends AbstractRaftResponse {
 
-  public InstallResponse(final Status status, final RaftError error) {
+  public static final int DEFAULT_CHUNK_SIZE = 1024 * 1024;
+  protected int preferredChunkSize;
+
+  public InstallResponse(final Status status, final RaftError error, final int preferredChunkSize) {
     super(status, error);
+    this.preferredChunkSize = preferredChunkSize;
+  }
+
+  public int preferredChunkSize() {
+    return preferredChunkSize;
   }
 
   /**
@@ -42,11 +52,18 @@ public class InstallResponse extends AbstractRaftResponse {
 
   /** Install response builder. */
   public static class Builder extends AbstractRaftResponse.Builder<Builder, InstallResponse> {
+    protected int preferredChunkSize;
 
     @Override
     public InstallResponse build() {
       validate();
-      return new InstallResponse(status, error);
+      checkArgument(preferredChunkSize >= 0, "preferred chunk size must be positive");
+      return new InstallResponse(status, error, preferredChunkSize);
+    }
+
+    public Builder withPreferredChunkSize(final int preferredChunkSize) {
+      this.preferredChunkSize = preferredChunkSize;
+      return this;
     }
   }
 }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -502,7 +502,7 @@ final class LeaderAppender {
 
     //    if not given in response defaults to 0
     if (response.preferredChunkSize() > 0) {
-      member.getSnapshotChunkReader().setChunkSize(response.preferredChunkSize());
+      member.getSnapshotChunkReader().setMaximumChunkSize(response.preferredChunkSize());
     }
     // If the install request was completed successfully, set the member's snapshotIndex and reset
     // the next snapshot index/offset.

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/LeaderAppender.java
@@ -494,10 +494,16 @@ final class LeaderAppender {
 
   /** Handles an OK install response. */
   private void handleInstallResponseOk(
-      final RaftMemberContext member, final InstallRequest request) {
+      final RaftMemberContext member,
+      final InstallRequest request,
+      final InstallResponse response) {
     // Reset the member failure count and update the member's status if necessary.
     succeedAttempt(member);
 
+    //    if not given in response defaults to 0
+    if (response.preferredChunkSize() > 0) {
+      member.getSnapshotChunkReader().setChunkSize(response.preferredChunkSize());
+    }
     // If the install request was completed successfully, set the member's snapshotIndex and reset
     // the next snapshot index/offset.
     if (request.complete()) {
@@ -843,7 +849,7 @@ final class LeaderAppender {
       final InstallResponse response,
       final long timestamp) {
     if (response.status() == RaftResponse.Status.OK) {
-      handleInstallResponseOk(member, request);
+      handleInstallResponseOk(member, request, response);
     } else {
       handleInstallResponseError(member, request, response);
     }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -134,11 +134,7 @@ public class PassiveRole extends InactiveRole {
     // Skip the snapshot and response successfully.
     if (raft.getCommitIndex() > request.index()) {
       return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.OK)
-                  .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
-                  .build()));
+          logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
     }
 
     // If a snapshot is currently being received and the snapshot versions don't match, simply
@@ -159,11 +155,7 @@ public class PassiveRole extends InactiveRole {
       abortPendingSnapshots();
 
       return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.OK)
-                  .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
-                  .build()));
+          logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
     }
 
     if (!request.complete() && request.nextChunkId() == null) {
@@ -288,11 +280,7 @@ public class PassiveRole extends InactiveRole {
     }
 
     return CompletableFuture.completedFuture(
-        logResponse(
-            InstallResponse.builder()
-                .withStatus(RaftResponse.Status.OK)
-                .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
-                .build()));
+        logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
   }
 
   @Override
@@ -454,11 +442,7 @@ public class PassiveRole extends InactiveRole {
       // happens, instead of crashing raft thread, we respond with success because we already
       // have the snapshot.
       return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(Status.OK)
-                  .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
-                  .build()));
+          logResponse(InstallResponse.builder().withStatus(Status.OK).build()));
     } else {
       log.warn(
           "Failed to create pending snapshot when receiving snapshot {}",

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -134,7 +134,11 @@ public class PassiveRole extends InactiveRole {
     // Skip the snapshot and response successfully.
     if (raft.getCommitIndex() > request.index()) {
       return CompletableFuture.completedFuture(
-          logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(RaftResponse.Status.OK)
+                  .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
+                  .build()));
     }
 
     // If a snapshot is currently being received and the snapshot versions don't match, simply
@@ -155,7 +159,11 @@ public class PassiveRole extends InactiveRole {
       abortPendingSnapshots();
 
       return CompletableFuture.completedFuture(
-          logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(RaftResponse.Status.OK)
+                  .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
+                  .build()));
     }
 
     if (!request.complete() && request.nextChunkId() == null) {
@@ -280,7 +288,11 @@ public class PassiveRole extends InactiveRole {
     }
 
     return CompletableFuture.completedFuture(
-        logResponse(InstallResponse.builder().withStatus(RaftResponse.Status.OK).build()));
+        logResponse(
+            InstallResponse.builder()
+                .withStatus(RaftResponse.Status.OK)
+                .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
+                .build()));
   }
 
   @Override
@@ -442,7 +454,11 @@ public class PassiveRole extends InactiveRole {
       // happens, instead of crashing raft thread, we respond with success because we already
       // have the snapshot.
       return CompletableFuture.completedFuture(
-          logResponse(InstallResponse.builder().withStatus(Status.OK).build()));
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.OK)
+                  .withPreferredChunkSize(InstallResponse.DEFAULT_CHUNK_SIZE)
+                  .build()));
     } else {
       log.warn(
           "Failed to create pending snapshot when receiving snapshot {}",

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
@@ -35,8 +35,8 @@ public final class SnapshotChunkImpl
   private String chunkName;
   private long checksum;
   private long snapshotChecksum;
-  private long fileBlockIndex;
-  private long totalFileBlocks;
+  private long fileBlockPosition;
+  private long totalFileSize;
 
   public SnapshotChunkImpl() {}
 
@@ -47,8 +47,8 @@ public final class SnapshotChunkImpl
     checksum = chunk.getChecksum();
     snapshotChecksum = chunk.getSnapshotChecksum();
     content.wrap(chunk.getContent());
-    fileBlockIndex = chunk.getFileBlockIndex();
-    totalFileBlocks = chunk.getTotalFileBlocks();
+    fileBlockPosition = chunk.getFileBlockPosition();
+    totalFileSize = chunk.getTotalFileSize();
   }
 
   @Override
@@ -68,8 +68,8 @@ public final class SnapshotChunkImpl
     totalCount = SnapshotChunkDecoder.totalCountNullValue();
     checksum = SnapshotChunkDecoder.checksumNullValue();
     snapshotChecksum = SnapshotChunkDecoder.snapshotChecksumNullValue();
-    fileBlockIndex = SnapshotChunkDecoder.fileBlockIndexNullValue();
-    totalFileBlocks = SnapshotChunkDecoder.totalFileBlocksNullValue();
+    fileBlockPosition = SnapshotChunkDecoder.fileBlockPositionNullValue();
+    totalFileSize = SnapshotChunkDecoder.totalFileSizeNullValue();
 
     snapshotId = "";
     chunkName = "";
@@ -93,8 +93,8 @@ public final class SnapshotChunkImpl
 
     encoder
         .totalCount(totalCount)
-        .fileBlockIndex(fileBlockIndex)
-        .totalFileBlocks(totalFileBlocks)
+        .fileBlockPosition(fileBlockPosition)
+        .totalFileSize(totalFileSize)
         .snapshotId(snapshotId)
         .chunkName(chunkName)
         .checksum(checksum)
@@ -107,8 +107,8 @@ public final class SnapshotChunkImpl
     super.wrap(buffer, offset, length);
 
     totalCount = decoder.totalCount();
-    fileBlockIndex = decoder.fileBlockIndex();
-    totalFileBlocks = decoder.totalFileBlocks();
+    fileBlockPosition = decoder.fileBlockPosition();
+    totalFileSize = decoder.totalFileSize();
     snapshotId = decoder.snapshotId();
     chunkName = decoder.chunkName();
     checksum = decoder.checksum();
@@ -150,13 +150,13 @@ public final class SnapshotChunkImpl
   }
 
   @Override
-  public long getFileBlockIndex() {
-    return fileBlockIndex;
+  public long getFileBlockPosition() {
+    return fileBlockPosition;
   }
 
   @Override
-  public long getTotalFileBlocks() {
-    return totalFileBlocks;
+  public long getTotalFileSize() {
+    return totalFileSize;
   }
 
   @Override
@@ -173,10 +173,10 @@ public final class SnapshotChunkImpl
         + checksum
         + ", snapshotChecksum="
         + snapshotChecksum
-        + ", fileBlockIndex="
-        + fileBlockIndex
-        + ", totalFileBlocks="
-        + totalFileBlocks
+        + ", fileBlockPosition="
+        + fileBlockPosition
+        + ", totalFileSize="
+        + totalFileSize
         + "} "
         + super.toString();
   }

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
@@ -30,6 +30,7 @@ public final class SnapshotChunkImpl
   private final SnapshotChunkEncoder encoder = new SnapshotChunkEncoder();
   private final SnapshotChunkDecoder decoder = new SnapshotChunkDecoder();
   private final DirectBuffer content = new UnsafeBuffer(0, 0);
+  private String chunkId;
   private String snapshotId;
   private int totalCount;
   private String chunkName;
@@ -45,6 +46,7 @@ public final class SnapshotChunkImpl
     checksum = chunk.getChecksum();
     snapshotChecksum = chunk.getSnapshotChecksum();
     content.wrap(chunk.getContent());
+    chunkId = chunk.getChunkId();
   }
 
   @Override
@@ -67,6 +69,7 @@ public final class SnapshotChunkImpl
 
     snapshotId = "";
     chunkName = "";
+    chunkId = "";
     content.wrap(0, 0);
   }
 
@@ -78,7 +81,9 @@ public final class SnapshotChunkImpl
         + SnapshotChunkEncoder.chunkNameHeaderLength()
         + chunkName.length()
         + SnapshotChunkEncoder.contentHeaderLength()
-        + content.capacity();
+        + content.capacity()
+        + SnapshotChunkEncoder.chunkIdHeaderLength()
+        + chunkId.length();
   }
 
   @Override
@@ -91,6 +96,7 @@ public final class SnapshotChunkImpl
         .chunkName(chunkName)
         .checksum(checksum)
         .snapshotChecksum(snapshotChecksum)
+        .chunkId(chunkId)
         .putContent(content, 0, content.capacity());
   }
 
@@ -103,6 +109,7 @@ public final class SnapshotChunkImpl
     chunkName = decoder.chunkName();
     checksum = decoder.checksum();
     snapshotChecksum = decoder.snapshotChecksum();
+    chunkId = decoder.chunkId();
 
     if (decoder.contentLength() > 0) {
       decoder.wrapContent(content);
@@ -140,6 +147,11 @@ public final class SnapshotChunkImpl
   }
 
   @Override
+  public String getChunkId() {
+    return chunkId;
+  }
+
+  @Override
   public String toString() {
     return "SnapshotChunkImpl{"
         + "snapshotId="
@@ -153,6 +165,8 @@ public final class SnapshotChunkImpl
         + checksum
         + ", snapshotChecksum="
         + snapshotChecksum
+        + ", chunkId='"
+        + chunkId
         + "} "
         + super.toString();
   }

--- a/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
+++ b/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
@@ -22,5 +22,6 @@
     <data name="snapshotId" id="2" type="varDataEncoding"/>
     <data name="chunkName" id="3" type="varDataEncoding"/>
     <data name="content" id="4" type="blob"/>
+    <data name="chunkId" id="6" type="varDataEncoding"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
+++ b/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
@@ -19,8 +19,8 @@
     <field name="totalCount" id="0" type="int32"/>
     <field name="checksum" id="1" type="uint64"/>
     <field name="snapshotChecksum" id="5" type="uint64" sinceVersion="2"/>
-    <field name="fileBlockIndex" id="6" type="uint64"/>
-    <field name="totalFileBlocks" id="7" type="uint64"/>
+    <field name="fileBlockPosition" id="6" type="uint64"/>
+    <field name="totalFileSize" id="7" type="uint64"/>
     <data name="snapshotId" id="2" type="varDataEncoding"/>
     <data name="chunkName" id="3" type="varDataEncoding"/>
     <data name="content" id="4" type="blob"/>

--- a/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
+++ b/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
@@ -19,9 +19,10 @@
     <field name="totalCount" id="0" type="int32"/>
     <field name="checksum" id="1" type="uint64"/>
     <field name="snapshotChecksum" id="5" type="uint64" sinceVersion="2"/>
+    <field name="fileBlockIndex" id="6" type="uint64"/>
+    <field name="totalFileBlocks" id="7" type="uint64"/>
     <data name="snapshotId" id="2" type="varDataEncoding"/>
     <data name="chunkName" id="3" type="varDataEncoding"/>
     <data name="content" id="4" type="blob"/>
-    <data name="chunkId" id="6" type="varDataEncoding"/>
   </sbe:message>
 </sbe:messageSchema>

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -119,6 +119,9 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
       }
 
       @Override
+      public void setChunkSize(final int chunkSize) {}
+
+      @Override
       public void close() {
         iterator = null;
       }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -119,7 +119,7 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
       }
 
       @Override
-      public void setChunkSize(final int chunkSize) {}
+      public void setMaximumChunkSize(final int maximumChunkSize) {}
 
       @Override
       public void close() {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
@@ -63,7 +63,12 @@ class TestSnapshotChunkImpl implements SnapshotChunk {
   }
 
   @Override
-  public String getChunkId() {
-    return "";
+  public long getFileBlockIndex() {
+    return 0;
+  }
+
+  @Override
+  public long getTotalFileBlocks() {
+    return 0;
   }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
@@ -61,4 +61,9 @@ class TestSnapshotChunkImpl implements SnapshotChunk {
   public long getSnapshotChecksum() {
     return 0;
   }
+
+  @Override
+  public String getChunkId() {
+    return "";
+  }
 }

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
@@ -63,12 +63,12 @@ class TestSnapshotChunkImpl implements SnapshotChunk {
   }
 
   @Override
-  public long getFileBlockIndex() {
+  public long getFileBlockPosition() {
     return 0;
   }
 
   @Override
-  public long getTotalFileBlocks() {
+  public long getTotalFileSize() {
     return 0;
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
@@ -41,7 +41,9 @@ public interface SnapshotChunk {
   long getSnapshotChecksum();
 
   /**
-   * @return the chunk id format <file_name>-<file_part> e.g. foo-1, foo-2
+   * @return the index of the part of the chunk contents.
    */
-  String getChunkId();
+  long getFileBlockIndex();
+
+  long getTotalFileBlocks();
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
@@ -39,4 +39,9 @@ public interface SnapshotChunk {
    * @return the checksum of the entire snapshot
    */
   long getSnapshotChecksum();
+
+  /**
+   * @return the chunk id format <file_name>-<file_part> e.g. foo-1, foo-2
+   */
+  String getChunkId();
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
@@ -43,7 +43,7 @@ public interface SnapshotChunk {
   /**
    * @return the index of the part of the chunk contents.
    */
-  long getFileBlockIndex();
+  long getFileBlockPosition();
 
-  long getTotalFileBlocks();
+  long getTotalFileSize();
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunkReader.java
@@ -34,4 +34,11 @@ public interface SnapshotChunkReader extends Iterator<SnapshotChunk>, CloseableS
    * @return the next chunk ID
    */
   ByteBuffer nextId();
+
+  /**
+   * Sets the maximum chunk size for the reader when sending files.
+   *
+   * @param chunkSize
+   */
+  void setChunkSize(final int chunkSize);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunkReader.java
@@ -38,7 +38,7 @@ public interface SnapshotChunkReader extends Iterator<SnapshotChunk>, CloseableS
   /**
    * Sets the maximum chunk size for the reader when sending files.
    *
-   * @param chunkSize
+   * @param maximumChunkSize
    */
-  void setChunkSize(final int chunkSize);
+  void setMaximumChunkSize(final int maximumChunkSize);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -19,9 +19,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.NavigableSet;
 import java.util.TreeSet;
-import org.agrona.AsciiSequenceView;
-import org.agrona.DirectBuffer;
-import org.agrona.concurrent.UnsafeBuffer;
 
 /**
  * Implements a chunk reader where each chunk is a single file in a root directory. Chunks are then
@@ -149,8 +146,6 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   }
 
   private CharSequence decodeChunkId(final ByteBuffer id) {
-    final DirectBuffer buffer = new UnsafeBuffer(id);
-    final var chunkId = new AsciiSequenceView().wrap(buffer, 0, buffer.capacity());
-    return chunkId.toString();
+    return ID_CHARSET.decode(id).toString();
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -39,7 +39,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   private final int totalCount;
   private final long snapshotChecksum;
   private final String snapshotID;
-  private final int chunkSize;
+  private int chunkSize;
 
   FileBasedSnapshotChunkReader(final Path directory, final long checksum) throws IOException {
     this(directory, checksum, Integer.MAX_VALUE);
@@ -89,6 +89,11 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
     }
 
     return encodeChunkId(chunksView.first());
+  }
+
+  @Override
+  public void setChunkSize(final int chunkSize) {
+    this.chunkSize = chunkSize;
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -89,9 +89,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       return null;
     }
 
-    final var nextFilePartIndex = Math.ceilDiv(offset, chunkSize) + 1;
-
-    return encodeChunkId(chunksView.first().toString() + "-" + nextFilePartIndex);
+    return encodeChunkId(chunksView.first().toString() + "__" + offset);
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -79,8 +79,12 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       return;
     }
 
-    final var fileName = decodeChunkId(id);
-    chunksView = new TreeSet<>(chunks.tailSet(fileName, true));
+    final var chunkId = decodeChunkId(id);
+    final var chunkIdParts = chunkId.toString().split("__");
+
+    offset = Long.valueOf(chunkIdParts[1]);
+
+    chunksView = new TreeSet<>(chunks.tailSet(chunkIdParts[0], true));
   }
 
   @Override
@@ -149,6 +153,6 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   private CharSequence decodeChunkId(final ByteBuffer id) {
     final DirectBuffer buffer = new UnsafeBuffer(id);
     final var chunkId = new AsciiSequenceView().wrap(buffer, 0, buffer.capacity());
-    return chunkId.toString().split("-")[0];
+    return chunkId.toString();
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -34,7 +34,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   private final Path directory;
   private final NavigableSet<CharSequence> chunks;
 
-  private int offset;
+  private long offset;
   private NavigableSet<CharSequence> chunksView;
   private final int totalCount;
   private final long snapshotChecksum;

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -120,7 +120,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       final var bytesToRead = Math.min(maximumChunkSize, fileLength - offset);
       final byte[] buffer = new byte[(int) bytesToRead];
       file.seek(offset);
-      file.read(buffer);
+      file.readFully(buffer);
 
       final var fileBlockPosition = offset;
       offset += bytesToRead;

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -114,19 +114,20 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
     final var filePath = directory.resolve(fileName).toString();
 
     try (final var file = new RandomAccessFile(filePath, "r")) {
-      final var bytesToRead = Math.min(chunkSize, file.length() - offset);
+      final var fileLength = file.length();
+      final var bytesToRead = Math.min(chunkSize, fileLength - offset);
       final byte[] buffer = new byte[(int) bytesToRead];
       file.seek(offset);
       file.read(buffer);
 
       offset += bytesToRead;
       final var fileBlockIndex = Math.ceilDiv(offset, chunkSize);
-      if (offset == file.length()) {
+      if (offset == fileLength) {
         offset = 0;
         chunksView.pollFirst();
       }
 
-      final var totalFileBlocks = Math.ceilDiv(file.length(), chunkSize);
+      final var totalFileBlocks = Math.ceilDiv(fileLength, chunkSize);
 
       return SnapshotChunkUtil.createSnapshotChunkFromFileChunk(
           snapshotID,

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.snapshots.SnapshotChunk;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
@@ -137,7 +138,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
           fileBlockPosition,
           fileLength);
     } catch (final IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -36,14 +36,14 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   private final int totalCount;
   private final long snapshotChecksum;
   private final String snapshotID;
-  private int chunkSize;
+  private long maximumChunkSize;
 
   public FileBasedSnapshotChunkReader(final Path directory, final long checksum)
       throws IOException {
-    this(directory, checksum, Integer.MAX_VALUE);
+    this(directory, checksum, Long.MAX_VALUE);
   }
 
-  FileBasedSnapshotChunkReader(final Path directory, final long checksum, final int chunkSize)
+  FileBasedSnapshotChunkReader(final Path directory, final long checksum, final long maximumChunkSize)
       throws IOException {
     this.directory = directory;
     chunks = collectChunks(directory);
@@ -54,7 +54,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
 
     snapshotID = directory.getFileName().toString();
 
-    this.chunkSize = chunkSize;
+    this.maximumChunkSize = maximumChunkSize;
   }
 
   private NavigableSet<CharSequence> collectChunks(final Path directory) throws IOException {
@@ -94,8 +94,8 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   }
 
   @Override
-  public void setChunkSize(final int chunkSize) {
-    this.chunkSize = chunkSize;
+  public void setMaximumChunkSize(final int maximumChunkSize) {
+    this.maximumChunkSize = maximumChunkSize;
   }
 
   @Override
@@ -116,7 +116,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
 
     try (final var file = new RandomAccessFile(filePath, "r")) {
       final var fileLength = file.length();
-      final var bytesToRead = Math.min(chunkSize, fileLength - offset);
+      final var bytesToRead = Math.min(maximumChunkSize, fileLength - offset);
       final byte[] buffer = new byte[(int) bytesToRead];
       file.seek(offset);
       file.read(buffer);

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -79,8 +79,8 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       return;
     }
 
-    final var path = decodeChunkId(id);
-    chunksView = new TreeSet<>(chunks.tailSet(path, true));
+    final var fileName = decodeChunkId(id);
+    chunksView = new TreeSet<>(chunks.tailSet(fileName, true));
   }
 
   @Override
@@ -150,6 +150,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
 
   private CharSequence decodeChunkId(final ByteBuffer id) {
     final DirectBuffer buffer = new UnsafeBuffer(id);
-    return new AsciiSequenceView().wrap(buffer, 0, buffer.capacity());
+    final var chunkId = new AsciiSequenceView().wrap(buffer, 0, buffer.capacity());
+    return chunkId.toString().split("-")[0];
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -89,7 +89,9 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       return null;
     }
 
-    return encodeChunkId(chunksView.first());
+    final var nextFilePartIndex = Math.ceilDiv(offset, chunkSize) + 1;
+
+    return encodeChunkId(chunksView.first().toString() + "-" + nextFilePartIndex);
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -43,8 +43,8 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
     this(directory, checksum, Long.MAX_VALUE);
   }
 
-  FileBasedSnapshotChunkReader(final Path directory, final long checksum, final long maximumChunkSize)
-      throws IOException {
+  FileBasedSnapshotChunkReader(
+      final Path directory, final long checksum, final long maximumChunkSize) throws IOException {
     this.directory = directory;
     chunks = collectChunks(directory);
     totalCount = chunks.size();

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -41,7 +41,8 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   private final String snapshotID;
   private int chunkSize;
 
-  FileBasedSnapshotChunkReader(final Path directory, final long checksum) throws IOException {
+  public FileBasedSnapshotChunkReader(final Path directory, final long checksum)
+      throws IOException {
     this(directory, checksum, Integer.MAX_VALUE);
   }
 
@@ -119,14 +120,22 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       file.read(buffer);
 
       offset += bytesToRead;
-      final var filePart = Math.ceilDiv(offset, chunkSize);
+      final var fileBlockIndex = Math.ceilDiv(offset, chunkSize);
       if (offset == file.length()) {
         offset = 0;
         chunksView.pollFirst();
       }
 
+      final var totalFileBlocks = Math.ceilDiv(file.length(), chunkSize);
+
       return SnapshotChunkUtil.createSnapshotChunkFromFileChunk(
-          snapshotID, totalCount, snapshotChecksum, fileName, buffer, filePart);
+          snapshotID,
+          totalCount,
+          snapshotChecksum,
+          fileName,
+          buffer,
+          fileBlockIndex,
+          totalFileBlocks);
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -124,14 +124,12 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       file.seek(offset);
       file.read(buffer);
 
+      final var fileBlockPosition = offset;
       offset += bytesToRead;
-      final var fileBlockIndex = Math.ceilDiv(offset, chunkSize);
       if (offset == fileLength) {
         offset = 0;
         chunksView.pollFirst();
       }
-
-      final var totalFileBlocks = Math.ceilDiv(fileLength, chunkSize);
 
       return SnapshotChunkUtil.createSnapshotChunkFromFileChunk(
           snapshotID,
@@ -139,8 +137,8 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
           snapshotChecksum,
           fileName,
           buffer,
-          fileBlockIndex,
-          totalFileBlocks);
+          fileBlockPosition,
+          fileLength);
     } catch (final IOException e) {
       throw new RuntimeException(e);
     }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -31,7 +31,8 @@ final class SnapshotChunkUtil {
       final long snapshotChecksum,
       final String fileName,
       final byte[] fileData,
-      final long filePart) {
+      final long fileBlockIndex,
+      final long totalFileBlocks) {
 
     final long checksum = createChecksum(fileData);
     return new SnapshotChunkImpl(
@@ -41,7 +42,8 @@ final class SnapshotChunkUtil {
         checksum,
         fileData,
         snapshotChecksum,
-        fileName + "-" + filePart);
+        fileBlockIndex,
+        totalFileBlocks);
   }
 
   private static final class SnapshotChunkImpl implements SnapshotChunk {
@@ -51,7 +53,8 @@ final class SnapshotChunkUtil {
     private final byte[] content;
     private final long snapshotChecksum;
     private final long checksum;
-    private final String chunkId;
+    private final long fileBlockIndex;
+    private final long totalFileBlocks;
 
     SnapshotChunkImpl(
         final String snapshotId,
@@ -60,14 +63,16 @@ final class SnapshotChunkUtil {
         final long checksum,
         final byte[] content,
         final long snapshotChecksum,
-        final String chunkId) {
+        final long fileBlockIndex,
+        final long totalFileBlocks) {
       this.snapshotId = snapshotId;
       this.totalCount = totalCount;
       this.chunkName = chunkName;
       this.checksum = checksum;
       this.content = content;
       this.snapshotChecksum = snapshotChecksum;
-      this.chunkId = chunkId;
+      this.fileBlockIndex = fileBlockIndex;
+      this.totalFileBlocks = totalFileBlocks;
     }
 
     @Override
@@ -101,8 +106,13 @@ final class SnapshotChunkUtil {
     }
 
     @Override
-    public String getChunkId() {
-      return chunkId;
+    public long getFileBlockIndex() {
+      return fileBlockIndex;
+    }
+
+    @Override
+    public long getTotalFileBlocks() {
+      return totalFileBlocks;
     }
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -8,9 +8,6 @@
 package io.camunda.zeebe.snapshots.impl;
 
 import io.camunda.zeebe.snapshots.SnapshotChunk;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.zip.CRC32C;
 import java.util.zip.Checksum;
 
@@ -52,6 +49,7 @@ final class SnapshotChunkUtil {
     private final byte[] content;
     private final long snapshotChecksum;
     private final long checksum;
+    private final String chunkId;
 
     SnapshotChunkImpl(
         final String snapshotId,
@@ -59,13 +57,15 @@ final class SnapshotChunkUtil {
         final String chunkName,
         final long checksum,
         final byte[] content,
-        final long snapshotChecksum) {
+        final long snapshotChecksum,
+        final String chunkId) {
       this.snapshotId = snapshotId;
       this.totalCount = totalCount;
       this.chunkName = chunkName;
       this.checksum = checksum;
       this.content = content;
       this.snapshotChecksum = snapshotChecksum;
+      this.chunkId = chunkId;
     }
 
     @Override
@@ -96,6 +96,11 @@ final class SnapshotChunkUtil {
     @Override
     public long getSnapshotChecksum() {
       return snapshotChecksum;
+    }
+
+    @Override
+    public String getChunkId() {
+      return chunkId;
     }
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -31,8 +31,8 @@ final class SnapshotChunkUtil {
       final long snapshotChecksum,
       final String fileName,
       final byte[] fileData,
-      final long fileBlockIndex,
-      final long totalFileBlocks) {
+      final long fileBlockPosition,
+      final long totalFileSize) {
 
     final long checksum = createChecksum(fileData);
     return new SnapshotChunkImpl(
@@ -42,8 +42,8 @@ final class SnapshotChunkUtil {
         checksum,
         fileData,
         snapshotChecksum,
-        fileBlockIndex,
-        totalFileBlocks);
+        fileBlockPosition,
+        totalFileSize);
   }
 
   private static final class SnapshotChunkImpl implements SnapshotChunk {
@@ -53,8 +53,8 @@ final class SnapshotChunkUtil {
     private final byte[] content;
     private final long snapshotChecksum;
     private final long checksum;
-    private final long fileBlockIndex;
-    private final long totalFileBlocks;
+    private final long fileBlockPosition;
+    private final long totalFileSize;
 
     SnapshotChunkImpl(
         final String snapshotId,
@@ -63,16 +63,16 @@ final class SnapshotChunkUtil {
         final long checksum,
         final byte[] content,
         final long snapshotChecksum,
-        final long fileBlockIndex,
-        final long totalFileBlocks) {
+        final long fileBlockPosition,
+        final long totalFileSize) {
       this.snapshotId = snapshotId;
       this.totalCount = totalCount;
       this.chunkName = chunkName;
       this.checksum = checksum;
       this.content = content;
       this.snapshotChecksum = snapshotChecksum;
-      this.fileBlockIndex = fileBlockIndex;
-      this.totalFileBlocks = totalFileBlocks;
+      this.fileBlockPosition = fileBlockPosition;
+      this.totalFileSize = totalFileSize;
     }
 
     @Override
@@ -106,13 +106,13 @@ final class SnapshotChunkUtil {
     }
 
     @Override
-    public long getFileBlockIndex() {
-      return fileBlockIndex;
+    public long getFileBlockPosition() {
+      return fileBlockPosition;
     }
 
     @Override
-    public long getTotalFileBlocks() {
-      return totalFileBlocks;
+    public long getTotalFileSize() {
+      return totalFileSize;
     }
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -31,7 +31,7 @@ final class SnapshotChunkUtil {
       final long snapshotChecksum,
       final String fileName,
       final byte[] fileData,
-      final int filePart) {
+      final long filePart) {
 
     final long checksum = createChecksum(fileData);
     return new SnapshotChunkImpl(

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -25,21 +25,23 @@ final class SnapshotChunkUtil {
     return new CRC32C();
   }
 
-  static SnapshotChunk createSnapshotChunkFromFile(
-      final Path chunkFile,
+  static SnapshotChunk createSnapshotChunkFromFileChunk(
       final String snapshotId,
       final int totalCount,
-      final long snapshotChecksum)
-      throws IOException {
-    final byte[] content = Files.readAllBytes(chunkFile);
-    final long checksum = createChecksum(content);
+      final long snapshotChecksum,
+      final String fileName,
+      final byte[] fileData,
+      final int filePart) {
+
+    final long checksum = createChecksum(fileData);
     return new SnapshotChunkImpl(
         snapshotId,
         totalCount,
-        chunkFile.getFileName().toString(),
+        fileName,
         checksum,
-        content,
-        snapshotChecksum);
+        fileData,
+        snapshotChecksum,
+        fileName + "-" + filePart);
   }
 
   private static final class SnapshotChunkImpl implements SnapshotChunk {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
@@ -104,4 +104,9 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
     }
     return snapshotChecksum;
   }
+
+  @Override
+  public String getChunkId() {
+    return "";
+  }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
@@ -106,7 +106,12 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
   }
 
   @Override
-  public String getChunkId() {
-    return "";
+  public long getFileBlockIndex() {
+    return 0;
+  }
+
+  @Override
+  public long getTotalFileBlocks() {
+    return 0;
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
@@ -106,12 +106,12 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
   }
 
   @Override
-  public long getFileBlockIndex() {
+  public long getFileBlockPosition() {
     return 0;
   }
 
   @Override
-  public long getTotalFileBlocks() {
+  public long getTotalFileSize() {
     return 0;
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -203,12 +203,12 @@ public final class FileBasedSnapshotChunkReaderTest {
 
   @Test
   public void shouldHaveCorrectChunkIdsForSplitFiles() throws IOException {
-    //given
+    // given
     final int maxChunkSize = 3;
     final var snapshotChunkReader = newReader(maxChunkSize);
     final var snapshotChunks = getAllChunks(snapshotChunkReader);
 
-    //when - then
+    // when - then
     final var expectedChunkIds = new ArrayList<String>();
 
     for (final var entry : SORTED_CHUNKS) {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -202,9 +202,11 @@ public final class FileBasedSnapshotChunkReaderTest {
 
   @Test
   public void shouldHaveCorrectFileBlockFieldsForSplitFiles() throws IOException { // given final
+    // given
     final int maxChunkSize = 3;
     final var snapshotChunkReader = newReader(maxChunkSize);
     final var snapshotChunks = getAllChunks(snapshotChunkReader);
+
     // when - then
     final var fileChunksGroupedByFileName =
         snapshotChunks.stream().collect(Collectors.groupingBy(SnapshotChunk::getChunkName));

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -271,7 +271,7 @@ public final class FileBasedSnapshotChunkReaderTest {
       snapshotChunks.add(snapshotChunkReader.next());
     }
 
-    snapshotChunkReader.setChunkSize(maxChunkSize);
+    snapshotChunkReader.setMaximumChunkSize(maxChunkSize);
     while (snapshotChunkReader.hasNext()) {
       snapshotChunks.add(snapshotChunkReader.next());
     }
@@ -299,7 +299,7 @@ public final class FileBasedSnapshotChunkReaderTest {
     return ByteBuffer.wrap(string.getBytes()).order(Protocol.ENDIANNESS);
   }
 
-  private FileBasedSnapshotChunkReader newReader(final int chunkSize) throws IOException {
+  private FileBasedSnapshotChunkReader newReader(final long chunkSize) throws IOException {
     snapshotDirectory = temporaryFolder.getRoot().toPath();
 
     for (final var chunk : SNAPSHOT_CHUNK.keySet()) {
@@ -312,6 +312,6 @@ public final class FileBasedSnapshotChunkReaderTest {
   }
 
   private FileBasedSnapshotChunkReader newReader() throws IOException {
-    return newReader(Integer.MAX_VALUE);
+    return newReader(Long.MAX_VALUE);
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -92,7 +92,7 @@ public final class FileBasedSnapshotChunkReaderTest {
 
         // then
 
-        final var chunkId = chunk.getChunkName() + "-" + chunk.getFileBlockIndex();
+        final var chunkId = chunk.getChunkName() + "__" + chunk.getFileBlockPosition();
         assertThat(ByteBuffer.wrap(chunkId.getBytes(StandardCharsets.UTF_8)))
             .isNotNull()
             .isEqualTo(nextId);
@@ -121,7 +121,8 @@ public final class FileBasedSnapshotChunkReaderTest {
 
     // then
     assertThat(snapshotChunkIds)
-        .containsExactly(asByteBuffer("file1-1"), asByteBuffer("file2-1"), asByteBuffer("file3-1"));
+        .containsExactly(
+            asByteBuffer("file1__0"), asByteBuffer("file2__0"), asByteBuffer("file3__0"));
 
     assertThat(snapshotChunks)
         .extracting(SnapshotChunk::getContent)
@@ -134,7 +135,7 @@ public final class FileBasedSnapshotChunkReaderTest {
     // when
     final var snapshotChunkIds = new ArrayList<String>();
     try (final var snapshotChunkReader = newReader()) {
-      snapshotChunkReader.seek(asByteBuffer("file2"));
+      snapshotChunkReader.seek(asByteBuffer("file2__0"));
       while (snapshotChunkReader.hasNext()) {
         snapshotChunkIds.add(snapshotChunkReader.next().getChunkName());
       }
@@ -149,7 +150,7 @@ public final class FileBasedSnapshotChunkReaderTest {
     // given
     final var snapshotChunkIds = new ArrayList<String>();
     try (final var snapshotChunkReader = newReader()) {
-      snapshotChunkReader.seek(asByteBuffer("file2"));
+      snapshotChunkReader.seek(asByteBuffer("file2__0"));
       snapshotChunkReader.next();
 
       // when
@@ -221,8 +222,12 @@ public final class FileBasedSnapshotChunkReaderTest {
 
       final var fileBlocks = entry.getValue();
       assertThat(fileBlocks.size()).isEqualTo(expectedFileBlocksCount);
-      assertThat(fileBlocks.stream().map(SnapshotChunk::getFileBlockIndex).toList())
-          .isEqualTo(LongStream.range(1, expectedFileBlocksCount + 1).boxed().toList());
+      assertThat(fileBlocks.stream().map(SnapshotChunk::getFileBlockPosition).toList())
+          .isEqualTo(
+              LongStream.range(0, expectedFileBlocksCount)
+                  .map(l -> l * maxChunkSize)
+                  .boxed()
+                  .toList());
     }
   }
 
@@ -244,12 +249,12 @@ public final class FileBasedSnapshotChunkReaderTest {
     final var expectedChunkIds = new ArrayList<ByteBuffer>();
     Collections.addAll(
         expectedChunkIds,
-        ByteBuffer.wrap("file1-1".getBytes()),
-        ByteBuffer.wrap("file1-2".getBytes()),
-        ByteBuffer.wrap("file2-1".getBytes()),
-        ByteBuffer.wrap("file3-1".getBytes()),
-        ByteBuffer.wrap("file3-2".getBytes()),
-        ByteBuffer.wrap("file3-3".getBytes()));
+        ByteBuffer.wrap("file1__0".getBytes()),
+        ByteBuffer.wrap("file1__3".getBytes()),
+        ByteBuffer.wrap("file2__0".getBytes()),
+        ByteBuffer.wrap("file3__0".getBytes()),
+        ByteBuffer.wrap("file3__3".getBytes()),
+        ByteBuffer.wrap("file3__6".getBytes()));
 
     assertThat(snapshotChunkIds).isEqualTo(expectedChunkIds);
   }


### PR DESCRIPTION
## Description
This will result in split file snapshot chunks being sent to a broker which supports it.

Changes:
- Install Response, added a `preferredChunKSize` field which defaults to 0 for old versions.
- Changed `FileBasedSnapshotChunkReader.next()` to instead read files chunk by chunk.
- Added `chunkSize` field to the `FileBasedSnapshotChunkReader`.
- Changed `FileBasedSnapshotChunkReader.nextId()` from a `<file-name>` to `<file name>-<file-part>` format e.g. file-1, file-2.
- Added `fileBlockPosition` and `totalFileSize` field to `SnapshotChunk` in order to aid in processing on the receiver side as it is useful to know the current position in the file for next expected chunk checks and total file size for any completion actions when all blocks have been received for example file flushing. (Can be calculated with data.length, position and file size if it is the last chunk for a given file)

## Related issues
Sender side of #12795 
