### PR TITLE
chore(optimize8): fix errors in optimize workflows

### DIFF
--- a/.github/workflows/optimize-backend-linting.yml
+++ b/.github/workflows/optimize-backend-linting.yml
@@ -15,10 +15,17 @@ jobs:
     name: Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
-      - uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
+      - name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+      - name: Fetch main branch
+        run: git fetch origin main:refs/remote/origin/main
+
+      - name: Setup Java
+        uses: actions/setup-java@99b8673ff64fbf99d8d325f52d9a5bdedb8483e9 # v4
         with:
           distribution: "adopt"
           java-version: "17"
-      - run: mvn -q spotless:check
-        name: Check Google Java codestyle
+
+      - name: Check Google Java codestyle
+        run: mvn -q spotless:check

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -272,21 +272,30 @@ jobs:
           profiles: 'it,engine-latest'
           requiresCambpm: true
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    - name: Checkout repository
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+    - name: Fetch main branch
+      run: git fetch origin main:refs/remote/origin/main
+
     - name: Setup Maven
       uses: ./.github/actions/setup-maven
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: Login to Harbor registry
       uses: ./.github/actions/login-registry
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: "Read Java / Version Info"
       id: "pom-info"
       uses: YunaBraska/java-info-action@main
+
     - name: Expose Parsed Elastic Version
       run: |
         echo "ELASTIC_VERSION=${{ steps.pom-info.outputs.x_elasticsearch8_test_version }}" >> "$GITHUB_ENV"
+
     - name: Start Cambpm
       if: ${{ matrix.requiresCambpm }}
       uses: ./.github/actions/compose
@@ -296,6 +305,7 @@ jobs:
       env:
         CAMBPM_VERSION: ${{ steps.pom-info.outputs.x_camunda_engine_version }}
         CAMBPM_JVM_MEMORY: 8
+
     - name: Start Elastic
       uses: ./.github/actions/compose
       with:
@@ -305,6 +315,7 @@ jobs:
         ELASTIC_VERSION: ${{ env.ELASTIC_VERSION }}
         ELASTIC_JVM_MEMORY: 16
         ELASTIC_HTTP_PORT: 9200
+
     - name: Verify integration
       uses: ./.github/actions/run-maven
       env:
@@ -327,6 +338,7 @@ jobs:
           **/failsafe-reports/**/*.xml
         retention-days: 7
         if-no-files-found: ignore
+
     - name: Docker log dump
       uses: ./.github/actions/docker-logs
       if: always()
@@ -355,20 +367,29 @@ jobs:
             profiles: 'it,engine-latest'
             requiresCambpm: true
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+      - name: Fetch main branch
+        run: git fetch origin main:refs/remote/origin/main
+
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
           secrets: ${{ toJSON(secrets) }}
+
       - name: Login to Harbor registry
         uses: ./.github/actions/login-registry
         with:
           secrets: ${{ toJSON(secrets) }}
+
       - name: "Read Java / Version Info"
         id: "pom-info"
         uses: YunaBraska/java-info-action@main
+
       - name: Expose Parsed OpenSearch Version
         run: echo "OPENSEARCH_VERSION=${{ steps.pom-info.outputs.x_opensearch_test_version }}" >> "$GITHUB_ENV"
+
       - name: Start Cambpm
         if: ${{ matrix.requiresCambpm }}
         uses: ./.github/actions/compose
@@ -378,6 +399,7 @@ jobs:
         env:
           CAMBPM_VERSION: ${{ steps.pom-info.outputs.x_camunda_engine_version }}
           CAMBPM_JVM_MEMORY: 8
+
       - name: Start OpenSearch
         uses: ./.github/actions/compose
         with:
@@ -387,6 +409,7 @@ jobs:
           OPENSEARCH_VERSION: ${{ env.OPENSEARCH_VERSION }}
           OPENSEARCH_JVM_MEMORY: 16
           OPENSEARCH_HTTP_PORT: 9205
+
       - name: Verify integration
         uses: ./.github/actions/run-maven
         env:
@@ -409,6 +432,7 @@ jobs:
             **/failsafe-reports/**/*.xml
           retention-days: 7
           if-no-files-found: ignore
+
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
         if: always()
@@ -433,20 +457,29 @@ jobs:
             excludedGroups: ''
             profiles: 'it,engine-latest'
     steps:
-      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+      - name: Checkout repository
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+      - name: Fetch main branch
+        run: git fetch origin main:refs/remote/origin/main
+
       - name: Setup Maven
         uses: ./.github/actions/setup-maven
         with:
           secrets: ${{ toJSON(secrets) }}
+
       - name: Login to Harbor registry
         uses: ./.github/actions/login-registry
         with:
           secrets: ${{ toJSON(secrets) }}
+
       - name: "Read Java / Version Info"
         id: "pom-info"
         uses: YunaBraska/java-info-action@main
+
       - name: Expose Parsed OpenSearch Version
         run: echo "OPENSEARCH_VERSION=${{ steps.pom-info.outputs.x_opensearch_test_version }}" >> "$GITHUB_ENV"
+
       - name: Start Cambpm
         uses: ./.github/actions/compose
         with:
@@ -455,6 +488,7 @@ jobs:
         env:
           CAMBPM_VERSION: ${{ steps.pom-info.outputs.x_camunda_engine_version }}
           CAMBPM_JVM_MEMORY: 8
+
       - name: Start OpenSearch
         uses: ./.github/actions/compose
         with:
@@ -464,6 +498,7 @@ jobs:
           OPENSEARCH_VERSION: ${{ env.OPENSEARCH_VERSION }}
           OPENSEARCH_JVM_MEMORY: 16
           OPENSEARCH_HTTP_PORT: 9205
+
       - name: Verify integration
         uses: ./.github/actions/run-maven
         env:
@@ -486,6 +521,7 @@ jobs:
             **/failsafe-reports/**/*.xml
           retention-days: 7
           if-no-files-found: ignore
+
       - name: Docker log dump
         uses: ./.github/actions/docker-logs
         if: always()

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -35,22 +35,31 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    - name: Checkout repository
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+    - name: Fetch main branch
+      run: git fetch origin main:refs/remote/origin/main
+
     - name: "Read Java / Version Info"
       id: pom-info
       uses: YunaBraska/java-info-action@a39db57e7ff3656a1ad67b920444363dd1ec11e9 # 2.0.0
+
     - name: Login to Harbor registry
       uses: ./.github/actions/login-registry
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: Setup Maven
       uses: ./.github/actions/setup-maven
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: Generate production .tar.gz
       uses: ./.github/actions/run-maven
       with:
         parameters: install -DskipTests -Dskip.docker
+
     - name: Build and push Docker image
       uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5
       with:

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -68,18 +68,26 @@ jobs:
     runs-on: gcp-core-8-default
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    - name: Checkout repository
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+    - name: Fetch main branch
+      run: git fetch origin main:refs/remote/origin/main
+
     - name: Setup Maven
       uses: ./.github/actions/setup-maven
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: Login to Harbor registry
       uses: ./.github/actions/login-registry
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: "Read Java / Version Info"
       id: "pom-info"
       uses: YunaBraska/java-info-action@main
+
     - name: Start Cambpm
       uses: ./.github/actions/compose
       with:
@@ -88,6 +96,7 @@ jobs:
       env:
         CAMBPM_VERSION: ${{ steps.pom-info.outputs.x_camunda_engine_version }}
         CAMBPM_JVM_MEMORY: 1
+
     - name: Start Elastic - Old
       uses: ./.github/actions/compose
       with:
@@ -97,6 +106,7 @@ jobs:
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_previous_optimize_elasticsearch_version }}
         ELASTIC_JVM_MEMORY: 1
         ELASTIC_HTTP_PORT: ${{ steps.pom-info.outputs.x_old_elasticsearch_port }}
+
     - name: Start Elastic - New
       uses: ./.github/actions/compose
       with:
@@ -106,22 +116,27 @@ jobs:
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
         ELASTIC_JVM_MEMORY: 1
         ELASTIC_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_elasticsearch_port }}
+
     - name: Install
       uses: ./.github/actions/run-maven
       with:
         parameters: install -Pengine-latest -Dskip.fe.build -Dskip.docker -DskipTests
+
     - name: Verify upgrade
       uses: ./.github/actions/run-maven
       with:
         parameters: verify -Dskip.docker -pl optimize/upgrade
+
     - name: Verify optimize/util/optimize-reimport-preparation
       uses: ./.github/actions/run-maven
       with:
         parameters: verify -Dskip.docker -pl optimize/util/optimize-reimport-preparation -Pengine-latest,it
+
     - name: Verify optimize/qa/upgrade-tests
       uses: ./.github/actions/run-maven
       with:
         parameters: verify -Dskip.docker -pl optimize/qa/upgrade-tests -Pupgrade-es-schema-tests
+
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
@@ -133,6 +148,7 @@ jobs:
           **/*.json
         retention-days: 7
         if-no-files-found: ignore
+
     - name: Docker log dump
       uses: ./.github/actions/docker-logs
       if: always()

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -160,18 +160,26 @@ jobs:
     runs-on: gcp-core-8-default
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    - name: Checkout repository
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+    - name: Fetch main branch
+      run: git fetch origin main:refs/remote/origin/main
+
     - name: Setup Maven
       uses: ./.github/actions/setup-maven
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: Login to Harbor registry
       uses: ./.github/actions/login-registry
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: "Read Java / Version Info"
       id: "pom-info"
       uses: YunaBraska/java-info-action@main
+
     - name: Start Cambpm # Cambpm even needed?
       uses: ./.github/actions/compose
       with:
@@ -180,6 +188,7 @@ jobs:
       env:
         CAMBPM_VERSION: ${{ steps.pom-info.outputs.x_camunda_engine_version }}
         CAMBPM_JVM_MEMORY: 1
+
     - name: Start Elastic - Old
       uses: ./.github/actions/compose
       with:
@@ -189,6 +198,7 @@ jobs:
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_previous_optimize_elasticsearch_version }}
         ELASTIC_JVM_MEMORY: 1
         ELASTIC_HTTP_PORT: ${{ steps.pom-info.outputs.x_old_elasticsearch_port }}
+
     - name: Start Elastic - New
       uses: ./.github/actions/compose
       with:
@@ -198,14 +208,17 @@ jobs:
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
         ELASTIC_JVM_MEMORY: 1
         ELASTIC_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_elasticsearch_port }}
+
     - name: Install
       uses: ./.github/actions/run-maven
       with:
         parameters: install -Pengine-latest -Dskip.fe.build -Dskip.docker -DskipTests
+
     - name: Verify optimize/qa/upgrade-tests
       uses: ./.github/actions/run-maven
       with:
         parameters: verify -Dskip.docker -Dskip.fe.build -f optimize/qa/upgrade-tests -Pupgrade-optimize-data
+
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
@@ -216,6 +229,7 @@ jobs:
           **/*.log
         retention-days: 7
         if-no-files-found: ignore
+
     - name: Docker log dump
       uses: ./.github/actions/docker-logs
       if: always()

--- a/.github/workflows/optimize-unit-tests.yml
+++ b/.github/workflows/optimize-unit-tests.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Test
       uses: ./.github/actions/run-maven
       with:
-        parameters: test -Dskip.fe.build -Dskip.docker
+        parameters: test -pl optimize -Dskip.fe.build -Dskip.docker
 
     - name: Upload Test Results
       if: always()

--- a/.github/workflows/optimize-unit-tests.yml
+++ b/.github/workflows/optimize-unit-tests.yml
@@ -8,15 +8,22 @@ jobs:
     runs-on: gcp-core-8-default
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    - name: Checkout repository
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+    - name: Fetch main branch
+      run: git fetch origin main:refs/remote/origin/main
+
     - name: Setup Maven
       uses: ./.github/actions/setup-maven
       with:
         secrets: ${{ toJSON(secrets) }}
+
     - name: Test
       uses: ./.github/actions/run-maven
       with:
         parameters: test -Dskip.fe.build -Dskip.docker
+
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4
@@ -32,24 +39,33 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-    - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+    - name: Checkout repository
+      uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4
+
+    - name: Fetch main branch
+      run: git fetch origin main:refs/remote/origin/main
+
     - name: "Parse pom.xml for versions"
       id: "pom_info"
       uses: YunaBraska/java-info-action@main
+
     - name: Set Node.js
       uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
       with:
         node-version: ${{ steps.pom_info.outputs.x_version_node }}
         cache: yarn
         cache-dependency-path: ./optimize/client/yarn.lock
+
     - name: Pull Dependencies
       working-directory: ./optimize/client
       run: |
         yarn
+
     - name: Test
       working-directory: ./optimize/client
       run: |
         yarn test:ci
+
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4

--- a/.github/workflows/optimize-unit-tests.yml
+++ b/.github/workflows/optimize-unit-tests.yml
@@ -23,7 +23,7 @@ jobs:
       run: cd optimize
 
     - name: Test
-      uses: ./.github/actions/run-maven
+      uses: ../.github/actions/run-maven
       with:
         parameters: test -Dskip.fe.build -Dskip.docker
 

--- a/.github/workflows/optimize-unit-tests.yml
+++ b/.github/workflows/optimize-unit-tests.yml
@@ -19,10 +19,13 @@ jobs:
       with:
         secrets: ${{ toJSON(secrets) }}
 
+    - name: Optimize context
+      run: cd optimize
+
     - name: Test
       uses: ./.github/actions/run-maven
       with:
-        parameters: test -pl optimize -Dskip.fe.build -Dskip.docker
+        parameters: test -Dskip.fe.build -Dskip.docker
 
     - name: Upload Test Results
       if: always()

--- a/.github/workflows/optimize-unit-tests.yml
+++ b/.github/workflows/optimize-unit-tests.yml
@@ -19,13 +19,10 @@ jobs:
       with:
         secrets: ${{ toJSON(secrets) }}
 
-    - name: Optimize context
-      run: cd optimize
-
     - name: Test
-      uses: ../.github/actions/run-maven
+      uses: ./.github/actions/run-maven
       with:
-        parameters: test -Dskip.fe.build -Dskip.docker
+        parameters: -f optimize/pom.xml test -Dskip.fe.build -Dskip.docker
 
     - name: Upload Test Results
       if: always()


### PR DESCRIPTION
## Description

Trying to fix the spotless errors in the following workflows:
* `Optimize Backend Linting / Linting (pull_request)`
* `Optimize CI / Migration (pull_request)`
* `Optimize CI / Data Upgrade Test (pull_request)`
* `Optimize CI / Unit Tests / Optimize Unit Tests - Backend (pull_request) `
* `Optimize CI / Integration Tests / *`

The problem is happening because some modules are configured in a way to apply `spotless` only to the differences from `origin/main`. This is currently not working because the repo happens to be in detached mode and the branch `main` was not being fetched. Fixing either of these conditions should fix the problem. I'll simply fetch `main` to see if it works.

This PR is also fixing other side problems, such as optimize unit tests not being limited to optimize only. The correctness of the changes can be observed in the logs of the run, as only the optimize tests are being scoped:

<img width="762" alt="image" src="https://github.com/camunda/camunda/assets/11213785/95ce8970-0b12-4f15-8085-a22c35260c17">
