### PR TITLE
ci: build-platform-docker gha: do not create docker context if already exists

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -55,7 +55,9 @@ runs:
     - name: Create context
       shell: bash
       run: |
-        docker context create zeebe-context
+        if ! docker context ls --format '{{.Name}}' | grep -q "^zeebe-context$"; then
+          docker context create zeebe-context
+        fi
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->
When `build-platform-docker` GHA is used twice in the same job, the second time fails to create a docker context as it already exists (already created by the first invocation) 
Example of failing job: https://github.com/camunda/camunda/actions/runs/9588846208/job/26441612535
Adding a check if the context already exists before creating it
## Related issues

closes #
