### PR TITLE
fix: adjust version in migration IT

### DIFF
--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/AbstractUpgrade86IT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/AbstractUpgrade86IT.java
@@ -5,20 +5,20 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.upgrade.migrate313to314;
+package io.camunda.optimize.upgrade.migrate313to86;
 
 import io.camunda.optimize.upgrade.AbstractUpgradeIT;
-import io.camunda.optimize.upgrade.migrate313to314.indices.OnboardingStateIndexV2;
-import io.camunda.optimize.upgrade.migrate313to314.indices.SettingsIndexV2;
+import io.camunda.optimize.upgrade.migrate313to86.indices.OnboardingStateIndexV2;
+import io.camunda.optimize.upgrade.migrate313to86.indices.SettingsIndexV2;
 import io.camunda.optimize.upgrade.plan.UpgradePlan;
 import io.camunda.optimize.upgrade.plan.UpgradePlanRegistry;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 
-public class AbstractUpgrade314IT extends AbstractUpgradeIT {
+public class AbstractUpgrade86IT extends AbstractUpgradeIT {
 
   protected static final String FROM_VERSION = "3.13.0";
-  protected static final String TO_VERSION = "3.14.0";
+  protected static final String TO_VERSION = "8.6.0";
 
   protected final OnboardingStateIndexV2 ONBOARDING_STATE_INDEX = new OnboardingStateIndexV2();
   protected final SettingsIndexV2 SETTINGS_INDEX = new SettingsIndexV2();

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/DeleteOnboardingStateIndex86IT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/DeleteOnboardingStateIndex86IT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.upgrade.migrate313to314;
+package io.camunda.optimize.upgrade.migrate313to86;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +13,7 @@ import java.util.List;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 
-public class DeleteOnboardingStateIndex314IT extends AbstractUpgrade314IT {
+public class DeleteOnboardingStateIndex86IT extends AbstractUpgrade86IT {
 
   @Test
   @SneakyThrows

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/DeleteSettingsIndexFields86IT.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/DeleteSettingsIndexFields86IT.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.upgrade.migrate313to314;
+package io.camunda.optimize.upgrade.migrate313to86;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -13,7 +13,7 @@ import io.camunda.optimize.service.db.DatabaseConstants;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
-public class DeleteSettingsIndexFields314IT extends AbstractUpgrade314IT {
+public class DeleteSettingsIndexFields86IT extends AbstractUpgrade86IT {
 
   @Test
   public void deleteTelemetryFieldAndLastModifierFieldsFromSettingIndex() {

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/indices/OnboardingStateIndexV2.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/indices/OnboardingStateIndexV2.java
@@ -5,26 +5,19 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.upgrade.migrate313to314.indices;
+package io.camunda.optimize.upgrade.migrate313to86.indices;
 
-import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
-
-import io.camunda.optimize.dto.optimize.SettingsDto;
-import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
 import java.io.IOException;
 import org.elasticsearch.xcontent.XContentBuilder;
 
-public class SettingsIndexV2 extends DefaultIndexMappingCreator<XContentBuilder> {
+public class OnboardingStateIndexV2 extends DefaultIndexMappingCreator<XContentBuilder> {
 
   public static final int VERSION = 2;
 
-  public static final String SHARING_ENABLED = SettingsDto.Fields.sharingEnabled.name();
-  public static final String LAST_MODIFIED = SettingsDto.Fields.lastModified.name();
-
   @Override
   public String getIndexName() {
-    return DatabaseConstants.SETTINGS_INDEX_NAME;
+    return "onboarding-state";
   }
 
   @Override
@@ -36,18 +29,17 @@ public class SettingsIndexV2 extends DefaultIndexMappingCreator<XContentBuilder>
   public XContentBuilder addProperties(final XContentBuilder xContentBuilder) throws IOException {
     // @formatter:off
     return xContentBuilder
-        .startObject("metadataTelemetryEnabled")
-        .field("type", "boolean")
-        .endObject()
-        .startObject(SHARING_ENABLED)
-        .field("type", "boolean")
-        .endObject()
-        .startObject(LAST_MODIFIED)
-        .field("type", "date")
-        .field("format", OPTIMIZE_DATE_FORMAT)
-        .endObject()
-        .startObject("lastModifier")
+        .startObject("id")
         .field("type", "keyword")
+        .endObject()
+        .startObject("key")
+        .field("type", "keyword")
+        .endObject()
+        .startObject("userId")
+        .field("type", "keyword")
+        .endObject()
+        .startObject("seen")
+        .field("type", "boolean")
         .endObject();
     // @formatter:on
   }

--- a/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/indices/SettingsIndexV2.java
+++ b/optimize/upgrade/src/test/java/io/camunda/optimize/upgrade/migrate313to86/indices/SettingsIndexV2.java
@@ -5,19 +5,26 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.optimize.upgrade.migrate313to314.indices;
+package io.camunda.optimize.upgrade.migrate313to86.indices;
 
+import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FORMAT;
+
+import io.camunda.optimize.dto.optimize.SettingsDto;
+import io.camunda.optimize.service.db.DatabaseConstants;
 import io.camunda.optimize.service.db.schema.DefaultIndexMappingCreator;
 import java.io.IOException;
 import org.elasticsearch.xcontent.XContentBuilder;
 
-public class OnboardingStateIndexV2 extends DefaultIndexMappingCreator<XContentBuilder> {
+public class SettingsIndexV2 extends DefaultIndexMappingCreator<XContentBuilder> {
 
   public static final int VERSION = 2;
 
+  public static final String SHARING_ENABLED = SettingsDto.Fields.sharingEnabled.name();
+  public static final String LAST_MODIFIED = SettingsDto.Fields.lastModified.name();
+
   @Override
   public String getIndexName() {
-    return "onboarding-state";
+    return DatabaseConstants.SETTINGS_INDEX_NAME;
   }
 
   @Override
@@ -29,17 +36,18 @@ public class OnboardingStateIndexV2 extends DefaultIndexMappingCreator<XContentB
   public XContentBuilder addProperties(final XContentBuilder xContentBuilder) throws IOException {
     // @formatter:off
     return xContentBuilder
-        .startObject("id")
-        .field("type", "keyword")
-        .endObject()
-        .startObject("key")
-        .field("type", "keyword")
-        .endObject()
-        .startObject("userId")
-        .field("type", "keyword")
-        .endObject()
-        .startObject("seen")
+        .startObject("metadataTelemetryEnabled")
         .field("type", "boolean")
+        .endObject()
+        .startObject(SHARING_ENABLED)
+        .field("type", "boolean")
+        .endObject()
+        .startObject(LAST_MODIFIED)
+        .field("type", "date")
+        .field("format", OPTIMIZE_DATE_FORMAT)
+        .endObject()
+        .startObject("lastModifier")
+        .field("type", "keyword")
         .endObject();
     // @formatter:on
   }


### PR DESCRIPTION
## Description

Adjust the version of Migration IT to match 8.x scheme for Optimize 8 - overlooked this in the initial version adjustment

