### PR TITLE
ci: do not overwrite Zeebe status check with Tasklist test result

### DIFF
--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -1,0 +1,143 @@
+name: Tasklist Frontend Jobs
+
+on:
+  workflow_call: {}
+
+jobs:
+  fe-type-check:
+    name: Type check
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tasklist/client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+          cache-dependency-path: tasklist/client/yarn.lock
+      - run: yarn install --frozen-lockfile
+        name: Install dependencies
+      - run: yarn ts-check
+        name: Type checks
+
+  fe-eslint:
+    name: ESLint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tasklist/client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+          cache-dependency-path: tasklist/client/yarn.lock
+      - run: yarn install --frozen-lockfile
+        name: Install dependencies
+      - run: yarn eslint
+        name: ESLint
+
+  fe-stylelint:
+    name: Stylelint
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tasklist/client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+          cache-dependency-path: tasklist/client/yarn.lock
+      - run: yarn install --frozen-lockfile
+        name: Install dependencies
+      - run: yarn stylelint
+        name: Stylelint
+
+  fe-tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tasklist/client
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+          cache-dependency-path: tasklist/client/yarn.lock
+      - run: yarn install --frozen-lockfile
+        name: Install dependencies
+      - run: yarn test:ci
+        name: Unit & Integration tests
+
+  fe-visual-regression-tests:
+    name: Visual regression tests
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.44.1
+      options: --user 1001:1000
+    defaults:
+      run:
+        working-directory: tasklist/client
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Setup yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+          cache-dependency-path: tasklist/client/yarn.lock
+      - name: Install node dependencies
+        run: yarn
+      - name: Build frontend
+        run: yarn build:visual-regression
+      - name: Start server
+        run: yarn start:visual-regression &
+      - name: Run Playwright tests
+        run: yarn playwright e2e/visual
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: visual-regression-report
+          path: tasklist/client/playwright-report/
+          retention-days: 30
+
+  fe-a11y-tests:
+    name: a11y tests
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.44.1
+      options: --user 1001:1000
+    defaults:
+      run:
+        working-directory: tasklist/client
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+      - name: Setup yarn cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "yarn"
+          cache-dependency-path: tasklist/client/yarn.lock
+      - name: Install node dependencies
+        run: yarn
+      - name: Build frontend
+        run: yarn build
+      - name: Start server
+        run: yarn start:visual-regression &
+      - name: Run A11y tests
+        run: yarn playwright a11y
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: a11y-report
+          path: tasklist/client/playwright-report/
+          retention-days: 30

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -72,171 +72,18 @@ jobs:
     with:
       branch: ${{ github.head_ref || github.ref_name }}
 
-  fe-type-check:
-    name: Type check
-    runs-on: ubuntu-latest
+  run-fe-ci:
+    name: run-frontend-tests
     needs: check_changes
     if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
-    defaults:
-      run:
-        working-directory: tasklist/client
-    steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
-      - run: yarn install --frozen-lockfile
-        name: Install dependencies
-      - run: yarn ts-check
-        name: Type checks
-
-  fe-eslint:
-    name: ESLint
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
-    defaults:
-      run:
-        working-directory: tasklist/client
-    steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
-      - run: yarn install --frozen-lockfile
-        name: Install dependencies
-      - run: yarn eslint
-        name: ESLint
-
-  fe-stylelint:
-    name: Stylelint
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
-    defaults:
-      run:
-        working-directory: tasklist/client
-    steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
-      - run: yarn install --frozen-lockfile
-        name: Install dependencies
-      - run: yarn stylelint
-        name: Stylelint
-
-  fe-tests:
-    name: Tests
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
-    defaults:
-      run:
-        working-directory: tasklist/client
-    steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
-      - run: yarn install --frozen-lockfile
-        name: Install dependencies
-      - run: yarn test:ci
-        name: Unit & Integration tests
-
-  fe-visual-regression-tests:
-    name: Visual regression tests
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
-    container:
-      image: mcr.microsoft.com/playwright:v1.44.1
-      options: --user 1001:1000
-    defaults:
-      run:
-        working-directory: tasklist/client
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - name: Setup yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
-      - name: Install node dependencies
-        run: yarn
-      - name: Build frontend
-        run: yarn build:visual-regression
-      - name: Start server
-        run: yarn start:visual-regression &
-      - name: Run Playwright tests
-        run: yarn playwright e2e/visual
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: visual-regression-report
-          path: tasklist/client/playwright-report/
-          retention-days: 30
-
-  fe-a11y-tests:
-    name: a11y tests
-    runs-on: ubuntu-latest
-    needs: check_changes
-    if: ${{ needs.check_changes.outputs.has_changed_frontend == 'true' }}
-    container:
-      image: mcr.microsoft.com/playwright:v1.44.1
-      options: --user 1001:1000
-    defaults:
-      run:
-        working-directory: tasklist/client
-    steps:
-      - name: Check out repository code
-        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - name: Setup yarn cache
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
-      - name: Install node dependencies
-        run: yarn
-      - name: Build frontend
-        run: yarn build
-      - name: Start server
-        run: yarn start:visual-regression &
-      - name: Run A11y tests
-        run: yarn playwright a11y
-      - uses: actions/upload-artifact@v4
-        if: always()
-        with:
-          name: a11y-report
-          path: tasklist/client/playwright-report/
-          retention-days: 30
+    uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
 
   test-summary:
-    # Used by the merge queue as a dummy instead of the Zeebe CI in case only Operate files got changed:
+    # Used by the merge queue as a dummy instead of the Zeebe CI in case only Tasklist files got changed:
     # https://github.com/orgs/community/discussions/26251
     # This name is hard-coded in the branch rules; remember to update that if this name changes
     name: Test summary
     if: always()
     runs-on: ubuntu-latest
-    needs:
-      - run-build
-      - check_changes
-      - fe-type-check
-      - fe-eslint
-      - fe-tests
-      - fe-visual-regression-tests
-      - fe-a11y-tests
-      - fe-stylelint
     steps:
-      - run: exit ${{ ((needs.check_changes.outputs.has_changed_frontend == 'true' && contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+      - run: exit 0

--- a/.github/workflows/tasklist-merge-ci.yml
+++ b/.github/workflows/tasklist-merge-ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request: { }
   workflow_dispatch: { }
 
+concurrency:
+  cancel-in-progress: true
+  group: "${{ github.workflow }}-${{ github.ref }}"
 
 jobs:
   run-build:
@@ -15,6 +18,10 @@ jobs:
       branch: ${{ github.head_ref || github.ref_name }} # head_ref = branch name on PR, ref_name = `main` or `stable/**`
       pushDocker: false
 
+  run-fe-ci:
+    name: run-frontend-tests
+    uses: ./.github/workflows/tasklist-ci-fe-reusable.yml
+
   tasklist-ci-test-summary:
     # Used by the merge queue to check all jobs.
     # New test jobs must be added to the `needs` lists!
@@ -24,5 +31,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - run-build
+      - run-fe-ci
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}


### PR DESCRIPTION
## Description
Make Tasklist Frontend CI tests status checks part of `Tasklist CI test summary` instead of Zeebe's `Test summary`
These tests will be run by `tasklist-merge-ci.yml` in every pull request + merge queue. These tests are stable enough.
Also keeping them in `tasklist-ci.yml` so that they are run for `main` and `stable` branches

`Test summary` status check that is part of `tasklist-ci.yml` will be refactored in https://github.com/camunda/camunda/pull/19307

## Related issues

closes #19428 
