### PR TITLE
test: wait until deployment is distributed

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/dynamic/ScaleDownBrokersTest.java
@@ -46,6 +46,13 @@ final class ScaleDownBrokersTest {
           .withBrokersCount(CLUSTER_SIZE)
           .withPartitionsCount(PARTITIONS_COUNT)
           .withReplicationFactor(1)
+          .withBrokerConfig(
+              b ->
+                  b.brokerConfig()
+                      .getCluster()
+                      .getMembership()
+                      // Decrease the timeouts for fast convergence of broker topology.
+                      .setSyncInterval(Duration.ofSeconds(1)))
           .withGatewayConfig(
               g ->
                   g.gatewayConfig()


### PR DESCRIPTION
## Description

The test failed because the deployment was not distributed with in 20 seconds. In the first attempt, the broker did not know about the leaders. The retry was done 20s later by which the test had timed out.

To improve this situation:
1. Decrease the swim timeouts so that the broker will learn about the leaders faster.
2. Wait until deployment is distributed before moving to the next operation. This step waits for 30s. So in worst case, it will distribute in the second attempt atleast.

## Related issues

closes #18190 
