### PR TITLE
Introduce broker client to service layer

### DIFF
--- a/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
@@ -9,9 +9,12 @@ package io.camunda.commons.service;
 
 import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.CamundaServices;
+import io.camunda.service.JobServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
+import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -48,5 +51,12 @@ public class CamundaServicesConfiguration {
   @Bean
   public UserTaskServices userTaskServices(final CamundaServices camundaServices) {
     return camundaServices.userTaskServices();
+  }
+
+  @Bean
+  public JobServices<JobActivationResponse> jobServices(
+      final CamundaServices camundaServices,
+      final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
+    return camundaServices.jobServices(activateJobsHandler);
   }
 }

--- a/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
@@ -10,6 +10,8 @@ package io.camunda.commons.service;
 import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.CamundaServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.UserTaskServices;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -23,20 +25,28 @@ import org.springframework.context.annotation.Configuration;
     matchIfMissing = true)
 public class CamundaServicesConfiguration {
 
+  private final BrokerClient brokerClient;
   private final CamundaSearchClient camundaSearchClient;
 
   @Autowired
-  public CamundaServicesConfiguration(final CamundaSearchClient camundaSearchClient) {
+  public CamundaServicesConfiguration(
+      final BrokerClient brokerClient, final CamundaSearchClient camundaSearchClient) {
+    this.brokerClient = brokerClient;
     this.camundaSearchClient = camundaSearchClient;
   }
 
   @Bean
   public CamundaServices camundaServices() {
-    return new CamundaServices(camundaSearchClient);
+    return new CamundaServices(brokerClient, camundaSearchClient);
   }
 
   @Bean
   public ProcessInstanceServices processInstanceServices(final CamundaServices camundaServices) {
     return camundaServices.processInstanceServices();
+  }
+
+  @Bean
+  public UserTaskServices userTaskServices(final CamundaServices camundaServices) {
+    return camundaServices.userTaskServices();
   }
 }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -20,12 +20,46 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-broker-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-gateway</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-cluster-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-msgpack-value</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-protocol-impl</artifactId>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
     </dependency>
 
     <dependency>
@@ -47,8 +81,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <scope>test</scope>
     </dependency>
 
   </dependencies>

--- a/service/src/main/java/io/camunda/service/ApiServices.java
+++ b/service/src/main/java/io/camunda/service/ApiServices.java
@@ -11,24 +11,37 @@ import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.msgpack.value.DocumentValue;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
 
 public abstract class ApiServices<T extends ApiServices<T>> {
 
+  protected final BrokerClient brokerClient;
   protected final CamundaSearchClient searchClient;
   protected final Authentication authentication;
   protected final ServiceTransformers transformers;
 
   protected ApiServices(
-      final CamundaSearchClient searchClient, final Authentication authentication) {
-    this(searchClient, null, authentication);
+      final BrokerClient brokerClient,
+      final CamundaSearchClient searchClient,
+      final Authentication authentication) {
+    this(brokerClient, searchClient, null, authentication);
   }
 
   protected ApiServices(
+      final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
+    this.brokerClient = brokerClient;
     this.searchClient = searchClient;
     this.authentication = authentication;
     this.transformers = Objects.requireNonNullElse(transformers, new ServiceTransformers());

--- a/service/src/main/java/io/camunda/service/CamundaServiceException.java
+++ b/service/src/main/java/io/camunda/service/CamundaServiceException.java
@@ -7,19 +7,50 @@
  */
 package io.camunda.service;
 
+import io.camunda.zeebe.broker.client.api.dto.BrokerError;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import java.util.Optional;
+
 public class CamundaServiceException extends RuntimeException {
 
   private static final long serialVersionUID = 1L;
 
-  public CamundaServiceException(String message) {
+  private final BrokerRejection brokerRejection;
+  private final BrokerError brokerError;
+
+  public CamundaServiceException(final String message) {
     super(message);
+    brokerError = null;
+    brokerRejection = null;
   }
 
-  public CamundaServiceException(String message, Throwable cause) {
+  public CamundaServiceException(final String message, final Throwable cause) {
     super(message, cause);
+    brokerRejection = null;
+    brokerError = null;
   }
 
-  public CamundaServiceException(Throwable cause) {
+  public CamundaServiceException(final Throwable cause) {
     super(cause);
+    brokerRejection = null;
+    brokerError = null;
+  }
+
+  public CamundaServiceException(final BrokerError brokerError) {
+    this.brokerError = brokerError;
+    brokerRejection = null;
+  }
+
+  public CamundaServiceException(final BrokerRejection brokerRejection) {
+    this.brokerRejection = brokerRejection;
+    brokerError = null;
+  }
+
+  public Optional<BrokerError> getBrokerError() {
+    return Optional.ofNullable(brokerError);
+  }
+
+  public Optional<BrokerRejection> getBrokerRejection() {
+    return Optional.ofNullable(brokerRejection);
   }
 }

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 
 public final class CamundaServices extends ApiServices<CamundaServices> {
 
@@ -24,6 +25,11 @@ public final class CamundaServices extends ApiServices<CamundaServices> {
       final ServiceTransformers transformers,
       final Authentication authentication) {
     super(brokerClient, searchClient, transformers, authentication);
+  }
+
+  public <T> JobServices<T> jobServices(final ActivateJobsHandler<T> activateJobsHandler) {
+    return new JobServices<>(
+        brokerClient, activateJobsHandler, searchClient, transformers, authentication);
   }
 
   public ProcessInstanceServices processInstanceServices() {

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -10,30 +10,32 @@ package io.camunda.service;
 import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 
 public final class CamundaServices extends ApiServices<CamundaServices> {
 
-  public CamundaServices(final CamundaSearchClient searchClient) {
-    this(searchClient, null, null);
+  public CamundaServices(final BrokerClient brokerClient, final CamundaSearchClient searchClient) {
+    this(brokerClient, searchClient, null, null);
   }
 
   public CamundaServices(
+      final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication);
   }
 
   public ProcessInstanceServices processInstanceServices() {
-    return new ProcessInstanceServices(searchClient, transformers, authentication);
+    return new ProcessInstanceServices(brokerClient, searchClient, transformers, authentication);
   }
 
   public UserTaskServices userTaskServices() {
-    return new UserTaskServices(searchClient, transformers, authentication);
+    return new UserTaskServices(brokerClient, searchClient, transformers, authentication);
   }
 
   public VariableServices variableServices() {
-    return new VariableServices(searchClient, transformers, authentication);
+    return new VariableServices(brokerClient, searchClient, transformers, authentication);
   }
 
   public ManagementService managementService() {
@@ -42,6 +44,6 @@ public final class CamundaServices extends ApiServices<CamundaServices> {
 
   @Override
   public CamundaServices withAuthentication(final Authentication authentication) {
-    return new CamundaServices(searchClient, transformers, authentication);
+    return new CamundaServices(brokerClient, searchClient, transformers, authentication);
   }
 }

--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
+import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
+import io.camunda.zeebe.gateway.impl.job.ResponseObserver;
+import java.util.List;
+import java.util.function.Consumer;
+
+public final class JobServices<T> extends ApiServices<JobServices<T>> {
+
+  private final ActivateJobsHandler<T> activateJobsHandler;
+
+  public JobServices(
+      final BrokerClient brokerClient,
+      final ActivateJobsHandler<T> activateJobsHandler,
+      final CamundaSearchClient dataStoreClient) {
+    this(brokerClient, activateJobsHandler, dataStoreClient, null, null);
+  }
+
+  public JobServices(
+      final BrokerClient brokerClient,
+      final ActivateJobsHandler<T> activateJobsHandler,
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    super(brokerClient, searchClient, transformers, authentication);
+    this.activateJobsHandler = activateJobsHandler;
+  }
+
+  @Override
+  public JobServices<T> withAuthentication(final Authentication authentication) {
+    return new JobServices<>(
+        brokerClient, activateJobsHandler, searchClient, transformers, authentication);
+  }
+
+  public void activateJobs(
+      final ActivateJobsRequest request,
+      final ResponseObserver<T> responseObserver,
+      final Consumer<Runnable> cancelationHandlerConsumer) {
+    final var brokerRequest =
+        new BrokerActivateJobsRequest(request.type())
+            .setMaxJobsToActivate(request.maxJobsToActivate())
+            .setTenantIds(request.tenantIds())
+            .setTimeout(request.timeout())
+            .setWorker(request.worker())
+            .setVariables(request.fetchVariable());
+    activateJobsHandler.activateJobs(
+        brokerRequest, responseObserver, cancelationHandlerConsumer, request.requestTimeout());
+  }
+
+  public record ActivateJobsRequest(
+      String type,
+      int maxJobsToActivate,
+      List<String> tenantIds,
+      long timeout,
+      String worker,
+      List<String> fetchVariable,
+      long requestTimeout) {}
+}

--- a/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
+++ b/service/src/main/java/io/camunda/service/ProcessInstanceServices.java
@@ -16,26 +16,29 @@ import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.function.Function;
 
 public final class ProcessInstanceServices
     extends SearchQueryService<
         ProcessInstanceServices, ProcessInstanceQuery, ProcessInstanceEntity> {
 
-  public ProcessInstanceServices(final CamundaSearchClient dataStoreClient) {
-    this(dataStoreClient, null, null);
+  public ProcessInstanceServices(
+      final BrokerClient brokerClient, final CamundaSearchClient dataStoreClient) {
+    this(brokerClient, dataStoreClient, null, null);
   }
 
   public ProcessInstanceServices(
+      final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override
   public ProcessInstanceServices withAuthentication(final Authentication authentication) {
-    return new ProcessInstanceServices(searchClient, transformers, authentication);
+    return new ProcessInstanceServices(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/UserTaskServices.java
+++ b/service/src/main/java/io/camunda/service/UserTaskServices.java
@@ -17,25 +17,35 @@ import io.camunda.service.search.query.UserTaskQuery.Builder;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserTaskAssignmentRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserTaskCompletionRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUserTaskUpdateRequest;
+import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
+import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 
 public final class UserTaskServices
     extends SearchQueryService<UserTaskServices, UserTaskQuery, UserTaskEntity> {
 
-  public UserTaskServices(final CamundaSearchClient dataStoreClient) {
-    this(dataStoreClient, null, null);
+  public UserTaskServices(
+      final BrokerClient brokerClient, final CamundaSearchClient dataStoreClient) {
+    this(brokerClient, dataStoreClient, null, null);
   }
 
   public UserTaskServices(
+      final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override
   public UserTaskServices withAuthentication(final Authentication authentication) {
-    return new UserTaskServices(searchClient, transformers, authentication);
+    return new UserTaskServices(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override
@@ -46,5 +56,35 @@ public final class UserTaskServices
   public SearchQueryResult<UserTaskEntity> search(
       final Function<Builder, ObjectBuilder<UserTaskQuery>> fn) {
     return search(SearchQueryBuilders.userTaskSearchQuery(fn));
+  }
+
+  public CompletableFuture<UserTaskRecord> assignUserTask(
+      final long userTaskKey,
+      final String assignee,
+      final String action,
+      final boolean allowOverride) {
+    return sendBrokerRequest(
+        new BrokerUserTaskAssignmentRequest(
+            userTaskKey,
+            assignee,
+            action,
+            allowOverride ? UserTaskIntent.ASSIGN : UserTaskIntent.CLAIM));
+  }
+
+  public CompletableFuture<UserTaskRecord> completeUserTask(
+      final long userTaskKey, final Map<String, Object> variables, final String action) {
+    return sendBrokerRequest(
+        new BrokerUserTaskCompletionRequest(userTaskKey, getDocumentOrEmpty(variables), action));
+  }
+
+  public CompletableFuture<UserTaskRecord> unassignUserTask(
+      final long userTaskKey, final String action) {
+    return sendBrokerRequest(
+        new BrokerUserTaskAssignmentRequest(userTaskKey, "", action, UserTaskIntent.ASSIGN));
+  }
+
+  public CompletableFuture<UserTaskRecord> updateUserTask(
+      final long userTaskKey, final UserTaskRecord changeset, final String action) {
+    return sendBrokerRequest(new BrokerUserTaskUpdateRequest(userTaskKey, changeset, action));
   }
 }

--- a/service/src/main/java/io/camunda/service/VariableServices.java
+++ b/service/src/main/java/io/camunda/service/VariableServices.java
@@ -17,25 +17,28 @@ import io.camunda.service.search.query.VariableQuery.Builder;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.util.ObjectBuilder;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 import java.util.function.Function;
 
 public final class VariableServices
     extends SearchQueryService<VariableServices, VariableQuery, VariableEntity> {
 
-  public VariableServices(final CamundaSearchClient dataStoreClient) {
-    this(dataStoreClient, null, null);
+  public VariableServices(
+      final BrokerClient brokerClient, final CamundaSearchClient dataStoreClient) {
+    this(brokerClient, dataStoreClient, null, null);
   }
 
   public VariableServices(
+      final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override
   public VariableServices withAuthentication(final Authentication authentication) {
-    return new VariableServices(searchClient, transformers, authentication);
+    return new VariableServices(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchQueryService.java
@@ -13,6 +13,7 @@ import io.camunda.service.search.query.SearchQueryBase;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
 
 public abstract class SearchQueryService<T extends ApiServices<T>, Q extends SearchQueryBase, D>
     extends ApiServices<T> {
@@ -20,10 +21,11 @@ public abstract class SearchQueryService<T extends ApiServices<T>, Q extends Sea
   protected final SearchClientBasedQueryExecutor executor;
 
   protected SearchQueryService(
+      final BrokerClient brokerClient,
       final CamundaSearchClient searchClient,
       final ServiceTransformers transformers,
       final Authentication authentication) {
-    super(searchClient, transformers, authentication);
+    super(brokerClient, searchClient, transformers, authentication);
     executor = initiateExecutor();
   }
 

--- a/service/src/main/java/io/camunda/service/security/auth/Authentication.java
+++ b/service/src/main/java/io/camunda/service/security/auth/Authentication.java
@@ -13,10 +13,11 @@ import io.camunda.service.search.filter.FilterBase;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
 
-public final record Authentication(
+public record Authentication(
     String authenticatedUserId,
     List<String> authenticatedGroupIds,
-    List<String> authenticatedTenantIds)
+    List<String> authenticatedTenantIds,
+    String token)
     implements FilterBase {
 
   public static final class Builder implements ObjectBuilder<Authentication> {
@@ -24,6 +25,7 @@ public final record Authentication(
     private String user;
     private List<String> groups;
     private List<String> tenants;
+    private String token;
 
     public Builder user(final String value) {
       user = value;
@@ -48,9 +50,14 @@ public final record Authentication(
       return this;
     }
 
+    public Builder token(final String value) {
+      token = value;
+      return this;
+    }
+
     @Override
     public Authentication build() {
-      return new Authentication(user, groups, tenants);
+      return new Authentication(user, groups, tenants, token);
     }
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceFilterTest.java
@@ -21,6 +21,7 @@ import io.camunda.service.search.filter.VariableValueFilter;
 import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.util.StubbedBrokerClient;
 import io.camunda.service.util.StubbedCamundaSearchClient;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -31,12 +32,13 @@ public final class ProcessInstanceFilterTest {
 
   private ProcessInstanceServices services;
   private StubbedCamundaSearchClient client;
+  private StubbedBrokerClient brokerClient;
 
   @BeforeEach
   public void before() {
     client = new StubbedCamundaSearchClient();
     new ProcessInstanceSearchQueryStub().registerWith(client);
-    services = new ProcessInstanceServices(client);
+    services = new ProcessInstanceServices(brokerClient, client);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/query/filter/UserTaskFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/UserTaskFilterTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.search.filter.FilterBuilders;
 import io.camunda.service.search.filter.UserTaskFilter;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.util.StubbedBrokerClient;
 import io.camunda.service.util.StubbedCamundaSearchClient;
 import java.time.OffsetDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,12 +30,13 @@ public class UserTaskFilterTest {
 
   private UserTaskServices services;
   private StubbedCamundaSearchClient client;
+  private StubbedBrokerClient brokerClient;
 
   @BeforeEach
   public void before() {
     client = new StubbedCamundaSearchClient();
     new UserTaskSearchQueryStub().registerWith(client);
-    services = new UserTaskServices(client);
+    services = new UserTaskServices(brokerClient, client);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/query/filter/VariableFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/VariableFilterTest.java
@@ -21,6 +21,7 @@ import io.camunda.service.search.filter.VariableFilter;
 import io.camunda.service.search.filter.VariableValueFilter;
 import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.util.StubbedBrokerClient;
 import io.camunda.service.util.StubbedCamundaSearchClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,12 +30,13 @@ public final class VariableFilterTest {
 
   private VariableServices services;
   private StubbedCamundaSearchClient client;
+  private StubbedBrokerClient brokerClient;
 
   @BeforeEach
   public void before() {
     client = new StubbedCamundaSearchClient();
     new VariableSearchQueryStub().registerWith(client);
-    services = new VariableServices(client);
+    services = new VariableServices(brokerClient, client);
   }
 
   @Test

--- a/service/src/test/java/io/camunda/service/util/StubbedBrokerClient.java
+++ b/service/src/test/java/io/camunda/service/util/StubbedBrokerClient.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerErrorException;
+import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
+import io.camunda.zeebe.broker.client.api.BrokerResponseConsumer;
+import io.camunda.zeebe.broker.client.api.BrokerResponseException;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.api.IllegalBrokerResponseException;
+import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
+import io.camunda.zeebe.protocol.Protocol;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+public final class StubbedBrokerClient implements BrokerClient {
+
+  final BrokerTopologyManager topologyManager = new StubbedTopologyManager();
+  private Consumer<String> jobsAvailableHandler;
+
+  private final Map<Class<?>, RequestHandler<?, ?>> requestHandlers = new HashMap<>();
+
+  private final List<BrokerRequest<?>> brokerRequests = new ArrayList<>();
+
+  public StubbedBrokerClient() {}
+
+  @Override
+  public Collection<ActorFuture<Void>> start() {
+    return null;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public <T> CompletableFuture<BrokerResponse<T>> sendRequest(final BrokerRequest<T> request) {
+    return sendRequestWithRetry(request);
+  }
+
+  @Override
+  public <T> CompletableFuture<BrokerResponse<T>> sendRequest(
+      final BrokerRequest<T> request, final Duration requestTimeout) {
+    return sendRequestWithRetry(request);
+  }
+
+  @Override
+  public <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
+      final BrokerRequest<T> request) {
+    final CompletableFuture<BrokerResponse<T>> future = new CompletableFuture<>();
+    sendRequestWithRetry(
+        request,
+        (key, response) ->
+            future.complete(new BrokerResponse<>(response, Protocol.decodePartitionId(key), key)),
+        future::completeExceptionally);
+    return future;
+  }
+
+  @Override
+  public <T> CompletableFuture<BrokerResponse<T>> sendRequestWithRetry(
+      final BrokerRequest<T> request, final Duration requestTimeout) {
+    final CompletableFuture<BrokerResponse<T>> result = new CompletableFuture<>();
+
+    sendRequestWithRetry(
+        request,
+        (key, response) ->
+            result.complete(new BrokerResponse<>(response, Protocol.decodePartitionId(key), key)),
+        result::completeExceptionally);
+
+    return result.orTimeout(requestTimeout.toNanos(), TimeUnit.NANOSECONDS);
+  }
+
+  @Override
+  public <T> void sendRequestWithRetry(
+      final BrokerRequest<T> request,
+      final BrokerResponseConsumer<T> responseConsumer,
+      final Consumer<Throwable> throwableConsumer) {
+    brokerRequests.add(request);
+    try {
+      final RequestHandler requestHandler = requestHandlers.get(request.getClass());
+      final BrokerResponse<T> response = requestHandler.handle(request);
+      try {
+        if (response.isResponse()) {
+          responseConsumer.accept(response.getKey(), response.getResponse());
+        } else if (response.isRejection()) {
+          throwableConsumer.accept(new BrokerRejectionException(response.getRejection()));
+        } else if (response.isError()) {
+          throwableConsumer.accept(new BrokerErrorException(response.getError()));
+        } else {
+          throwableConsumer.accept(
+              new IllegalBrokerResponseException(
+                  "Expected broker response to be either response, rejection, or error, but is neither of them []"));
+        }
+      } catch (final RuntimeException e) {
+        throwableConsumer.accept(new BrokerResponseException(e));
+      }
+    } catch (final Exception e) {
+      throwableConsumer.accept(new BrokerResponseException(e));
+    }
+  }
+
+  @Override
+  public BrokerTopologyManager getTopologyManager() {
+    return topologyManager;
+  }
+
+  @Override
+  public void subscribeJobAvailableNotification(
+      final String topic, final Consumer<String> handler) {
+    jobsAvailableHandler = handler;
+  }
+
+  public <RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>>
+      void registerHandler(
+          final Class<?> requestType, final RequestHandler<RequestT, ResponseT> requestHandler) {
+    requestHandlers.put(requestType, requestHandler);
+  }
+
+  public void notifyJobsAvailable(final String type) {
+    jobsAvailableHandler.accept(type);
+  }
+
+  public <T extends BrokerRequest<?>> T getSingleBrokerRequest() {
+    assertThat(brokerRequests).hasSize(1);
+    return (T) brokerRequests.get(0);
+  }
+
+  public List<BrokerRequest<?>> getBrokerRequests() {
+    return brokerRequests;
+  }
+
+  public interface RequestStub<
+          RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>>
+      extends RequestHandler<RequestT, ResponseT> {
+    void registerWith(StubbedBrokerClient gateway);
+  }
+
+  @FunctionalInterface
+  public interface RequestHandler<
+      RequestT extends BrokerRequest<?>, ResponseT extends BrokerResponse<?>> {
+    ResponseT handle(RequestT request) throws Exception;
+  }
+}

--- a/service/src/test/java/io/camunda/service/util/StubbedTopologyManager.java
+++ b/service/src/test/java/io/camunda/service/util/StubbedTopologyManager.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service.util;
+
+import static io.camunda.zeebe.protocol.Protocol.START_PARTITION_ID;
+
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.broker.client.impl.BrokerClusterStateImpl;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+
+public final class StubbedTopologyManager implements BrokerTopologyManager {
+
+  private final BrokerClusterStateImpl clusterState;
+
+  StubbedTopologyManager() {
+    this(8);
+  }
+
+  StubbedTopologyManager(final int partitionsCount) {
+    clusterState = new BrokerClusterStateImpl();
+    clusterState.addBrokerIfAbsent(0);
+    clusterState.setBrokerAddressIfPresent(0, "localhost:26501");
+    for (int partitionOffset = 0; partitionOffset < partitionsCount; partitionOffset++) {
+      clusterState.setPartitionLeader(START_PARTITION_ID + partitionOffset, 0, 1);
+      clusterState.addPartitionIfAbsent(START_PARTITION_ID + partitionOffset);
+    }
+    clusterState.setPartitionsCount(partitionsCount);
+  }
+
+  @Override
+  public BrokerClusterState getTopology() {
+    return clusterState;
+  }
+
+  @Override
+  public ClusterConfiguration getClusterConfiguration() {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public void addTopologyListener(final BrokerTopologyListener listener) {
+    throw new UnsupportedOperationException("Not yet implemented; implement if need be");
+  }
+
+  @Override
+  public void removeTopologyListener(final BrokerTopologyListener listener) {
+    throw new UnsupportedOperationException("Not yet implemented; implement if need be");
+  }
+
+  @Override
+  public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RestErrorMapper.java
@@ -7,12 +7,13 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
+import io.camunda.service.CamundaServiceException;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
-import io.camunda.zeebe.broker.client.api.dto.BrokerResponse;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
@@ -26,17 +27,37 @@ import org.springframework.http.ResponseEntity;
 
 public class RestErrorMapper {
 
+  public static final Function<BrokerRejection, ProblemDetail> DEFAULT_REJECTION_MAPPER =
+      rejection -> {
+        final String message =
+            String.format(
+                "Command '%s' rejected with code '%s': %s",
+                rejection.intent(), rejection.type(), rejection.reason());
+        final String title = rejection.type().name();
+        return switch (rejection.type()) {
+          case NOT_FOUND:
+            yield RestErrorMapper.createProblemDetail(HttpStatus.NOT_FOUND, message, title);
+          case INVALID_STATE:
+            yield RestErrorMapper.createProblemDetail(HttpStatus.CONFLICT, message, title);
+          case INVALID_ARGUMENT:
+          case ALREADY_EXISTS:
+            yield RestErrorMapper.createProblemDetail(HttpStatus.BAD_REQUEST, message, title);
+          default:
+            {
+              yield RestErrorMapper.createProblemDetail(
+                  HttpStatus.INTERNAL_SERVER_ERROR, message, title);
+            }
+        };
+      };
   private static final Logger REST_GATEWAY_LOGGER =
       LoggerFactory.getLogger("io.camunda.zeebe.gateway.rest");
 
   public static <T> Optional<ResponseEntity<T>> getResponse(
-      final BrokerResponse<?> brokerResponse,
-      final Throwable error,
-      final Function<BrokerRejection, ProblemDetail> rejectionMapper) {
+      final Throwable error, final Function<BrokerRejection, ProblemDetail> rejectionMapper) {
     return Optional.ofNullable(error)
         .map(e -> mapErrorToProblem(e, rejectionMapper))
-        .or(() -> mapBrokerErrorToProblem(brokerResponse))
-        .or(() -> mapRejectionToProblem(brokerResponse, rejectionMapper))
+        .or(() -> mapBrokerErrorToProblem(error))
+        .or(() -> mapRejectionToProblem(error, rejectionMapper))
         .map(RestErrorMapper::mapProblemToResponse);
   }
 
@@ -46,8 +67,10 @@ public class RestErrorMapper {
       return null;
     }
     return switch (error) {
+      case final CamundaServiceException cse:
+        yield cse.getCause() != null ? mapErrorToProblem(cse.getCause(), rejectionMapper) : null;
       case final BrokerErrorException bee:
-        yield mapBrokerErrorToProblem(error, bee.getError());
+        yield mapBrokerErrorToProblem(bee.getError(), error);
       case final BrokerRejectionException bre:
         REST_GATEWAY_LOGGER.trace(
             "Expected to handle REST request, but the broker rejected it", error);
@@ -66,16 +89,17 @@ public class RestErrorMapper {
     };
   }
 
-  private static Optional<ProblemDetail> mapBrokerErrorToProblem(
-      final BrokerResponse<?> brokerResponse) {
-    if (brokerResponse.isError()) {
-      return Optional.ofNullable(mapBrokerErrorToProblem(null, brokerResponse.getError()));
+  private static Optional<ProblemDetail> mapBrokerErrorToProblem(final Throwable exception) {
+    if (!(exception instanceof CamundaServiceException)) {
+      return Optional.empty();
     }
-    return Optional.empty();
+    return ((CamundaServiceException) exception)
+        .getBrokerError()
+        .map(error -> mapBrokerErrorToProblem(error, null));
   }
 
   private static ProblemDetail mapBrokerErrorToProblem(
-      final Throwable rootError, final BrokerError error) {
+      final BrokerError error, final Throwable rootError) {
     if (error == null) {
       return null;
     }
@@ -113,12 +137,11 @@ public class RestErrorMapper {
   }
 
   private static Optional<ProblemDetail> mapRejectionToProblem(
-      final BrokerResponse<?> brokerResponse,
-      final Function<BrokerRejection, ProblemDetail> rejectionMapper) {
-    if (brokerResponse.isRejection()) {
-      return Optional.ofNullable(rejectionMapper.apply(brokerResponse.getRejection()));
+      final Throwable exception, final Function<BrokerRejection, ProblemDetail> rejectionMapper) {
+    if (!(exception instanceof CamundaServiceException)) {
+      return Optional.empty();
     }
-    return Optional.empty();
+    return ((CamundaServiceException) exception).getBrokerRejection().map(rejectionMapper);
   }
 
   public static ProblemDetail createProblemDetail(
@@ -132,5 +155,10 @@ public class RestErrorMapper {
     return ResponseEntity.of(problemDetail)
         .headers(httpHeaders -> httpHeaders.setContentType(MediaType.APPLICATION_PROBLEM_JSON))
         .build();
+  }
+
+  public static CompletableFuture<ResponseEntity<Object>> mapProblemToCompletedResponse(
+      final ProblemDetail problemDetail) {
+    return CompletableFuture.completedFuture(RestErrorMapper.mapProblemToResponse(problemDetail));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobActivationRequestResponseObserver.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobActivationRequestResponseObserver.java
@@ -47,7 +47,8 @@ public class JobActivationRequestResponseObserver
   public void onError(final Throwable throwable) {
     result.complete(
         RestErrorMapper.mapProblemToResponse(
-            RestErrorMapper.mapErrorToProblem(throwable, JobController::mapRejectionToProblem)));
+            RestErrorMapper.mapErrorToProblem(
+                throwable, RestErrorMapper.DEFAULT_REJECTION_MAPPER)));
   }
 
   public void setCancelationHandler(final Runnable handler) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -7,19 +7,18 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
-import io.camunda.zeebe.broker.client.api.BrokerClient;
-import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
-import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
+import io.camunda.service.UserTaskServices;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.RequestMapper.AssignUserTaskRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper.CompleteUserTaskRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper.UpdateUserTaskRequest;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -32,11 +31,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @RequestMapping(path = {"/v1", "/v2"})
 public class UserTaskController {
 
-  private final BrokerClient brokerClient;
+  private final UserTaskServices userTaskServices;
 
   @Autowired
-  public UserTaskController(final BrokerClient brokerClient) {
-    this.brokerClient = brokerClient;
+  public UserTaskController(final UserTaskServices userTaskServices) {
+    this.userTaskServices = userTaskServices;
   }
 
   @PostMapping(
@@ -48,7 +47,7 @@ public class UserTaskController {
       @RequestBody(required = false) final UserTaskCompletionRequest completionRequest) {
 
     return RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey)
-        .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
+        .fold(this::completeUserTask, RestErrorMapper::mapProblemToCompletedResponse);
   }
 
   @PostMapping(
@@ -60,7 +59,7 @@ public class UserTaskController {
       @RequestBody final UserTaskAssignmentRequest assignmentRequest) {
 
     return RequestMapper.toUserTaskAssignmentRequest(assignmentRequest, userTaskKey)
-        .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
+        .fold(this::assignUserTask, RestErrorMapper::mapProblemToCompletedResponse);
   }
 
   @DeleteMapping(path = "/user-tasks/{userTaskKey}/assignee")
@@ -68,7 +67,7 @@ public class UserTaskController {
       @PathVariable final long userTaskKey) {
 
     return RequestMapper.toUserTaskUnassignmentRequest(userTaskKey)
-        .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
+        .fold(this::unassignUserTask, RestErrorMapper::mapProblemToCompletedResponse);
   }
 
   @PatchMapping(
@@ -80,44 +79,46 @@ public class UserTaskController {
       @RequestBody(required = false) final UserTaskUpdateRequest updateRequest) {
 
     return RequestMapper.toUserTaskUpdateRequest(updateRequest, userTaskKey)
-        .fold(this::sendBrokerRequest, UserTaskController::handleRequestMappingError);
+        .fold(this::updateUserTask, RestErrorMapper::mapProblemToCompletedResponse);
   }
 
-  private CompletableFuture<ResponseEntity<Object>> sendBrokerRequest(
-      final BrokerRequest<?> brokerRequest) {
-    return brokerClient
-        .sendRequest(brokerRequest)
-        .handleAsync(
-            (response, error) ->
-                RestErrorMapper.getResponse(
-                        response, error, UserTaskController::mapRejectionToProblem)
-                    .orElseGet(() -> ResponseEntity.noContent().build()));
+  private CompletableFuture<ResponseEntity<Object>> assignUserTask(
+      final AssignUserTaskRequest request) {
+    return RequestMapper.executeServiceMethodWithNoContenResult(
+        () ->
+            userTaskServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .assignUserTask(
+                    request.userTaskKey(),
+                    request.assignee(),
+                    request.action(),
+                    request.allowOverride()));
   }
 
-  private static CompletableFuture<ResponseEntity<Object>> handleRequestMappingError(
-      final ProblemDetail problemDetail) {
-    return CompletableFuture.completedFuture(RestErrorMapper.mapProblemToResponse(problemDetail));
+  private CompletableFuture<ResponseEntity<Object>> completeUserTask(
+      final CompleteUserTaskRequest request) {
+    return RequestMapper.executeServiceMethodWithNoContenResult(
+        () ->
+            userTaskServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .completeUserTask(request.userTaskKey(), request.variables(), request.action()));
   }
 
-  private static ProblemDetail mapRejectionToProblem(final BrokerRejection rejection) {
-    final String message =
-        String.format(
-            "Command '%s' rejected with code '%s': %s",
-            rejection.intent(), rejection.type(), rejection.reason());
-    final String title = rejection.type().name();
-    return switch (rejection.type()) {
-      case NOT_FOUND:
-        yield RestErrorMapper.createProblemDetail(HttpStatus.NOT_FOUND, message, title);
-      case INVALID_STATE:
-        yield RestErrorMapper.createProblemDetail(HttpStatus.CONFLICT, message, title);
-      case INVALID_ARGUMENT:
-      case ALREADY_EXISTS:
-        yield RestErrorMapper.createProblemDetail(HttpStatus.BAD_REQUEST, message, title);
-      default:
-        {
-          yield RestErrorMapper.createProblemDetail(
-              HttpStatus.INTERNAL_SERVER_ERROR, message, title);
-        }
-    };
+  private CompletableFuture<ResponseEntity<Object>> unassignUserTask(
+      final AssignUserTaskRequest request) {
+    return RequestMapper.executeServiceMethodWithNoContenResult(
+        () ->
+            userTaskServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .unassignUserTask(request.userTaskKey(), request.action()));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> updateUserTask(
+      final UpdateUserTaskRequest request) {
+    return RequestMapper.executeServiceMethodWithNoContenResult(
+        () ->
+            userTaskServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .updateUserTask(request.userTaskKey(), request.changeset(), request.action()));
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/ErrorMapperTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 
 import io.camunda.service.CamundaServiceException;
+import io.camunda.service.JobServices;
 import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.security.auth.Authentication;
@@ -25,7 +26,6 @@ import io.camunda.zeebe.gateway.rest.ErrorMapperTest.TestErrorMapperConfiguratio
 import io.camunda.zeebe.gateway.rest.controller.ResponseObserverProvider;
 import io.camunda.zeebe.gateway.rest.controller.UserTaskController;
 import io.camunda.zeebe.gateway.rest.controller.usermanagement.UserController;
-import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;
@@ -234,7 +234,7 @@ public class ErrorMapperTest {
   }
 
   @Test
-  public void shouldThrowExceptionWithRequestBodyMissing() throws Exception {
+  public void shouldThrowExceptionWithRequestBodyMissing() {
     // given
     final var expectedBody =
         ProblemDetail.forStatusAndDetail(
@@ -293,6 +293,18 @@ public class ErrorMapperTest {
     @Bean
     public HttpSecurity httpSecurity() {
       return Mockito.mock(HttpSecurity.class);
+    }
+
+    @Bean
+    public BrokerClient brokerClient() {
+      return Mockito.mock(BrokerClient.class);
+    }
+
+    @Bean
+    public JobServices<JobActivationResponse> jobServices(
+        final BrokerClient brokerClient,
+        final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
+      return new JobServices<>(brokerClient, activateJobsHandler, null);
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.jayway.jsonpath.JsonPath;
+import io.camunda.service.JobServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
@@ -350,6 +351,13 @@ public class JobControllerLongPollingTest extends RestControllerTest {
               .build();
       actorScheduler.submitActor(actor);
       return handler;
+    }
+
+    @Bean
+    public JobServices<JobActivationResponse> jobServices(
+        final BrokerClient brokerClient,
+        final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
+      return new JobServices<>(brokerClient, activateJobsHandler, null);
     }
   }
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 
 import com.jayway.jsonpath.JsonPath;
+import io.camunda.service.JobServices;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejectionResponse;
@@ -348,6 +349,13 @@ public class JobControllerTest extends RestControllerTest {
               .build();
       actorScheduler.submitActor(actor);
       return handler;
+    }
+
+    @Bean
+    public JobServices<JobActivationResponse> jobServices(
+        final BrokerClient brokerClient,
+        final ActivateJobsHandler<JobActivationResponse> activateJobsHandler) {
+      return new JobServices<>(brokerClient, activateJobsHandler, null);
     }
   }
 }


### PR DESCRIPTION
## Description

* Introduce services for user tasks to handle broker communication.
* Introduce services for jobs to handle broker communication and job activation handlers.
* Use the services from the respective REST controllers instead of handling the broker client there specifically.

## Related issues

closes #19524 
