### PR TITLE
Add support for custom REST API middleware in Zeebe Gateway

### DIFF
--- a/dist/src/main/java/io/camunda/commons/configuration/BrokerBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/configuration/BrokerBasedConfiguration.java
@@ -24,7 +24,6 @@ import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository;
 import jakarta.servlet.Filter;
 import java.time.Duration;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.context.LifecycleProperties;
@@ -90,8 +89,7 @@ public final class BrokerBasedConfiguration {
   @Bean
   public CompositeFilter restApiCompositeFilter() {
     final List<FilterCfg> filterCfgs = properties.getGateway().getFilters();
-    final List<Filter> filters =
-        new FilterRepository().load(filterCfgs).instantiate().collect(Collectors.toList());
+    final List<Filter> filters = new FilterRepository().load(filterCfgs).instantiate().toList();
 
     return new RestApiCompositeFilter(filters);
   }

--- a/dist/src/main/java/io/camunda/commons/configuration/GatewayBasedConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/configuration/GatewayBasedConfiguration.java
@@ -77,8 +77,7 @@ public final class GatewayBasedConfiguration {
   @Bean
   public CompositeFilter restApiCompositeFilter() {
     final List<FilterCfg> filterCfgs = properties.getFilters();
-    final List<Filter> filters =
-        new FilterRepository().load(filterCfgs).instantiate().collect(Collectors.toList());
+    final List<Filter> filters = new FilterRepository().load(filterCfgs).instantiate().toList();
 
     return new RestApiCompositeFilter(filters);
   }

--- a/dist/src/main/java/io/camunda/zeebe/gateway/RestApiCompositeFilter.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/RestApiCompositeFilter.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.CompositeFilter;
+
+public class RestApiCompositeFilter extends CompositeFilter {
+
+  public RestApiCompositeFilter(final List<Filter> filters) {
+    setFilters(filters);
+  }
+
+  @Override
+  public void doFilter(
+      final ServletRequest request, final ServletResponse response, final FilterChain chain)
+      throws IOException, ServletException {
+    try {
+      super.doFilter(request, response, chain);
+    } catch (final Exception e) {
+      final HttpServletRequest servletRequest = (HttpServletRequest) request;
+      final HttpServletResponse servletResponse = (HttpServletResponse) response;
+      final var msg =
+          "{ \"type\": \"about:blank\", \"status\": 500, \"title\": \"Filter issue\", \"detail\": \""
+              + e.getMessage()
+              + "\", \"instance\": \" "
+              + servletRequest.getRequestURI()
+              + "\" }";
+
+      servletResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      servletResponse.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+      servletResponse.getWriter().write(msg);
+    }
+  }
+}

--- a/dist/src/main/java/io/camunda/zeebe/gateway/RestApiCompositeFilter.java
+++ b/dist/src/main/java/io/camunda/zeebe/gateway/RestApiCompositeFilter.java
@@ -36,30 +36,23 @@ public class RestApiCompositeFilter extends CompositeFilter {
       super.doFilter(request, response, chain);
     } catch (final Exception e) {
 
-      if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
-        response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
-        final var internalErrorMsg = "REST API filter error couldn't be handled properly.";
-        response
-            .getWriter()
-            .write(
-                "{ \"type\": \"about:blank\", \"status\": 500, \"title\": \"Filter issue\", \"detail\": \""
-                    + internalErrorMsg
-                    + "\" }");
-        LOG.error(internalErrorMsg, e);
-      }
-
-      final HttpServletRequest servletRequest = (HttpServletRequest) request;
-      final HttpServletResponse servletResponse = (HttpServletResponse) response;
+      final var instance =
+          request instanceof HttpServletRequest
+              ? ((HttpServletRequest) request).getRequestURI()
+              : "";
       final var msg =
           "{ \"type\": \"about:blank\", \"status\": 500, \"title\": \"Filter issue\", \"detail\": \""
               + e.getMessage()
               + "\", \"instance\": \" "
-              + servletRequest.getRequestURI()
+              + instance
               + "\" }";
 
-      servletResponse.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-      servletResponse.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
-      servletResponse.getWriter().write(msg);
+      if (response instanceof HttpServletResponse) {
+        ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      }
+
+      response.setContentType(MediaType.APPLICATION_PROBLEM_JSON_VALUE);
+      response.getWriter().write(msg);
     }
   }
 }

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -205,6 +205,12 @@
     </dependency>
 
     <dependency>
+      <groupId>net.bytebuddy</groupId>
+      <artifactId>byte-buddy</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/impl/filters/FilterLoadException.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/impl/filters/FilterLoadException.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.impl.filters;
+
+/** Exception thrown when an interceptor cannot be loaded. */
+public class FilterLoadException extends RuntimeException {
+  private static final long serialVersionUID = -9192947670450762759L;
+  private static final String MESSAGE_FORMAT = "Cannot load filter [%s]: %s";
+
+  public FilterLoadException(final String id, final String reason, final Throwable cause) {
+    super(String.format(MESSAGE_FORMAT, id, reason), cause);
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/impl/filters/FilterRepository.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/impl/filters/FilterRepository.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.impl.filters;
+
+import io.camunda.zeebe.gateway.Loggers;
+import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
+import io.camunda.zeebe.util.ReflectUtil;
+import io.camunda.zeebe.util.jar.ExternalJarLoadException;
+import io.camunda.zeebe.util.jar.ExternalJarRepository;
+import jakarta.servlet.Filter;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.agrona.LangUtil;
+import org.slf4j.Logger;
+
+/** Loads and holds references to the configured filters. */
+public final class FilterRepository {
+  private static final Logger LOGGER = Loggers.GATEWAY_LOGGER;
+
+  private final ExternalJarRepository jarRepository;
+  private final List<FilterElement> filters;
+  private final Path basePath;
+
+  public FilterRepository() {
+    this(
+        new ArrayList<>(),
+        new ExternalJarRepository(),
+        Paths.get(Optional.ofNullable(System.getProperty("basedir")).orElse(".")));
+  }
+
+  public FilterRepository(
+      final List<FilterElement> filters,
+      final ExternalJarRepository jarRepository,
+      final Path basePath) {
+    this.filters = filters;
+    this.jarRepository = jarRepository;
+    this.basePath = basePath;
+  }
+
+  public List<FilterElement> getFilters() {
+    return filters;
+  }
+
+  public Stream<Filter> instantiate() {
+    return filters.stream().map(entry -> instantiate(entry.id, entry.clazz));
+  }
+
+  public FilterRepository load(final List<? extends FilterCfg> configs) {
+    configs.forEach(
+        config -> {
+          try {
+            load(config);
+          } catch (final Exception e) {
+            LOGGER.debug("Failed to load filter {} with config {}", config.getId(), config);
+            LangUtil.rethrowUnchecked(e);
+          }
+        });
+
+    return this;
+  }
+
+  public Class<? extends Filter> load(final FilterCfg config) throws ExternalJarLoadException {
+    final ClassLoader classLoader;
+    final Class<? extends Filter> filterClass;
+    final String id = config.getId();
+
+    final var existingFilter =
+        filters.stream().filter(filterElement -> filterElement.id.equals(id)).findFirst();
+    if (existingFilter.isPresent()) {
+      return existingFilter.get().clazz;
+    }
+
+    if (!config.isExternal()) {
+      classLoader = getClass().getClassLoader();
+    } else {
+      final var jarPath = basePath.resolve(config.getJarPath());
+      classLoader = jarRepository.load(jarPath);
+    }
+
+    try {
+      final Class<?> specifiedClass = classLoader.loadClass(config.getClassName());
+      filterClass = specifiedClass.asSubclass(Filter.class);
+    } catch (final ClassNotFoundException e) {
+      throw new FilterLoadException(id, "cannot load specified class", e);
+    } catch (final ClassCastException e) {
+      throw new FilterLoadException(id, "specified class does not implement Filter", e);
+    }
+
+    final FilterElement filterElement = new FilterElement(id, filterClass);
+    filters.add(filterElement);
+
+    return filterClass;
+  }
+
+  private Filter instantiate(final String id, final Class<? extends Filter> filterClass) {
+    try {
+      return ReflectUtil.newInstance(filterClass);
+    } catch (final Exception e) {
+      throw new FilterLoadException(id, "cannot instantiate via the default constructor", e);
+    }
+  }
+
+  public record FilterElement(String id, Class<? extends Filter> clazz) {}
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/filters/ExternalFilter.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/filters/ExternalFilter.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.filters;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.File;
+import java.io.IOException;
+import net.bytebuddy.ByteBuddy;
+import net.bytebuddy.dynamic.DynamicType.Unloaded;
+import net.bytebuddy.implementation.MethodDelegation;
+import net.bytebuddy.jar.asm.Opcodes;
+import net.bytebuddy.matcher.ElementMatchers;
+
+public final class ExternalFilter {
+  public static final String CLASS_NAME = "com.acme.ExternalFilter";
+
+  /**
+   * Creates a new, unloaded class - that is, unavailable via any existing class loaders - which
+   * implements {@link jakarta.servlet.Filter}. The implementation of {@link
+   * Filter#doFilter(ServletRequest, ServletResponse, FilterChain)}} here simply delegates to {@link
+   * ExternalFilterImpl}. The class also defines a {@link String} attribute called {@code FOO} which
+   * returns the value {@code "bar"}.
+   *
+   * <p>The class is created with {@link #CLASS_NAME} as its canonical class name.
+   *
+   * <p>You can easily create a JAR from this class by using {@link Unloaded#toJar(File)}.
+   *
+   * @return the unloaded class
+   */
+  public static Unloaded<Filter> createUnloadedFilterClass() {
+    return new ByteBuddy()
+        .subclass(Filter.class)
+        .name(CLASS_NAME)
+        .method(ElementMatchers.named("doFilter"))
+        .intercept(MethodDelegation.to(ExternalFilterImpl.class))
+        .defineField("FOO", String.class, Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC)
+        .value("bar")
+        .make();
+  }
+
+  /**
+   * Must be public so that the ByteBuddy generated class can find it to ensure we have some default
+   * implementation.
+   */
+  public static final class ExternalFilterImpl {
+    public static void doFilter(
+        final ServletRequest servletRequest,
+        final ServletResponse servletResponse,
+        final FilterChain filterChain)
+        throws ServletException, IOException {
+      servletRequest.setAttribute("FOO", "bar");
+      filterChain.doFilter(servletRequest, servletResponse);
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/filters/FilterRepositoryTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/impl/filters/FilterRepositoryTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.filters;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
+import io.camunda.zeebe.gateway.rest.impl.filters.FilterLoadException;
+import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository;
+import io.camunda.zeebe.gateway.rest.impl.filters.FilterRepository.FilterElement;
+import io.camunda.zeebe.util.jar.ExternalJarLoadException;
+import io.camunda.zeebe.util.jar.ExternalJarRepository;
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import net.bytebuddy.ByteBuddy;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+class FilterRepositoryTest {
+  private final FilterRepository repository = new FilterRepository();
+
+  @Test
+  void shouldFailToLoadNonFilterClassFromClassPath() {
+    // given
+    final var id = "myFilter";
+    final var config = new FilterCfg();
+    config.setClassName(String.class.getName());
+    config.setId(id);
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(FilterLoadException.class)
+        .hasCauseInstanceOf(ClassCastException.class);
+  }
+
+  @Test
+  void shouldFailToLoadNonExistingClassFromClassPath() {
+    // given
+    final var id = "myFilter";
+    final var config = new FilterCfg();
+    config.setClassName("a");
+    config.setId(id);
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(FilterLoadException.class)
+        .hasCauseInstanceOf(ClassNotFoundException.class);
+  }
+
+  @Test
+  void shouldLoadFilterFromClassPath() throws FilterLoadException, ExternalJarLoadException {
+    // given
+    final var id = "myFilter";
+    final var config = new FilterCfg();
+    config.setClassName(MinimalFilter.class.getName());
+    config.setJarPath(null);
+    config.setId(id);
+
+    // when
+    final var loadedClass = repository.load(config);
+
+    // then
+    assertThat(config.isExternal()).isFalse();
+    assertThat(loadedClass).isEqualTo(MinimalFilter.class);
+    assertThat(loadedClass.getClassLoader()).isEqualTo(getClass().getClassLoader());
+    assertThat(repository.getFilters()).contains(new FilterElement(id, loadedClass));
+  }
+
+  @Test
+  void shouldLoadFilterFromJar(final @TempDir File tempDir) throws Exception {
+    // given
+    final var id = "myFilter";
+    final var filterClass = ExternalFilter.createUnloadedFilterClass();
+    final var jarFile = filterClass.toJar(new File(tempDir, "filter.jar"));
+    final var config = new FilterCfg();
+
+    // when
+    config.setClassName(ExternalFilter.CLASS_NAME);
+    config.setJarPath(jarFile.getAbsolutePath());
+    config.setId(id);
+
+    // when
+    final var loadedClass = repository.load(config);
+
+    // then
+    assertThat(config.isExternal()).isTrue();
+    assertThat(Filter.class.isAssignableFrom(loadedClass))
+        .as("the loaded class implements Filter")
+        .isTrue();
+    assertThat(loadedClass.getClassLoader()).isNotEqualTo(getClass().getClassLoader());
+    assertThat(repository.getFilters()).contains(new FilterElement(id, loadedClass));
+  }
+
+  @Test
+  void shouldFailToLoadNonFilterClassFromJar(final @TempDir File tempDir) throws IOException {
+    // given
+    final var id = "myFilter";
+    final var externalClass =
+        new ByteBuddy().subclass(Object.class).name("com.acme.MyObject").make();
+    final var jarFile = externalClass.toJar(new File(tempDir, "library.jar"));
+    final var config = new FilterCfg();
+
+    // when
+    config.setId(id);
+    config.setClassName("com.acme.MyObject");
+    config.setJarPath(jarFile.getAbsolutePath());
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(FilterLoadException.class)
+        .hasCauseInstanceOf(ClassCastException.class);
+  }
+
+  @Test
+  void shouldFailToLoadNonExistingClassFromJar(final @TempDir File tempDir) throws IOException {
+    // given
+    final var id = "myFilter";
+    final var filterClass = ExternalFilter.createUnloadedFilterClass();
+    final var jarFile = filterClass.toJar(new File(tempDir, "filter.jar"));
+    final var config = new FilterCfg();
+
+    // when
+    config.setId(id);
+    config.setClassName("xyz.i.dont.Exist");
+    config.setJarPath(jarFile.getAbsolutePath());
+
+    // then
+    assertThatThrownBy(() -> repository.load(config))
+        .isInstanceOf(FilterLoadException.class)
+        .hasCauseInstanceOf(ClassNotFoundException.class);
+  }
+
+  @Test
+  void shouldLoadExternalFilterRelativeToBasedir(final @TempDir File tempDir) throws IOException {
+    // given
+    final var baseRepository =
+        new FilterRepository(new ArrayList<>(), new ExternalJarRepository(), tempDir.toPath());
+    final var id = "myFilter";
+    final var filterClass = ExternalFilter.createUnloadedFilterClass();
+    final var jarFile = filterClass.toJar(new File(tempDir, "filter.jar"));
+    final var config = new FilterCfg();
+
+    // when
+    config.setId(id);
+    config.setClassName(ExternalFilter.CLASS_NAME);
+    config.setJarPath(jarFile.getName());
+
+    // when
+    final Class<? extends Filter> loadedClass;
+    loadedClass = baseRepository.load(config);
+
+    // then
+    assertThat(Filter.class.isAssignableFrom(loadedClass))
+        .as("the loaded class implements Filter")
+        .isTrue();
+  }
+
+  @Test
+  void shouldInstantiateFilters(final @TempDir File tempDir)
+      throws IOException, ClassNotFoundException {
+    // given
+    final var internalConfig = new FilterCfg();
+    internalConfig.setClassName(MinimalFilter.class.getName());
+    internalConfig.setJarPath(null);
+    internalConfig.setId("internal");
+    final var externalClass = ExternalFilter.createUnloadedFilterClass();
+    final var jarFile = externalClass.toJar(new File(tempDir, "filter.jar"));
+    final var externalConfig = new FilterCfg();
+    externalConfig.setClassName(ExternalFilter.CLASS_NAME);
+    externalConfig.setJarPath(jarFile.getAbsolutePath());
+    externalConfig.setId("external");
+
+    // when
+    final var filters = repository.load(List.of(internalConfig, externalConfig)).instantiate();
+
+    // then
+    final var loadedClass =
+        repository.getFilters().stream()
+            .filter(filterElement -> filterElement.id().equals("external"))
+            .findFirst()
+            .get()
+            .clazz();
+    assertThat(filters)
+        .hasSize(2)
+        .map(Filter::getClass)
+        .containsExactly(MinimalFilter.class, loadedClass);
+  }
+
+  public static final class MinimalFilter implements Filter {
+    @Override
+    public void doFilter(
+        final ServletRequest servletRequest,
+        final ServletResponse servletResponse,
+        final FilterChain filterChain)
+        throws IOException, ServletException {
+      filterChain.doFilter(servletRequest, servletResponse);
+    }
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/BaseExternalCodeCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/BaseExternalCodeCfg.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.configuration;
+
+import java.util.Objects;
+
+public class BaseExternalCodeCfg {
+
+  protected String id;
+  protected String jarPath;
+  protected String className;
+
+  /**
+   * @return true if the class must be loaded from an external JAR, false otherwise
+   */
+  public boolean isExternal() {
+    return !isEmpty(jarPath);
+  }
+
+  /**
+   * Returns a human-readable identifier, mostly for debugging purposes to differentiate instances
+   * of the same implementation, for example. If not specified, defaults to the {@link #className}.
+   *
+   * @return a human-readable identifier, mostly for debugging purposes
+   */
+  public String getId() {
+    return id == null ? className : id;
+  }
+
+  /**
+   * @param id the new debug identifier of the implementation
+   */
+  public void setId(final String id) {
+    this.id = id;
+  }
+
+  /**
+   * Returns the path to the JAR file containing the class. Note that this may be null, as this
+   * field is optional. If it is null, then the implementation is looked up within the base class
+   * path.
+   *
+   * <p>NOTE: the path may be relative or absolute. The caller must handle both cases.
+   *
+   * @return a path to the JAR, or null
+   */
+  public String getJarPath() {
+    return jarPath;
+  }
+
+  /**
+   * Sets the path to the class JAR. Can be null if the implementation class can be found on the
+   * class path.
+   *
+   * @param jarPath the new JAR path, or null
+   */
+  public void setJarPath(final String jarPath) {
+    this.jarPath = jarPath;
+  }
+
+  /**
+   * @return the fully qualified class name of the filter implementation
+   */
+  public String getClassName() {
+    return className;
+  }
+
+  /**
+   * Sets a new class name. Note that this must be a fully qualified class name to avoid any
+   * collisions.
+   *
+   * @param className the new class name
+   */
+  public void setClassName(final String className) {
+    this.className = className;
+  }
+
+  private boolean isEmpty(final String value) {
+    return value == null || value.isEmpty();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(jarPath, className);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final BaseExternalCodeCfg that = (BaseExternalCodeCfg) o;
+    return Objects.equals(jarPath, that.jarPath) && Objects.equals(className, that.className);
+  }
+}

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/FilterCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/FilterCfg.java
@@ -8,25 +8,17 @@
 package io.camunda.zeebe.gateway.impl.configuration;
 
 /**
- * Configuration to load a single extra interceptor. The {@link #className} property is required,
- * and must be a fully qualified name referring to an implementation of {@link
- * io.grpc.ServerInterceptor}.
+ * Configuration to load a single extra filter. The {@link #className} property is required, and
+ * must be a fully qualified name referring to an implementation of {@link jakarta.servlet.Filter}.
  *
  * <p>Optionally, a {@link #jarPath} can be supplied, and the class will be looked up there. Note
  * that the JAR is loaded within an isolated class loader to avoid dependency conflicts, so you must
  * make sure that all dependencies are available in the JAR, or via the gateway itself.
  */
-public final class InterceptorCfg extends BaseExternalCodeCfg {
+public final class FilterCfg extends BaseExternalCodeCfg {
 
   @Override
   public String toString() {
-    return "InterceptorCfg{"
-        + ", jarPath='"
-        + jarPath
-        + '\''
-        + ", className='"
-        + className
-        + '\''
-        + '}';
+    return "FilterCfg{" + ", jarPath='" + jarPath + '\'' + ", className='" + className + '\'' + '}';
   }
 }

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfg.java
@@ -19,6 +19,7 @@ public class GatewayCfg {
   private SecurityCfg security = new SecurityCfg();
   private LongPollingCfg longPolling = new LongPollingCfg();
   private List<InterceptorCfg> interceptors = new ArrayList<>();
+  private List<FilterCfg> filters = new ArrayList<>();
   private MultiTenancyCfg multiTenancy = new MultiTenancyCfg();
 
   public void init() {
@@ -80,6 +81,14 @@ public class GatewayCfg {
 
   public void setInterceptors(final List<InterceptorCfg> interceptors) {
     this.interceptors = interceptors;
+  }
+
+  public List<FilterCfg> getFilters() {
+    return filters;
+  }
+
+  public void setFilters(final List<FilterCfg> filters) {
+    this.filters = filters;
   }
 
   public MultiTenancyCfg getMultiTenancy() {

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/configuration/GatewayCfgTest.java
@@ -59,6 +59,14 @@ public final class GatewayCfgTest {
     CUSTOM_CFG.getInterceptors().get(1).setId("example2");
     CUSTOM_CFG.getInterceptors().get(1).setClassName("io.camunda.zeebe.example.Interceptor2");
     CUSTOM_CFG.getInterceptors().get(1).setJarPath("./interceptor2.jar");
+    CUSTOM_CFG.getFilters().add(new FilterCfg());
+    CUSTOM_CFG.getFilters().get(0).setId("filterExample");
+    CUSTOM_CFG.getFilters().get(0).setClassName("io.camunda.zeebe.example.Filter");
+    CUSTOM_CFG.getFilters().get(0).setJarPath("./filter.jar");
+    CUSTOM_CFG.getFilters().add(new FilterCfg());
+    CUSTOM_CFG.getFilters().get(1).setId("filterExample2");
+    CUSTOM_CFG.getFilters().get(1).setClassName("io.camunda.zeebe.example.Filter2");
+    CUSTOM_CFG.getFilters().get(1).setJarPath("./filter2.jar");
   }
 
   private final Map<String, String> environment = new HashMap<>();
@@ -142,6 +150,9 @@ public final class GatewayCfgTest {
     setEnv("zeebe.gateway.interceptors.0.id", "overwritten");
     setEnv("zeebe.gateway.interceptors.0.className", "Overwritten");
     setEnv("zeebe.gateway.interceptors.0.jarPath", "./overwritten.jar");
+    setEnv("zeebe.gateway.filters.0.id", "overwrittenFilter");
+    setEnv("zeebe.gateway.filters.0.className", "OverwrittenFilter");
+    setEnv("zeebe.gateway.filters.0.jarPath", "./overwrittenFilter.jar");
 
     final GatewayCfg expected = new GatewayCfg();
     expected
@@ -174,6 +185,11 @@ public final class GatewayCfgTest {
     expected.getInterceptors().get(0).setId("overwritten");
     expected.getInterceptors().get(0).setClassName("Overwritten");
     expected.getInterceptors().get(0).setJarPath("./overwritten.jar");
+
+    expected.getFilters().add(new FilterCfg());
+    expected.getFilters().get(0).setId("overwrittenFilter");
+    expected.getFilters().get(0).setClassName("OverwrittenFilter");
+    expected.getFilters().get(0).setJarPath("./overwrittenFilter.jar");
 
     // when
     final GatewayCfg gatewayCfg = readCustomConfig();

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -178,6 +178,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.tomcat.embed</groupId>
+      <artifactId>tomcat-embed-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/FilterIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.gateway.rest;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.client.api.command.ProblemException;
+import io.camunda.zeebe.gateway.impl.configuration.FilterCfg;
+import io.camunda.zeebe.it.gateway.rest.util.DisableTopologyFilter;
+import io.camunda.zeebe.it.gateway.rest.util.DisableUserTasksTestFilter;
+import io.camunda.zeebe.qa.util.cluster.TestCluster;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import java.time.Duration;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class FilterIT {
+
+  @TestZeebe
+  private final TestCluster cluster =
+      TestCluster.builder()
+          .withEmbeddedGateway(false)
+          .withGatewaysCount(1)
+          .withBrokersCount(1)
+          .withGatewayConfig(
+              (memberId, testGateway) -> {
+                final var firstFilterCfg = new FilterCfg();
+                firstFilterCfg.setId("firstFilter");
+                firstFilterCfg.setClassName(DisableTopologyFilter.class.getName());
+
+                final var secondFilterCfg = new FilterCfg();
+                secondFilterCfg.setId("secondFilter");
+                secondFilterCfg.setClassName(DisableUserTasksTestFilter.class.getName());
+
+                testGateway.gatewayConfig().setFilters(List.of(firstFilterCfg, secondFilterCfg));
+              })
+          .build();
+
+  @AutoCloseResource private CamundaClient client;
+
+  @BeforeEach
+  void initClient() {
+    client = cluster.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+  }
+
+  @Test
+  void shouldFailWithFirstFilterThrowingException() {
+    // when / then
+    assertThatThrownBy(() -> client.newTopologyRequest().useRest().send().join())
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("No topology interactions while testing");
+  }
+
+  @Test
+  void shouldFailWithSecondFilterThrowingException() {
+    // when / then
+    assertThatThrownBy(() -> client.newUserTaskCompleteCommand(12345).send().join())
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("No user task interactions while testing");
+  }
+
+  @Test
+  void shouldIgnoreFailingFilterOverGrpc() {
+    // when
+    client.newTopologyRequest().send().join();
+
+    // then no error is thrown
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/util/DisableTopologyFilter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/util/DisableTopologyFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.gateway.rest.util;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class DisableTopologyFilter extends HttpFilter {
+
+  @Override
+  public void doFilter(
+      final HttpServletRequest servletRequest,
+      final HttpServletResponse servletResponse,
+      final FilterChain filterChain)
+      throws IOException, ServletException {
+
+    if (servletRequest.getRequestURI().contains("topology")) {
+      throw new RuntimeException("No topology interactions while testing.");
+    }
+
+    filterChain.doFilter(servletRequest, servletResponse);
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/util/DisableUserTasksTestFilter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/gateway/rest/util/DisableUserTasksTestFilter.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.gateway.rest.util;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class DisableUserTasksTestFilter extends HttpFilter {
+
+  @Override
+  protected void doFilter(
+      final HttpServletRequest servletRequest,
+      final HttpServletResponse servletResponse,
+      final FilterChain filterChain)
+      throws ServletException, IOException {
+
+    if (servletRequest.getRequestURI().contains("user-tasks")) {
+      throw new RuntimeException("No user task interactions while testing.");
+    }
+
+    filterChain.doFilter(servletRequest, servletResponse);
+  }
+}


### PR DESCRIPTION
## Description

Adds support for custom REST API middleware in the Zeebe Gateway. 
- Support is added through the use of (Jakarta Servlet) `Filters`.
- Loading and management of the customer middleware instances is based on the existing `InterceptorRepository` mechanism.

Note: The PR also resolves the #15695 tech debt since it simplifies the new `FilterRepository` implementation as well.

## Related issues

closes #19291 
closes #15695