### PR TITLE
refactor: move test into right package

### DIFF
--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -5,31 +5,30 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.clients;
+package io.camunda.search.es.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import io.camunda.data.util.StubbedOpensearchClient;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
+import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
 import io.camunda.search.clients.core.SearchQueryRequest;
-import io.camunda.search.os.clients.OpensearchSearchClient;
+import io.camunda.search.es.util.StubbedElasticsearchClient;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opensearch.client.opensearch.core.SearchResponse;
-import org.opensearch.client.opensearch.core.search.HitsMetadata;
-import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 
-public class OpensearchSearchClientTest {
+public class ElasticsearchDataStoreClientTest {
 
-  private OpensearchSearchClient client;
-  private StubbedOpensearchClient stubbedOpensearchClient;
+  private ElasticsearchSearchClient client;
+  private StubbedElasticsearchClient stubbedElasticsearchClient;
 
   @BeforeEach
   public void before() {
-    stubbedOpensearchClient = new StubbedOpensearchClient();
-    stubbedOpensearchClient.registerHandler(
+    stubbedElasticsearchClient = new StubbedElasticsearchClient();
+    stubbedElasticsearchClient.registerHandler(
         (h) -> {
-          return SearchResponse.searchResponseOf(
+          return SearchResponse.of(
               (f) ->
                   f.took(122)
                       .hits(
@@ -41,7 +40,7 @@ public class OpensearchSearchClientTest {
                       .timedOut(false));
         });
 
-    client = new OpensearchSearchClient(stubbedOpensearchClient);
+    client = new ElasticsearchSearchClient(stubbedElasticsearchClient);
   }
 
   @Test
@@ -54,7 +53,7 @@ public class OpensearchSearchClientTest {
     client.search(request, Object.class);
 
     // then
-    final var searchRequest = stubbedOpensearchClient.getSingleSearchRequest();
+    final var searchRequest = stubbedElasticsearchClient.getSingleSearchRequest();
     assertThat(searchRequest.index()).hasSize(1).contains("operate-list-view-8.3.0_");
   }
 

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/ElasticsearchTransfomersTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/ElasticsearchTransfomersTest.java
@@ -5,13 +5,12 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.transformers;
+package io.camunda.search.es.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import io.camunda.search.clients.core.SearchQueryRequest;
-import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import io.camunda.search.transformers.SearchTransfomer;
 import org.junit.jupiter.api.Test;
 

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
@@ -5,21 +5,20 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.transformers;
+package io.camunda.search.es.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.clients.query.SearchRangeQuery;
-import io.camunda.search.os.transformers.OpensearchTransformers;
 import io.camunda.search.transformers.SearchTransfomer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 
 public class RangeQueryTransformerTest {
 
-  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
   private SearchTransfomer<SearchRangeQuery, RangeQuery> transformer;
 
   @BeforeEach

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/SearchRequestTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/SearchRequestTransformerTest.java
@@ -5,14 +5,13 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.transformers;
+package io.camunda.search.es.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import co.elastic.clients.elasticsearch._types.SortOrder;
 import co.elastic.clients.elasticsearch.core.SearchRequest;
 import io.camunda.search.clients.core.SearchQueryRequest;
-import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import io.camunda.search.transformers.SearchTransfomer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/util/StubbedElasticsearchClient.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/util/StubbedElasticsearchClient.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.util;
+package io.camunda.search.es.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchSearchClientTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/clients/OpensearchSearchClientTest.java
@@ -5,31 +5,30 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.clients;
+package io.camunda.search.os.clients;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch.core.SearchResponse;
-import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
-import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
-import io.camunda.data.util.StubbedElasticsearchClient;
 import io.camunda.search.clients.core.SearchQueryRequest;
-import io.camunda.search.es.clients.ElasticsearchSearchClient;
+import io.camunda.search.os.util.StubbedOpensearchClient;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 
-public class ElasticsearchDataStoreClientTest {
+public class OpensearchSearchClientTest {
 
-  private ElasticsearchSearchClient client;
-  private StubbedElasticsearchClient stubbedElasticsearchClient;
+  private OpensearchSearchClient client;
+  private StubbedOpensearchClient stubbedOpensearchClient;
 
   @BeforeEach
   public void before() {
-    stubbedElasticsearchClient = new StubbedElasticsearchClient();
-    stubbedElasticsearchClient.registerHandler(
+    stubbedOpensearchClient = new StubbedOpensearchClient();
+    stubbedOpensearchClient.registerHandler(
         (h) -> {
-          return SearchResponse.of(
+          return SearchResponse.searchResponseOf(
               (f) ->
                   f.took(122)
                       .hits(
@@ -41,7 +40,7 @@ public class ElasticsearchDataStoreClientTest {
                       .timedOut(false));
         });
 
-    client = new ElasticsearchSearchClient(stubbedElasticsearchClient);
+    client = new OpensearchSearchClient(stubbedOpensearchClient);
   }
 
   @Test
@@ -54,7 +53,7 @@ public class ElasticsearchDataStoreClientTest {
     client.search(request, Object.class);
 
     // then
-    final var searchRequest = stubbedElasticsearchClient.getSingleSearchRequest();
+    final var searchRequest = stubbedOpensearchClient.getSingleSearchRequest();
     assertThat(searchRequest.index()).hasSize(1).contains("operate-list-view-8.3.0_");
   }
 

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/OpensearchTransfomersTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/OpensearchTransfomersTest.java
@@ -5,12 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.transformers;
+package io.camunda.search.os.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.core.SearchQueryRequest;
-import io.camunda.search.os.transformers.OpensearchTransformers;
 import io.camunda.search.transformers.SearchTransfomer;
 import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch.core.SearchRequest;

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/RangeQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/RangeQueryTransformerTest.java
@@ -5,21 +5,20 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.transformers;
+package io.camunda.search.os.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.clients.query.SearchRangeQuery;
-import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import io.camunda.search.transformers.SearchTransfomer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 
 public class RangeQueryTransformerTest {
 
-  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
   private SearchTransfomer<SearchRangeQuery, RangeQuery> transformer;
 
   @BeforeEach

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/SearchRequestTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/SearchRequestTransformerTest.java
@@ -5,12 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.transformers;
+package io.camunda.search.os.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.search.clients.core.SearchQueryRequest;
-import io.camunda.search.os.transformers.OpensearchTransformers;
 import io.camunda.search.transformers.SearchTransfomer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/util/StubbedOpensearchClient.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/util/StubbedOpensearchClient.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.data.util;
+package io.camunda.search.os.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 


### PR DESCRIPTION
## Description

In order to avoid duplication of tests (in flaky test detection) and align with src packages move test classes in the right locations



See for example for the unfied CI where we run all unit-tests https://github.com/camunda/camunda/pull/19436 we detect duplicated tests due to the same name and packages https://github.com/camunda/camunda/actions/runs/9576914432/job/26404218862

```
io.camunda.data.transformers.RangeQueryTransformerTest
io.camunda.data.transformers.SearchRequestTransformerTest
io.camunda.tasklist.webapp.security.oauth.IdentityJwt2AuthenticationTokenConverterTest
```

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

related https://github.com/camunda/camunda/pull/19436
