### PR TITLE
[Backport stable/8.2] fix: check version before reading metadata length

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptor.java
@@ -51,6 +51,7 @@ public final class LogEntryDescriptor {
 
   public static final long KEY_NULL_VALUE = -1;
 
+  // When VERSION is incremented, also update the version check in getMetadataLength
   private static final short VERSION = 1;
   private static final int VERSION_OFFSET;
 
@@ -190,7 +191,12 @@ public final class LogEntryDescriptor {
   }
 
   public static int getMetadataLength(final DirectBuffer buffer, final int offset) {
-    return buffer.getInt(metadataLengthOffset(offset), Protocol.ENDIANNESS);
+    if (getVersion(buffer, offset) == 1) {
+      return buffer.getInt(metadataLengthOffset(offset), Protocol.ENDIANNESS);
+    } else {
+      // previous versions never set a version, so the version could be a garbage value or 0.
+      return buffer.getShort(metadataLengthOffset(offset), Protocol.ENDIANNESS);
+    }
   }
 
   public static void setMetadataLength(

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogEntryDescriptorTest.java
@@ -7,14 +7,16 @@
  */
 package io.camunda.zeebe.logstreams.impl.log;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.protocol.Protocol;
+import java.util.Arrays;
 import org.agrona.concurrent.UnsafeBuffer;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class LogEntryDescriptorTest {
-
+final class LogEntryDescriptorTest {
   @Test
-  public void shouldBeNonProcessedAsDefault() {
+  void shouldBeNonProcessedAsDefault() {
     // given
     final var buffer = new UnsafeBuffer(new byte[128]);
 
@@ -22,11 +24,11 @@ public class LogEntryDescriptorTest {
     final boolean processed = LogEntryDescriptor.shouldSkipProcessing(buffer, 0);
 
     // then
-    Assertions.assertThat(processed).isFalse();
+    assertThat(processed).isFalse();
   }
 
   @Test
-  public void shouldMarkAsProcessed() {
+  void shouldMarkAsProcessed() {
     // given
     final var buffer = new UnsafeBuffer(new byte[128]);
 
@@ -34,6 +36,64 @@ public class LogEntryDescriptorTest {
     LogEntryDescriptor.skipProcessing(buffer, 0);
 
     // then
-    Assertions.assertThat(LogEntryDescriptor.shouldSkipProcessing(buffer, 0)).isTrue();
+    assertThat(LogEntryDescriptor.shouldSkipProcessing(buffer, 0)).isTrue();
+  }
+
+  @Test
+  void shouldReadShortMetadataLength() {
+    // given
+    final var buffer = new UnsafeBuffer(new byte[128]);
+
+    // when
+    LogEntryDescriptor.setVersion(buffer, 0);
+    LogEntryDescriptor.setMetadataLength(buffer, 0, 34);
+
+    // then
+    assertThat(LogEntryDescriptor.getMetadataLength(buffer, 0)).isEqualTo(34);
+  }
+
+  @Test
+  void shouldReadLargeMetadataLength() {
+    // given
+    final var buffer = new UnsafeBuffer(new byte[128]);
+
+    // when
+    LogEntryDescriptor.setVersion(buffer, 0);
+    LogEntryDescriptor.setMetadataLength(buffer, 0, Short.MAX_VALUE + 10);
+
+    // then
+    assertThat(LogEntryDescriptor.getMetadataLength(buffer, 0)).isEqualTo(Short.MAX_VALUE + 10);
+  }
+
+  @Test
+  void shouldReadMetadataLengthFromOldVersion() {
+    // given
+    final byte[] byteArray = new byte[128];
+    Arrays.fill(byteArray, (byte) 8);
+    final var buffer = new UnsafeBuffer(byteArray);
+
+    // when
+    // set version 0
+    buffer.putShort(LogEntryDescriptor.versionOffset(0), (short) 0, Protocol.ENDIANNESS);
+    LogEntryDescriptor.setMetadataLength(buffer, 0, 34);
+
+    // then
+    assertThat(LogEntryDescriptor.getMetadataLength(buffer, 0)).isEqualTo(34);
+  }
+
+  @Test
+  void shouldReadMetadataLengthFromOldVersionWhenVersionNotSet() {
+    // given
+    final byte[] byteArray = new byte[128];
+    Arrays.fill(byteArray, (byte) 8);
+    final var buffer = new UnsafeBuffer(byteArray);
+
+    // when
+    // set garbage value for version
+    buffer.putShort(LogEntryDescriptor.versionOffset(0), (short) 123, Protocol.ENDIANNESS);
+    LogEntryDescriptor.setMetadataLength(buffer, 0, 34);
+
+    // then
+    assertThat(LogEntryDescriptor.getMetadataLength(buffer, 0)).isEqualTo(34);
   }
 }


### PR DESCRIPTION
# Description
Backport of #19582 to `stable/8.2`.

relates to #19379
original author: @deepthidevaki