### PR TITLE
build: set missing name tag in required poms

### DIFF
--- a/identity/common/pom.xml
+++ b/identity/common/pom.xml
@@ -16,6 +16,7 @@
   </parent>
 
   <artifactId>identity-common</artifactId>
+  <name>Identity Common</name>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>

--- a/webapps-common/pom.xml
+++ b/webapps-common/pom.xml
@@ -17,6 +17,7 @@
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>webapps-common</artifactId>
+  <name>Webapps Common</name>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
## Description

As per the Slack [conversation](https://camunda.slack.com/archives/C06HTSPD5AP/p1718789659544339) there are a couple of `<name>` tags missing from two modules that are causing issues with staging the release on Maven. This PR adds in the tags.
