### PR TITLE
Add endpoint to query status of exporters

### DIFF
--- a/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
+++ b/dist/src/main/java/io/camunda/zeebe/shared/management/ExportersEndpoint.java
@@ -10,12 +10,16 @@ package io.camunda.zeebe.shared.management;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterDisableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequest.ExporterEnableRequest;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestSender;
+import io.camunda.zeebe.dynamic.config.api.ErrorResponse;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.util.Either;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.web.annotation.RestControllerEndpoint;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -54,6 +58,24 @@ public class ExportersEndpoint {
                 Optional.ofNullable(initializeInfo).map(InitializationInfo::initializeFrom),
                 dryRun))
         .handle(ClusterApiUtils::mapOperationResponse);
+  }
+
+  @GetMapping(produces = "application/json")
+  public CompletableFuture<ResponseEntity<?>> listExporters() {
+    return requestSender.getTopology().handle(this::mapQueryResponse);
+  }
+
+  private ResponseEntity<?> mapQueryResponse(
+      final Either<ErrorResponse, ClusterConfiguration> response, final Throwable throwable) {
+    if (throwable != null) {
+      return ClusterApiUtils.mapError(throwable);
+    }
+
+    if (response.isLeft()) {
+      return ClusterApiUtils.mapErrorResponse(response.getLeft());
+    }
+
+    return ResponseEntity.status(200).body(ClusterApiUtils.aggregateExporterState(response.get()));
   }
 
   private record InitializationInfo(String initializeFrom) {}

--- a/dist/src/main/resources/api/cluster/exporter-api.yaml
+++ b/dist/src/main/resources/api/cluster/exporter-api.yaml
@@ -17,6 +17,8 @@ servers:
 paths:
   /{exporterId}/disable:
     post:
+      summary: Disable an exporter
+      description: Disable the exporter with the given exporterId. After the exporter is disabled, the records are not exported to this exporter anymore.
       parameters:
         - $ref: '#/components/parameters/ExporterId'
       responses:
@@ -33,6 +35,37 @@ paths:
         '504':
           $ref: 'components.yaml#/responses/TimeoutError'
 
+  /{exporterId}/enable:
+    summary: Enable an exporter
+    description: Enable the exporter with the given exporterId. After the exporter is enabled, the records are exported to this exporter.
+    post:
+      parameters:
+        - $ref: '#/components/parameters/ExporterId'
+      responses:
+        '202':
+          $ref: "#/components/responses/ExporterDisableResponse"
+        '400':
+          $ref: 'components.yaml#/responses/InvalidRequest'
+        '409':
+          $ref: 'components.yaml#/responses/ConcurrentChangeError'
+        '500':
+          $ref: 'components.yaml#/responses/InternalError'
+        '502':
+          $ref: 'components.yaml#/responses/GatewayError'
+        '504':
+          $ref: 'components.yaml#/responses/TimeoutError'
+
+  /:
+    get:
+      summary: List all exporters
+      description: List all exporters and their status whether they are enabled or disabled.
+      responses:
+        '200':
+          description: "List of exporters"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExporterList"
 components:
   parameters:
     ExporterId:
@@ -50,3 +83,26 @@ components:
         application.json:
           schema:
             $ref: "components.yaml#/schemas/PlannedOperationsResponse"
+
+  schemas:
+    ExporterList:
+        type: array
+        items:
+            $ref: "#/components/schemas/ExporterStatus"
+
+    ExporterStatus:
+      type: object
+      properties:
+        exporterId:
+          type: string
+          description: Id of the exporter
+        status:
+          type: string
+          enum:
+            - ENABLING
+            - ENABLED
+            - DISABLING
+            - DISABLED
+            - UNKNOWN
+          description: Status of the exporter
+

--- a/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
+++ b/dist/src/test/java/io/camunda/zeebe/shared/management/ClusterApiUtilsTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.shared.management;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionDisableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionEnableExporterOperation;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.ExporterState;
+import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
+import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.management.cluster.ExporterStatus;
+import io.camunda.zeebe.management.cluster.ExporterStatus.StatusEnum;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class ClusterApiUtilsTest {
+
+  @ParameterizedTest
+  @MethodSource("provideClusterConfigurationWithExporters")
+  void shouldAggregateExporterState(final ExporterConfigParam param) {
+    // when
+    final var result = ClusterApiUtils.aggregateExporterState(param.configuration());
+
+    // then
+    assertThat(result).containsExactlyInAnyOrderElementsOf(param.expectedResult());
+  }
+
+  public static Stream<Arguments> provideClusterConfigurationWithExporters() {
+    return Stream.of(
+        disabledExporters(),
+        enabledExporters(),
+        enablingExporters(),
+        disablingExporters(),
+        unknownState());
+  }
+
+  private static Arguments unknownState() {
+    return Arguments.of(
+        Named.of(
+            "Unknown State",
+            new ExporterConfigParam(
+                getConfigWithTwoPartitions(State.ENABLED)
+                    .updateMember(
+                        member(1),
+                        m -> updateExporterState(m, e -> e.disableExporter("exporter-1"))),
+                List.of(
+                    new ExporterStatus().exporterId("exporter-1").status(StatusEnum.UNKNOWN),
+                    new ExporterStatus().exporterId("exporter-2").status(StatusEnum.ENABLED)))));
+  }
+
+  private static Arguments disablingExporters() {
+    return Arguments.of(
+        Named.of(
+            "Disabling Exporters",
+            new ExporterConfigParam(
+                getConfigWithTwoPartitions(State.ENABLED)
+                    .startConfigurationChange(
+                        List.of(new PartitionDisableExporterOperation(member(1), 1, "exporter-1")))
+                    .updateMember(
+                        member(2),
+                        m -> updateExporterState(m, e -> e.disableExporter("exporter-1"))),
+                List.of(
+                    new ExporterStatus().exporterId("exporter-1").status(StatusEnum.DISABLING),
+                    new ExporterStatus().exporterId("exporter-2").status(StatusEnum.ENABLED)))));
+  }
+
+  private static Arguments enablingExporters() {
+    return Arguments.of(
+        Named.of(
+            "Enabling Exporters",
+            new ExporterConfigParam(
+                getConfigWithTwoPartitions(State.DISABLED)
+                    .startConfigurationChange(
+                        List.of(
+                            new PartitionEnableExporterOperation(
+                                member(1), 1, "exporter-1", Optional.empty())))
+                    .updateMember(
+                        member(2),
+                        m -> updateExporterState(m, e -> e.enableExporter("exporter-1", 2))),
+                List.of(
+                    new ExporterStatus().exporterId("exporter-1").status(StatusEnum.ENABLING),
+                    new ExporterStatus().exporterId("exporter-2").status(StatusEnum.DISABLED)))));
+  }
+
+  private static Arguments enabledExporters() {
+    return Arguments.of(
+        Named.of(
+            "Enabled Exporters",
+            new ExporterConfigParam(
+                getConfigWithTwoPartitions(State.ENABLED),
+                List.of(
+                    new ExporterStatus().exporterId("exporter-1").status(StatusEnum.ENABLED),
+                    new ExporterStatus().exporterId("exporter-2").status(StatusEnum.ENABLED)))));
+  }
+
+  private static Arguments disabledExporters() {
+    return Arguments.of(
+        Named.of(
+            "Disabled Exporters",
+            new ExporterConfigParam(
+                getConfigWithTwoPartitions(State.DISABLED),
+                List.of(
+                    new ExporterStatus().exporterId("exporter-1").status(StatusEnum.DISABLED),
+                    new ExporterStatus().exporterId("exporter-2").status(StatusEnum.DISABLED)))));
+  }
+
+  private static ClusterConfiguration getConfigWithTwoPartitions(final State exporterState) {
+    final DynamicPartitionConfig partitionConfig =
+        new DynamicPartitionConfig(
+            new ExportersConfig(
+                Map.of(
+                    "exporter-1",
+                    new ExporterState(0, exporterState, Optional.empty()),
+                    "exporter-2",
+                    new ExporterState(0, exporterState, Optional.empty()))));
+    return ClusterConfiguration.init()
+        .addMember(
+            member(1),
+            MemberState.initializeAsActive(
+                Map.of(
+                    1,
+                    PartitionState.active(1, partitionConfig),
+                    2,
+                    PartitionState.active(2, partitionConfig))))
+        .addMember(
+            member(2),
+            MemberState.initializeAsActive(
+                Map.of(
+                    1,
+                    PartitionState.active(2, partitionConfig),
+                    2,
+                    PartitionState.active(2, partitionConfig))));
+  }
+
+  private static MemberState updateExporterState(
+      final MemberState m, final UnaryOperator<ExportersConfig> exporterUpdater) {
+    return m.updatePartition(1, p -> p.updateConfig(c -> c.updateExporting(exporterUpdater)));
+  }
+
+  private static MemberId member(final int id) {
+    return MemberId.from(String.valueOf(id));
+  }
+
+  private record ExporterConfigParam(
+      ClusterConfiguration configuration, List<ExporterStatus> expectedResult) {}
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/ExportersActuator.java
@@ -20,6 +20,7 @@ import feign.Retryer;
 import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.management.cluster.ExporterStatus;
 import io.camunda.zeebe.management.cluster.PlannedOperationsResponse;
 import io.camunda.zeebe.qa.util.cluster.TestApplication;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -101,6 +102,15 @@ public interface ExportersActuator {
   @RequestLine("POST /{exporterId}/enable")
   @Headers({"Content-Type: application/json", "Accept: application/json"})
   PlannedOperationsResponse enableExporter(@Param final String exporterId);
+
+  /**
+   * Returns the list of exporters with their status
+   *
+   * @throws feign.FeignException if the request is not successful (e.g. 4xx or 5xx)
+   */
+  @RequestLine("GET")
+  @Headers({"Content-Type: application/json", "Accept: application/json"})
+  List<ExporterStatus> getExporters();
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   @JsonInclude(Include.NON_EMPTY)


### PR DESCRIPTION
## Description

This PR adds an endpoint `GET actuator/exporters` which returns a list of exporters with their current status - enabling,enabled,disabling or disabled.
```
[
  {
    "exporterId": "exporter-A",
    "status": "ENABLING"
  },
  {
    "exporterId": "exporter-B",
    "status": "ENABLED"
  }
]
```
There is also a status `unknown` as a fallback incase we are not able to determine the aggregated status reliably. This can happen when some partitions have enabled, and some partition have disabled but there is no pending changes to disable or enable the rest of them. This case is not expected, because we do not provide API to change it per partition or per broker. So this is more of a fallback option in case something unexpected happen.

For debugging purposes, we can use the cluster endpoint which returns the detailed configuration per broker per partition.

## Related issues

closes #19023 
