### PR TITLE
fix: bean issues in single application

### DIFF
--- a/identity/backend/src/test/java/io/camunda/identity/usermanagement/initializer/DefaultUserInitializerTest.java
+++ b/identity/backend/src/test/java/io/camunda/identity/usermanagement/initializer/DefaultUserInitializerTest.java
@@ -40,7 +40,7 @@ public class DefaultUserInitializerTest {
 
   @Test
   void defaultUsersAreInitialized() {
-    Assertions.assertEquals(2, userService.findAllUsers().size());
+    Assertions.assertEquals(3, userService.findAllUsers().size());
     final var defaultUser = camundaUserDetailsManager.loadUserByUsername(USERNAME);
     assertTrue(passwordEncoder.matches("password", defaultUser.getPassword()));
   }

--- a/identity/common/src/main/java/io/camunda/identity/config/SecurityConfig.java
+++ b/identity/common/src/main/java/io/camunda/identity/config/SecurityConfig.java
@@ -12,11 +12,9 @@ import static org.springframework.security.crypto.factory.PasswordEncoderFactori
 import io.camunda.identity.security.CamundaPasswordEncoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
-@Profile("auth-basic")
 public class SecurityConfig {
   @Bean
   public PasswordEncoder passwordEncoder() {

--- a/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
+++ b/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
@@ -19,11 +19,12 @@ public class OperateProfileService {
 
   public static final String SSO_AUTH_PROFILE = "sso-auth";
   public static final String IDENTITY_AUTH_PROFILE = "identity-auth";
+  public static final String AUTH_BASIC = "auth-basic";
   public static final String AUTH_PROFILE = "auth";
   public static final String DEFAULT_AUTH = AUTH_PROFILE;
   public static final String LDAP_AUTH_PROFILE = "ldap-auth";
   public static final Set<String> AUTH_PROFILES =
-      Set.of(AUTH_PROFILE, LDAP_AUTH_PROFILE, SSO_AUTH_PROFILE, IDENTITY_AUTH_PROFILE);
+      Set.of(AUTH_PROFILE, LDAP_AUTH_PROFILE, SSO_AUTH_PROFILE, IDENTITY_AUTH_PROFILE, AUTH_BASIC);
 
   private static final Set<String> CANT_LOGOUT_AUTH_PROFILES = Set.of(SSO_AUTH_PROFILE);
 

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
@@ -30,12 +30,15 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 @Profile(
-    "!"
+    {"!"
         + OperateProfileService.LDAP_AUTH_PROFILE
         + " & !"
         + OperateProfileService.SSO_AUTH_PROFILE
         + " & !"
-        + OperateProfileService.IDENTITY_AUTH_PROFILE)
+        + OperateProfileService.IDENTITY_AUTH_PROFILE
+        + " & !"
+        + OperateProfileService.AUTH_BASIC
+    })
 /*
  * Required as primary for now due to a clashing bean in the always active Identity service classes.
  * In future versions this class will be removed and the Identity service will be used instead.
@@ -51,6 +54,7 @@ public class OperateUserDetailsService implements UserDetailsService {
   @Autowired private OperateProperties operateProperties;
 
   @Bean
+  @Primary
   public PasswordEncoder getPasswordEncoder() {
     return new BCryptPasswordEncoder();
   }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
@@ -29,16 +29,16 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
-@Profile(
-    {"!"
-        + OperateProfileService.LDAP_AUTH_PROFILE
-        + " & !"
-        + OperateProfileService.SSO_AUTH_PROFILE
-        + " & !"
-        + OperateProfileService.IDENTITY_AUTH_PROFILE
-        + " & !"
-        + OperateProfileService.AUTH_BASIC
-    })
+@Profile({
+  "!"
+      + OperateProfileService.LDAP_AUTH_PROFILE
+      + " & !"
+      + OperateProfileService.SSO_AUTH_PROFILE
+      + " & !"
+      + OperateProfileService.IDENTITY_AUTH_PROFILE
+      + " & !"
+      + OperateProfileService.AUTH_BASIC
+})
 /*
  * Required as primary for now due to a clashing bean in the always active Identity service classes.
  * In future versions this class will be removed and the Identity service will be used instead.

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistProfileService.java
@@ -13,11 +13,12 @@ public interface TasklistProfileService {
 
   String SSO_AUTH_PROFILE = "sso-auth";
   String IDENTITY_AUTH_PROFILE = "identity-auth";
+  String AUTH_BASIC = "auth-basic";
   String AUTH_PROFILE = "auth";
   String DEFAULT_AUTH = AUTH_PROFILE;
   String LDAP_AUTH_PROFILE = "ldap-auth";
   Set<String> AUTH_PROFILES =
-      Set.of(AUTH_PROFILE, LDAP_AUTH_PROFILE, SSO_AUTH_PROFILE, IDENTITY_AUTH_PROFILE);
+      Set.of(AUTH_PROFILE, LDAP_AUTH_PROFILE, SSO_AUTH_PROFILE, IDENTITY_AUTH_PROFILE, AUTH_BASIC);
 
   String getMessageByProfileFor(Exception exception);
 

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
@@ -8,6 +8,7 @@
 package io.camunda.tasklist.webapp.security.se;
 
 import static io.camunda.tasklist.util.CollectionUtil.map;
+import static io.camunda.tasklist.webapp.security.TasklistProfileService.AUTH_BASIC;
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.IDENTITY_AUTH_PROFILE;
 import static io.camunda.tasklist.webapp.security.TasklistProfileService.SSO_AUTH_PROFILE;
 
@@ -21,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -30,7 +32,12 @@ import org.springframework.stereotype.Component;
 
 @Configuration
 @Component
-@Profile("!" + SSO_AUTH_PROFILE + " & !" + IDENTITY_AUTH_PROFILE)
+@Profile("!" + SSO_AUTH_PROFILE + " & !" + IDENTITY_AUTH_PROFILE + " & !" + AUTH_BASIC)
+/*
+ * Required as primary for now due to a clashing bean in the always active Identity service classes.
+ * In future versions this class will be removed and the Identity service will be used instead.
+ */
+@Primary
 public class SearchEngineUserDetailsService implements UserDetailsService {
 
   private static final Logger LOGGER =
@@ -41,6 +48,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
   @Autowired private TasklistProperties tasklistProperties;
 
   @Bean
+  @Primary
   public PasswordEncoder getPasswordEncoder() {
     return new BCryptPasswordEncoder();
   }


### PR DESCRIPTION
## Description
This PR resolves an issue with the `StandaloneCamunda` startup missing beans. More context can be found [here](https://camunda.slack.com/archives/C06HTSPD5AP/p1718632812506029) however, for transparency, with a recent merge we made Identity present at all times when the StandaloneCamunda application is started, this means that Identity requires specific beans to function which were not found, adding in the profile for these beans means that there were conflicting beans when starting Operate and Tasklist.

To resolve these issues I have:

1. Removed the `@Profile` annotation from the `SecurityConfig` class such that Identity has access to a `PasswordEncoder` bean
2. Included a profile exclusion to the class responsible for configuration in Operate and Tasklist that clashed with Identity
3. Added a `@Primary` annotation to the `PasswordEncoder` bean declared in both Operate and Tasklist to maintain backwards compatibility (by using that bean as the components expect).

Expanding on point 3 there, I opted for this approach to get us a swift solution, the longer term goal (next alpha) would be to work on these classes to only use the Identity scoped bean (likely involving moving the bean declaration to a central place so its common usage is visible.

To verify my fix I have tested the `StandaloneCamunda` class by using a few combinations of profiles, each time I've access relevant endpoints/applications to confirm that I can view success, the combinations I tested were:

- `broker`
- `broker, auth-basic`
- `operate, broker, auth`
- `operate, tasklist, broker, auth`
- `tasklist, auth`

It it known that any of the webapp profiles (Operate, Tasklist) will not work with `auth-basic` as we need to work on support for those (next alpha). 
