### PR TITLE
feat: create connect module to create a ES or OS client

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -805,6 +805,12 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-search-client-connect</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- sibling projects -->
 
       <dependency>

--- a/search/pom.xml
+++ b/search/pom.xml
@@ -18,6 +18,7 @@
     <module>search-client</module>
     <module>search-client-elasticsearch</module>
     <module>search-client-opensearch</module>
+    <module>search-client-connect</module>
   </modules>
 
 </project>

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>camunda-search</artifactId>
+    <version>8.6.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <artifactId>camunda-search-client-connect</artifactId>
+
+  <name>Camunda Search Client - Connect</name>
+
+  <dependencies>
+
+    <!--  camunda search client -->
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-elasticsearch</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-opensearch</artifactId>
+    </dependency>
+
+    <!-- elasticsearch -->
+
+    <dependency>
+      <groupId>co.elastic.clients</groupId>
+      <artifactId>elasticsearch-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpasyncclient</artifactId>
+    </dependency>
+
+    <!-- opensearch -->
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.opensearch.client</groupId>
+      <artifactId>opensearch-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>auth</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>http-client-spi</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>regions</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jdk8</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+    </dependency>
+
+    <!-- logging -->
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/search/search-client-connect/pom.xml
+++ b/search/search-client-connect/pom.xml
@@ -76,6 +76,11 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>netty-nio-client</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
     </dependency>
@@ -93,11 +98,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents.client5</groupId>
       <artifactId>httpclient5</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>software.amazon.awssdk</groupId>
-      <artifactId>apache-client</artifactId>
     </dependency>
 
     <dependency>

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/SearchClientConnectException.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/SearchClientConnectException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect;
+
+import io.camunda.search.clients.CamundaSearchClientException;
+
+public class SearchClientConnectException extends CamundaSearchClientException {
+
+  private static final long serialVersionUID = 1L;
+
+  public SearchClientConnectException() {}
+
+  public SearchClientConnectException(final String message) {
+    super(message);
+  }
+
+  public SearchClientConnectException(final String message, final Throwable cause) {
+    super(message, cause);
+  }
+
+  public SearchClientConnectException(final Throwable cause) {
+    super(cause);
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/SearchClientProvider.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/SearchClientProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.es.ElasticsearchConnector;
+import io.camunda.search.connect.os.OpensearchConnector;
+import io.camunda.search.es.clients.ElasticsearchSearchClient;
+import io.camunda.search.os.clients.OpensearchSearchClient;
+import java.util.function.Function;
+
+public interface SearchClientProvider extends Function<ConnectConfiguration, CamundaSearchClient> {
+
+  public static final class SearchClientProviders {
+
+    private SearchClientProviders() {}
+
+    public static CamundaSearchClient createElasticsearchProvider(
+        final ConnectConfiguration configuration) {
+      final var connector = new ElasticsearchConnector(configuration);
+      final var elasticsearch = connector.createClient();
+      return new ElasticsearchSearchClient(elasticsearch);
+    }
+
+    public static CamundaSearchClient createOpensearchProvider(
+        final ConnectConfiguration configuration) {
+      final var connector = new OpensearchConnector(configuration);
+      final var opensearch = connector.createClient();
+      return new OpensearchSearchClient(opensearch);
+    }
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/ConnectConfiguration.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.configuration;
+
+public class ConnectConfiguration {
+
+  private static final String DATABASE_TYPE_DEFAULT = "elasticsearch";
+  private static final String CLUSTER_NAME_DEFAULT = "elasticsearch";
+  private static final String DATE_FORMAT_FIELD = "yyyy-MM-dd'T'HH:mm:ss.SSSZZ";
+  private static final String FIELD_DATE_FORMAT_DEFAULT = "date_time";
+  private static final String URL_DEFAULT = "http://localhost:9200";
+
+  private String type = DATABASE_TYPE_DEFAULT;
+  private String clusterName = CLUSTER_NAME_DEFAULT;
+
+  private String dateFormat = DATE_FORMAT_FIELD;
+  private String fieldDateFormat = FIELD_DATE_FORMAT_DEFAULT;
+
+  private Integer socketTimeout;
+  private Integer connectTimeout;
+
+  private String url = URL_DEFAULT;
+  private String username;
+  private String password;
+
+  private SecurityConfiguration security = new SecurityConfiguration();
+
+  private String indexPrefix;
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(String type) {
+    this.type = type;
+  }
+
+  public String getClusterName() {
+    return clusterName;
+  }
+
+  public void setClusterName(String clusterName) {
+    this.clusterName = clusterName;
+  }
+
+  public String getDateFormat() {
+    return dateFormat;
+  }
+
+  public void setDateFormat(String dateFormat) {
+    this.dateFormat = dateFormat;
+  }
+
+  public String getFieldDateFormat() {
+    return fieldDateFormat;
+  }
+
+  public void setFieldDateFormat(String fieldDateFormat) {
+    this.fieldDateFormat = fieldDateFormat;
+  }
+
+  public Integer getSocketTimeout() {
+    return socketTimeout;
+  }
+
+  public void setSocketTimeout(Integer socketTimeout) {
+    this.socketTimeout = socketTimeout;
+  }
+
+  public Integer getConnectTimeout() {
+    return connectTimeout;
+  }
+
+  public void setConnectTimeout(Integer connectTimeout) {
+    this.connectTimeout = connectTimeout;
+  }
+
+  public String getUrl() {
+    return url;
+  }
+
+  public void setUrl(String url) {
+    this.url = url;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public SecurityConfiguration getSecurity() {
+    return security;
+  }
+
+  public void setSecurity(SecurityConfiguration security) {
+    this.security = security;
+  }
+
+  public String getIndexPrefix() {
+    return indexPrefix;
+  }
+
+  public void setIndexPrefix(String indexPrefix) {
+    this.indexPrefix = indexPrefix;
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/SecurityConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/configuration/SecurityConfiguration.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.configuration;
+
+public class SecurityConfiguration {
+
+  private static final boolean ENABLED_DEFAULT = false;
+  private static final boolean VERIFY_HOSTNAME_DEFAULT = true;
+  private static final boolean SELF_SIGNED_DEFAULT = false;
+
+  private boolean enabled = ENABLED_DEFAULT;
+  private String certificatePath;
+  private boolean verifyHostname = VERIFY_HOSTNAME_DEFAULT;
+  private boolean selfSigned = SELF_SIGNED_DEFAULT;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getCertificatePath() {
+    return certificatePath;
+  }
+
+  public void setCertificatePath(String certificatePath) {
+    this.certificatePath = certificatePath;
+  }
+
+  public boolean isVerifyHostname() {
+    return verifyHostname;
+  }
+
+  public void setVerifyHostname(boolean verifyHostname) {
+    this.verifyHostname = verifyHostname;
+  }
+
+  public boolean isSelfSigned() {
+    return selfSigned;
+  }
+
+  public void setSelfSigned(boolean selfSigned) {
+    this.selfSigned = selfSigned;
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/es/ElasticsearchConnector.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.es;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.connect.SearchClientConnectException;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import io.camunda.search.connect.jackson.JacksonConfiguration;
+import io.camunda.search.connect.util.SecurityUtil;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.config.RequestConfig.Builder;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.elasticsearch.client.RestClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ElasticsearchConnector {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ElasticsearchConnector.class);
+
+  private final ConnectConfiguration configuration;
+  private final ObjectMapper objectMapper;
+
+  public ElasticsearchConnector(final ConnectConfiguration configuration) {
+    this(configuration, new JacksonConfiguration(configuration).createObjectMapper());
+  }
+
+  public ElasticsearchConnector(
+      final ConnectConfiguration configuration, final ObjectMapper objectMapper) {
+    this.configuration = configuration;
+    this.objectMapper = objectMapper;
+  }
+
+  public ElasticsearchClient createClient() {
+    LOGGER.debug("Creating Elasticsearch Client ...");
+
+    // create rest client
+    final var restClient = createRestClient(configuration);
+
+    // Create the transport with a Jackson mapper
+    final var transport = new RestClientTransport(restClient, new JacksonJsonpMapper(objectMapper));
+
+    // And create the API client
+    return new ElasticsearchClient(transport);
+  }
+
+  private RestClient createRestClient(final ConnectConfiguration configuration) {
+    final var httpHost = getHttpHost(configuration);
+    final var restClientBuilder = RestClient.builder(httpHost);
+
+    if (configuration.getConnectTimeout() != null || configuration.getSocketTimeout() != null) {
+      restClientBuilder.setRequestConfigCallback(
+          configCallback -> setTimeouts(configCallback, configuration));
+    }
+    final var restClient =
+        restClientBuilder
+            .setHttpClientConfigCallback(
+                httpClientBuilder -> configureHttpClient(httpClientBuilder, configuration))
+            .build();
+
+    return restClient;
+  }
+
+  protected HttpAsyncClientBuilder configureHttpClient(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder,
+      final ConnectConfiguration configuration) {
+    setupAuthentication(httpAsyncClientBuilder, configuration);
+    final var security = configuration.getSecurity();
+    if (security != null && security.isEnabled()) {
+      setupSSLContext(httpAsyncClientBuilder, security);
+    }
+    return httpAsyncClientBuilder;
+  }
+
+  private void setupSSLContext(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder,
+      final SecurityConfiguration configuration) {
+    try {
+      final var sslContext = SecurityUtil.getSSLContext(configuration, "elasticsearch-host");
+      httpAsyncClientBuilder.setSSLContext(sslContext);
+      if (!configuration.isVerifyHostname()) {
+        httpAsyncClientBuilder.setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error in setting up SSLContext", e);
+    }
+  }
+
+  private Builder setTimeouts(final Builder builder, final ConnectConfiguration elsConfig) {
+    if (elsConfig.getSocketTimeout() != null) {
+      builder.setSocketTimeout(elsConfig.getSocketTimeout());
+    }
+    if (elsConfig.getConnectTimeout() != null) {
+      builder.setConnectTimeout(elsConfig.getConnectTimeout());
+    }
+    return builder;
+  }
+
+  private HttpHost getHttpHost(final ConnectConfiguration elsConfig) {
+    try {
+      final var uri = new URI(elsConfig.getUrl());
+      return new HttpHost(uri.getHost(), uri.getPort(), uri.getScheme());
+    } catch (URISyntaxException e) {
+      throw new SearchClientConnectException("Error in url: " + elsConfig.getUrl(), e);
+    }
+  }
+
+  private void setupAuthentication(
+      final HttpAsyncClientBuilder builder, final ConnectConfiguration configuration) {
+    final var username = configuration.getUsername();
+    final var password = configuration.getPassword();
+
+    if (username == null || password == null || username.isEmpty() || password.isEmpty()) {
+      LOGGER.warn(
+          "Username and/or password for are empty. Basic authentication for elasticsearch is not used.");
+      return;
+    }
+
+    final var credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(
+        AuthScope.ANY, new UsernamePasswordCredentials(username, password));
+    builder.setDefaultCredentialsProvider(credentialsProvider);
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/CustomInstantDeserializer.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/CustomInstantDeserializer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.time.Instant;
+
+public final class CustomInstantDeserializer extends JsonDeserializer<Instant> {
+
+  @Override
+  public Instant deserialize(final JsonParser parser, final DeserializationContext ctxt)
+      throws IOException {
+    return Instant.ofEpochMilli(Long.valueOf(parser.getText()));
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/CustomOffsetDateTimeDeserializer.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/CustomOffsetDateTimeDeserializer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.jackson;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+public final class CustomOffsetDateTimeDeserializer extends JsonDeserializer<OffsetDateTime> {
+
+  private DateTimeFormatter formatter;
+
+  public CustomOffsetDateTimeDeserializer(DateTimeFormatter formatter) {
+    this.formatter = formatter;
+  }
+
+  @Override
+  public OffsetDateTime deserialize(final JsonParser parser, final DeserializationContext context)
+      throws IOException {
+
+    OffsetDateTime parsedDate;
+    try {
+      parsedDate = OffsetDateTime.parse(parser.getText(), formatter);
+    } catch (final DateTimeParseException exception) {
+      parsedDate =
+          ZonedDateTime.parse(
+                  parser.getText(),
+                  DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss")
+                      .withZone(ZoneId.systemDefault()))
+              .toOffsetDateTime();
+    }
+    return parsedDate;
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/CustomOffsetDateTimeSerializer.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/CustomOffsetDateTimeSerializer.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.jackson;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class CustomOffsetDateTimeSerializer extends JsonSerializer<OffsetDateTime> {
+
+  private DateTimeFormatter formatter;
+
+  public CustomOffsetDateTimeSerializer(final DateTimeFormatter formatter) {
+    this.formatter = formatter;
+  }
+
+  @Override
+  public void serialize(
+      final OffsetDateTime value, final JsonGenerator gen, final SerializerProvider provider)
+      throws IOException {
+    gen.writeString(value.format(formatter));
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/JacksonConfiguration.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/jackson/JacksonConfiguration.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.jackson;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+
+public final class JacksonConfiguration {
+
+  private final ConnectConfiguration configuration;
+
+  public JacksonConfiguration(final ConnectConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  public ObjectMapper createObjectMapper() {
+    final var dateTimeFormatter = createDateTimeFormatter();
+    final JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+    javaTimeModule.addSerializer(
+        OffsetDateTime.class, new CustomOffsetDateTimeSerializer(dateTimeFormatter));
+    javaTimeModule.addDeserializer(
+        OffsetDateTime.class, new CustomOffsetDateTimeDeserializer(dateTimeFormatter));
+    javaTimeModule.addDeserializer(Instant.class, new CustomInstantDeserializer());
+
+    return new ObjectMapper()
+        .registerModules(javaTimeModule, new Jdk8Module())
+        // disable
+        .configure(SerializationFeature.INDENT_OUTPUT, false)
+        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+        .configure(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE, false)
+        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        .configure(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES, false)
+        // enable
+        .configure(JsonParser.Feature.ALLOW_COMMENTS, true)
+        // make sure that Jackson uses setters and getters, not fields
+        .setVisibility(PropertyAccessor.GETTER, Visibility.ANY)
+        .setVisibility(PropertyAccessor.IS_GETTER, Visibility.ANY)
+        .setVisibility(PropertyAccessor.SETTER, Visibility.ANY)
+        .setVisibility(PropertyAccessor.FIELD, Visibility.NONE)
+        .setVisibility(PropertyAccessor.CREATOR, Visibility.ANY);
+  }
+
+  public DateTimeFormatter createDateTimeFormatter() {
+    return DateTimeFormatter.ofPattern(configuration.getDateFormat());
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.os;
+
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.connect.SearchClientConnectException;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import io.camunda.search.connect.jackson.JacksonConfiguration;
+import io.camunda.search.connect.os.json.SearchRequestJacksonJsonpMapperWrapper;
+import io.camunda.search.connect.util.SecurityUtil;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.config.RequestConfig;
+import org.apache.hc.client5.http.impl.async.HttpAsyncClientBuilder;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.client5.http.impl.nio.PoolingAsyncClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.ssl.ClientTlsStrategyBuilder;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.util.Timeout;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.aws.AwsSdk2Transport;
+import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.regions.Region;
+
+public final class OpensearchConnector {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchConnector.class);
+
+  private final ConnectConfiguration configuration;
+  private final ObjectMapper objectMapper;
+
+  public OpensearchConnector(final ConnectConfiguration configuration) {
+    this(configuration, new JacksonConfiguration(configuration).createObjectMapper());
+  }
+
+  public OpensearchConnector(
+      final ConnectConfiguration configuration, final ObjectMapper objectMapper) {
+    this.configuration = configuration;
+    this.objectMapper = objectMapper;
+  }
+
+  public OpenSearchClient createClient() {
+    final var transport = createTransport(configuration);
+    return new OpenSearchClient(transport);
+  }
+
+  public OpenSearchAsyncClient createAsyncClient() {
+    final var transport = createTransport(configuration);
+    return new OpenSearchAsyncClient(transport);
+  }
+
+  private OpenSearchTransport createTransport(final ConnectConfiguration configuration) {
+    if (shouldCreateAWSBasedTransport()) {
+      return createAWSBasedTransport(configuration);
+    } else {
+      return createDefaultTransport(configuration);
+    }
+  }
+
+  private OpenSearchTransport createAWSBasedTransport(final ConnectConfiguration configuration) {
+    final var httpHost = getHttpHost(configuration);
+    final var region = new DefaultAwsRegionProviderChain().getRegion();
+    final var httpClient = ApacheHttpClient.builder().build();
+    return new AwsSdk2Transport(
+        httpClient,
+        httpHost.getHostName(),
+        Region.of(region),
+        AwsSdk2TransportOptions.builder()
+            .setMapper(new SearchRequestJacksonJsonpMapperWrapper(objectMapper))
+            .build());
+  }
+
+  private OpenSearchTransport createDefaultTransport(final ConnectConfiguration configuration) {
+    final var host = getHttpHost(configuration);
+    final var builder = ApacheHttpClient5TransportBuilder.builder(host);
+
+    builder.setHttpClientConfigCallback(
+        httpClientBuilder -> {
+          configureHttpClient(httpClientBuilder, configuration);
+          return httpClientBuilder;
+        });
+
+    builder.setRequestConfigCallback(
+        requestConfigBuilder -> {
+          setTimeouts(requestConfigBuilder, configuration);
+          return requestConfigBuilder;
+        });
+
+    final var jsonpMapper = new SearchRequestJacksonJsonpMapperWrapper(objectMapper);
+    builder.setMapper(jsonpMapper);
+
+    return builder.build();
+  }
+
+  private boolean shouldCreateAWSBasedTransport() {
+    final var credentialsProvider = DefaultCredentialsProvider.create();
+    try {
+      credentialsProvider.resolveCredentials();
+      LOGGER.info("AWS Credentials can be resolved. Use AWS Opensearch");
+      return true;
+    } catch (Exception e) {
+      LOGGER.warn("AWS not configured due to: {} ", e.getMessage());
+      return false;
+    }
+  }
+
+  private HttpHost getHttpHost(final ConnectConfiguration osConfig) {
+    try {
+      final var uri = new URI(osConfig.getUrl());
+      return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
+    } catch (URISyntaxException e) {
+      throw new SearchClientConnectException("Error in url: " + osConfig.getUrl(), e);
+    }
+  }
+
+  protected HttpAsyncClientBuilder configureHttpClient(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final ConnectConfiguration osConfig) {
+    setupAuthentication(httpAsyncClientBuilder, osConfig);
+    if (osConfig.getSecurity() != null && osConfig.getSecurity().isEnabled()) {
+      setupSSLContext(httpAsyncClientBuilder, osConfig.getSecurity());
+    }
+    return httpAsyncClientBuilder;
+  }
+
+  private RequestConfig.Builder setTimeouts(
+      final RequestConfig.Builder builder, final ConnectConfiguration os) {
+    if (os.getSocketTimeout() != null) {
+      // builder.setSocketTimeout(os.getSocketTimeout());
+      builder.setResponseTimeout(Timeout.ofMilliseconds(os.getSocketTimeout()));
+    }
+    if (os.getConnectTimeout() != null) {
+      builder.setConnectTimeout(Timeout.ofMilliseconds(os.getConnectTimeout()));
+    }
+    return builder;
+  }
+
+  private HttpAsyncClientBuilder setupAuthentication(
+      final HttpAsyncClientBuilder builder, final ConnectConfiguration configuration) {
+    final var username = configuration.getUsername();
+    final var password = configuration.getPassword();
+
+    if (username == null || password == null || username.isEmpty() || password.isEmpty()) {
+      LOGGER.warn(
+          "Username and/or password for are empty. Basic authentication for OpenSearch is not used.");
+      return builder;
+    }
+
+    final var credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(
+        new AuthScope(getHttpHost(configuration)),
+        new UsernamePasswordCredentials(
+            configuration.getUsername(), configuration.getPassword().toCharArray()));
+
+    builder.setDefaultCredentialsProvider(credentialsProvider);
+    return builder;
+  }
+
+  private void setupSSLContext(
+      final HttpAsyncClientBuilder httpAsyncClientBuilder,
+      final SecurityConfiguration configuration) {
+    try {
+      final var tlsStrategyBuilder = ClientTlsStrategyBuilder.create();
+      final var sslContext = SecurityUtil.getSSLContext(configuration, "opensearch-host");
+
+      tlsStrategyBuilder.setSslContext(sslContext);
+      if (!configuration.isVerifyHostname()) {
+        tlsStrategyBuilder.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
+      }
+
+      final var tlsStrategy = tlsStrategyBuilder.build();
+      final var connectionManager =
+          PoolingAsyncClientConnectionManagerBuilder.create().setTlsStrategy(tlsStrategy).build();
+
+      httpAsyncClientBuilder.setConnectionManager(connectionManager);
+
+    } catch (Exception e) {
+      LOGGER.error("Error in setting up SSLContext", e);
+    }
+  }
+}

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/OpensearchConnector.java
@@ -36,7 +36,7 @@ import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBui
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
-import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.http.nio.netty.NettyNioAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 
 public final class OpensearchConnector {
@@ -77,7 +77,7 @@ public final class OpensearchConnector {
   private OpenSearchTransport createAWSBasedTransport(final ConnectConfiguration configuration) {
     final var httpHost = getHttpHost(configuration);
     final var region = new DefaultAwsRegionProviderChain().getRegion();
-    final var httpClient = ApacheHttpClient.builder().build();
+    final var httpClient = NettyNioAsyncHttpClient.builder().build();
     return new AwsSdk2Transport(
         httpClient,
         httpHost.getHostName(),

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/json/SearchRequestJacksonJsonpMapperWrapper.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/json/SearchRequestJacksonJsonpMapperWrapper.java
@@ -5,32 +5,19 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.search.os.clients.json;
+package io.camunda.search.connect.os.json;
 
-import io.camunda.search.os.clients.json.jackson.SearchAfterFieldJsonGenerator;
-import jakarta.json.spi.JsonProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.search.connect.os.json.jackson.SearchAfterFieldJsonGenerator;
 import jakarta.json.stream.JsonGenerator;
-import jakarta.json.stream.JsonParser;
-import org.opensearch.client.json.JsonpMapper;
 import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch.core.SearchRequest;
 
-public final class SearchRequestJsonMapper implements JsonpMapper {
+public final class SearchRequestJacksonJsonpMapperWrapper extends JacksonJsonpMapper {
 
-  private final JsonpMapper mapper;
-
-  public SearchRequestJsonMapper(final JsonpMapper mapper) {
-    this.mapper = mapper;
-  }
-
-  @Override
-  public JsonProvider jsonProvider() {
-    return mapper.jsonProvider();
-  }
-
-  @Override
-  public <T> T deserialize(JsonParser parser, Class<T> clazz) {
-    return mapper.deserialize(parser, clazz);
+  public SearchRequestJacksonJsonpMapperWrapper(final ObjectMapper objectMapper) {
+    super(objectMapper);
   }
 
   @Override
@@ -38,9 +25,9 @@ public final class SearchRequestJsonMapper implements JsonpMapper {
     if (SearchRequest.class.isAssignableFrom(value.getClass())) {
       final var wrappedGenerator =
           new SearchAfterFieldJsonGenerator((JacksonJsonpGenerator) generator);
-      mapper.serialize(value, wrappedGenerator);
+      super.serialize(value, wrappedGenerator);
     } else {
-      mapper.serialize(value, generator);
+      super.serialize(value, generator);
     }
   }
 }

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/os/json/jackson/SearchAfterFieldJsonGenerator.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/os/json/jackson/SearchAfterFieldJsonGenerator.java
@@ -5,14 +5,14 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.search.os.clients.json.jackson;
+package io.camunda.search.connect.os.json.jackson;
 
 import jakarta.json.stream.JsonGenerator;
 import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
 
 public final class SearchAfterFieldJsonGenerator extends JacksonJsonpGenerator {
 
-  private static final String MIN_LONG_AS_STRING = String.format("\"%s\"", Long.MIN_VALUE);
+  private static final String MIN_LONG_AS_STRING = String.format("%d", Long.MIN_VALUE);
   private static final String SEARCH_AFTER_FIELD = "search_after";
 
   private final JacksonJsonpGenerator generator;
@@ -28,20 +28,30 @@ public final class SearchAfterFieldJsonGenerator extends JacksonJsonpGenerator {
     if (SEARCH_AFTER_FIELD.equals(name)) {
       writesSearchAfter = true;
     }
-    return generator.writeKey(name);
+    generator.writeKey(name);
+    return this;
   }
 
   @Override
   public JsonGenerator writeEnd() {
-    writesSearchAfter = false;
-    return generator.writeEnd();
+    if (writesSearchAfter) {
+      // no need anymore to use this
+      // generator, can switch back to
+      // the actual generator
+      writesSearchAfter = false;
+      return generator.writeEnd();
+    }
+    generator.writeEnd();
+    return this;
   }
 
   @Override
   public JsonGenerator write(String value) {
     if (writesSearchAfter && MIN_LONG_AS_STRING.equals(value)) {
-      write(Long.MIN_VALUE);
+      generator.write(Long.MIN_VALUE);
+    } else {
+      generator.write(value);
     }
-    return generator.write(value);
+    return this;
   }
 }

--- a/search/search-client-connect/src/main/java/io/camunda/search/connect/util/SecurityUtil.java
+++ b/search/search-client-connect/src/main/java/io/camunda/search/connect/util/SecurityUtil.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.connect.util;
+
+import io.camunda.search.connect.SearchClientConnectException;
+import io.camunda.search.connect.configuration.SecurityConfiguration;
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import javax.net.ssl.SSLContext;
+import org.apache.http.conn.ssl.TrustSelfSignedStrategy;
+import org.apache.http.ssl.SSLContexts;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class SecurityUtil {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SecurityUtil.class);
+
+  private SecurityUtil() {}
+
+  public static SSLContext getSSLContext(
+      final SecurityConfiguration configuration, final String alias)
+      throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
+    final var trustStore = loadCustomTrustStore(configuration);
+
+    // load custom server certificate if configured
+    final var certificatePath = configuration.getCertificatePath();
+    if (certificatePath != null) {
+      final var certificate = loadCertificateFromPath(certificatePath);
+      setCertificateInTrustStore(trustStore, certificate, alias);
+    }
+
+    final var trustStrategy =
+        configuration.isSelfSigned() ? new TrustSelfSignedStrategy() : null; // default;
+    if (trustStore.size() > 0) {
+      return SSLContexts.custom().loadTrustMaterial(trustStore, trustStrategy).build();
+    } else {
+      // default if custom truststore is empty
+      return SSLContext.getDefault();
+    }
+  }
+
+  private static KeyStore loadCustomTrustStore(final SecurityConfiguration configuration) {
+    try {
+      final var trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
+      trustStore.load(null);
+      return trustStore;
+    } catch (final Exception e) {
+      final var message =
+          "Could not create certificate trustStore for the secured OpenSearch Connection!";
+      throw new SearchClientConnectException(message, e);
+    }
+  }
+
+  private static Certificate loadCertificateFromPath(final String certificatePath) {
+    final Certificate cert;
+
+    try (var bis = new BufferedInputStream(new FileInputStream(certificatePath))) {
+      final CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+      if (bis.available() > 0) {
+        cert = cf.generateCertificate(bis);
+        LOGGER.debug("Found certificate: {}", cert);
+      } else {
+        throw new SearchClientConnectException(
+            "Could not load certificate from file, file is empty. File: " + certificatePath);
+      }
+    } catch (final Exception e) {
+      final String message =
+          "Could not load configured server certificate for the secured Connection!";
+      throw new SearchClientConnectException(message, e);
+    }
+
+    return cert;
+  }
+
+  public static void setCertificateInTrustStore(
+      final KeyStore trustStore, final Certificate certificate, final String alias) {
+    try {
+      trustStore.setCertificateEntry(alias, certificate);
+    } catch (final Exception e) {
+      final String message = "Could not set configured server certificate in trust store!";
+      throw new SearchClientConnectException(message, e);
+    }
+  }
+}

--- a/search/search-client-opensearch/pom.xml
+++ b/search/search-client-opensearch/pom.xml
@@ -29,16 +29,6 @@
     </dependency>
 
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-core</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>jakarta.json</groupId>
-      <artifactId>jakarta.json-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
       <scope>test</scope>

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClientException.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClientException.java
@@ -10,4 +10,18 @@ package io.camunda.search.clients;
 public class CamundaSearchClientException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
+
+  public CamundaSearchClientException() {}
+
+  public CamundaSearchClientException(final String message) {
+    super(message);
+  }
+
+  public CamundaSearchClientException(final Throwable e) {
+    super(e);
+  }
+
+  public CamundaSearchClientException(final String message, final Throwable e) {
+    super(message, e);
+  }
 }


### PR DESCRIPTION
## Description

This PR introduces a common module to "connect" to Elasticsearch or Opensearch. Basically, it consolidates the existing `ElasticsearchConnector` and `OpensearchConnector` (which reside in Operate and Tasklist), provides common configuration properties and configures an `ObjectMapper.`

To sum up:
* A new module, `search-client-connect,` is introduced, providing respective "connectors" to connect with Elasticsearch or OpenSearch.
* Provides common configuration properties that are used to connect to Elasticsearch or Opensearch.
* It configures a common `ObjectMapper` that the clients use, i.e., it is a harmonized version between Tasklist and Operate.

Note: In this step, this module does not replace the existing "connectors" in Tasklist and Operate. This will be done in a separate step.

## Related issues

related to #19076
