### PR TITLE
test: convert Tasklist-Identity test to IT

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityJwt2AuthenticationTokenConverterIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/webapp/security/oauth/IdentityJwt2AuthenticationTokenConverterIT.java
@@ -59,7 +59,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
       "management.endpoint.health.group.readiness.include=readinessState"
     })
 @ActiveProfiles({IDENTITY_AUTH_PROFILE, "test"})
-public class IdentityJwt2AuthenticationTokenConverterTest {
+public class IdentityJwt2AuthenticationTokenConverterIT {
 
   @Autowired @SpyBean private IdentityJwt2AuthenticationTokenConverter tokenConverter;
 


### PR DESCRIPTION

## Description

Test had a duplicated name with a unit test in the web app, as it resists in the QA module renamed it to *IT to indicate an integration test and run it with failsafe


The duplicated test name was a problem because we wanted to run all unit-tests in the unified CI workflow, and analyze them for flaky tests. That is done via checking whether tests have been executed twice, etc. see [comment](https://github.com/camunda/camunda/pull/19436#issuecomment-2177867667) 

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

related https://github.com/camunda/camunda/pull/19436
