### PR TITLE
test: fix batch move modification e2e test

### DIFF
--- a/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
+++ b/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
@@ -11,6 +11,7 @@ import {test} from '../test-fixtures';
 import {expect} from '@playwright/test';
 import {SETUP_WAITING_TIME} from './constants';
 import {config} from '../config';
+import {ProcessInstancesStatisticsDto} from 'modules/api/processInstances/fetchProcessInstancesStatistics';
 
 let initialData: Awaited<ReturnType<typeof setup>>;
 
@@ -46,16 +47,17 @@ test.describe('Process Instance Batch Modification', () => {
     processesPage: {filtersPanel},
     commonPage,
     page,
+    request,
   }) => {
     test.slow();
-    const processInstanceKeys = initialData.processInstances
-      .map((instance) => instance.processInstanceKey)
-      .join(',');
+    const processInstanceKeys = initialData.processInstances.map(
+      (instance) => instance.processInstanceKey,
+    );
 
     await processesPage.navigateToProcesses({
       searchParams: {
         active: 'true',
-        ids: processInstanceKeys,
+        ids: processInstanceKeys.join(','),
         process: initialData.bpmnProcessId,
         version: initialData.version.toString(),
         flowNodeId: 'checkPayment',
@@ -133,7 +135,9 @@ test.describe('Process Instance Batch Modification', () => {
 
     // Filter by all process instances which have been created in setup
     await filtersPanel.displayOptionalFilter('Process Instance Key(s)');
-    await filtersPanel.processInstanceKeysFilter.fill(processInstanceKeys);
+    await filtersPanel.processInstanceKeysFilter.fill(
+      processInstanceKeys.join(','),
+    );
 
     // Expect the correct number of instances related to the move modification
     await expect(
@@ -142,24 +146,46 @@ test.describe('Process Instance Batch Modification', () => {
       ),
     ).toBeVisible();
 
-    // Expect that flow node instances have been created on shipArticles in all process instances.
-    // Reload page until data is updated.
+    // Wait for all process instances to be modified
     await expect
       .poll(
         async () => {
-          await page.reload();
-          return processesPage.diagram.diagram
-            .getByTestId('state-overlay-shipArticles-active')
-            .textContent();
+          const response = await request.post(
+            `${config.endpoint}/api/process-instances/statistics`,
+            {
+              data: {
+                active: true,
+                running: true,
+                processIds: ['2251799813685249'],
+                activityId: 'shipArticles',
+                ids: processInstanceKeys,
+              },
+            },
+          );
+          const statistics: ProcessInstancesStatisticsDto[] =
+            await response.json();
+          const targetFlowNodeStatistics = statistics.find(({activityId}) => {
+            return activityId === 'shipArticles';
+          });
+          return targetFlowNodeStatistics?.active;
         },
-        {intervals: [2000], timeout: 30000},
+        {timeout: SETUP_WAITING_TIME},
       )
-      .toBe(NUM_SELECTED_PROCESS_INSTANCES.toString());
+      .toBe(NUM_SELECTED_PROCESS_INSTANCES);
+
+    await page.reload();
 
     // Expect that checkPayment flow node instances got canceled in all process instances
     await expect(
       processesPage.diagram.diagram.getByTestId(
         'state-overlay-checkPayment-canceled',
+      ),
+    ).toHaveText(NUM_SELECTED_PROCESS_INSTANCES.toString());
+
+    // Expect that flow node instances have been created on shipArticles in all process instances.
+    expect(
+      processesPage.diagram.diagram.getByTestId(
+        'state-overlay-shipArticles-active',
       ),
     ).toHaveText(NUM_SELECTED_PROCESS_INSTANCES.toString());
   });


### PR DESCRIPTION
## Description

This stabilizes the batch move modification e2e test.

### Root cause
- After the migration is triggered, FE polls for `/api/batch-operations` to check if the operation is finished
- After the operation is finished, FE fetches the statistics once from `api/process-instances/statistics`
- In some cases the operation is finished, but the statistics data is not updated yet on BE side, so FE fetches old statistics
- In the test there is an assertion that statistics badges in the diagram are updated accordingly
- In the test the updated data is not fetched and the badges are showing the old data.

In the e2e test we had a mechanism which is supposed to refresh the page every 2 seconds, which didn't work properly

```
   await expect
      .poll(
        async () => {
          await page.reload();
          ...
        },
        {intervals: [2000], timeout: 30000},
      )
      .toBe(...);
```

### Solution

Instead of trying to refresh the page until the data is visible in the UI, there is now a polling on the `/api/process-instances/statistics` API endpoint to ensure data is updated, followed by the assertion on the statistics badges in the UI.

### Outcome

The `batchMoveModification.spec.ts` passed in the following test runs:
- 8/8 times: https://github.com/camunda/camunda/actions/runs/9517924498
- 3/3 times: https://github.com/camunda/camunda/actions/runs/9579236532/

## Related issues

closes #18149 
