### PR TITLE
ci: add webapps-common in Operate and Tasklist CI path filters

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -30,6 +30,7 @@ component/operate:
         - 'operate/**'
         - 'parent/*'
         - 'pom.xml'
+        - 'webapps-common/**'
 component/identity:
   - changed-files:
       - any-glob-to-any-file:
@@ -49,3 +50,4 @@ component/tasklist:
           - 'pom.xml'
           - 'tasklist/**'
           - 'tasklist.Dockerfile'
+          - 'webapps-common/**'

--- a/.github/workflows/common-ci.yml
+++ b/.github/workflows/common-ci.yml
@@ -19,6 +19,7 @@ on:
       - 'pom.xml'
       - 'tasklist.Dockerfile'
       - 'tasklist/**'
+      - 'webapps-common/**'
       - 'zeebe/**'
 
 jobs:

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -18,6 +18,7 @@ on:
       - 'operate/**'
       - 'parent/*'
       - 'pom.xml'
+      - 'webapps-common/**'
   pull_request:
     paths:
       - '.ci/**'
@@ -28,6 +29,7 @@ on:
       - 'pom.xml'
       - 'operate.Dockerfile'
       - 'parent/*'
+      - 'webapps-common/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).
 # If a new commits occurs, the current run will be canceled to save costs.

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -15,6 +15,7 @@ on:
       - 'operate/**'
       - 'parent/*'
       - 'pom.xml'
+      - 'webapps-common/**'
   pull_request:
     paths:
       - '.ci/**'
@@ -25,6 +26,7 @@ on:
       - 'operate/**'
       - 'parent/*'
       - 'pom.xml'
+      - 'webapps-common/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).
 # If a new commits occurs, the current run will be canceled to save costs.

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -13,6 +13,7 @@ on:
       - 'pom.xml'
       - 'tasklist/**'
       - 'tasklist.Dockerfile'
+      - 'webapps-common/**'
   pull_request:
     paths:
       - '.github/actions/**'
@@ -22,6 +23,7 @@ on:
       - 'pom.xml'
       - 'tasklist/**'
       - 'tasklist.Dockerfile'
+      - 'webapps-common/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).
 # If a new commits occurs, the current run will be canceled to save costs.

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -13,6 +13,7 @@ on:
       - 'pom.xml'
       - 'tasklist/**'
       - 'tasklist.Dockerfile'
+      - 'webapps-common/**'
   pull_request:
     paths:
       - '.github/actions/**'
@@ -22,6 +23,7 @@ on:
       - 'pom.xml'
       - 'tasklist/**'
       - 'tasklist.Dockerfile'
+      - 'webapps-common/**'
 
 # This will limit the workflow to 1 concurrent run per ref (branch / PR).
 # If a new commits occurs, the current run will be canceled to save costs.


### PR DESCRIPTION
## Description
New module `webapps-common` used by Operate and Tasklist, 
Triggering Operate and Tasklist CIs on changes in this folder

## Related issues

closes #
