### PR TITLE
[Backport release-8.6.0-alpha3] build: set missing name tag in required poms

### DIFF
--- a/identity/common/pom.xml
+++ b/identity/common/pom.xml
@@ -16,6 +16,7 @@
   </parent>
 
   <artifactId>identity-common</artifactId>
+  <name>Identity Common</name>
 
   <properties>
     <maven.compiler.source>21</maven.compiler.source>

--- a/webapps-common/pom.xml
+++ b/webapps-common/pom.xml
@@ -17,6 +17,7 @@
     <relativePath>../parent/pom.xml</relativePath>
   </parent>
   <artifactId>webapps-common</artifactId>
+  <name>Webapps Common</name>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
# Description
Backport of #19525 to `release-8.6.0-alpha3`.

relates to 
original author: @Ben-Sheppard