### PR TITLE
fix: avoid blocking the threads in importer

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -75,11 +75,10 @@ public class ImportProperties {
   private boolean readArchivedParents = false;
 
   /**
-   * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for
-   * the case when parent was imported with the previous batch but Elastic did not yet refresh
-   * the indices. This may degrade import performance (especially when parent data is lost and
-   * no retry will help to find it). In this case, disable the retry by setting the parameter
-   * to false.
+   * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for the case
+   * when parent was imported with the previous batch but Elastic did not yet refresh the indices.
+   * This may degrade import performance (especially when parent data is lost and no retry will help
+   * to find it). In this case, disable the retry by setting the parameter to false.
    */
   private boolean retryReadingParents = true;
 

--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -74,13 +74,21 @@ public class ImportProperties {
    */
   private boolean readArchivedParents = false;
 
+  /**
+   * When reading parent flow node instance from Elastic, we retry 1 time with 2 seconds delay for
+   * the case when parent was imported with the previous batch but Elastic did not yet refresh the
+   * indices. This may degrade import performance (expecially when parent data is lost and not retry
+   * will help to find it. In this case, disable this the retry but setting the parameter to false.
+   */
+  private final boolean retryReadingParents = true;
+
   private int maxEmptyRuns = DEFAULT_MAX_EMPTY_RUNS;
 
   public boolean isStartLoadingDataOnStartup() {
     return startLoadingDataOnStartup;
   }
 
-  public void setStartLoadingDataOnStartup(boolean startLoadingDataOnStartup) {
+  public void setStartLoadingDataOnStartup(final boolean startLoadingDataOnStartup) {
     this.startLoadingDataOnStartup = startLoadingDataOnStartup;
   }
 
@@ -88,7 +96,7 @@ public class ImportProperties {
     return threadsCount;
   }
 
-  public void setThreadsCount(int threadsCount) {
+  public void setThreadsCount(final int threadsCount) {
     this.threadsCount = threadsCount;
   }
 
@@ -105,7 +113,7 @@ public class ImportProperties {
     return postImportEnabled;
   }
 
-  public ImportProperties setPostImportEnabled(boolean postImportEnabled) {
+  public ImportProperties setPostImportEnabled(final boolean postImportEnabled) {
     this.postImportEnabled = postImportEnabled;
     return this;
   }
@@ -114,7 +122,8 @@ public class ImportProperties {
     return postImporterIgnoreMissingData;
   }
 
-  public ImportProperties setPostImporterIgnoreMissingData(boolean postImporterIgnoreMissingData) {
+  public ImportProperties setPostImporterIgnoreMissingData(
+      final boolean postImporterIgnoreMissingData) {
     this.postImporterIgnoreMissingData = postImporterIgnoreMissingData;
     return this;
   }
@@ -123,7 +132,7 @@ public class ImportProperties {
     return useOnlyPosition;
   }
 
-  public ImportProperties setUseOnlyPosition(boolean useOnlyPosition) {
+  public ImportProperties setUseOnlyPosition(final boolean useOnlyPosition) {
     this.useOnlyPosition = useOnlyPosition;
     return this;
   }
@@ -141,7 +150,7 @@ public class ImportProperties {
     return queueSize;
   }
 
-  public void setQueueSize(int queueSize) {
+  public void setQueueSize(final int queueSize) {
     this.queueSize = queueSize;
   }
 
@@ -149,7 +158,7 @@ public class ImportProperties {
     return readerBackoff;
   }
 
-  public void setReaderBackoff(int readerBackoff) {
+  public void setReaderBackoff(final int readerBackoff) {
     this.readerBackoff = readerBackoff;
   }
 
@@ -157,7 +166,7 @@ public class ImportProperties {
     return schedulerBackoff;
   }
 
-  public void setSchedulerBackoff(int schedulerBackoff) {
+  public void setSchedulerBackoff(final int schedulerBackoff) {
     this.schedulerBackoff = schedulerBackoff;
   }
 
@@ -182,7 +191,7 @@ public class ImportProperties {
     return importPositionUpdateInterval;
   }
 
-  public void setImportPositionUpdateInterval(int importPositionUpdateInterval) {
+  public void setImportPositionUpdateInterval(final int importPositionUpdateInterval) {
     this.importPositionUpdateInterval = importPositionUpdateInterval;
   }
 
@@ -190,16 +199,20 @@ public class ImportProperties {
     return readArchivedParents;
   }
 
-  public ImportProperties setReadArchivedParents(boolean readArchivedParents) {
+  public ImportProperties setReadArchivedParents(final boolean readArchivedParents) {
     this.readArchivedParents = readArchivedParents;
     return this;
+  }
+
+  public boolean isRetryReadingParents() {
+    return retryReadingParents;
   }
 
   public int getMaxEmptyRuns() {
     return maxEmptyRuns;
   }
 
-  public ImportProperties setMaxEmptyRuns(int maxEmptyRuns) {
+  public ImportProperties setMaxEmptyRuns(final int maxEmptyRuns) {
     this.maxEmptyRuns = maxEmptyRuns;
     return this;
   }

--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -75,10 +75,10 @@ public class ImportProperties {
   private boolean readArchivedParents = false;
 
   /**
-   * When reading parent flow node instance from Elastic, we retry 1 time with 2 seconds delay for
+   * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for
    * the case when parent was imported with the previous batch but Elastic did not yet refresh the
-   * indices. This may degrade import performance (expecially when parent data is lost and not retry
-   * will help to find it. In this case, disable this the retry but setting the parameter to false.
+   * indices. This may degrade import performance (especially when parent data is lost and
+   * no retry will help to find it). In this case, disable the retry by setting the parameter to false.
    */
   private final boolean retryReadingParents = true;
 

--- a/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/ImportProperties.java
@@ -76,11 +76,12 @@ public class ImportProperties {
 
   /**
    * When reading parent flow node instance from Elastic, we retry with 2 seconds delay for
-   * the case when parent was imported with the previous batch but Elastic did not yet refresh the
-   * indices. This may degrade import performance (especially when parent data is lost and
-   * no retry will help to find it). In this case, disable the retry by setting the parameter to false.
+   * the case when parent was imported with the previous batch but Elastic did not yet refresh
+   * the indices. This may degrade import performance (especially when parent data is lost and
+   * no retry will help to find it). In this case, disable the retry by setting the parameter
+   * to false.
    */
-  private final boolean retryReadingParents = true;
+  private boolean retryReadingParents = true;
 
   private int maxEmptyRuns = DEFAULT_MAX_EMPTY_RUNS;
 
@@ -206,6 +207,11 @@ public class ImportProperties {
 
   public boolean isRetryReadingParents() {
     return retryReadingParents;
+  }
+
+  public ImportProperties setRetryReadingParents(final boolean retryReadingParents) {
+    this.retryReadingParents = retryReadingParents;
+    return this;
   }
 
   public int getMaxEmptyRuns() {

--- a/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
+++ b/operate/importer/src/main/java/io/camunda/operate/zeebeimport/post/AbstractIncidentPostImportAction.java
@@ -38,7 +38,8 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
 public abstract class AbstractIncidentPostImportAction implements PostImportAction {
-  public static final long BACKOFF = 2000L;
+  public static final long BACKOFF = 5000L;
+  public static final long DELAY_BETWEEN_TWO_RUNS = 3000L;
   private static final Logger LOGGER =
       LoggerFactory.getLogger(AbstractIncidentPostImportAction.class);
   protected int partitionId;
@@ -76,7 +77,7 @@ public abstract class AbstractIncidentPostImportAction implements PostImportActi
     if (operateProperties.getImporter().isPostImportEnabled()) {
       try {
         if (performOneRound()) {
-          postImportScheduler.submit(this);
+          postImportScheduler.schedule(this, Instant.now().plus(DELAY_BETWEEN_TWO_RUNS, MILLIS));
         } else {
           postImportScheduler.schedule(this, Instant.now().plus(BACKOFF, MILLIS));
         }

--- a/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/elasticsearch/ElasticsearchFlowNodeStore.java
@@ -63,7 +63,7 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public String getFlowNodeIdByFlowNodeInstanceId(String flowNodeInstanceId) {
+  public String getFlowNodeIdByFlowNodeInstanceId(final String flowNodeInstanceId) {
     // TODO Elasticsearch changes
     final ElasticsearchUtil.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
@@ -84,14 +84,15 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
       } else {
         return String.valueOf(response.getHits().getAt(0).getSourceAsMap().get(ACTIVITY_ID));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(
           "Error occurred when searching for flow node instance: " + flowNodeInstanceId, e);
     }
   }
 
   @Override
-  public Map<String, String> getFlowNodeIdsForFlowNodeInstances(Set<String> flowNodeInstanceIds) {
+  public Map<String, String> getFlowNodeIdsForFlowNodeInstances(
+      final Set<String> flowNodeInstanceIds) {
     final Map<String, String> flowNodeIdsMap = new HashMap<>();
     final QueryBuilder q = termsQuery(FlowNodeInstanceTemplate.ID, flowNodeInstanceIds);
     final SearchRequest request =
@@ -125,7 +126,7 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
                 null);
             return null;
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(
           "Exception occurred when searching for flow node ids: " + e.getMessage(), e);
     }
@@ -133,11 +134,11 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
   }
 
   @Override
-  public String findParentTreePathFor(long parentFlowNodeInstanceKey) {
+  public String findParentTreePathFor(final long parentFlowNodeInstanceKey) {
     return findParentTreePath(parentFlowNodeInstanceKey, 0);
   }
 
-  private String findParentTreePath(final long parentFlowNodeInstanceKey, int attemptCount) {
+  private String findParentTreePath(final long parentFlowNodeInstanceKey, final int attemptCount) {
     final ElasticsearchUtil.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
             ? ElasticsearchUtil.QueryType.ALL
@@ -152,14 +153,14 @@ public class ElasticsearchFlowNodeStore implements FlowNodeStore {
       final SearchHits hits = tenantAwareClient.search(searchRequest).getHits();
       if (hits.getTotalHits().value > 0) {
         return (String) hits.getHits()[0].getSourceAsMap().get(FlowNodeInstanceTemplate.TREE_PATH);
-      } else if (attemptCount < 1) {
+      } else if (attemptCount < 1 && operateProperties.getImporter().isRetryReadingParents()) {
         // retry for the case, when ELS has not yet refreshed the indices
         ThreadUtil.sleepFor(2000L);
         return findParentTreePath(parentFlowNodeInstanceKey, attemptCount + 1);
       } else {
         return null;
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format(
               "Exception occurred, while searching for parent flow node instance processes: %s",

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchFlowNodeStore.java
@@ -52,7 +52,7 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
   @Autowired private OperateProperties operateProperties;
 
   @Override
-  public String getFlowNodeIdByFlowNodeInstanceId(String flowNodeInstanceId) {
+  public String getFlowNodeIdByFlowNodeInstanceId(final String flowNodeInstanceId) {
     record Result(String activityId) {}
     final RequestDSL.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
@@ -73,7 +73,8 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
   }
 
   @Override
-  public Map<String, String> getFlowNodeIdsForFlowNodeInstances(Set<String> flowNodeInstanceIds) {
+  public Map<String, String> getFlowNodeIdsForFlowNodeInstances(
+      final Set<String> flowNodeInstanceIds) {
     record Result(String flowNodeId) {}
     final Map<String, String> flowNodeIdsMap = new HashMap<>();
     final var searchRequestBuilder =
@@ -88,11 +89,11 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
   }
 
   @Override
-  public String findParentTreePathFor(long parentFlowNodeInstanceKey) {
+  public String findParentTreePathFor(final long parentFlowNodeInstanceKey) {
     return findParentTreePath(parentFlowNodeInstanceKey, 0);
   }
 
-  private String findParentTreePath(final long parentFlowNodeInstanceKey, int attemptCount) {
+  private String findParentTreePath(final long parentFlowNodeInstanceKey, final int attemptCount) {
     record Result(String treePath) {}
     final RequestDSL.QueryType queryType =
         operateProperties.getImporter().isReadArchivedParents()
@@ -107,7 +108,7 @@ public class OpensearchFlowNodeStore implements FlowNodeStore {
 
     if (hits.size() > 0) {
       return hits.get(0).source().treePath();
-    } else if (attemptCount < 1) {
+    } else if (attemptCount < 1 && operateProperties.getImporter().isRetryReadingParents()) {
       // retry for the case, when ELS has not yet refreshed the indices
       ThreadUtil.sleepFor(2000L);
       return findParentTreePath(parentFlowNodeInstanceKey, attemptCount + 1);


### PR DESCRIPTION
* introduce new config parameters `camunda.operate.importer.retryReadingParents` which will prevent retrying with sleep call when reading parents from Elastic/Opensearch
* we have a `sleep` call in Incident post processor also. The reason: we want to wait for Elastic refresh shards, before processing the next batch. Replaced it with scheduling next call with delay. Also increased backoff period to 5 sec.

Closes #19424
