### PR TITLE
deps: Update feel-engine to 1.18.0-alpha1

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,7 +91,7 @@
     <version.testcontainers>1.19.8</version.testcontainers>
     <version.netflix.concurrency>0.5.1</version.netflix.concurrency>
     <version.zeebe-test-container>3.6.3</version.zeebe-test-container>
-    <version.feel-scala>1.17.7</version.feel-scala>
+    <version.feel-scala>1.18.0-alpha1</version.feel-scala>
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>
     <version.spring>6.1.9</version.spring>


### PR DESCRIPTION
## Description

We update the `feel-engine` to the latest alpha version [1.18.0-alpha1](https://github.com/camunda/feel-scala/releases/tag/1.18.0-alpha1) to test new features in upcoming alpha versions of Camunda.

## Related issues
