### PR TITLE
fix: fix broken test

### DIFF
--- a/identity/backend/src/test/java/io/camunda/identity/usermanagement/initializer/DefaultUserInitializerTest.java
+++ b/identity/backend/src/test/java/io/camunda/identity/usermanagement/initializer/DefaultUserInitializerTest.java
@@ -40,7 +40,7 @@ public class DefaultUserInitializerTest {
 
   @Test
   void defaultUsersAreInitialized() {
-    Assertions.assertEquals(3, userService.findAllUsers().size());
+    Assertions.assertEquals(2, userService.findAllUsers().size());
     final var defaultUser = camundaUserDetailsManager.loadUserByUsername(USERNAME);
     assertTrue(passwordEncoder.matches("password", defaultUser.getPassword()));
   }


### PR DESCRIPTION
## Description

Fixes a broken integration test for Identity user initializer. We had a default user initializer that would always create a demo user hardcoded. This was removed in favor of configurable init users, so the test result should expect 2 users as passed by properties.


## Related issues

closes #
