### PR TITLE
feat: Provide Process Instance Search Request API in the Zeebe Client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.search.ProcessInstanceQuery;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
@@ -566,4 +567,22 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    */
   @ExperimentalApi("https://github.com/camunda/zeebe/issues/16166")
   UnassignUserTaskCommandStep1 newUserTaskUnassignCommand(long userTaskKey);
+
+  /**
+   * Executes a search request to query process instances.
+   *
+   * <pre>
+   * long processInstanceKey = ...;
+   *
+   * zeebeClient
+   *  .newProcessInstanceQuery()
+   *  .filter((f) -> f.processInstanceKeys(processInstanceKey))
+   *  .sort((s) -> s.startDate().asc())
+   *  .page((p) -> p.limit(100))
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the process instance query
+   */
+  ProcessInstanceQuery newProcessInstanceQuery();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/FinalSearchQueryStep.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/FinalSearchQueryStep.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.search.response.SearchQueryResponse;
+import java.time.Duration;
+
+public interface FinalSearchQueryStep<T> extends FinalCommandStep<SearchQueryResponse<T>> {
+
+  FinalSearchQueryStep<T> requestTimeout(Duration requestTimeout);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceFilter.java
@@ -22,7 +22,7 @@ import java.util.function.Consumer;
 public interface ProcessInstanceFilter extends SearchRequestFilter {
 
   /** Filter by process instance keys. */
-  ProcessInstanceFilter processInstanceKeys(final Long value, final Long... values);
+  ProcessInstanceFilter processInstanceKeys(final Long... values);
 
   /** Filter by process instance keys. */
   ProcessInstanceFilter processInstanceKeys(final List<Long> values);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceFilter.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import io.camunda.zeebe.client.api.search.TypedSearchQueryRequest.SearchRequestFilter;
+import java.util.List;
+import java.util.function.Consumer;
+
+public interface ProcessInstanceFilter extends SearchRequestFilter {
+
+  /** Filter by process instance keys. */
+  ProcessInstanceFilter processInstanceKeys(final Long value, final Long... values);
+
+  /** Filter by process instance keys. */
+  ProcessInstanceFilter processInstanceKeys(final List<Long> values);
+
+  /** Filter by variable values. */
+  ProcessInstanceFilter variable(final VariableValueFilter filter);
+
+  /** Filter by variable values. */
+  ProcessInstanceFilter variable(final Consumer<VariableValueFilter> fn);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceQuery.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceQuery.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import io.camunda.zeebe.client.api.search.response.ProcessInstance;
+
+public interface ProcessInstanceQuery
+    extends TypedSearchQueryRequest<
+            ProcessInstanceFilter, ProcessInstanceSort, ProcessInstanceQuery>,
+        FinalSearchQueryStep<ProcessInstance> {}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceSort.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/ProcessInstanceSort.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import io.camunda.zeebe.client.api.search.TypedSearchQueryRequest.SearchRequestSort;
+
+public interface ProcessInstanceSort extends SearchRequestSort<ProcessInstanceSort> {
+
+  /** Sort by process instance key. */
+  ProcessInstanceSort processInstanceKey();
+
+  /** Sort by process instance start date. */
+  ProcessInstanceSort startDate();
+
+  /** Sort by process instance end date. */
+  ProcessInstanceSort endDate();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestBuilders.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestBuilders.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import io.camunda.zeebe.client.impl.search.ProcessInstanceFilterImpl;
+import io.camunda.zeebe.client.impl.search.ProcessInstanceSortImpl;
+import io.camunda.zeebe.client.impl.search.SearchRequestPageImpl;
+import io.camunda.zeebe.client.impl.search.VariableValueFilterImpl;
+import java.util.function.Consumer;
+
+public final class SearchRequestBuilders {
+
+  private SearchRequestBuilders() {}
+
+  /** Create a process instance filter. */
+  public static ProcessInstanceFilter processInstanceFilter() {
+    return new ProcessInstanceFilterImpl();
+  }
+
+  /** Create a process instance filter by using a fluent builder. */
+  public static ProcessInstanceFilter processInstanceFilter(
+      final Consumer<ProcessInstanceFilter> fn) {
+    final ProcessInstanceFilter filter = processInstanceFilter();
+    fn.accept(filter);
+    return filter;
+  }
+
+  /** Create a variable value filter. */
+  public static VariableValueFilter variableValueFilter() {
+    return new VariableValueFilterImpl();
+  }
+
+  /** Create a variable value filter by using a fluent builder. */
+  public static VariableValueFilter variableValueFilter(final Consumer<VariableValueFilter> fn) {
+    final VariableValueFilter filter = variableValueFilter();
+    fn.accept(filter);
+    return filter;
+  }
+
+  /** Create a process instance sort option. */
+  public static ProcessInstanceSort processInstanceSort() {
+    return new ProcessInstanceSortImpl();
+  }
+
+  /** Create a process instance sort option by using a fluent builder. */
+  public static ProcessInstanceSort processInstanceSort(final Consumer<ProcessInstanceSort> fn) {
+    final ProcessInstanceSort sort = processInstanceSort();
+    fn.accept(sort);
+    return sort;
+  }
+
+  /** Create a search page. */
+  public static SearchRequestPage searchRequestPage() {
+    return new SearchRequestPageImpl();
+  }
+
+  /** Create a search page by using a fluent builder. */
+  public static SearchRequestPage searchRequestPage(final Consumer<SearchRequestPage> fn) {
+    final SearchRequestPage filter = searchRequestPage();
+    fn.accept(filter);
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestPage.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/SearchRequestPage.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import java.util.List;
+
+public interface SearchRequestPage {
+
+  /** Start the page from. */
+  SearchRequestPage from(final Integer value);
+
+  /** Limit the the number of returned entities. */
+  SearchRequestPage limit(final Integer value);
+
+  /** Get previous page before the set of values. */
+  SearchRequestPage searchBefore(final List<Object> values);
+
+  /** Get next page after the set of values. */
+  SearchRequestPage searchAfter(final List<Object> values);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/TypedSearchQueryRequest.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/TypedSearchQueryRequest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import io.camunda.zeebe.client.api.search.TypedSearchQueryRequest.SearchRequestFilter;
+import io.camunda.zeebe.client.api.search.TypedSearchQueryRequest.SearchRequestSort;
+import java.util.function.Consumer;
+
+public interface TypedSearchQueryRequest<
+    F extends SearchRequestFilter,
+    S extends SearchRequestSort<S>,
+    SELF extends TypedSearchQueryRequest<F, S, SELF>> {
+
+  /**
+   * Sets the filter to be included in the search request.
+   *
+   * @param value the filter
+   * @return the builder for the search request
+   */
+  SELF filter(final F value);
+
+  /**
+   * Provides a fluent builder to create a filter to be included in the search request.
+   *
+   * @param value consumer to create the filter
+   * @return the builder for the search request
+   */
+  SELF filter(final Consumer<F> fn);
+
+  /**
+   * Sets the sorting the returned entities should be sorted by.
+   *
+   * @param value the sort options
+   * @return the builder for the search request
+   */
+  SELF sort(final S value);
+
+  /**
+   * Provides a fluent builder to provide sorting options the returned entites should sorted by
+   *
+   * @param value consumer to create the sort options
+   * @return the builder for the search request
+   */
+  SELF sort(final Consumer<S> fn);
+
+  /**
+   * Support for pagination.
+   *
+   * @param value the next page
+   * @return the builder for the search request
+   */
+  SELF page(final SearchRequestPage value);
+
+  /**
+   * Provides a fluent builder to support pagination.
+   *
+   * @param value consumer to support pagination
+   * @return the builder for the search request
+   */
+  SELF page(final Consumer<SearchRequestPage> fn);
+
+  public static interface SearchRequestFilter {}
+
+  public static interface SearchRequestSort<S extends SearchRequestSort<S>> {
+
+    /**
+     * Sort in ascending order
+     *
+     * @return the sort builder
+     */
+    S asc();
+
+    /**
+     * Sort in descending order
+     *
+     * @return the sort builder
+     */
+    S desc();
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/VariableValueFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/VariableValueFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search;
+
+import io.camunda.zeebe.client.api.search.TypedSearchQueryRequest.SearchRequestFilter;
+
+public interface VariableValueFilter extends SearchRequestFilter {
+
+  /** Filter by variable name */
+  VariableValueFilter name(final String value);
+
+  /** Filter by variable value equal to value */
+  VariableValueFilter eq(final Object value);
+
+  /** Filter by variable value greater than value */
+  VariableValueFilter gt(final Object value);
+
+  /** Filter by variable value greater equals than value */
+  VariableValueFilter gte(final Object value);
+
+  /** Filter by variable value lower than value */
+  VariableValueFilter lt(final Object value);
+
+  /** Filter by variable value lower equals than value */
+  VariableValueFilter lte(final Object value);
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstance.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/ProcessInstance.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search.response;
+
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+
+public interface ProcessInstance extends ProcessInstanceEvent {
+
+  String getStartDate();
+
+  String getEndDate();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchQueryResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchQueryResponse.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search.response;
+
+import java.util.List;
+
+public interface SearchQueryResponse<T> {
+
+  /** Returns the list of items */
+  List<T> items();
+
+  /** Returns information about the returned page of items */
+  SearchResponsePage page();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchResponsePage.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/response/SearchResponsePage.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.api.search.response;
+
+import java.util.List;
+
+public interface SearchResponsePage {
+
+  /** Total number of items that matches the query */
+  Long totalItems();
+
+  /** The sort values of the first item in the returned page. */
+  List<Object> firstSortValues();
+
+  /** The sort values of the last item in the returned page. */
+  List<Object> lastSortValues();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -48,6 +48,7 @@ import io.camunda.zeebe.client.api.command.UpdateRetriesJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
+import io.camunda.zeebe.client.api.search.ProcessInstanceQuery;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.command.AssignUserTaskCommandImpl;
@@ -72,6 +73,7 @@ import io.camunda.zeebe.client.impl.command.UnassignUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.UpdateUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpClientFactory;
+import io.camunda.zeebe.client.impl.search.ProcessInstanceQueryImpl;
 import io.camunda.zeebe.client.impl.util.ExecutorResource;
 import io.camunda.zeebe.client.impl.util.VersionUtil;
 import io.camunda.zeebe.client.impl.worker.JobClientImpl;
@@ -512,5 +514,10 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public StreamJobsCommandStep1 newStreamJobsCommand() {
     return new StreamJobsCommandImpl(
         asyncStub, jsonMapper, credentialsProvider::shouldRetryRequest, config);
+  }
+
+  @Override
+  public ProcessInstanceQuery newProcessInstanceQuery() {
+    return new ProcessInstanceQueryImpl(httpClient, jsonMapper);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/http/HttpClient.java
@@ -109,7 +109,17 @@ public final class HttpClient implements AutoCloseable {
       final String body,
       final RequestConfig requestConfig,
       final HttpZeebeFuture<RespT> result) {
-    sendRequest(Method.POST, path, body, requestConfig, Void.class, r -> null, result);
+    post(path, body, requestConfig, Void.class, r -> null, result);
+  }
+
+  public <HttpT, RespT> void post(
+      final String path,
+      final String body,
+      final RequestConfig requestConfig,
+      final Class<HttpT> responseType,
+      final JsonResponseTransformer<HttpT, RespT> transformer,
+      final HttpZeebeFuture<RespT> result) {
+    sendRequest(Method.POST, path, body, requestConfig, responseType, transformer, result);
   }
 
   public <RespT> void patch(

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceFilterImpl.java
@@ -22,6 +22,7 @@ import static io.camunda.zeebe.client.impl.util.CollectionUtil.collectValues;
 import io.camunda.zeebe.client.api.search.ProcessInstanceFilter;
 import io.camunda.zeebe.client.api.search.VariableValueFilter;
 import io.camunda.zeebe.client.protocol.rest.ProcessInstanceFilterRequest;
+import io.camunda.zeebe.client.protocol.rest.VariableValueFilterRequest;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -48,8 +49,8 @@ public class ProcessInstanceFilterImpl
 
   @Override
   public ProcessInstanceFilter variable(final VariableValueFilter value) {
-    final VariableValueFilterImpl variableFilter = (VariableValueFilterImpl) value;
-    filter.addVariablesItem(variableFilter.getSearchRequestProperty());
+    final VariableValueFilterRequest variableFilter = provideSearchRequestProperty(value);
+    filter.addVariablesItem(variableFilter);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceFilterImpl.java
@@ -17,7 +17,7 @@ package io.camunda.zeebe.client.impl.search;
 
 import static io.camunda.zeebe.client.api.search.SearchRequestBuilders.variableValueFilter;
 import static io.camunda.zeebe.client.impl.util.CollectionUtil.addValuesToList;
-import static io.camunda.zeebe.client.impl.util.CollectionUtil.collectValues;
+import static io.camunda.zeebe.client.impl.util.CollectionUtil.toList;
 
 import io.camunda.zeebe.client.api.search.ProcessInstanceFilter;
 import io.camunda.zeebe.client.api.search.VariableValueFilter;
@@ -37,8 +37,8 @@ public class ProcessInstanceFilterImpl
   }
 
   @Override
-  public ProcessInstanceFilter processInstanceKeys(final Long value, final Long... values) {
-    return processInstanceKeys(collectValues(value, values));
+  public ProcessInstanceFilter processInstanceKeys(final Long... values) {
+    return processInstanceKeys(toList(values));
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceFilterImpl.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+import static io.camunda.zeebe.client.api.search.SearchRequestBuilders.variableValueFilter;
+import static io.camunda.zeebe.client.impl.util.CollectionUtil.addValuesToList;
+import static io.camunda.zeebe.client.impl.util.CollectionUtil.collectValues;
+
+import io.camunda.zeebe.client.api.search.ProcessInstanceFilter;
+import io.camunda.zeebe.client.api.search.VariableValueFilter;
+import io.camunda.zeebe.client.protocol.rest.ProcessInstanceFilterRequest;
+import java.util.List;
+import java.util.function.Consumer;
+
+public class ProcessInstanceFilterImpl
+    extends TypedSearchRequestPropertyProvider<ProcessInstanceFilterRequest>
+    implements ProcessInstanceFilter {
+
+  private final ProcessInstanceFilterRequest filter;
+
+  public ProcessInstanceFilterImpl() {
+    filter = new ProcessInstanceFilterRequest();
+  }
+
+  @Override
+  public ProcessInstanceFilter processInstanceKeys(final Long value, final Long... values) {
+    return processInstanceKeys(collectValues(value, values));
+  }
+
+  @Override
+  public ProcessInstanceFilter processInstanceKeys(final List<Long> values) {
+    filter.setKey(addValuesToList(filter.getKey(), values));
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter variable(final VariableValueFilter value) {
+    final VariableValueFilterImpl variableFilter = (VariableValueFilterImpl) value;
+    filter.addVariablesItem(variableFilter.getSearchRequestProperty());
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceFilter variable(final Consumer<VariableValueFilter> fn) {
+    return variable(variableValueFilter(fn));
+  }
+
+  @Override
+  protected ProcessInstanceFilterRequest getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceQueryImpl.java
@@ -30,9 +30,13 @@ import io.camunda.zeebe.client.api.search.response.ProcessInstance;
 import io.camunda.zeebe.client.api.search.response.SearchQueryResponse;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.client.protocol.rest.ProcessInstanceFilterRequest;
 import io.camunda.zeebe.client.protocol.rest.ProcessInstanceSearchQueryRequest;
 import io.camunda.zeebe.client.protocol.rest.ProcessInstanceSearchQueryResponse;
+import io.camunda.zeebe.client.protocol.rest.SearchQueryPageRequest;
+import io.camunda.zeebe.client.protocol.rest.SearchQuerySortRequest;
 import java.time.Duration;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -55,8 +59,8 @@ public class ProcessInstanceQueryImpl
 
   @Override
   public ProcessInstanceQuery filter(final ProcessInstanceFilter value) {
-    final ProcessInstanceFilterImpl filter = (ProcessInstanceFilterImpl) value;
-    request.setFilter(filter.getSearchRequestProperty());
+    final ProcessInstanceFilterRequest filter = provideSearchRequestProperty(value);
+    request.setFilter(filter);
     return this;
   }
 
@@ -67,8 +71,8 @@ public class ProcessInstanceQueryImpl
 
   @Override
   public ProcessInstanceQuery sort(final ProcessInstanceSort value) {
-    final ProcessInstanceSortImpl sorting = (ProcessInstanceSortImpl) value;
-    request.setSort(sorting.getSearchRequestProperty());
+    final List<SearchQuerySortRequest> sorting = provideSearchRequestProperty(value);
+    request.setSort(sorting);
     return this;
   }
 
@@ -79,8 +83,8 @@ public class ProcessInstanceQueryImpl
 
   @Override
   public ProcessInstanceQuery page(final SearchRequestPage value) {
-    final SearchRequestPageImpl page = (SearchRequestPageImpl) value;
-    request.setPage(page.getSearchRequestProperty());
+    final SearchQueryPageRequest page = provideSearchRequestProperty(value);
+    request.setPage(page);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceQueryImpl.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+import static io.camunda.zeebe.client.api.search.SearchRequestBuilders.processInstanceFilter;
+import static io.camunda.zeebe.client.api.search.SearchRequestBuilders.processInstanceSort;
+import static io.camunda.zeebe.client.api.search.SearchRequestBuilders.searchRequestPage;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.search.FinalSearchQueryStep;
+import io.camunda.zeebe.client.api.search.ProcessInstanceFilter;
+import io.camunda.zeebe.client.api.search.ProcessInstanceQuery;
+import io.camunda.zeebe.client.api.search.ProcessInstanceSort;
+import io.camunda.zeebe.client.api.search.SearchRequestPage;
+import io.camunda.zeebe.client.api.search.response.ProcessInstance;
+import io.camunda.zeebe.client.api.search.response.SearchQueryResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.client.protocol.rest.ProcessInstanceSearchQueryRequest;
+import io.camunda.zeebe.client.protocol.rest.ProcessInstanceSearchQueryResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class ProcessInstanceQueryImpl
+    extends TypedSearchRequestPropertyProvider<ProcessInstanceSearchQueryRequest>
+    implements ProcessInstanceQuery {
+
+  private final ProcessInstanceSearchQueryRequest request;
+  private final JsonMapper jsonMapper;
+  private final HttpClient httpClient;
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public ProcessInstanceQueryImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    request = new ProcessInstanceSearchQueryRequest();
+    this.jsonMapper = jsonMapper;
+    this.httpClient = httpClient;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public ProcessInstanceQuery filter(final ProcessInstanceFilter value) {
+    final ProcessInstanceFilterImpl filter = (ProcessInstanceFilterImpl) value;
+    request.setFilter(filter.getSearchRequestProperty());
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceQuery filter(final Consumer<ProcessInstanceFilter> fn) {
+    return filter(processInstanceFilter(fn));
+  }
+
+  @Override
+  public ProcessInstanceQuery sort(final ProcessInstanceSort value) {
+    final ProcessInstanceSortImpl sorting = (ProcessInstanceSortImpl) value;
+    request.setSort(sorting.getSearchRequestProperty());
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceQuery sort(final Consumer<ProcessInstanceSort> fn) {
+    return sort(processInstanceSort(fn));
+  }
+
+  @Override
+  public ProcessInstanceQuery page(final SearchRequestPage value) {
+    final SearchRequestPageImpl page = (SearchRequestPageImpl) value;
+    request.setPage(page.getSearchRequestProperty());
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceQuery page(final Consumer<SearchRequestPage> fn) {
+    return page(searchRequestPage(fn));
+  }
+
+  @Override
+  protected ProcessInstanceSearchQueryRequest getSearchRequestProperty() {
+    return request;
+  }
+
+  @Override
+  public FinalSearchQueryStep<ProcessInstance> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<SearchQueryResponse<ProcessInstance>> send() {
+    final HttpZeebeFuture<SearchQueryResponse<ProcessInstance>> result = new HttpZeebeFuture<>();
+    httpClient.post(
+        "/process-instances/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        ProcessInstanceSearchQueryResponse.class,
+        SearchResponseMapper::toProcessInstanceSearchResponse,
+        result);
+    return result;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceSortImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/ProcessInstanceSortImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+import io.camunda.zeebe.client.api.search.ProcessInstanceSort;
+
+public class ProcessInstanceSortImpl extends SearchQuerySortBase<ProcessInstanceSort>
+    implements ProcessInstanceSort {
+
+  @Override
+  public ProcessInstanceSort processInstanceKey() {
+    return field("processInstanceKey");
+  }
+
+  @Override
+  public ProcessInstanceSort startDate() {
+    return field("startDate");
+  }
+
+  @Override
+  public ProcessInstanceSort endDate() {
+    return field("endDate");
+  }
+
+  @Override
+  protected ProcessInstanceSort self() {
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchQuerySortBase.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchQuerySortBase.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+import io.camunda.zeebe.client.protocol.rest.SearchQuerySortRequest;
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class SearchQuerySortBase<T>
+    extends TypedSearchRequestPropertyProvider<List<SearchQuerySortRequest>> {
+
+  private final List<SearchQuerySortRequest> sorting = new ArrayList<>();
+  private SearchQuerySortRequest current;
+
+  protected T field(final String value) {
+    current = new SearchQuerySortRequest();
+    current.field(value);
+    return self();
+  }
+
+  protected T order(final String order) {
+    if (current != null) {
+      current.order(order);
+      sorting.add(current);
+      current = null;
+    }
+    return self();
+  }
+
+  public T asc() {
+    return order("asc");
+  }
+
+  public T desc() {
+    return order("desc");
+  }
+
+  protected abstract T self();
+
+  @Override
+  protected List<SearchQuerySortRequest> getSearchRequestProperty() {
+    return sorting;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchRequestPageImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchRequestPageImpl.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+import io.camunda.zeebe.client.api.search.SearchRequestPage;
+import io.camunda.zeebe.client.protocol.rest.SearchQueryPageRequest;
+import java.util.List;
+
+public class SearchRequestPageImpl
+    extends TypedSearchRequestPropertyProvider<SearchQueryPageRequest>
+    implements SearchRequestPage {
+
+  private final SearchQueryPageRequest page;
+
+  public SearchRequestPageImpl() {
+    page = new SearchQueryPageRequest();
+  }
+
+  @Override
+  public SearchRequestPage from(final Integer value) {
+    page.setFrom(value);
+    return this;
+  }
+
+  @Override
+  public SearchRequestPage limit(final Integer value) {
+    page.setLimit(value);
+    return this;
+  }
+
+  @Override
+  public SearchRequestPage searchBefore(final List<Object> values) {
+    page.setSearchBefore(values);
+    return this;
+  }
+
+  @Override
+  public SearchRequestPage searchAfter(final List<Object> values) {
+    page.setSearchAfter(values);
+    return this;
+  }
+
+  @Override
+  protected SearchQueryPageRequest getSearchRequestProperty() {
+    return page;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchResponseMapper.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+import io.camunda.zeebe.client.api.search.response.ProcessInstance;
+import io.camunda.zeebe.client.api.search.response.SearchQueryResponse;
+import io.camunda.zeebe.client.api.search.response.SearchResponsePage;
+import io.camunda.zeebe.client.impl.search.response.ProcessInstanceImpl;
+import io.camunda.zeebe.client.impl.search.response.SearchQueryResponseImpl;
+import io.camunda.zeebe.client.impl.search.response.SearchResponsePageImpl;
+import io.camunda.zeebe.client.protocol.rest.ProcessInstanceSearchQueryResponse;
+import io.camunda.zeebe.client.protocol.rest.SearchQueryPageResponse;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+public final class SearchResponseMapper {
+
+  private SearchResponseMapper() {}
+
+  public static SearchQueryResponse<ProcessInstance> toProcessInstanceSearchResponse(
+      final ProcessInstanceSearchQueryResponse response) {
+    final SearchQueryPageResponse pageResponse = response.getPage();
+    final SearchResponsePage page =
+        new SearchResponsePageImpl(
+            pageResponse.getTotalItems(),
+            pageResponse.getFirstSortValues(),
+            pageResponse.getLastSortValues());
+
+    final List<ProcessInstance> instances =
+        Optional.ofNullable(response.getItems())
+            .map(
+                (i) ->
+                    i.stream()
+                        .map(ProcessInstanceImpl::new)
+                        .map((p) -> (ProcessInstance) p)
+                        .collect(Collectors.toList()))
+            .orElse(Collections.emptyList());
+
+    return new SearchQueryResponseImpl<>(instances, page);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/TypedSearchRequestPropertyProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/TypedSearchRequestPropertyProvider.java
@@ -18,4 +18,14 @@ package io.camunda.zeebe.client.impl.search;
 public abstract class TypedSearchRequestPropertyProvider<T> {
 
   protected abstract T getSearchRequestProperty();
+
+  public static <T> T provideSearchRequestProperty(final Object value) {
+    if (value instanceof TypedSearchRequestPropertyProvider) {
+      final TypedSearchRequestPropertyProvider<T> provider =
+          (TypedSearchRequestPropertyProvider<T>) value;
+      return provider.getSearchRequestProperty();
+    }
+    throw new UnsupportedOperationException(
+        "Passed value is not of type " + TypedSearchRequestPropertyProvider.class);
+  }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/TypedSearchRequestPropertyProvider.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/TypedSearchRequestPropertyProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+public abstract class TypedSearchRequestPropertyProvider<T> {
+
+  protected abstract T getSearchRequestProperty();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/VariableValueFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/VariableValueFilterImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search;
+
+import io.camunda.zeebe.client.api.search.VariableValueFilter;
+import io.camunda.zeebe.client.protocol.rest.VariableValueFilterRequest;
+
+public class VariableValueFilterImpl
+    extends TypedSearchRequestPropertyProvider<VariableValueFilterRequest>
+    implements VariableValueFilter {
+
+  private final VariableValueFilterRequest filter;
+
+  public VariableValueFilterImpl() {
+    filter = new VariableValueFilterRequest();
+  }
+
+  @Override
+  public VariableValueFilter name(final String value) {
+    filter.setName(value);
+    return this;
+  }
+
+  @Override
+  public VariableValueFilter eq(final Object value) {
+    filter.setEq(value);
+    return this;
+  }
+
+  @Override
+  public VariableValueFilter gt(final Object value) {
+    filter.setGt(value);
+    return this;
+  }
+
+  @Override
+  public VariableValueFilter gte(final Object value) {
+    filter.setGte(value);
+    return this;
+  }
+
+  @Override
+  public VariableValueFilter lt(final Object value) {
+    filter.setLt(value);
+    return this;
+  }
+
+  @Override
+  public VariableValueFilter lte(final Object value) {
+    filter.setLte(value);
+    return this;
+  }
+
+  @Override
+  protected VariableValueFilterRequest getSearchRequestProperty() {
+    return filter;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/ProcessInstanceImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/ProcessInstanceImpl.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search.response;
+
+import io.camunda.zeebe.client.api.search.response.ProcessInstance;
+import io.camunda.zeebe.client.protocol.rest.ProcessInstanceItem;
+
+public class ProcessInstanceImpl implements ProcessInstance {
+
+  private final String tenantId;
+  private final Long key;
+  private final Long processDefinitionKey;
+  private final Integer processVersion;
+  private final String bpmnProcessId;
+  private final String startDate;
+  private final String endDate;
+
+  public ProcessInstanceImpl(final ProcessInstanceItem item) {
+    tenantId = item.getTenantId();
+    key = item.getKey();
+    processDefinitionKey = item.getProcessDefinitionKey();
+    processVersion = item.getProcessVersion();
+    bpmnProcessId = item.getBpmnProcessId();
+    startDate = item.getStartDate();
+    endDate = item.getEndDate();
+  }
+
+  @Override
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  @Override
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  @Override
+  public int getVersion() {
+    return processVersion;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return key;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public String getStartDate() {
+    return startDate;
+  }
+
+  @Override
+  public String getEndDate() {
+    return endDate;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/SearchQueryResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/SearchQueryResponseImpl.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search.response;
+
+import io.camunda.zeebe.client.api.search.response.SearchQueryResponse;
+import io.camunda.zeebe.client.api.search.response.SearchResponsePage;
+import java.util.List;
+
+public final class SearchQueryResponseImpl<T> implements SearchQueryResponse<T> {
+
+  private final List<T> items;
+  private final SearchResponsePage page;
+
+  public SearchQueryResponseImpl(final List<T> items, final SearchResponsePage page) {
+    this.items = items;
+    this.page = page;
+  }
+
+  @Override
+  public List<T> items() {
+    return items;
+  }
+
+  @Override
+  public SearchResponsePage page() {
+    return page;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/SearchResponsePageImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/SearchResponsePageImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search.response;
+
+import io.camunda.zeebe.client.api.search.response.SearchResponsePage;
+import java.util.List;
+
+public class SearchResponsePageImpl implements SearchResponsePage {
+
+  private final long totalItems;
+  private final List<Object> firstSortValues;
+  private final List<Object> lastSortValues;
+
+  public SearchResponsePageImpl(
+      final long totalItems,
+      final List<Object> firstSortValues,
+      final List<Object> lastSortValues) {
+    this.totalItems = totalItems;
+    this.firstSortValues = firstSortValues;
+    this.lastSortValues = lastSortValues;
+  }
+
+  @Override
+  public Long totalItems() {
+    return totalItems;
+  }
+
+  @Override
+  public List<Object> firstSortValues() {
+    return firstSortValues;
+  }
+
+  @Override
+  public List<Object> lastSortValues() {
+    return lastSortValues;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/CollectionUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/CollectionUtil.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.util;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+public final class CollectionUtil {
+
+  private CollectionUtil() {}
+
+  public static <T> List<T> addValuesToList(final List<T> list, final List<T> values) {
+    final List<T> result;
+    if (list == null) {
+      result = Objects.requireNonNull(values);
+    } else {
+      result = new ArrayList<>(list);
+      result.addAll(values);
+    }
+    return result;
+  }
+
+  public static <T> List<T> collectValues(final T value, final T... values) {
+    final List<T> collectedValues = new ArrayList<>();
+    collectedValues.add(value);
+    if (values != null && values.length > 0) {
+      collectedValues.addAll(Arrays.asList(values));
+    }
+    return collectedValues;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/CollectionUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/CollectionUtil.java
@@ -35,9 +35,8 @@ public final class CollectionUtil {
     return result;
   }
 
-  public static <T> List<T> collectValues(final T value, final T... values) {
+  public static <T> List<T> toList(final T... values) {
     final List<T> collectedValues = new ArrayList<>();
-    collectedValues.add(value);
     if (values != null && values.length > 0) {
       collectedValues.addAll(Arrays.asList(values));
     }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -658,6 +658,9 @@ components:
         key:
           type: integer
           format: int64
+        processDefinitionKey:
+          type: integer
+          format: int64
         processVersion:
           type: integer
           format: int32

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -214,6 +214,28 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+  /process-instances/search:
+    post:
+      tags:
+        - Process Instance
+      summary: Process Instance Search Query
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProcessInstanceSearchQueryRequest'
+      responses:
+        '200':
+          $ref: "#/components/responses/ProcessInstanceSearchQueryResponse"
+        '400':
+          description: >
+            The Process Instance Search Query failed.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
 
 components:
   responses:
@@ -527,6 +549,132 @@ components:
           type: string
           format: uri
           description: A URI identifying the origin of the problem.
+    SearchQueryRequest:
+      type: object
+      properties:
+        sort:
+          type: array
+          items:
+            allOf:
+              - $ref: "#/components/schemas/SearchQuerySortRequest"
+        page:
+          allOf:
+            - $ref: "#/components/schemas/SearchQueryPageRequest"
+          type: object
+    SearchQueryPageRequest:
+      type: object
+      properties:
+        from:
+          type: integer
+          format: int32
+        limit:
+          type: integer
+          format: int32
+        searchAfter:
+          type: array
+          items:
+            type: object
+        searchBefore:
+          type: array
+          items:
+            type: object
+    SearchQuerySortRequest:
+      type: object
+      properties:
+        field:
+          type: string
+        order:
+          type: string
+    SearchQueryResponse:
+      type: object
+      properties:
+        page:
+          allOf:
+            - $ref: "#/components/schemas/SearchQueryPageResponse"
+          type: object
+    SearchQueryPageResponse:
+      type: object
+      properties:
+        totalItems:
+          type: integer
+          format: int64
+        firstSortValues:
+          type: array
+          items:
+            type: object
+        lastSortValues:
+          type: array
+          items:
+            type: object
+    ProcessInstanceSearchQueryRequest:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryRequest"
+      type: object
+      properties:
+        filter:
+          allOf:
+            - $ref: "#/components/schemas/ProcessInstanceFilterRequest"
+    ProcessInstanceFilterRequest:
+      type: object
+      properties:
+        key:
+          type: array
+          items:
+            type: integer
+            format: int64
+        variables:
+          type: array
+          items:
+            $ref: "#/components/schemas/VariableValueFilterRequest"
+    VariableValueFilterRequest:
+      type: object
+      properties:
+        name:
+          type: string
+        eq:
+          type: object
+        gt:
+          type: object
+        gte:
+          type: object
+        lt:
+          type: object
+        lte:
+          type: object
+    ProcessInstanceSearchQueryResponse:
+      allOf:
+        - $ref: "#/components/schemas/SearchQueryResponse"
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProcessInstanceItem"
+    ProcessInstanceItem:
+      type: object
+      properties:
+        tenantId:
+          type: string
+        key:
+          type: integer
+          format: int64
+        processVersion:
+          type: integer
+          format: int32
+        bpmnProcessId:
+          type: string
+        parentKey:
+          type: integer
+          format: int64
+        parentFlowNodeInstanceKey:
+          type: integer
+          format: int64
+        startDate:
+          type: string
+          format: date-time
+        endDate:
+          type: string
+          format: date-time
   securitySchemes:
     bearerAuth:
       type: http

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import io.camunda.service.search.filter.FilterBuilders;
+import io.camunda.service.search.filter.ProcessInstanceFilter;
+import io.camunda.service.search.filter.VariableValueFilter;
+import io.camunda.service.search.page.SearchQueryPage;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.query.SearchQueryBuilders;
+import io.camunda.service.search.sort.ProcessInstanceSort;
+import io.camunda.service.search.sort.SortOptionBuilders;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilterRequest;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageRequest;
+import io.camunda.zeebe.gateway.protocol.rest.SearchQuerySortRequest;
+import io.camunda.zeebe.gateway.protocol.rest.VariableValueFilterRequest;
+import io.camunda.zeebe.util.Either;
+import java.util.List;
+import org.springframework.http.ProblemDetail;
+
+public final class SearchQueryRequestMapper {
+
+  private SearchQueryRequestMapper() {}
+
+  public static Either<ProblemDetail, ProcessInstanceQuery> toProcessInstanceQuery(
+      final ProcessInstanceSearchQueryRequest request) {
+    final var page = toSearchQueryPage(request.getPage()).get();
+    final var sorting = toSearchQuerySort(request.getSort()).get();
+    final var processInstanceFilter = toProcessInstanceFilter(request.getFilter()).get();
+    return Either.right(
+        SearchQueryBuilders.processInstanceSearchQuery()
+            .page(page)
+            .filter(processInstanceFilter)
+            .sort(sorting)
+            .build());
+  }
+
+  public static Either<ProblemDetail, ProcessInstanceFilter> toProcessInstanceFilter(
+      final ProcessInstanceFilterRequest filter) {
+    final var builder = FilterBuilders.processInstance();
+
+    if (filter != null) {
+      final var variableFilters = toVariableValueFilter(filter.getVariables()).get();
+      if (variableFilters != null) {
+        builder.variable(variableFilters);
+      }
+      if (filter.getKey() != null && !filter.getKey().isEmpty()) {
+        builder.processInstanceKeys(filter.getKey());
+      }
+    }
+
+    return Either.right(builder.build());
+  }
+
+  public static Either<ProblemDetail, List<VariableValueFilter>> toVariableValueFilter(
+      final List<VariableValueFilterRequest> filters) {
+
+    final List<VariableValueFilter> result;
+
+    if (filters != null && !filters.isEmpty()) {
+      result =
+          filters.stream()
+              .map(SearchQueryRequestMapper::toVariableValueFilter)
+              .map(Either::get)
+              .toList();
+    } else {
+      result = null;
+    }
+
+    return Either.right(result);
+  }
+
+  public static Either<ProblemDetail, VariableValueFilter> toVariableValueFilter(
+      final VariableValueFilterRequest f) {
+    return Either.right(
+        FilterBuilders.variableValue(
+            (v) ->
+                v.name(f.getName())
+                    .eq(f.getEq())
+                    .gt(f.getGt())
+                    .gte(f.getGte())
+                    .lt(f.getLt())
+                    .lte(f.getLte())));
+  }
+
+  public static Either<ProblemDetail, SearchQueryPage> toSearchQueryPage(
+      final SearchQueryPageRequest requestedPage) {
+    if (requestedPage != null) {
+      return Either.right(
+          SearchQueryPage.of(
+              (p) ->
+                  p.size(requestedPage.getLimit())
+                      .from(requestedPage.getFrom())
+                      .searchAfter(toArrayOrNull(requestedPage.getSearchAfter()))
+                      .searchBefore(toArrayOrNull(requestedPage.getSearchBefore()))));
+    }
+
+    return Either.right(null);
+  }
+
+  public static Either<ProblemDetail, ProcessInstanceSort> toSearchQuerySort(
+      final List<SearchQuerySortRequest> sorting) {
+    if (sorting != null && !sorting.isEmpty()) {
+      final var builder = SortOptionBuilders.processInstance();
+
+      for (SearchQuerySortRequest sort : sorting) {
+        final var field = sort.getField();
+        final var order = sort.getOrder();
+
+        if ("processInstanceKey".equals(field)) {
+          builder.processInstanceKey();
+        } else if ("startDate".equals(field)) {
+          builder.startDate();
+        } else if ("endDate".equals(field)) {
+          builder.endDate();
+        } else {
+          throw new RuntimeException("unkown sortBy " + field);
+        }
+
+        if ("asc".equalsIgnoreCase(order)) {
+          builder.asc();
+        } else if ("desc".equalsIgnoreCase(order)) {
+          builder.desc();
+        } else {
+          throw new RuntimeException("unkown sortOrder " + order);
+        }
+      }
+
+      return Either.right(builder.build());
+    }
+
+    return Either.right(null);
+  }
+
+  private static Object[] toArrayOrNull(final List<Object> values) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    } else {
+      return values.toArray();
+    }
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceItem;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResponse;
+import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
+import io.camunda.zeebe.util.Either;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.http.ProblemDetail;
+
+public final class SearchQueryResponseMapper {
+
+  public SearchQueryResponseMapper() {}
+
+  public static Either<ProblemDetail, ProcessInstanceSearchQueryResponse>
+      toProcessInstanceSearchQueryResponse(final SearchQueryResult<ProcessInstanceEntity> result) {
+    final var response = new ProcessInstanceSearchQueryResponse();
+    final var total = result.total();
+    final var sortValues = result.sortValues();
+    final var items = result.items();
+
+    final var page = new SearchQueryPageResponse();
+    page.setTotalItems(total);
+    response.setPage(page);
+
+    if (sortValues != null) {
+      page.setLastSortValues(Arrays.asList(sortValues));
+    }
+
+    if (items != null) {
+      response.setItems(toProcessInstances(items).get());
+    }
+
+    return Either.right(response);
+  }
+
+  public static Either<ProblemDetail, List<ProcessInstanceItem>> toProcessInstances(
+      final List<ProcessInstanceEntity> instances) {
+    return Either.right(
+        instances.stream()
+            .map(SearchQueryResponseMapper::toProcessInstance)
+            .map(Either::get)
+            .toList());
+  }
+
+  public static Either<ProblemDetail, ProcessInstanceItem> toProcessInstance(
+      final ProcessInstanceEntity p) {
+    return Either.right(
+        new ProcessInstanceItem()
+            .tenantId(p.tenantId())
+            .key(p.key())
+            .processVersion(p.processVersion())
+            .bpmnProcessId(p.bpmnProcessId())
+            .parentKey(p.parentKey())
+            .parentFlowNodeInstanceKey(p.parentFlowNodeInstanceKey())
+            .startDate(p.startDate())
+            .endDate(p.endDate()));
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceController.java
@@ -8,10 +8,19 @@
 package io.camunda.zeebe.gateway.rest.controller;
 
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryRequest;
+import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResponse;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryRequestMapper;
+import io.camunda.zeebe.gateway.rest.SearchQueryResponseMapper;
+import io.camunda.zeebe.gateway.rest.TenantAttributeHolder;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @ZeebeRestController
 public class ProcessInstanceController {
@@ -20,8 +29,31 @@ public class ProcessInstanceController {
 
   @PostMapping(
       path = "/process-instances/search",
-      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
-  public ResponseEntity<Object> searchProcessInstances() {
-    return ResponseEntity.ok(processInstanceServices.search((q) -> q));
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public ResponseEntity<ProcessInstanceSearchQueryResponse> searchProcessInstances(
+      @RequestBody final ProcessInstanceSearchQueryRequest query) {
+    return SearchQueryRequestMapper.toProcessInstanceQuery(query)
+        .fold(this::search, RestErrorMapper::mapProblemToResponse);
+  }
+
+  private ResponseEntity<ProcessInstanceSearchQueryResponse> search(
+      final ProcessInstanceQuery query) {
+    try {
+      final var tenantIds = TenantAttributeHolder.tenantIds();
+      final var result =
+          processInstanceServices.withAuthentication((a) -> a.tenants(tenantIds)).search(query);
+      return ResponseEntity.ok(
+          SearchQueryResponseMapper.toProcessInstanceSearchQueryResponse(result).get());
+    } catch (final Throwable e) {
+      final var problemDetail =
+          RestErrorMapper.createProblemDetail(
+              HttpStatus.BAD_REQUEST,
+              e.getMessage(),
+              "Failed to execute Process Instance Search Query");
+      return ResponseEntity.of(problemDetail)
+          .headers(httpHeaders -> httpHeaders.setContentType(MediaType.APPLICATION_PROBLEM_JSON))
+          .build();
+    }
   }
 }


### PR DESCRIPTION
## Description

Implements a search request API in the Zeebe Client so users can search process instances creating a query, for example
```java
final SearchQueryResponse<ProcessInstance> response = client.newProcessInstanceQuery()
        .filter((f) -> f.variable((v) -> v.name("foo").eq(5)))
        .sort((s) -> s.endDate().asc())
        .page((p) -> p.size(20))
        .send()
        .join();
```

## Related issues

closes #
