### PR TITLE
Increase user task client test coverage

### DIFF
--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/AssignUserTaskTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/AssignUserTaskTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.usertask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.protocol.rest.UserTaskAssignmentRequest;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public final class AssignUserTaskTest extends ClientRestTest {
+
+  @Test
+  void shouldAssignUserTask() {
+    // when
+    client.newUserTaskAssignCommand(123L).assignee("foo").send().join();
+
+    // then
+    final UserTaskAssignmentRequest request =
+        gatewayService.getLastRequest(UserTaskAssignmentRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getAllowOverride()).isNull();
+    assertThat(request.getAssignee()).isEqualTo("foo");
+  }
+
+  @Test
+  void shouldAssignUserTaskWithAction() {
+    // when
+    client.newUserTaskAssignCommand(123L).action("foo").send().join();
+
+    // then
+    final UserTaskAssignmentRequest request =
+        gatewayService.getLastRequest(UserTaskAssignmentRequest.class);
+    assertThat(request.getAction()).isEqualTo("foo");
+    assertThat(request.getAllowOverride()).isNull();
+    assertThat(request.getAssignee()).isNull();
+  }
+
+  @Test
+  void shouldAssignUserTaskWithAllowOverride() {
+    // when
+
+    client.newUserTaskAssignCommand(123L).allowOverride(true).send().join();
+
+    // then
+    final UserTaskAssignmentRequest request =
+        gatewayService.getLastRequest(UserTaskAssignmentRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getAllowOverride()).isTrue();
+    assertThat(request.getAssignee()).isNull();
+  }
+
+  @Test
+  void shouldAssignUserTaskWithAllowOverrideDisabled() {
+    // when
+
+    client.newUserTaskAssignCommand(123L).allowOverride(false).send().join();
+
+    // then
+    final UserTaskAssignmentRequest request =
+        gatewayService.getLastRequest(UserTaskAssignmentRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getAllowOverride()).isFalse();
+    assertThat(request.getAssignee()).isNull();
+  }
+
+  @Test
+  void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        String.format(RestGatewayService.URL_USER_TASK_ASSIGNMENT, 123L),
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(() -> client.newUserTaskAssignCommand(123L).send().join())
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/CompleteUserTaskTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/CompleteUserTaskTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.usertask;
+
+import static java.util.Collections.singletonMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.protocol.rest.UserTaskCompletionRequest;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public final class CompleteUserTaskTest extends ClientRestTest {
+
+  @Test
+  void shouldCompleteUserTask() {
+    // when
+    client.newUserTaskCompleteCommand(123L).send().join();
+
+    // then
+    final UserTaskCompletionRequest request =
+        gatewayService.getLastRequest(UserTaskCompletionRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getVariables()).isNull();
+  }
+
+  @Test
+  void shouldCompleteUserTaskWithAction() {
+    // when
+    client.newUserTaskCompleteCommand(123L).action("foo").send().join();
+
+    // then
+    final UserTaskCompletionRequest request =
+        gatewayService.getLastRequest(UserTaskCompletionRequest.class);
+    assertThat(request.getAction()).isEqualTo("foo");
+    assertThat(request.getVariables()).isNull();
+  }
+
+  @Test
+  void shouldCompleteUserTaskWithVariables() {
+    // when
+
+    client.newUserTaskCompleteCommand(123L).variables(singletonMap("foo", "bar")).send().join();
+
+    // then
+    final UserTaskCompletionRequest request =
+        gatewayService.getLastRequest(UserTaskCompletionRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getVariables()).isEqualTo(singletonMap("foo", "bar"));
+  }
+
+  @Test
+  void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        String.format(RestGatewayService.URL_USER_TASK_COMPLETION, 123L),
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(() -> client.newUserTaskCompleteCommand(123L).send().join())
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UnassignUserTaskTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UnassignUserTaskTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.usertask;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.verification.LoggedRequest;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import org.junit.jupiter.api.Test;
+
+public final class UnassignUserTaskTest extends ClientRestTest {
+
+  @Test
+  void shouldUnassignUserTask() {
+    // when
+    client.newUserTaskUnassignCommand(123L).send().join();
+
+    // then
+    final LoggedRequest request = RestGatewayService.getLastRequest();
+    assertThat(request.getMethod()).isEqualTo(RequestMethod.DELETE);
+    assertThat(request.getUrl())
+        .isEqualTo(String.format(RestGatewayService.URL_USER_TASK_UNASSIGNMENT, 123L));
+  }
+
+  @Test
+  void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        String.format(RestGatewayService.URL_USER_TASK_UNASSIGNMENT, 123L),
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(() -> client.newUserTaskUnassignCommand(123L).send().join())
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UpdateUserTaskTest.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UpdateUserTaskTest.java
@@ -1,0 +1,291 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.usertask;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
+import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequest;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import io.camunda.zeebe.client.util.RestGatewayService;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+public final class UpdateUserTaskTest extends ClientRestTest {
+
+  private static final String TEST_TIME =
+      ZonedDateTime.of(2023, 11, 11, 11, 11, 11, 11, ZoneId.of("UTC")).toString();
+
+  @Test
+  void shouldUpdateUserTask() {
+    // when
+    client.newUserTaskUpdateCommand(123L).send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset()).isNull();
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithAction() {
+    // when
+    client.newUserTaskUpdateCommand(123L).action("foo").send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isEqualTo("foo");
+    assertThat(request.getChangeset()).isNull();
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithDueDate() {
+    // when
+    client.newUserTaskUpdateCommand(123L).dueDate(TEST_TIME).send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("dueDate")
+        .hasFieldOrPropertyWithValue("dueDate", TEST_TIME);
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithFollowUpDate() {
+    // when
+    client.newUserTaskUpdateCommand(123L).followUpDate(TEST_TIME).send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("followUpDate")
+        .hasFieldOrPropertyWithValue("followUpDate", TEST_TIME);
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithDueDateAndFollowUpDate() {
+    // when
+    client.newUserTaskUpdateCommand(123L).dueDate(TEST_TIME).followUpDate(TEST_TIME).send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("followUpDate", "dueDate")
+        .hasFieldOrPropertyWithValue("followUpDate", TEST_TIME)
+        .hasFieldOrPropertyWithValue("dueDate", TEST_TIME);
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithCandidateGroup() {
+    // when
+    client.newUserTaskUpdateCommand(123L).candidateGroups("foo").send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
+        .hasFieldOrPropertyWithValue("candidateGroups", singletonList("foo"));
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithCandidateGroups() {
+    // when
+    client.newUserTaskUpdateCommand(123L).candidateGroups("foo", "bar").send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
+        .hasFieldOrPropertyWithValue("candidateGroups", Arrays.asList("foo", "bar"));
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithCandidateGroupsList() {
+    // when
+    client
+        .newUserTaskUpdateCommand(123L)
+        .candidateGroups(Arrays.asList("foo", "bar"))
+        .send()
+        .join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
+        .hasFieldOrPropertyWithValue("candidateGroups", Arrays.asList("foo", "bar"));
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithCandidateUser() {
+    // when
+    client.newUserTaskUpdateCommand(123L).candidateUsers("foo").send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
+        .hasFieldOrPropertyWithValue("candidateUsers", singletonList("foo"));
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithCandidateUsers() {
+    // when
+    client.newUserTaskUpdateCommand(123L).candidateUsers("foo", "bar").send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
+        .hasFieldOrPropertyWithValue("candidateUsers", Arrays.asList("foo", "bar"));
+  }
+
+  @Test
+  void shouldUpdateUserTaskWithCandidateUsersList() {
+    // when
+    client.newUserTaskUpdateCommand(123L).candidateUsers(Arrays.asList("foo", "bar")).send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
+        .hasFieldOrPropertyWithValue("candidateUsers", Arrays.asList("foo", "bar"));
+  }
+
+  @Test
+  void shouldClearUserTaskDueDate() {
+    // given
+    final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
+        client.newUserTaskUpdateCommand(123L).dueDate(TEST_TIME);
+
+    // when
+    updateUserTaskCommandStep1.clearDueDate().send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("dueDate")
+        .hasFieldOrPropertyWithValue("dueDate", "");
+  }
+
+  @Test
+  void shouldClearUserTaskFollowUpDate() {
+    // given
+    final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
+        client.newUserTaskUpdateCommand(123L).followUpDate(TEST_TIME);
+
+    // when
+    updateUserTaskCommandStep1.clearFollowUpDate().send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("followUpDate")
+        .hasFieldOrPropertyWithValue("followUpDate", "");
+  }
+
+  @Test
+  void shouldClearUserTaskCandidateGroups() {
+    // given
+    final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
+        client.newUserTaskUpdateCommand(123L).candidateGroups("foo");
+
+    // when
+    updateUserTaskCommandStep1.clearCandidateGroups().send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
+        .hasFieldOrPropertyWithValue("candidateGroups", emptyList());
+  }
+
+  @Test
+  void shouldClearUserTaskCandidateUsers() {
+    // given
+    final UpdateUserTaskCommandStep1 updateUserTaskCommandStep1 =
+        client.newUserTaskUpdateCommand(123L).candidateUsers("foo");
+
+    // when
+    updateUserTaskCommandStep1.clearCandidateUsers().send().join();
+
+    // then
+    final UserTaskUpdateRequest request =
+        gatewayService.getLastRequest(UserTaskUpdateRequest.class);
+    assertThat(request.getAction()).isNull();
+    assertThat(request.getChangeset())
+        .isNotNull()
+        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
+        .hasFieldOrPropertyWithValue("candidateUsers", emptyList());
+  }
+
+  @Test
+  void shouldRaiseExceptionOnError() {
+    // given
+    gatewayService.errorOnRequest(
+        String.format(RestGatewayService.URL_USER_TASK_UPDATE, 123L),
+        () -> new ProblemDetail().title("Not Found").status(404));
+
+    // when / then
+    assertThatThrownBy(() -> client.newUserTaskUpdateCommand(123L).send().join())
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("Failed with code 404: 'Not Found'");
+  }
+}

--- a/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
+++ b/zeebe/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
@@ -37,6 +37,18 @@ public class RestGatewayService {
   /** The job activation request URL */
   public static final String URL_JOB_ACTIVATION = REST_API_PATH + "/jobs/activation";
 
+  /** The user task assignment request URL, including a placeholder for the user task key */
+  public static final String URL_USER_TASK_ASSIGNMENT = REST_API_PATH + "/user-tasks/%s/assignment";
+
+  /** The user task completion request URL, including a placeholder for the user task key */
+  public static final String URL_USER_TASK_COMPLETION = REST_API_PATH + "/user-tasks/%s/completion";
+
+  /** The user task unassignment request URL, including a placeholder for the user task key */
+  public static final String URL_USER_TASK_UNASSIGNMENT = REST_API_PATH + "/user-tasks/%s/assignee";
+
+  /** The user task update request URL, including a placeholder for the user task key */
+  public static final String URL_USER_TASK_UPDATE = REST_API_PATH + "/user-tasks/%s";
+
   private static final ZeebeObjectMapper JSON_MAPPER = new ZeebeObjectMapper();
 
   private final WireMockRuntimeInfo mockInfo;
@@ -89,8 +101,9 @@ public class RestGatewayService {
   }
 
   /**
-   * Register the given error response for a URL. The client will receive a BAD_REQUEST (HTTP status
-   * 400) response with the given problem detail upon a request to the URL with any HTTP method.
+   * Register the given error response for a URL. The client will receive a response with the status
+   * provided by the given problem detail upon a request to the URL with any HTTP method. If the
+   * problem detail does not contain a status, BAD_REQUEST (HTTP status 400) is used.
    *
    * @param url the URL to register the error response for
    * @param problemDetailSupplier the supplier for the error details the client will receive upon a
@@ -98,17 +111,25 @@ public class RestGatewayService {
    */
   public void errorOnRequest(
       final String url, final Supplier<ProblemDetail> problemDetailSupplier) {
+    final ProblemDetail problemDetail = problemDetailSupplier.get();
     mockInfo
         .getWireMock()
         .register(
             WireMock.any(WireMock.urlEqualTo(url))
                 .willReturn(
-                    WireMock.badRequest()
-                        .withBody(JSON_MAPPER.toJson(problemDetailSupplier.get()))
+                    WireMock.jsonResponse(
+                            JSON_MAPPER.toJson(problemDetail),
+                            problemDetail.getStatus() == null ? 400 : problemDetail.getStatus())
                         .withHeader("Content-Type", "application/problem+json")));
   }
 
-  private static LoggedRequest getLastRequest() {
+  /**
+   * Fetch the last request that was served. This is a generic {@link LoggedRequest}, provided by
+   * the test framework.
+   *
+   * @return the last logged request
+   */
+  public static LoggedRequest getLastRequest() {
     final List<ServeEvent> serveEvents = WireMock.getAllServeEvents();
     if (serveEvents.isEmpty()) {
       Assertions.fail("No request was found");


### PR DESCRIPTION
## Description

Adds unit tests to the Java client to ensure the user task-related commands for assigning, completing, unassigning, and updating tasks work as expected.

## Related issues

closes #19374 