### PR TITLE
Stabilize `ReplayStateRandomizedPropertyTest`

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -18,12 +18,14 @@ import io.camunda.zeebe.engine.util.TestStreams;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.util.ArrayList;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.junit.rules.TemporaryFolder;
 
 /** Helper class which should help to make it easy to create an engine for tests. */
@@ -34,7 +36,10 @@ public final class TestEngine {
   private final int partitionCount;
 
   private TestEngine(
-      final int partitionId, final int partitionCount, final TestContext testContext) {
+      final int partitionId,
+      final int partitionCount,
+      final TestContext testContext,
+      final Consumer<StreamProcessorBuilder> processorConfiguration) {
     this.partitionCount = partitionCount;
 
     testStreams =
@@ -82,7 +87,8 @@ public final class TestEngine {
                             new ProcessingExporterTransistor(
                                 testStreams.getLogStream(
                                     StreamProcessingComposite.getLogName(partitionId)))),
-                Optional.empty()));
+                Optional.empty(),
+                processorConfiguration));
     interPartitionCommandSenders.forEach(s -> s.initializeWriters(partitionCount));
   }
 
@@ -95,7 +101,7 @@ public final class TestEngine {
   }
 
   public static TestEngine createSinglePartitionEngine(final TestContext testContext) {
-    return new TestEngine(1, 1, testContext);
+    return new TestEngine(1, 1, testContext, cfg -> {});
   }
 
   public void reset() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -88,7 +88,8 @@ public final class TestEngine {
                                 testStreams.getLogStream(
                                     StreamProcessingComposite.getLogName(partitionId)))),
                 Optional.empty(),
-                processorConfiguration));
+                processorConfiguration,
+                true));
     interPartitionCommandSenders.forEach(s -> s.initializeWriters(partitionCount));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -101,10 +101,7 @@ public class ReplayStateRandomizedPropertyTest {
     // given
     Awaitility.await(
             "await the last written record to be processed, then wait a GRACE_PERIOD to make sure no new events are added")
-        .untilAsserted(
-            () -> {
-              processingHasStoppedAndNoNewRecordsAreAddedDuringGracePeriod();
-            });
+        .untilAsserted(this::processingHasStoppedAndNoNewRecordsAreAddedDuringGracePeriod);
 
     engineRule.pauseProcessing(1);
 
@@ -162,14 +159,10 @@ public class ReplayStateRandomizedPropertyTest {
     assertThat(engineRule.hasReachedEnd())
         .describedAs("Processing has reached end of the log.")
         .isTrue();
-    final var stateBeforeGracePeriod = engineRule.collectState();
     Thread.sleep(GRACE_PERIOD);
     assertThat(engineRule.hasReachedEnd())
         .describedAs("Processing has reached end of the log.")
         .isTrue();
-    final var stateAfterGracePeriod = engineRule.collectState();
-
-    assertIdenticalStates(stateBeforeGracePeriod, stateAfterGracePeriod);
   }
 
   @Parameters(name = "{0}")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
+import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.bpmn.random.ExecutionPath;
 import io.camunda.zeebe.test.util.bpmn.random.ScheduledExecutionStep;
 import io.camunda.zeebe.test.util.bpmn.random.TestDataGenerator;
@@ -118,7 +119,7 @@ public class ReplayStateRandomizedPropertyTest {
     engineRule.stop();
 
     // when
-    engineRule.start();
+    engineRule.start(StreamProcessorMode.PROCESSING);
 
     Awaitility.await()
         .untilAsserted(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Map;
 import org.assertj.core.api.SoftAssertions;
 import org.awaitility.Awaitility;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -50,13 +49,7 @@ public class ReplayStateRandomizedPropertyTest {
       new FailedPropertyBasedTestDataPrinter(this::getDataRecord);
 
   @Rule public final EngineRule engineRule = EngineRule.singlePartition();
-  private long lastProcessedPosition = -1L;
   private final ProcessExecutor processExecutor = new ProcessExecutor(engineRule);
-
-  @Before
-  public void init() {
-    lastProcessedPosition = -1L;
-  }
 
   public TestDataRecord getDataRecord() {
     return record;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/randomized/ReplayStateRandomizedPropertyTest.java
@@ -109,7 +109,7 @@ public class ReplayStateRandomizedPropertyTest {
     engineRule.stop();
 
     // when
-    engineRule.start(StreamProcessorMode.PROCESSING);
+    engineRule.start(StreamProcessorMode.PROCESSING, true);
 
     Awaitility.await()
         .untilAsserted(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -121,11 +121,15 @@ public final class EngineRule extends ExternalResource {
 
   @Override
   protected void before() {
-    startProcessors();
+    startProcessors(StreamProcessorMode.PROCESSING);
   }
 
   public void start() {
-    startProcessors();
+    startProcessors(StreamProcessorMode.PROCESSING);
+  }
+
+  public void start(final StreamProcessorMode mode) {
+    startProcessors(mode);
   }
 
   public void stop() {
@@ -157,7 +161,7 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
-  private void startProcessors() {
+  private void startProcessors(final StreamProcessorMode mode) {
     interPartitionCommandSenders = new ArrayList<>();
 
     forEachPartition(
@@ -191,7 +195,8 @@ public final class EngineRule extends ExternalResource {
                       lastProcessedPosition = skippedRecord.getPosition();
                       onSkippedCallback.accept(skippedRecord);
                     }
-                  }));
+                  }),
+              cfg -> cfg.streamProcessorMode(mode));
         });
     interPartitionCommandSenders.forEach(s -> s.initializeWriters(partitionCount));
   }
@@ -233,7 +238,7 @@ public final class EngineRule extends ExternalResource {
     // we need to reset the record exporter
     RecordingExporter.reset();
 
-    startProcessors();
+    startProcessors(StreamProcessorMode.PROCESSING);
     TestUtil.waitUntil(
         () -> RecordingExporter.getRecords().size() >= lastSize,
         "Failed to reprocess all events, only re-exported %d but expected %d",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -121,15 +121,15 @@ public final class EngineRule extends ExternalResource {
 
   @Override
   protected void before() {
-    startProcessors(StreamProcessorMode.PROCESSING);
+    start();
   }
 
   public void start() {
-    startProcessors(StreamProcessorMode.PROCESSING);
+    start(StreamProcessorMode.PROCESSING, true);
   }
 
-  public void start(final StreamProcessorMode mode) {
-    startProcessors(mode);
+  public void start(final StreamProcessorMode mode, final boolean awaitOpening) {
+    startProcessors(mode, awaitOpening);
   }
 
   public void stop() {
@@ -161,7 +161,7 @@ public final class EngineRule extends ExternalResource {
     return this;
   }
 
-  private void startProcessors(final StreamProcessorMode mode) {
+  private void startProcessors(final StreamProcessorMode mode, final boolean awaitOpening) {
     interPartitionCommandSenders = new ArrayList<>();
 
     forEachPartition(
@@ -196,7 +196,8 @@ public final class EngineRule extends ExternalResource {
                       onSkippedCallback.accept(skippedRecord);
                     }
                   }),
-              cfg -> cfg.streamProcessorMode(mode));
+              cfg -> cfg.streamProcessorMode(mode),
+              awaitOpening);
         });
     interPartitionCommandSenders.forEach(s -> s.initializeWriters(partitionCount));
   }
@@ -238,7 +239,7 @@ public final class EngineRule extends ExternalResource {
     // we need to reset the record exporter
     RecordingExporter.reset();
 
-    startProcessors(StreamProcessorMode.PROCESSING);
+    startProcessors(StreamProcessorMode.PROCESSING, true);
     TestUtil.waitUntil(
         () -> RecordingExporter.getRecords().size() >= lastSize,
         "Failed to reprocess all events, only re-exported %d but expected %d",

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -24,10 +24,12 @@ import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.function.Consumer;
 
 public class StreamProcessingComposite implements CommandWriter {
 
@@ -81,13 +83,14 @@ public class StreamProcessingComposite implements CommandWriter {
   public StreamProcessor startTypedStreamProcessor(
       final TypedRecordProcessorFactory factory,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
-    return startTypedStreamProcessor(partitionId, factory, streamProcessorListenerOpt);
+    return startTypedStreamProcessor(partitionId, factory, streamProcessorListenerOpt, cfg -> {});
   }
 
   public StreamProcessor startTypedStreamProcessor(
       final int partitionId,
       final TypedRecordProcessorFactory factory,
-      final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
+      final Optional<StreamProcessorListener> streamProcessorListenerOpt,
+      final Consumer<StreamProcessorBuilder> processorConfiguration) {
     final var result =
         streams.startStreamProcessor(
             getLogName(partitionId),
@@ -97,7 +100,8 @@ public class StreamProcessingComposite implements CommandWriter {
 
               return factory.createProcessors(processingContext);
             }),
-            streamProcessorListenerOpt);
+            streamProcessorListenerOpt,
+            processorConfiguration);
 
     return result;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -83,14 +83,16 @@ public class StreamProcessingComposite implements CommandWriter {
   public StreamProcessor startTypedStreamProcessor(
       final TypedRecordProcessorFactory factory,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
-    return startTypedStreamProcessor(partitionId, factory, streamProcessorListenerOpt, cfg -> {});
+    return startTypedStreamProcessor(
+        partitionId, factory, streamProcessorListenerOpt, cfg -> {}, true);
   }
 
   public StreamProcessor startTypedStreamProcessor(
       final int partitionId,
       final TypedRecordProcessorFactory factory,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt,
-      final Consumer<StreamProcessorBuilder> processorConfiguration) {
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
+      final boolean awaitOpening) {
     final var result =
         streams.startStreamProcessor(
             getLogName(partitionId),
@@ -101,7 +103,8 @@ public class StreamProcessingComposite implements CommandWriter {
               return factory.createProcessors(processingContext);
             }),
             streamProcessorListenerOpt,
-            processorConfiguration);
+            processorConfiguration,
+            awaitOpening);
 
     return result;
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorContext;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
@@ -33,6 +34,7 @@ import io.camunda.zeebe.util.allocation.DirectBufferAllocator;
 import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.RuleChain;
@@ -137,9 +139,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
   public StreamProcessor startTypedStreamProcessor(
       final int partitionId,
       final TypedRecordProcessorFactory factory,
-      final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
+      final Optional<StreamProcessorListener> streamProcessorListenerOpt,
+      final Consumer<StreamProcessorBuilder> processorConfiguration) {
     return streamProcessingComposite.startTypedStreamProcessor(
-        partitionId, factory, streamProcessorListenerOpt);
+        partitionId, factory, streamProcessorListenerOpt, processorConfiguration);
   }
 
   public void pauseProcessing(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -140,9 +140,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
       final int partitionId,
       final TypedRecordProcessorFactory factory,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt,
-      final Consumer<StreamProcessorBuilder> processorConfiguration) {
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
+      final boolean awaitOpening) {
     return streamProcessingComposite.startTypedStreamProcessor(
-        partitionId, factory, streamProcessorListenerOpt, processorConfiguration);
+        partitionId, factory, streamProcessorListenerOpt, processorConfiguration, awaitOpening);
   }
 
   public void pauseProcessing(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -208,7 +208,7 @@ public final class TestStreams {
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory typedRecordProcessorFactory) {
     return startStreamProcessor(
-        log, zeebeDbFactory, typedRecordProcessorFactory, Optional.empty(), cfg -> {});
+        log, zeebeDbFactory, typedRecordProcessorFactory, Optional.empty(), cfg -> {}, true);
   }
 
   public StreamProcessor startStreamProcessor(
@@ -216,14 +216,15 @@ public final class TestStreams {
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory typedRecordProcessorFactory,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt,
-      final Consumer<StreamProcessorBuilder> processorConfiguration) {
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
+      final boolean awaitOpening) {
     final SynchronousLogStream stream = getLogStream(log);
     return buildStreamProcessor(
         stream,
         zeebeDbFactory,
         processorConfiguration,
         typedRecordProcessorFactory,
-        true,
+        awaitOpening,
         streamProcessorListenerOpt);
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -41,6 +41,7 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
+import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorContext;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
 import io.camunda.zeebe.stream.impl.StreamProcessorMode;
@@ -206,22 +207,30 @@ public final class TestStreams {
       final String log,
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory typedRecordProcessorFactory) {
-    return startStreamProcessor(log, zeebeDbFactory, typedRecordProcessorFactory, Optional.empty());
+    return startStreamProcessor(
+        log, zeebeDbFactory, typedRecordProcessorFactory, Optional.empty(), cfg -> {});
   }
 
   public StreamProcessor startStreamProcessor(
       final String log,
       final ZeebeDbFactory zeebeDbFactory,
       final TypedRecordProcessorFactory typedRecordProcessorFactory,
-      final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
+      final Optional<StreamProcessorListener> streamProcessorListenerOpt,
+      final Consumer<StreamProcessorBuilder> processorConfiguration) {
     final SynchronousLogStream stream = getLogStream(log);
     return buildStreamProcessor(
-        stream, zeebeDbFactory, typedRecordProcessorFactory, true, streamProcessorListenerOpt);
+        stream,
+        zeebeDbFactory,
+        processorConfiguration,
+        typedRecordProcessorFactory,
+        true,
+        streamProcessorListenerOpt);
   }
 
   public StreamProcessor buildStreamProcessor(
       final SynchronousLogStream stream,
       final ZeebeDbFactory zeebeDbFactory,
+      final Consumer<StreamProcessorBuilder> processorConfiguration,
       final TypedRecordProcessorFactory factory,
       final boolean awaitOpening,
       final Optional<StreamProcessorListener> streamProcessorListenerOpt) {
@@ -261,6 +270,8 @@ public final class TestStreams {
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
             .partitionCommandSender(mock(InterPartitionCommandSender.class));
+
+    processorConfiguration.accept(builder);
 
     final StreamProcessor streamProcessor = builder.build();
     final var openFuture = streamProcessor.openAsync(false);


### PR DESCRIPTION
## Description

Makes `ReplayStateRandomizedPropertyTest` deterministic by restarting the engine in `REPLAY` mode, by avoiding processing any leftover commands after the engine restart.

This test case ensures that the state after replay is equivalent to state before restart, i.e. it verifies that replay is deterministic. It does this as follows:
- deploy a random process
- determine a random execution path through this process
- for each step in the random execution path:
  - run the step
  - stop the engine and collect the state for later comparison
  - restart the engine in replay mode
  - collect the state again and compare with previous state
  - continue processing

There is a small window where processing is stopped before the restart and new commands could be appended by a checker. For example, a timer trigger command. This made it possible for unprocessed commands on the log stream to be processed at restart, because the test did restarted the engine after restart in processing mode. The main change of this PR is to restart the engine in replay mode and to continue in processing mode after each verification step.

## Related issues

closes #14596
