### PR TITLE
feat: declare service bean to be used in REST controllers

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -21,6 +21,22 @@
   </properties>
 
   <dependencies>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client-connect</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-service</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-broker</artifactId>

--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -89,6 +89,16 @@ zeebe:
       ioThreadCount: 2
 
 camunda:
+  database:
+    # Controls which database must be used, possible values: elasticsearch, opensearch
+    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_TYPE
+    type: elasticsearch
+    # Sets the name of the cluster, default name is "elasticsearch"
+    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_CLUSTERNAME
+    clusterName: elasticsearch
+    # Sets the database url.
+    # This setting can also be overridden using the environment variable CAMUNDA_DATABASE_URL
+    url: http://localhost:9200
   # Operate configuration properties
   operate:
     # Set operate username and password.

--- a/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.commons.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.CamundaServices;
+import io.camunda.service.ProcessInstanceServices;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(
+    prefix = "zeebe.broker.gateway",
+    name = "enable",
+    havingValue = "true",
+    matchIfMissing = true)
+public class CamundaServicesConfiguration {
+
+  private final CamundaSearchClient camundaSearchClient;
+
+  @Autowired
+  public CamundaServicesConfiguration(final CamundaSearchClient camundaSearchClient) {
+    this.camundaSearchClient = camundaSearchClient;
+  }
+
+  @Bean
+  public CamundaServices camundaServices() {
+    return new CamundaServices(camundaSearchClient);
+  }
+
+  @Bean
+  public ProcessInstanceServices processInstanceServices(final CamundaServices camundaServices) {
+    return camundaServices.processInstanceServices();
+  }
+}

--- a/dist/src/main/java/io/camunda/commons/service/SearchClientDatabaseConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/service/SearchClientDatabaseConfiguration.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.commons.service;
+
+import io.camunda.commons.service.SearchClientDatabaseConfiguration.SearchClientProperties;
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.search.connect.SearchClientProvider;
+import io.camunda.search.connect.SearchClientProvider.SearchClientProviders;
+import io.camunda.search.connect.configuration.ConnectConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnProperty(
+    prefix = "zeebe.broker.gateway",
+    name = "enable",
+    havingValue = "true",
+    matchIfMissing = true)
+@EnableConfigurationProperties(SearchClientProperties.class)
+public class SearchClientDatabaseConfiguration {
+
+  private final ConnectConfiguration configuration;
+
+  @Autowired
+  public SearchClientDatabaseConfiguration(final SearchClientProperties configuration) {
+    this.configuration = configuration;
+  }
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "camunda.database",
+      name = "type",
+      havingValue = "elasticsearch",
+      matchIfMissing = true)
+  public SearchClientProvider elasticsearchClientProvider() {
+    return SearchClientProviders::createElasticsearchProvider;
+  }
+
+  @Bean
+  @ConditionalOnProperty(prefix = "camunda.database", name = "type", havingValue = "opensearch")
+  public SearchClientProvider opensearchClientProvider() {
+    return SearchClientProviders::createOpensearchProvider;
+  }
+
+  @Bean
+  public CamundaSearchClient camundaSearchClient(final SearchClientProvider searchClientProvider) {
+    return searchClientProvider.apply(configuration);
+  }
+
+  @ConfigurationProperties("camunda.database")
+  public static final class SearchClientProperties extends ConnectConfiguration {}
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/clients/ElasticsearchSearchClient.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/clients/ElasticsearchSearchClient.java
@@ -59,4 +59,15 @@ public final class ElasticsearchSearchClient implements CamundaSearchClient {
   private <T> SearchResponseTransformer<T> getSearchResponseTransformer() {
     return new SearchResponseTransformer<>(transformers);
   }
+
+  @Override
+  public void close() throws Exception {
+    if (client != null) {
+      try {
+        client._transport().close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
 }

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/clients/OpensearchSearchClient.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/clients/OpensearchSearchClient.java
@@ -59,4 +59,15 @@ public final class OpensearchSearchClient implements CamundaSearchClient {
   private <T> SearchResponseTransformer<T> getSearchResponseTransformer() {
     return new SearchResponseTransformer<>(transformers);
   }
+
+  @Override
+  public void close() throws Exception {
+    if (client != null) {
+      try {
+        client._transport().close();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClient.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/CamundaSearchClient.java
@@ -15,7 +15,7 @@ import io.camunda.util.ObjectBuilder;
 import io.camunda.zeebe.util.Either;
 import java.util.function.Function;
 
-public interface CamundaSearchClient {
+public interface CamundaSearchClient extends AutoCloseable {
 
   <T> Either<Exception, SearchQueryResponse<T>> search(
       final SearchQueryRequest searchRequest, final Class<T> documentClass);

--- a/service/src/test/java/io/camunda/service/util/StubbedCamundaSearchClient.java
+++ b/service/src/test/java/io/camunda/service/util/StubbedCamundaSearchClient.java
@@ -50,6 +50,11 @@ public class StubbedCamundaSearchClient implements CamundaSearchClient {
     this.searchRequestHandler = searchRequestHandler;
   }
 
+  @Override
+  public void close() throws Exception {
+    // noop
+  }
+
   public interface RequestStub<DocumentT> extends SearchRequestHandler<DocumentT> {
     void registerWith(final StubbedCamundaSearchClient client);
   }

--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -38,6 +38,16 @@
       <artifactId>zeebe-gateway</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-service</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-search-client</artifactId>
+    </dependency>
+
     <!-- zeebe dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.service.ProcessInstanceServices;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@ZeebeRestController
+public class ProcessInstanceController {
+
+  @Autowired private ProcessInstanceServices processInstanceServices;
+
+  @PostMapping(
+      path = "/process-instances/search",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public ResponseEntity<Object> searchProcessInstances() {
+    return ResponseEntity.ok(processInstanceServices.search((q) -> q));
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ErrorMapperTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.gateway.rest;
 
 import static org.mockito.ArgumentMatchers.any;
 
+import io.camunda.service.ProcessInstanceServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerErrorResponse;
@@ -273,6 +274,11 @@ public class ErrorMapperTest {
     @Bean
     public ResponseObserverProvider responseObserverProvider() {
       return Mockito.mock(ResponseObserverProvider.class);
+    }
+
+    @Bean
+    public ProcessInstanceServices processInstanceService() {
+      return Mockito.mock(ProcessInstanceServices.class);
     }
   }
 }


### PR DESCRIPTION
## Description

Based on https://github.com/camunda/camunda/pull/19419, this PR declares the required service beans (i.e., `CamundaServices` and `ProcessInstanceServices`) and the required `CamundaSearchClient` all of that to be used by REST controllers.

## Related issues

related #19076 
