### PR TITLE
fix: avoid blocking the threads in importer

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -67,11 +67,12 @@ public class ImportProperties {
 
   /**
    * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for
-   * the case when parent was imported with the previous batch but Elastic did not yet refresh the
-   * indices. This may degrade import performance (especially when parent data is lost and
-   * no retry will help to find it). In this case, disable the retry by setting the parameter to false.
+   * the case when parent was imported with the previous batch but Elastic did not yet refresh
+   * the indices. This may degrade import performance (especially when parent data is lost and
+   * no retry will help to find it). In this case, disable the retry by setting the parameter
+   * to false.
    */
-  private final boolean retryReadingParents = true;
+  private boolean retryReadingParents = true;
 
   private int maxEmptyRuns = DEFAULT_MAX_EMPTY_RUNS;
 
@@ -197,6 +198,11 @@ public class ImportProperties {
 
   public boolean isRetryReadingParents() {
     return retryReadingParents;
+  }
+
+  public ImportProperties setRetryReadingParents(final boolean retryReadingParents) {
+    this.retryReadingParents = retryReadingParents;
+    return this;
   }
 
   public int getMaxEmptyRuns() {

--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -65,13 +65,21 @@ public class ImportProperties {
    */
   private boolean readArchivedParents = false;
 
+  /**
+   * When reading parent flow node instance from Elastic, we retry 1 time with 2 seconds delay for
+   * the case when parent was imported with the previous batch but Elastic did not yet refresh the
+   * indices. This may degrade import performance (expecially when parent data is lost and not retry
+   * will help to find it. In this case, disable this the retry but setting the parameter to false.
+   */
+  private final boolean retryReadingParents = true;
+
   private int maxEmptyRuns = DEFAULT_MAX_EMPTY_RUNS;
 
   public boolean isStartLoadingDataOnStartup() {
     return startLoadingDataOnStartup;
   }
 
-  public void setStartLoadingDataOnStartup(boolean startLoadingDataOnStartup) {
+  public void setStartLoadingDataOnStartup(final boolean startLoadingDataOnStartup) {
     this.startLoadingDataOnStartup = startLoadingDataOnStartup;
   }
 
@@ -79,7 +87,7 @@ public class ImportProperties {
     return threadsCount;
   }
 
-  public void setThreadsCount(int threadsCount) {
+  public void setThreadsCount(final int threadsCount) {
     this.threadsCount = threadsCount;
   }
 
@@ -96,7 +104,7 @@ public class ImportProperties {
     return postImportEnabled;
   }
 
-  public ImportProperties setPostImportEnabled(boolean postImportEnabled) {
+  public ImportProperties setPostImportEnabled(final boolean postImportEnabled) {
     this.postImportEnabled = postImportEnabled;
     return this;
   }
@@ -105,7 +113,8 @@ public class ImportProperties {
     return postImporterIgnoreMissingData;
   }
 
-  public ImportProperties setPostImporterIgnoreMissingData(boolean postImporterIgnoreMissingData) {
+  public ImportProperties setPostImporterIgnoreMissingData(
+      final boolean postImporterIgnoreMissingData) {
     this.postImporterIgnoreMissingData = postImporterIgnoreMissingData;
     return this;
   }
@@ -114,7 +123,7 @@ public class ImportProperties {
     return useOnlyPosition;
   }
 
-  public ImportProperties setUseOnlyPosition(boolean useOnlyPosition) {
+  public ImportProperties setUseOnlyPosition(final boolean useOnlyPosition) {
     this.useOnlyPosition = useOnlyPosition;
     return this;
   }
@@ -132,7 +141,7 @@ public class ImportProperties {
     return queueSize;
   }
 
-  public void setQueueSize(int queueSize) {
+  public void setQueueSize(final int queueSize) {
     this.queueSize = queueSize;
   }
 
@@ -140,7 +149,7 @@ public class ImportProperties {
     return readerBackoff;
   }
 
-  public void setReaderBackoff(int readerBackoff) {
+  public void setReaderBackoff(final int readerBackoff) {
     this.readerBackoff = readerBackoff;
   }
 
@@ -148,7 +157,7 @@ public class ImportProperties {
     return schedulerBackoff;
   }
 
-  public void setSchedulerBackoff(int schedulerBackoff) {
+  public void setSchedulerBackoff(final int schedulerBackoff) {
     this.schedulerBackoff = schedulerBackoff;
   }
 
@@ -173,7 +182,7 @@ public class ImportProperties {
     return importPositionUpdateInterval;
   }
 
-  public void setImportPositionUpdateInterval(int importPositionUpdateInterval) {
+  public void setImportPositionUpdateInterval(final int importPositionUpdateInterval) {
     this.importPositionUpdateInterval = importPositionUpdateInterval;
   }
 
@@ -181,16 +190,20 @@ public class ImportProperties {
     return readArchivedParents;
   }
 
-  public ImportProperties setReadArchivedParents(boolean readArchivedParents) {
+  public ImportProperties setReadArchivedParents(final boolean readArchivedParents) {
     this.readArchivedParents = readArchivedParents;
     return this;
+  }
+
+  public boolean isRetryReadingParents() {
+    return retryReadingParents;
   }
 
   public int getMaxEmptyRuns() {
     return maxEmptyRuns;
   }
 
-  public ImportProperties setMaxEmptyRuns(int maxEmptyRuns) {
+  public ImportProperties setMaxEmptyRuns(final int maxEmptyRuns) {
     this.maxEmptyRuns = maxEmptyRuns;
     return this;
   }

--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -66,10 +66,10 @@ public class ImportProperties {
   private boolean readArchivedParents = false;
 
   /**
-   * When reading parent flow node instance from Elastic, we retry 1 time with 2 seconds delay for
+   * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for
    * the case when parent was imported with the previous batch but Elastic did not yet refresh the
-   * indices. This may degrade import performance (expecially when parent data is lost and not retry
-   * will help to find it. In this case, disable this the retry but setting the parameter to false.
+   * indices. This may degrade import performance (especially when parent data is lost and
+   * no retry will help to find it). In this case, disable the retry by setting the parameter to false.
    */
   private final boolean retryReadingParents = true;
 

--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -66,11 +66,10 @@ public class ImportProperties {
   private boolean readArchivedParents = false;
 
   /**
-   * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for
-   * the case when parent was imported with the previous batch but Elastic did not yet refresh
-   * the indices. This may degrade import performance (especially when parent data is lost and
-   * no retry will help to find it). In this case, disable the retry by setting the parameter
-   * to false.
+   * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for the case
+   * when parent was imported with the previous batch but Elastic did not yet refresh the indices.
+   * This may degrade import performance (especially when parent data is lost and no retry will help
+   * to find it). In this case, disable the retry by setting the parameter to false.
    */
   private boolean retryReadingParents = true;
 

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
@@ -29,7 +29,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 public abstract class AbstractIncidentPostImportAction implements PostImportAction {
-  public static final long BACKOFF = 2000L;
+  public static final long BACKOFF = 5000L;
+  public static final long DELAY_BETWEEN_TWO_RUNS = 3000L;
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractIncidentPostImportAction.class);
   protected int partitionId;
@@ -67,7 +68,7 @@ public abstract class AbstractIncidentPostImportAction implements PostImportActi
     if (operateProperties.getImporter().isPostImportEnabled()) {
       try {
         if (performOneRound()) {
-          postImportScheduler.submit(this);
+          postImportScheduler.schedule(this, Instant.now().plus(DELAY_BETWEEN_TWO_RUNS, MILLIS));
         } else {
           postImportScheduler.schedule(this, Instant.now().plus(BACKOFF, MILLIS));
         }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
@@ -43,7 +43,7 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public String getFlowNodeIdByFlowNodeInstanceId(String flowNodeInstanceId) {
+  public String getFlowNodeIdByFlowNodeInstanceId(final String flowNodeInstanceId) {
     record Result(String activityId) {}
     final RequestDSL.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
@@ -64,7 +64,8 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
   }
 
   @Override
-  public Map<String, String> getFlowNodeIdsForFlowNodeInstances(Set<String> flowNodeInstanceIds) {
+  public Map<String, String> getFlowNodeIdsForFlowNodeInstances(
+      final Set<String> flowNodeInstanceIds) {
     record Result(String flowNodeId) {}
     final Map<String, String> flowNodeIdsMap = new HashMap<>();
     final var searchRequestBuilder =
@@ -79,11 +80,11 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
   }
 
   @Override
-  public String findParentTreePathFor(long parentFlowNodeInstanceKey) {
+  public String findParentTreePathFor(final long parentFlowNodeInstanceKey) {
     return findParentTreePath(parentFlowNodeInstanceKey, 0);
   }
 
-  private String findParentTreePath(final long parentFlowNodeInstanceKey, int attemptCount) {
+  private String findParentTreePath(final long parentFlowNodeInstanceKey, final int attemptCount) {
     record Result(String treePath) {}
     final RequestDSL.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
@@ -98,7 +99,7 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
 
     if (hits.size() > 0) {
       return hits.get(0).source().treePath();
-    } else if (attemptCount < 1) {
+    } else if (attemptCount < 1 && operateProperties.getImporter().isRetryReadingParents()) {
       // retry for the case, when ELS has not yet refreshed the indices
       ThreadUtil.sleepFor(2000L);
       return findParentTreePath(parentFlowNodeInstanceKey, attemptCount + 1);


### PR DESCRIPTION
* introduce new config parameters `camunda.operate.importer.retryReadingParents` which will prevent retrying with sleep call when reading parents from Elastic/Opensearch
* we have a `sleep` call in Incident post processor also. The reason: we want to wait for Elastic refresh shards, before processing the next batch. Replaced it with scheduling next call with delay. Also increased backoff period to 5 sec.

Closes #19424

