### PR TITLE
feat: Integrate `start` execution listener support for gateway elements

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractGatewayBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractGatewayBuilder.java
@@ -19,6 +19,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.GatewayDirection;
 import io.camunda.zeebe.model.bpmn.instance.Gateway;
+import java.util.function.Consumer;
 
 /**
  * @author Sebastian Menski
@@ -27,9 +28,12 @@ public abstract class AbstractGatewayBuilder<
         B extends AbstractGatewayBuilder<B, E>, E extends Gateway>
     extends AbstractFlowNodeBuilder<B, E> {
 
+  private final ZeebeExecutionListenersBuilder<B> zeebeExecutionListenersBuilder;
+
   protected AbstractGatewayBuilder(
       final BpmnModelInstance modelInstance, final E element, final Class<?> selfType) {
     super(modelInstance, element, selfType);
+    zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
   }
 
   /**
@@ -41,5 +45,18 @@ public abstract class AbstractGatewayBuilder<
   public B gatewayDirection(final GatewayDirection gatewayDirection) {
     element.setGatewayDirection(gatewayDirection);
     return myself;
+  }
+
+  public B zeebeStartExecutionListener(final String type, final String retries) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type, retries);
+  }
+
+  public B zeebeStartExecutionListener(final String type) {
+    return zeebeExecutionListenersBuilder.zeebeStartExecutionListener(type);
+  }
+
+  public B zeebeExecutionListener(
+      final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
+    return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ExecutionListenersValidator.java
@@ -34,9 +34,11 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
   private static final Set<String> ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS =
       new LinkedHashSet<>(
           Arrays.asList(
+              // processes
               BpmnModelConstants.BPMN_ELEMENT_PROCESS,
               BpmnModelConstants.BPMN_ELEMENT_SUB_PROCESS,
               BpmnModelConstants.BPMN_ELEMENT_CALL_ACTIVITY,
+              // tasks
               BpmnModelConstants.BPMN_ELEMENT_TASK,
               BpmnModelConstants.BPMN_ELEMENT_SEND_TASK,
               BpmnModelConstants.BPMN_ELEMENT_SERVICE_TASK,
@@ -45,11 +47,17 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
               BpmnModelConstants.BPMN_ELEMENT_RECEIVE_TASK,
               BpmnModelConstants.BPMN_ELEMENT_BUSINESS_RULE_TASK,
               BpmnModelConstants.BPMN_ELEMENT_MANUAL_TASK,
+              // events
               BpmnModelConstants.BPMN_ELEMENT_START_EVENT,
               BpmnModelConstants.BPMN_ELEMENT_INTERMEDIATE_THROW_EVENT,
               BpmnModelConstants.BPMN_ELEMENT_INTERMEDIATE_CATCH_EVENT,
               BpmnModelConstants.BPMN_ELEMENT_BOUNDARY_EVENT,
-              BpmnModelConstants.BPMN_ELEMENT_END_EVENT));
+              BpmnModelConstants.BPMN_ELEMENT_END_EVENT,
+              // gateways
+              BpmnModelConstants.BPMN_ELEMENT_EXCLUSIVE_GATEWAY,
+              BpmnModelConstants.BPMN_ELEMENT_INCLUSIVE_GATEWAY,
+              BpmnModelConstants.BPMN_ELEMENT_PARALLEL_GATEWAY,
+              BpmnModelConstants.BPMN_ELEMENT_EVENT_BASED_GATEWAY));
 
   @Override
   public Class<ZeebeExecutionListeners> getElementType() {
@@ -65,18 +73,6 @@ public class ExecutionListenersValidator implements ModelElementValidator<ZeebeE
       return;
     }
 
-    /*
-     * Temporary validation check to ensure execution listeners are only associated with supported
-     * BPMN elements.
-     *
-     * <p>Note: This validation is currently limited to specific BPMN elements that support
-     * execution listeners. As we extend the support for execution listeners across more BPMN
-     * elements, this check will be updated accordingly to reflect those changes. This is a
-     * transitional safeguard to ensure consistency and correctness in the model until full support
-     * is implemented.
-     *
-     * TODO: Review and update this validation as execution listener support is expanded to additional BPMN elements.
-     */
     final String parentElementTypeName =
         element.getParentElement().getParentElement().getElementType().getTypeName();
     if (!ELEMENTS_THAT_SUPPORT_EXECUTION_LISTENERS.contains(parentElementTypeName)) {

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/GatewayValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/GatewayValidator.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import static io.camunda.zeebe.model.bpmn.util.ModelUtil.validateExecutionListenersDefinitionForElement;
+
+import io.camunda.zeebe.model.bpmn.instance.Gateway;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class GatewayValidator implements ModelElementValidator<Gateway> {
+
+  @Override
+  public Class<Gateway> getElementType() {
+    return Gateway.class;
+  }
+
+  @Override
+  public void validate(
+      final Gateway element, final ValidationResultCollector validationResultCollector) {
+
+    validateExecutionListenersDefinitionForElement(
+        element,
+        validationResultCollector,
+        listeners -> {
+          final boolean endExecutionListenersDefined =
+              listeners.stream()
+                  .map(ZeebeExecutionListener::getEventType)
+                  .anyMatch(ZeebeExecutionListenerEventType.end::equals);
+          if (endExecutionListenersDefined) {
+            validationResultCollector.addError(
+                0, "Execution listeners of type 'end' are not supported by gateway element");
+          }
+        });
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -49,6 +49,7 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new DefinitionsValidator());
     validators.add(new EndEventValidator());
     validators.add(new EventDefinitionValidator());
+    validators.add(new GatewayValidator());
     validators.add(new EventBasedGatewayValidator());
     validators.add(new ErrorEventDefinitionValidator());
     validators.add(new ExclusiveGatewayValidator());

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeExecutionListenersValidationTest.java
@@ -136,7 +136,8 @@ public class ZeebeExecutionListenersValidationTest {
             "Execution listeners are not supported for the 'sequenceFlow' element. "
                 + "Currently, only [process, subProcess, callActivity, task, sendTask, serviceTask, "
                 + "scriptTask, userTask, receiveTask, businessRuleTask, manualTask, startEvent, "
-                + "intermediateThrowEvent, intermediateCatchEvent, boundaryEvent, endEvent] "
+                + "intermediateThrowEvent, intermediateCatchEvent, boundaryEvent, endEvent, "
+                + "exclusiveGateway, inclusiveGateway, parallelGateway, eventBasedGateway] "
                 + "elements can have execution listeners."));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/EventBasedGatewayProcessor.java
@@ -39,7 +39,7 @@ public final class EventBasedGatewayProcessor
   }
 
   @Override
-  public Either<Failure, ?> onActivate(
+  public Either<Failure, ?> finalizeActivation(
       final ExecutableEventBasedGateway element, final BpmnElementContext context) {
     return eventSubscriptionBehavior
         .subscribeToEvents(element, context)
@@ -50,8 +50,12 @@ public final class EventBasedGatewayProcessor
   @Override
   public Either<Failure, ?> onComplete(
       final ExecutableEventBasedGateway element, final BpmnElementContext context) {
+    return SUCCESS.thenDo(ok -> eventSubscriptionBehavior.unsubscribeFromEvents(context));
+  }
 
-    eventSubscriptionBehavior.unsubscribeFromEvents(context);
+  @Override
+  public Either<Failure, ?> finalizeCompletion(
+      final ExecutableEventBasedGateway element, final BpmnElementContext context) {
 
     final var eventTrigger =
         eventSubscriptionBehavior

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -45,7 +45,7 @@ public final class ExclusiveGatewayProcessor
   }
 
   @Override
-  public Either<Failure, ?> onActivate(
+  public Either<Failure, ?> finalizeActivation(
       final ExecutableExclusiveGateway element, final BpmnElementContext activating) {
     // find outgoing sequence flow with fulfilled condition or the default (or none if implicit end)
     return findSequenceFlowToTake(element, activating)
@@ -65,7 +65,7 @@ public final class ExclusiveGatewayProcessor
   }
 
   @Override
-  public Either<Failure, ?> onComplete(
+  public Either<Failure, ?> finalizeCompletion(
       final ExecutableExclusiveGateway element, final BpmnElementContext context) {
     throw new UnsupportedOperationException(
         String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/InclusiveGatewayProcessor.java
@@ -46,7 +46,7 @@ public final class InclusiveGatewayProcessor
   }
 
   @Override
-  public Either<Failure, ?> onActivate(
+  public Either<Failure, ?> finalizeActivation(
       final ExecutableInclusiveGateway element, final BpmnElementContext activating) {
     // find outgoing sequence flow with fulfilled condition or the default (or none if implicit end)
     return findSequenceFlowsToTake(element, activating)
@@ -68,7 +68,7 @@ public final class InclusiveGatewayProcessor
   }
 
   @Override
-  public Either<Failure, ?> onComplete(
+  public Either<Failure, ?> finalizeCompletion(
       final ExecutableInclusiveGateway element, final BpmnElementContext context) {
     throw new UnsupportedOperationException(
         String.format(
@@ -94,9 +94,10 @@ public final class InclusiveGatewayProcessor
     }
 
     final var outgoingSequenceFlows = element.getOutgoing();
-    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.get(0).getCondition() == null) {
+    if (outgoingSequenceFlows.size() == 1
+        && outgoingSequenceFlows.getFirst().getCondition() == null) {
       // only one flow without a condition, can just be taken
-      executableSequenceFlows.add(outgoingSequenceFlows.get(0));
+      executableSequenceFlows.add(outgoingSequenceFlows.getFirst());
       return Either.right(executableSequenceFlows);
     }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ParallelGatewayProcessor.java
@@ -34,7 +34,7 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
   }
 
   @Override
-  public Either<Failure, ?> onActivate(
+  public Either<Failure, ?> finalizeActivation(
       final ExecutableFlowNode element, final BpmnElementContext context) {
     // the joining of the incoming sequence flows into the parallel gateway happens in the
     // sequence flow processor. The activating event of the parallel gateway is written when all
@@ -52,7 +52,7 @@ public final class ParallelGatewayProcessor implements BpmnElementProcessor<Exec
   }
 
   @Override
-  public Either<Failure, ?> onComplete(
+  public Either<Failure, ?> finalizeCompletion(
       final ExecutableFlowNode element, final BpmnElementContext context) {
     throw new UnsupportedOperationException(
         String.format(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceElementActivatingApplier.java
@@ -10,8 +10,10 @@ package io.camunda.zeebe.engine.state.appliers;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableActivity;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCatchEventSupplier;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableExclusiveGateway;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowElementContainer;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableFlowNode;
+import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableInclusiveGateway;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableJobWorkerElement;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableMultiInstanceBody;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableSequenceFlow;
@@ -299,8 +301,10 @@ final class ProcessInstanceElementActivatingApplier
           eventSupplier.getInterruptingElementIds(),
           eventSupplier.getBoundaryElementIds());
     } else if (flowElement instanceof ExecutableJobWorkerElement
-        || flowElement instanceof ExecutableActivity) {
-      // job worker elements without events (e.g. message throw events)
+        || flowElement instanceof ExecutableActivity
+        || flowElement instanceof ExecutableExclusiveGateway
+        || flowElement instanceof ExecutableInclusiveGateway) {
+      // executable elements without events
       eventScopeInstanceState.createInstance(
           elementInstanceKey, Collections.emptySet(), Collections.emptySet());
     }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerGatewayElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/ExecutionListenerGatewayElementsTest.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.bpmn.activity;
+
+import static io.camunda.zeebe.engine.processing.bpmn.activity.ExecutionListenerTest.END_EL_TYPE;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.ExecutionListenerTest.PROCESS_ID;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.ExecutionListenerTest.SERVICE_TASK_TYPE;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.ExecutionListenerTest.START_EL_TYPE;
+import static io.camunda.zeebe.engine.processing.bpmn.activity.ExecutionListenerTest.createProcessInstance;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
+
+import io.camunda.zeebe.engine.processing.deployment.model.validation.ExpectedValidationResult;
+import io.camunda.zeebe.engine.processing.deployment.model.validation.ProcessValidationUtil;
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.builder.AbstractBpmnModelElementBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractFlowNodeBuilder;
+import io.camunda.zeebe.model.bpmn.builder.AbstractGatewayBuilder;
+import io.camunda.zeebe.model.bpmn.builder.StartEventBuilder;
+import io.camunda.zeebe.model.bpmn.instance.Gateway;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Enclosed.class)
+public class ExecutionListenerGatewayElementsTest {
+  @RunWith(Parameterized.class)
+  public static class ParametrizedTest {
+
+    @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+    private static final String GATEWAY_ELEMENT_ID = "gateway_element_under_test";
+
+    @Rule
+    public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+        new RecordingExporterTestWatcher();
+
+    @Parameter public GatewayTestScenario scenario;
+
+    @Parameters(name = "{index}: {0}")
+    public static Collection<Object[]> parameters() {
+      return Arrays.asList(
+          new Object[][] {
+            {
+              GatewayTestScenario.of(
+                  "exclusive",
+                  BpmnElementType.EXCLUSIVE_GATEWAY,
+                  Map.of("foo", 1),
+                  start -> start.exclusiveGateway(GATEWAY_ELEMENT_ID),
+                  process ->
+                      process
+                          .sequenceFlowId("to_end_a")
+                          .conditionExpression("foo < 5")
+                          .serviceTask(SERVICE_TASK_TYPE, t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                          .endEvent("end_a")
+                          .moveToLastExclusiveGateway()
+                          .sequenceFlowId("to_end_b")
+                          .defaultFlow()
+                          .endEvent("end_b"))
+            },
+            {
+              GatewayTestScenario.of(
+                  "inclusive",
+                  BpmnElementType.INCLUSIVE_GATEWAY,
+                  Map.of("foo", 1),
+                  start -> start.inclusiveGateway(GATEWAY_ELEMENT_ID),
+                  process ->
+                      process
+                          .sequenceFlowId("to_end_a")
+                          .conditionExpression("foo < 5")
+                          .serviceTask(SERVICE_TASK_TYPE, t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                          .endEvent("end_a")
+                          .moveToLastInclusiveGateway()
+                          .sequenceFlowId("to_end_b")
+                          .defaultFlow()
+                          .endEvent("end_b"))
+            },
+            {
+              GatewayTestScenario.of(
+                  "parallel",
+                  BpmnElementType.PARALLEL_GATEWAY,
+                  Map.of("foo", 1),
+                  start -> start.parallelGateway(GATEWAY_ELEMENT_ID),
+                  process ->
+                      process
+                          .serviceTask(SERVICE_TASK_TYPE, t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                          .endEvent("end_a")
+                          .moveToLastGateway()
+                          .manualTask("manual_task")
+                          .endEvent("end_b"))
+            },
+            {
+              GatewayTestScenario.of(
+                  "event-based",
+                  BpmnElementType.EVENT_BASED_GATEWAY,
+                  Collections.emptyMap(),
+                  start -> start.eventBasedGateway(GATEWAY_ELEMENT_ID),
+                  process ->
+                      process
+                          .intermediateCatchEvent("signal", e -> e.signal("my_signal"))
+                          .serviceTask(SERVICE_TASK_TYPE, t -> t.zeebeJobType(SERVICE_TASK_TYPE))
+                          .endEvent("end_signal")
+                          .moveToLastGateway()
+                          .intermediateCatchEvent(
+                              "message",
+                              e ->
+                                  e.message(
+                                      m -> m.name("my_message").zeebeCorrelationKey("=\"my_key\"")))
+                          .endEvent("end_message"),
+                  () -> ENGINE.signal().withSignalName("my_signal").broadcast())
+            }
+          });
+    }
+
+    @Test
+    public void shouldCompleteGatewayElementWithMultipleStartExecutionListeners() {
+      // given
+      final var modelInstance =
+          scenario
+              .processBuilder
+              .apply(
+                  scenario
+                      .gatewayBuilderFunction
+                      .apply(Bpmn.createExecutableProcess(PROCESS_ID).startEvent("start"))
+                      .zeebeStartExecutionListener(START_EL_TYPE + "_1")
+                      .zeebeStartExecutionListener(START_EL_TYPE + "_2"))
+              .done();
+
+      final long processInstanceKey =
+          createProcessInstance(ENGINE, modelInstance, scenario.variables);
+
+      // when: complete `start` execution listener jobs
+      ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_1").complete();
+      ENGINE.job().ofInstance(processInstanceKey).withType(START_EL_TYPE + "_2").complete();
+
+      // process gateway element
+      scenario.gatewayProcessor.run();
+
+      // complete service task on the chosen flow
+      ENGINE.job().ofInstance(processInstanceKey).withType(SERVICE_TASK_TYPE).complete();
+
+      // assert the process with gateway and multiple start EL has completed as expected
+      assertThat(
+              RecordingExporter.processInstanceRecords()
+                  .withProcessInstanceKey(processInstanceKey)
+                  .limitToProcessInstanceCompleted())
+          .extracting(
+              r -> r.getValue().getElementId(),
+              r -> r.getValue().getBpmnElementType(),
+              Record::getIntent)
+          .containsSubsequence(
+              tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple(
+                  GATEWAY_ELEMENT_ID,
+                  scenario.elementType,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATING),
+              tuple(
+                  GATEWAY_ELEMENT_ID,
+                  scenario.elementType,
+                  ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+              tuple(
+                  GATEWAY_ELEMENT_ID,
+                  scenario.elementType,
+                  ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+              tuple(
+                  GATEWAY_ELEMENT_ID,
+                  scenario.elementType,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple(
+                  GATEWAY_ELEMENT_ID,
+                  scenario.elementType,
+                  ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(
+                  SERVICE_TASK_TYPE,
+                  BpmnElementType.SERVICE_TASK,
+                  ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+    }
+
+    @Test
+    public void shouldNotDeployProcessWithGatewayWithEndExecutionListeners() {
+      // given
+      final var modelInstance =
+          scenario
+              .processBuilder
+              .apply(
+                  scenario
+                      .gatewayBuilderFunction
+                      .apply(Bpmn.createExecutableProcess(PROCESS_ID).startEvent("start"))
+                      .zeebeStartExecutionListener(START_EL_TYPE)
+                      .zeebeExecutionListener(b -> b.end().type(END_EL_TYPE)))
+              .done();
+
+      // when - then
+      ProcessValidationUtil.validateProcess(
+          modelInstance,
+          ExpectedValidationResult.expect(
+              Gateway.class,
+              "Execution listeners of type 'end' are not supported by gateway element"));
+    }
+
+    private record GatewayTestScenario(
+        String name,
+        BpmnElementType elementType,
+        Map<String, Object> variables,
+        Function<StartEventBuilder, AbstractGatewayBuilder<?, ?>> gatewayBuilderFunction,
+        Function<AbstractFlowNodeBuilder<?, ?>, AbstractBpmnModelElementBuilder<?, ?>>
+            processBuilder,
+        Runnable gatewayProcessor) {
+
+      @Override
+      public String toString() {
+        return name;
+      }
+
+      private static GatewayTestScenario of(
+          final String name,
+          final BpmnElementType elementType,
+          final Map<String, Object> variables,
+          final Function<StartEventBuilder, AbstractGatewayBuilder<?, ?>> gatewayBuilderFunction,
+          final Function<AbstractFlowNodeBuilder<?, ?>, AbstractBpmnModelElementBuilder<?, ?>>
+              processBuilder,
+          final Runnable gatewayProcessor) {
+        return new GatewayTestScenario(
+            name, elementType, variables, gatewayBuilderFunction, processBuilder, gatewayProcessor);
+      }
+
+      private static GatewayTestScenario of(
+          final String name,
+          final BpmnElementType elementType,
+          final Map<String, Object> variables,
+          final Function<StartEventBuilder, AbstractGatewayBuilder<?, ?>> gatewayBuilderFunction,
+          final Function<AbstractFlowNodeBuilder<?, ?>, AbstractBpmnModelElementBuilder<?, ?>>
+              processBuilder) {
+        return new GatewayTestScenario(
+            name, elementType, variables, gatewayBuilderFunction, processBuilder, () -> {});
+      }
+    }
+  }
+
+  public static class ExtraTests {
+    @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+    @Rule
+    public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+        new RecordingExporterTestWatcher();
+
+    @Test
+    public void shouldSetVariableInStartListenerForExclusiveGatewayCondition() {
+      // given
+      final var modelInstance =
+          Bpmn.createExecutableProcess(PROCESS_ID)
+              .startEvent("start")
+              .exclusiveGateway("xor")
+              .zeebeStartExecutionListener(START_EL_TYPE)
+              .sequenceFlowId("to_end_a")
+              .conditionExpression("foo < 5")
+              .endEvent("end_a")
+              .moveToLastExclusiveGateway()
+              .sequenceFlowId("to_end_b")
+              .defaultFlow()
+              .endEvent("end_b")
+              .done();
+
+      final long processInstanceKey = createProcessInstance(ENGINE, modelInstance);
+
+      // when: complete `start` execution listener jobs with `foo` variable
+      ENGINE
+          .job()
+          .ofInstance(processInstanceKey)
+          .withType(START_EL_TYPE)
+          .withVariable("foo", 55)
+          .complete();
+
+      // assert the process instance has completed as expected,
+      // and default `to_end_b` flow was taken
+      assertThat(
+              RecordingExporter.processInstanceRecords()
+                  .withProcessInstanceKey(processInstanceKey)
+                  .limitToProcessInstanceCompleted())
+          .extracting(
+              r -> r.getValue().getElementId(),
+              r -> r.getValue().getBpmnElementType(),
+              Record::getIntent)
+          .containsSubsequence(
+              tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple("start", BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(
+                  "xor",
+                  BpmnElementType.EXCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATING),
+              tuple(
+                  "xor",
+                  BpmnElementType.EXCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+              tuple(
+                  "xor",
+                  BpmnElementType.EXCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple(
+                  "xor",
+                  BpmnElementType.EXCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(
+                  "to_end_b",
+                  BpmnElementType.SEQUENCE_FLOW,
+                  ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+              tuple("end_b", BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+    }
+
+    @Test
+    public void shouldSetVariableInStartListenerForMessageEventAfterEventBasedGatewayElement() {
+      // given
+      final var modelInstance =
+          Bpmn.createExecutableProcess(PROCESS_ID)
+              .startEvent("start")
+              .eventBasedGateway("event_gateway")
+              .zeebeStartExecutionListener(START_EL_TYPE)
+              .intermediateCatchEvent("signal", e -> e.signal("my_signal"))
+              .endEvent("end_signal")
+              .moveToLastGateway()
+              .intermediateCatchEvent(
+                  "message",
+                  e ->
+                      e.message(m -> m.name("my_message").zeebeCorrelationKeyExpression("key_var")))
+              .endEvent("end_message")
+              .done();
+
+      final long processInstanceKey = createProcessInstance(ENGINE, modelInstance);
+
+      // when: complete `start` execution listener jobs with `key_var` variable
+      ENGINE
+          .job()
+          .ofInstance(processInstanceKey)
+          .withType(START_EL_TYPE)
+          .withVariable("key_var", "my_key")
+          .complete();
+
+      // trigger message event
+      ENGINE.message().withName("my_message").withCorrelationKey("my_key").publish();
+
+      // assert the process instance has completed as expected, and `to_end_a` flow was taken
+      assertThat(
+              RecordingExporter.processInstanceRecords()
+                  .withProcessInstanceKey(processInstanceKey)
+                  .limitToProcessInstanceCompleted())
+          .extracting(
+              r -> r.getValue().getElementId(),
+              r -> r.getValue().getBpmnElementType(),
+              Record::getIntent)
+          .containsSubsequence(
+              tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple("start", BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(
+                  "event_gateway",
+                  BpmnElementType.EVENT_BASED_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATING),
+              tuple(
+                  "event_gateway",
+                  BpmnElementType.EVENT_BASED_GATEWAY,
+                  ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+              tuple(
+                  "event_gateway",
+                  BpmnElementType.EVENT_BASED_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple(
+                  "event_gateway",
+                  BpmnElementType.EVENT_BASED_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(
+                  "end_message",
+                  BpmnElementType.END_EVENT,
+                  ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED))
+          .doesNotContain(
+              tuple(
+                  "end_signal",
+                  BpmnElementType.END_EVENT,
+                  ProcessInstanceIntent.ELEMENT_COMPLETED));
+    }
+
+    @Test
+    public void shouldSetVariableInStartListenerForSequenceFlowConditionAfterInclusiveGateway() {
+      // given
+      final var modelInstance =
+          Bpmn.createExecutableProcess(PROCESS_ID)
+              .startEvent("start")
+              .inclusiveGateway("fork")
+              .zeebeStartExecutionListener(START_EL_TYPE)
+              .sequenceFlowId("to_end_a")
+              .conditionExpression("contains(str,\"a\")")
+              .endEvent("end_a")
+              .moveToLastInclusiveGateway()
+              .sequenceFlowId("to_end_b")
+              .conditionExpression("contains(str,\"b\")")
+              .endEvent("end_b")
+              .moveToLastInclusiveGateway()
+              .sequenceFlowId("to_end_c")
+              .conditionExpression("contains(str,\"c\")")
+              .endEvent("end_c")
+              .done();
+
+      final long processInstanceKey = createProcessInstance(ENGINE, modelInstance);
+
+      // when: complete `start` execution listener jobs with `str` variable
+      ENGINE
+          .job()
+          .ofInstance(processInstanceKey)
+          .withType(START_EL_TYPE)
+          .withVariable("str", "ac")
+          .complete();
+
+      // assert the process instance has completed as expected
+      // and `to_end_a` & `to_end_c` flows were taken
+      assertThat(
+              RecordingExporter.processInstanceRecords()
+                  .withProcessInstanceKey(processInstanceKey)
+                  .limitToProcessInstanceCompleted())
+          .extracting(
+              r -> r.getValue().getElementId(),
+              r -> r.getValue().getBpmnElementType(),
+              Record::getIntent)
+          .containsSubsequence(
+              tuple(PROCESS_ID, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple("start", BpmnElementType.START_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED),
+              tuple(
+                  "fork",
+                  BpmnElementType.INCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATING),
+              tuple(
+                  "fork",
+                  BpmnElementType.INCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.COMPLETE_EXECUTION_LISTENER),
+              tuple(
+                  "fork",
+                  BpmnElementType.INCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_ACTIVATED),
+              tuple(
+                  "fork",
+                  BpmnElementType.INCLUSIVE_GATEWAY,
+                  ProcessInstanceIntent.ELEMENT_COMPLETED))
+          .containsSubsequence(
+              tuple(
+                  "to_end_a",
+                  BpmnElementType.SEQUENCE_FLOW,
+                  ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+              tuple("end_a", BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED))
+          .containsSubsequence(
+              tuple(
+                  "to_end_c",
+                  BpmnElementType.SEQUENCE_FLOW,
+                  ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+              tuple("end_c", BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED))
+          .doesNotContain(
+              tuple(
+                  "to_end_b",
+                  BpmnElementType.SEQUENCE_FLOW,
+                  ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+              tuple("end_b", BpmnElementType.END_EVENT, ProcessInstanceIntent.ELEMENT_COMPLETED));
+    }
+  }
+}


### PR DESCRIPTION
## Description:
This PR enhances the Zeebe workflow engine by introducing Execution Listener support for various gateway elements, providing increased flexibility and control in managing complex workflows.

### Scope:
1. Exclusive Gateways:
   - Integrate `start` EL support to execute custom logic before evaluating conditions, enhancing decision-making processes.
2. Parallel Gateways:
   - Implement `start` EL support to execute before splitting into parallel paths or synchronizing paths, improving parallel process management.
3. Event-Based Gateways:
   - Provide `start` EL support to execute before waiting for an event, enhancing responsiveness to dynamic events.
4. Inclusive Gateways:
   - Add `start` EL support to execute custom logic before evaluating conditions, ensuring flexible flow control.

### Key Aspects:
1. Configuration:
   - Seamless integration of ELs within the BPMN Java builder APIs for intuitive configuration.
2. Testing:
   - Thorough testing across all supported gateways to ensure reliable and consistent EL behaviour.

By expanding Execution Listener support to these key gateway types, this PR empowers Zeebe users to build more dynamic, efficient, and controlled workflows.

## Related issues
closes #16215

## Checklist:
- [x] Implement start EL support for exclusive gateways
- [x] Implement start EL support for parallel gateways
- [x] Implement start EL support for event-based gateways
- [x] Implement start EL support for inclusive gateways
- [x] Add validation checks for unsupported EL configurations
- [x] Conduct thorough testing
