### PR TITLE
feat: skip creating update requests for missing batch operations

### DIFF
--- a/operate/schema/src/test/java/io/camunda/operate/util/OperationsManagerTest.java
+++ b/operate/schema/src/test/java/io/camunda/operate/util/OperationsManagerTest.java
@@ -11,7 +11,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,10 +25,14 @@ import io.camunda.operate.schema.templates.OperationTemplate;
 import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.OperationStore;
 import java.time.OffsetDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
 import org.springframework.beans.factory.BeanFactory;
 
 @ExtendWith(MockitoExtension.class)
@@ -53,5 +60,55 @@ class OperationsManagerTest {
             contains("ctx._source.completedDate = params.now;"),
             argThat(
                 m -> m.containsKey("now") && m.get("now").getClass().equals(OffsetDateTime.class)));
+  }
+
+  @Test
+  void shouldCreateRequestForBatchOperation() throws PersistenceException {
+    // given
+    when(batchOperationTemplate.getAlias()).thenReturn("batch-operation_alias");
+    final var batchRequest = mock(BatchRequest.class);
+    when(operationStore.getIndexNameForAliasAndIds("batch-operation_alias", List.of("Exist")))
+        .thenReturn(Map.of("Exist", "batch-operation-index"));
+    final var operationManager =
+        new OperationsManager(
+            beanFactory, batchOperationTemplate, operationTemplate, operationStore);
+    operationManager.updateFinishedInBatchOperation("Exist", batchRequest);
+    // then
+    verify(batchRequest)
+        .updateWithScript(
+            eq("batch-operation-index"),
+            eq("Exist"),
+            contains("ctx._source.endDate = params.now;"),
+            argThat(
+                m -> m.containsKey("now") && m.get("now").getClass().equals(OffsetDateTime.class)));
+  }
+
+  @Test // https://github.com/camunda/operate/issues/6077
+  void shouldNotCreateRequestForMissingBatchOperation() throws PersistenceException {
+    // given
+    final var logger = mock(Logger.class);
+    when(batchOperationTemplate.getAlias()).thenReturn("batch-operation_alias");
+    final var batchRequest = mock(BatchRequest.class);
+    final var ids2indexNames = new HashMap<String, String>();
+    ids2indexNames.put("Does not exist", null);
+    when(operationStore.getIndexNameForAliasAndIds(
+            "batch-operation_alias", List.of("Does not exist")))
+        .thenReturn(ids2indexNames);
+    final var operationManager =
+        new OperationsManager(
+            logger, beanFactory, batchOperationTemplate, operationTemplate, operationStore);
+    operationManager.updateFinishedInBatchOperation("Does not exist", batchRequest);
+    // then
+    verify(batchRequest, never())
+        .updateWithScript(
+            isNull(),
+            eq("Does not exist"),
+            contains("ctx._source.endDate = params.now;"),
+            argThat(
+                m -> m.containsKey("now") && m.get("now").getClass().equals(OffsetDateTime.class)));
+    verify(logger)
+        .warn(
+            "No index found for batchOperationId={}. Skip adding an update request.",
+            "Does not exist");
   }
 }


### PR DESCRIPTION
## Description

* Check for index value of `null` and skip creating of update requests
* Add warn log message with `batch operation id`

## Related issues

closes [#6077](https://github.com/camunda/operate/issues/6077)
