### PR TITLE
Add unit-tests to unified CI

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -11,6 +11,15 @@ outputs:
         github.event_name == 'push' ||
         steps.filter-common.outputs.github-actions-change
       }}
+  java-unit-tests:
+    description: Output whether `unit-tests` (java) should be run based on GitHub event and files changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        steps.filter-common.outputs.github-actions-change ||
+        steps.filter-common.outputs.java-code-change ||
+        steps.filter-common.outputs.maven-change
+      }}
 
 runs:
   using: composite
@@ -27,6 +36,14 @@ runs:
           - '.github/workflows/**'
           - '.github/actionlint*'
 
+        # We use specific src/main and src/test path to:
+        #  * react on java code (production + test) changes
+        #  * react on resource changes like bpmn, XML, etc.
+        #  * but _not_ react on frontend src folder changes
+        java-code-change:
+          - '**/src/main/**'
+          - '**/src/test/**'
+          
         maven-change:
           - 'bom/*'
           - 'build-tools/**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
           -D skipITs -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
           -P skip-random-tests,parallel-tests,extract-flaky-tests
+          -pl '!testing/camunda-process-test-java'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
+          build_status: ${{ job.status }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,10 +122,10 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     outputs:
-      flakyUnitTests: ${{ needs.unit-tests.outputs.flakyTests }}
+      flakyUnitTests: ${{ needs.java-unit-tests.outputs.flakyTests }}
     needs:
       - actionlint
-      - unit-tests
+      - java-unit-tests
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,13 +58,125 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  unit-tests:
+    if: needs.detect-changes.outputs.actionlint == 'true'
+    needs: [detect-changes]
+    runs-on: [ self-hosted, linux, amd64, "16" ]
+    timeout-minutes: 30
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install and allow strace tests
+        run: |
+          sudo apt-get -qq update && sudo apt-get install -y strace
+          sudo sysctl -w kernel.yama.ptrace_scope=0
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          go: false
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Maven Test Build
+        # we use the verify goal here as flaky test extraction is bound to the post-integration-test
+        # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle
+        run: >
+          ./mvnw -T2 -B --no-snapshot-updates
+          -D skipITs -D skipChecks -D surefire.rerunFailingTestsCount=3
+          -D junitThreadCount=16
+          -P skip-random-tests,parallel-tests,extract-flaky-tests
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: "unit tests"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   check-results:
     # Used by the merge queue to check all tests, including the unit test matrix.
     # New test jobs must be added to the `needs` lists!
     # This name is hard-coded in the branch rules; remember to update that if this name changes
     if: always()
     runs-on: ubuntu-latest
+    outputs:
+      flakyUnitTests: ${{ needs.unit-tests.outputs.flakyTests }}
     needs:
       - actionlint
+      - unit-tests
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+
+  notify-if-failed:
+    name: Send slack notification on build failure
+    runs-on: ubuntu-latest
+    needs: [ check-results ]
+    if: failure() && github.repository == 'camunda/camunda' && github.ref == 'refs/heads/main'
+    steps:
+      - id: slack-notify
+        name: Send slack notification
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "text": ":alarm: Build on `main` failed! :alarm:\n${{ github.event.head_commit.url }}",
+             	"blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":alarm: Build on `main` failed! :alarm:"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related commit: ${{ github.event.head_commit.url }}\n \\cc @zeebe-medic"
+                  }
+                },
+                {
+                  "type": "divider"
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Detected flaky unit tests:* \n ${{ env.FLAKY_UNIT_TESTS }}"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Detected flaky integration tests:* \n ${{ env.FLAKY_INTEGRATION_TESTS }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          FLAKY_UNIT_TESTS: ${{needs.check-results.outputs.flakyUnitTests}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           -D skipITs -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
           -P skip-random-tests,parallel-tests,extract-flaky-tests
-          -pl '!testing/camunda-process-test-java'
+          -pl '!testing/camunda-process-test-java,!spring-boot-starter-camunda-sdk'
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
   detect-changes:
     outputs:
       actionlint: ${{ steps.filter.outputs.actionlint }}
+      java-unit-tests: ${{ steps.filter.outputs.java-unit-tests }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -58,8 +59,8 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  unit-tests:
-    if: needs.detect-changes.outputs.actionlint == 'true'
+  java-unit-tests:
+    if: needs.detect-changes.outputs.java-unit-tests == 'true'
     needs: [detect-changes]
     runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,13 +167,6 @@ jobs:
                     "type": "mrkdwn",
                     "text": "*Detected flaky unit tests:* \n ${{ env.FLAKY_UNIT_TESTS }}"
                   }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "*Detected flaky integration tests:* \n ${{ env.FLAKY_INTEGRATION_TESTS }}"
-                  }
                 }
               ]
             }


### PR DESCRIPTION
## Description

Adds all unit tests to the unified CI workflow thus moving https://github.com/camunda/camunda/issues/17721 forward.

* Java Unit tests are expected to be executed on
  * `**/src/main/**` changes; java files and resources
  * `**/src/test/**` changes; test files and resources
  * maven module/pom changes, like dependencies, etc.
  * github action/workflow changes
 * Unit tests are not expected to be executed when
   * frontend files have been changed 
   * readme's or other markdown files have been changed
   * grafana dashboard changes

This is one of the first increments (iteration) to get the unified workflow improved. We can think about [maven caching extension, and incremental builds](https://maven.apache.org/extensions/maven-build-cache-extension/) in the future to only run unit tests for affected modules, dependents, etc. 

With this we can get rid of unit-test executions in other github workflows, allow us to clean up streamline workflows.



## Related issues

Related to #17721
