### PR TITLE
feat: user task mappers and controller

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.search.ProcessInstanceQuery;
+import io.camunda.zeebe.client.api.search.UserTaskQuery;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
@@ -585,4 +586,6 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the process instance query
    */
   ProcessInstanceQuery newProcessInstanceQuery();
+
+  UserTaskQuery newUserTaskQuery();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/search/UserTaskFilter.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/search/UserTaskFilter.java
@@ -24,41 +24,21 @@ import java.util.Objects;
 
 public interface UserTaskFilter extends SearchRequestFilter {
 
-  UserTaskFilter userTaskKeys(final Long value, final Long... values);
+  UserTaskFilter userTaskKey(final Long value);
 
-  UserTaskFilter userTaskKeys(final List<Long> values);
+  UserTaskFilter userTaskState(final String state);
 
-  UserTaskFilter userTaskStates(final String state, final String... states);
+  UserTaskFilter userTaskAssignee(final String assignee);
 
-  UserTaskFilter userTaskStates(final List<String> states);
+  UserTaskFilter userTaskTaskDefinitionId(final String taskDefinitionId);
 
-  UserTaskFilter userTaskAssignees(final String assignee, final String... assignees);
+  UserTaskFilter userTaskCandidateGroup(final String candidateGroup);
 
-  UserTaskFilter userTaskAssignees(final List<String> assignees);
+  UserTaskFilter userTaskCandidateUser(final String candidateUser);
 
-  UserTaskFilter userTaskTaskDefinitionIds(
-      final String taskDefinitionId, final String... taskDefinitionIds);
+  UserTaskFilter userTaskProcessDefinitionKey(final Long processDefinitionKey);
 
-  UserTaskFilter userTaskTaskDefinitionIds(final List<String> taskDefinitionIds);
-
-  UserTaskFilter userTaskCandidateGroups(
-      final String candidateGroup, final String... candidateGroups);
-
-  UserTaskFilter userTaskCandidateGroups(final List<String> candidateGroups);
-
-  UserTaskFilter userTaskCandidateUsers(final String candidateUser, final String... candidateUsers);
-
-  UserTaskFilter userTaskCandidateUsers(final List<String> candidateUsers);
-
-  UserTaskFilter userTaskProcessDefinitionKeys(
-      final Long processDefinitionKey, final Long... processDefinitionKeys);
-
-  UserTaskFilter userTaskProcessDefinitionKeys(final List<Long> processDefinitionKeys);
-
-  UserTaskFilter userTaskProcessInstanceKeys(
-      final Long processInstanceKey, final Long... processInstanceKeys);
-
-  UserTaskFilter userTaskProcessInstanceKeys(final List<Long> processInstanceKeys);
+  UserTaskFilter userTaskProcessInstanceKey(final Long processInstanceKey);
 
   UserTaskFilter userTaskFollowUpDate(final DateFilter dateFilter);
 
@@ -68,11 +48,7 @@ public interface UserTaskFilter extends SearchRequestFilter {
 
   UserTaskFilter userTaskCompletionDate(final DateFilter dateFilter);
 
-  UserTaskFilter userTaskTenantIds(final String tenantId, final String... tenantIds);
-
-  UserTaskFilter userTaskTenantIds(final List<String> tenantIds);
-
-  UserTaskFilter userTaskCreatedDate(final DateFilter dateFilter);
+  UserTaskFilter userTaskTenantId(final String tenantId);
 
   // TODO move this to a shared utility module
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -49,6 +49,7 @@ import io.camunda.zeebe.client.api.command.UpdateTimeoutJobCommandStep1;
 import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.ActivatedJob;
 import io.camunda.zeebe.client.api.search.ProcessInstanceQuery;
+import io.camunda.zeebe.client.api.search.UserTaskQuery;
 import io.camunda.zeebe.client.api.worker.JobClient;
 import io.camunda.zeebe.client.api.worker.JobWorkerBuilderStep1;
 import io.camunda.zeebe.client.impl.command.AssignUserTaskCommandImpl;
@@ -74,6 +75,7 @@ import io.camunda.zeebe.client.impl.command.UpdateUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpClientFactory;
 import io.camunda.zeebe.client.impl.search.ProcessInstanceQueryImpl;
+import io.camunda.zeebe.client.impl.search.UserTaskQueryImpl;
 import io.camunda.zeebe.client.impl.util.ExecutorResource;
 import io.camunda.zeebe.client.impl.util.VersionUtil;
 import io.camunda.zeebe.client.impl.worker.JobClientImpl;
@@ -470,6 +472,16 @@ public final class ZeebeClientImpl implements ZeebeClient {
     return new UnassignUserTaskCommandImpl(httpClient, userTaskKey);
   }
 
+  @Override
+  public ProcessInstanceQuery newProcessInstanceQuery() {
+    return new ProcessInstanceQueryImpl(httpClient, jsonMapper);
+  }
+
+  @Override
+  public UserTaskQuery newUserTaskQuery() {
+    return new UserTaskQueryImpl(httpClient, jsonMapper);
+  }
+
   private JobClient newJobClient() {
     return new JobClientImpl(
         asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
@@ -514,10 +526,5 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public StreamJobsCommandStep1 newStreamJobsCommand() {
     return new StreamJobsCommandImpl(
         asyncStub, jsonMapper, credentialsProvider::shouldRetryRequest, config);
-  }
-
-  @Override
-  public ProcessInstanceQuery newProcessInstanceQuery() {
-    return new ProcessInstanceQueryImpl(httpClient, jsonMapper);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchResponseMapper.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/SearchResponseMapper.java
@@ -21,8 +21,11 @@ import io.camunda.zeebe.client.api.search.response.SearchResponsePage;
 import io.camunda.zeebe.client.impl.search.response.ProcessInstanceImpl;
 import io.camunda.zeebe.client.impl.search.response.SearchQueryResponseImpl;
 import io.camunda.zeebe.client.impl.search.response.SearchResponsePageImpl;
+import io.camunda.zeebe.client.impl.search.response.UserTaskImpl;
 import io.camunda.zeebe.client.protocol.rest.ProcessInstanceSearchQueryResponse;
 import io.camunda.zeebe.client.protocol.rest.SearchQueryPageResponse;
+import io.camunda.zeebe.client.protocol.rest.UserTaskItem;
+import io.camunda.zeebe.client.protocol.rest.UserTaskSearchQueryResponse;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -47,10 +50,32 @@ public final class SearchResponseMapper {
                 (i) ->
                     i.stream()
                         .map(ProcessInstanceImpl::new)
-                        .map((p) -> (ProcessInstance) p)
+                        .map(ProcessInstance.class::cast)
                         .collect(Collectors.toList()))
             .orElse(Collections.emptyList());
 
     return new SearchQueryResponseImpl<>(instances, page);
+  }
+
+  public static SearchQueryResponse<UserTaskItem> toUserTaskSearchResponse(
+      final UserTaskSearchQueryResponse response) {
+    final SearchQueryPageResponse pageResponse = response.getPage();
+    final SearchResponsePage page =
+        new SearchResponsePageImpl(
+            pageResponse.getTotalItems(),
+            pageResponse.getFirstSortValues(),
+            pageResponse.getLastSortValues());
+
+    final List<UserTaskItem> userTasks =
+        Optional.ofNullable(response.getItems())
+            .map(
+                (i) ->
+                    i.stream()
+                        .map(UserTaskImpl::new)
+                        .map(UserTaskItem.class::cast)
+                        .collect(Collectors.toList()))
+            .orElse(Collections.emptyList());
+
+    return new SearchQueryResponseImpl<>(userTasks, page);
   }
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/UserTaskFilterImpl.java
@@ -51,7 +51,7 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
 
   @Override
   public UserTaskFilter userTaskStates(final List<String> states) {
-    filter.setState(UserTaskFilter.addValuesToList(filter.getState(), states));
+    filter.setTaskState(UserTaskFilter.addValuesToList(filter.getTaskState(), states));
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/UserTaskFilterImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/UserTaskFilterImpl.java
@@ -18,7 +18,6 @@ package io.camunda.zeebe.client.impl.search;
 import io.camunda.zeebe.client.api.search.UserTaskFilter;
 import io.camunda.zeebe.client.protocol.rest.DateFilter;
 import io.camunda.zeebe.client.protocol.rest.UserTaskFilterRequest;
-import java.util.List;
 
 public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserTaskFilterRequest>
     implements UserTaskFilter {
@@ -34,103 +33,50 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
   }
 
   @Override
-  public UserTaskFilter userTaskKeys(final Long value, final Long... values) {
-    return userTaskKeys(UserTaskFilter.collectValues(value, values));
-  }
-
-  @Override
-  public UserTaskFilter userTaskKeys(final List<Long> values) {
-    filter.setKey(UserTaskFilter.addValuesToList(filter.getKey(), values));
+  public UserTaskFilter userTaskKey(final Long value) {
+    filter.setKey(value);
     return this;
   }
 
   @Override
-  public UserTaskFilter userTaskStates(final String state, final String... states) {
-    return userTaskStates(UserTaskFilter.collectValues(state, states));
-  }
-
-  @Override
-  public UserTaskFilter userTaskStates(final List<String> states) {
-    filter.setTaskState(UserTaskFilter.addValuesToList(filter.getTaskState(), states));
+  public UserTaskFilter userTaskState(final String state) {
+    filter.setTaskState(state);
     return this;
   }
 
   @Override
-  public UserTaskFilter userTaskAssignees(final String assignee, final String... assignees) {
-    return userTaskAssignees(UserTaskFilter.collectValues(assignee, assignees));
-  }
-
-  @Override
-  public UserTaskFilter userTaskAssignees(final List<String> assignees) {
-    filter.setAssignee(UserTaskFilter.addValuesToList(filter.getAssignee(), assignees));
+  public UserTaskFilter userTaskAssignee(final String assignee) {
+    filter.setAssignee(assignee);
     return this;
   }
 
   @Override
-  public UserTaskFilter userTaskTaskDefinitionIds(
-      final String taskDefinitionId, final String... taskDefinitionIds) {
-    return userTaskTaskDefinitionIds(
-        UserTaskFilter.collectValues(taskDefinitionId, taskDefinitionIds));
-  }
-
-  @Override
-  public UserTaskFilter userTaskTaskDefinitionIds(final List<String> taskDefinitionIds) {
-    filter.setTaskDefinitionId(
-        UserTaskFilter.addValuesToList(filter.getTaskDefinitionId(), taskDefinitionIds));
+  public UserTaskFilter userTaskTaskDefinitionId(final String taskDefinitionId) {
+    filter.setTaskDefinitionId(taskDefinitionId);
     return this;
   }
 
   @Override
-  public UserTaskFilter userTaskCandidateGroups(
-      final String candidateGroup, final String... candidateGroups) {
-    return userTaskCandidateGroups(UserTaskFilter.collectValues(candidateGroup, candidateGroups));
-  }
-
-  @Override
-  public UserTaskFilter userTaskCandidateGroups(final List<String> candidateGroups) {
-    filter.setCandidateGroup(
-        UserTaskFilter.addValuesToList(filter.getCandidateGroup(), candidateGroups));
+  public UserTaskFilter userTaskCandidateGroup(final String candidateGroup) {
+    filter.setCandidateGroup(candidateGroup);
     return this;
   }
 
   @Override
-  public UserTaskFilter userTaskCandidateUsers(
-      final String candidateUser, final String... candidateUsers) {
-    return userTaskCandidateUsers(UserTaskFilter.collectValues(candidateUser, candidateUsers));
-  }
-
-  @Override
-  public UserTaskFilter userTaskCandidateUsers(final List<String> candidateUsers) {
-    filter.setCandidateUser(
-        UserTaskFilter.addValuesToList(filter.getCandidateUser(), candidateUsers));
+  public UserTaskFilter userTaskCandidateUser(final String candidateUser) {
+    filter.setCandidateUser(candidateUser);
     return this;
   }
 
   @Override
-  public UserTaskFilter userTaskProcessDefinitionKeys(
-      final Long processDefinitionKey, final Long... processDefinitionKeys) {
-    return userTaskProcessDefinitionKeys(
-        UserTaskFilter.collectValues(processDefinitionKey, processDefinitionKeys));
-  }
-
-  @Override
-  public UserTaskFilter userTaskProcessDefinitionKeys(final List<Long> processDefinitionKeys) {
-    filter.setProcessDefinitionKey(
-        UserTaskFilter.addValuesToList(filter.getProcessDefinitionKey(), processDefinitionKeys));
+  public UserTaskFilter userTaskProcessDefinitionKey(final Long processDefinitionKey) {
+    filter.setProcessDefinitionKey(processDefinitionKey);
     return this;
   }
 
   @Override
-  public UserTaskFilter userTaskProcessInstanceKeys(
-      final Long processInstanceKey, final Long... processInstanceKeys) {
-    return userTaskProcessInstanceKeys(
-        UserTaskFilter.collectValues(processInstanceKey, processInstanceKeys));
-  }
-
-  @Override
-  public UserTaskFilter userTaskProcessInstanceKeys(final List<Long> processInstanceKeys) {
-    filter.setProcessInstanceKey(
-        UserTaskFilter.addValuesToList(filter.getProcessInstanceKey(), processInstanceKeys));
+  public UserTaskFilter userTaskProcessInstanceKey(final Long processInstanceKey) {
+    filter.setProcessInstanceKey(processInstanceKey);
     return this;
   }
 
@@ -148,7 +94,8 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
 
   @Override
   public UserTaskFilter userTaskCreationDate(final DateFilter dateFilter) {
-    return null;
+    filter.setCreationTime(dateFilter);
+    return this;
   }
 
   @Override
@@ -158,19 +105,8 @@ public class UserTaskFilterImpl extends TypedSearchRequestPropertyProvider<UserT
   }
 
   @Override
-  public UserTaskFilter userTaskTenantIds(final String tenantId, final String... tenantIds) {
-    return userTaskTenantIds(UserTaskFilter.collectValues(tenantId, tenantIds));
-  }
-
-  @Override
-  public UserTaskFilter userTaskTenantIds(final List<String> tenantIds) {
-    filter.setTenantIds(UserTaskFilter.addValuesToList(filter.getTenantIds(), tenantIds));
-    return this;
-  }
-
-  @Override
-  public UserTaskFilter userTaskCreatedDate(final DateFilter dateFilter) {
-    filter.setCreationTime(dateFilter);
+  public UserTaskFilter userTaskTenantId(final String tenantId) {
+    filter.setTenantIds(tenantId);
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/UserTaskQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/UserTaskQueryImpl.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
 import io.camunda.zeebe.client.protocol.rest.UserTaskItem;
 import io.camunda.zeebe.client.protocol.rest.UserTaskSearchQueryRequest;
+import io.camunda.zeebe.client.protocol.rest.UserTaskSearchQueryResponse;
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.apache.hc.client5.http.config.RequestConfig;
@@ -60,13 +61,13 @@ public class UserTaskQueryImpl
   public ZeebeFuture<SearchQueryResponse<UserTaskItem>> send() {
     final HttpZeebeFuture<SearchQueryResponse<UserTaskItem>> result = new HttpZeebeFuture<>();
     // TODO: Implement the following method on the PR with the mappers
-    /*httpClient.post(
-    "/user-tasks/search",
-    jsonMapper.toJson(request),
-    httpRequestConfig.build(),
-    UserTaskSearchQueryResponse.class,
-    SearchResponseMapper::toUserTaskSearchResponse,
-    result);*/
+    httpClient.post(
+        "/user-tasks/search",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        UserTaskSearchQueryResponse.class,
+        SearchResponseMapper::toUserTaskSearchResponse,
+        result);
     return result;
   }
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.search.response;
+
+import io.camunda.zeebe.client.protocol.rest.UserTaskItem;
+import java.util.List;
+
+public class UserTaskImpl {
+
+  private final Long key;
+  private final String state;
+  private final String assignee;
+  private final String taskDefinitionId;
+  private final List<String> candidateGroup;
+  private final List<String> candidateUser;
+  private final String processDefinitionKey;
+  private final Long processInstanceKey;
+  private final String creationDate;
+  private final String completionDate;
+  private final String followUpDate;
+  private final String dueDate;
+  private final String tenantIds;
+
+  public UserTaskImpl(final UserTaskItem item) {
+    key = item.getKey();
+    state = item.getState();
+    assignee = item.getAssignee();
+    taskDefinitionId = item.getTaskDefinitionId();
+    candidateGroup = item.getCandidateGroup();
+    candidateUser = item.getCandidateUser();
+    processDefinitionKey = item.getProcessDefinitionKey();
+    processInstanceKey = item.getProcessInstanceKey();
+    creationDate = item.getCreationDate();
+    completionDate = item.getCompletionDate();
+    followUpDate = item.getFollowUpDate();
+    dueDate = item.getDueDate();
+    tenantIds = item.getTenantIds();
+  }
+
+  public Long getKey() {
+    return key;
+  }
+
+  public String getState() {
+    return state;
+  }
+
+  public String getAssignee() {
+    return assignee;
+  }
+
+  public String getTaskDefinitionId() {
+    return taskDefinitionId;
+  }
+
+  public List<String> getCandidateGroup() {
+    return candidateGroup;
+  }
+
+  public List<String> getCandidateUser() {
+    return candidateUser;
+  }
+
+  public String getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public String getCreationDate() {
+    return creationDate;
+  }
+
+  public String getCompletionDate() {
+    return completionDate;
+  }
+
+  public String getFollowUpDate() {
+    return followUpDate;
+  }
+
+  public String getDueDate() {
+    return dueDate;
+  }
+
+  public String getTenantIds() {
+    return tenantIds;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/response/UserTaskImpl.java
@@ -21,13 +21,14 @@ import java.util.List;
 public class UserTaskImpl {
 
   private final Long key;
-  private final String state;
+  private final String taskState;
   private final String assignee;
   private final String taskDefinitionId;
   private final List<String> candidateGroup;
   private final List<String> candidateUser;
-  private final String processDefinitionKey;
+  private final Long processDefinitionKey;
   private final Long processInstanceKey;
+  private final Long formKey;
   private final String creationDate;
   private final String completionDate;
   private final String followUpDate;
@@ -36,13 +37,14 @@ public class UserTaskImpl {
 
   public UserTaskImpl(final UserTaskItem item) {
     key = item.getKey();
-    state = item.getState();
+    taskState = item.getTaskState();
     assignee = item.getAssignee();
     taskDefinitionId = item.getTaskDefinitionId();
     candidateGroup = item.getCandidateGroup();
     candidateUser = item.getCandidateUser();
     processDefinitionKey = item.getProcessDefinitionKey();
     processInstanceKey = item.getProcessInstanceKey();
+    formKey = item.getFormKey();
     creationDate = item.getCreationDate();
     completionDate = item.getCompletionDate();
     followUpDate = item.getFollowUpDate();
@@ -54,8 +56,8 @@ public class UserTaskImpl {
     return key;
   }
 
-  public String getState() {
-    return state;
+  public String getTaskState() {
+    return taskState;
   }
 
   public String getAssignee() {
@@ -74,12 +76,20 @@ public class UserTaskImpl {
     return candidateUser;
   }
 
-  public String getProcessDefinitionKey() {
+  public Long getProcessDefinitionKey() {
     return processDefinitionKey;
   }
 
   public Long getProcessInstanceKey() {
     return processInstanceKey;
+  }
+
+  public Long getFormKey() {
+    return formKey;
+  }
+
+  public Long setFormKey() {
+    return formKey;
   }
 
   public String getCreationDate() {

--- a/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
@@ -10,6 +10,7 @@ package io.camunda.commons.service;
 import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.CamundaServices;
 import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.UserTaskServices;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
@@ -38,5 +39,10 @@ public class CamundaServicesConfiguration {
   @Bean
   public ProcessInstanceServices processInstanceServices(final CamundaServices camundaServices) {
     return camundaServices.processInstanceServices();
+  }
+
+  @Bean
+  public UserTaskServices userTaskServices(final CamundaServices camundaServices) {
+    return camundaServices.userTaskServices();
   }
 }

--- a/service/src/main/java/io/camunda/service/transformers/filter/UserTaskFilterTransformer.java
+++ b/service/src/main/java/io/camunda/service/transformers/filter/UserTaskFilterTransformer.java
@@ -77,13 +77,12 @@ public class UserTaskFilterTransformer implements FilterTransformer<UserTaskFilt
 
   @Override
   public List<String> toIndices(final UserTaskFilter filter) {
-    final var completed = filter.completed();
-    final var canceled = filter.canceled();
+    final var created = filter.created();
 
-    if (completed || canceled) {
-      return Arrays.asList("tasklist-task-8.5.0_alias");
-    } else {
+    if (created) {
       return Arrays.asList("tasklist-task-8.5.0_");
+    } else {
+      return Arrays.asList("tasklist-task-8.5.0_alias");
     }
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -740,7 +740,7 @@ components:
           items:
             type: integer
             format: int64
-        state:
+        taskState:
           type: array
           items:
             type: string
@@ -792,7 +792,7 @@ components:
         key:
           type: integer
           format: int64
-        state:
+        taskState:
           type: string
         assignee:
           type: string
@@ -807,8 +807,12 @@ components:
           items:
             type: string
         processDefinitionKey:
-          type: string
+          type: integer
+          format: int64
         processInstanceKey:
+          type: integer
+          format: int64
+        formKey:
           type: integer
           format: int64
         creationDate:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -736,40 +736,24 @@ components:
       type: object
       properties:
         key:
-          type: array
-          items:
-            type: integer
-            format: int64
+          type: integer
+          format: int64
         taskState:
-          type: array
-          items:
-            type: string
+          type: string
         assignee:
-          type: array
-          items:
-            type: string
+          type: string
         taskDefinitionId:
-          type: array
-          items:
-            type: string
+          type: string
         candidateGroup:
-          type: array
-          items:
-            type: string
+          type: string
         candidateUser:
-          type: array
-          items:
-            type: string
+          type: string
         processDefinitionKey:
-          type: array
-          items:
-            type: integer
-            format: int64
+          type: integer
+          format: int64
         processInstanceKey:
-          type: array
-          items:
-            type: integer
-            format: int64
+          type: integer
+          format: int64
         creationTime:
           $ref: "#/components/schemas/DateFilter"
         completionTime:
@@ -783,9 +767,7 @@ components:
           items:
             $ref: "#/components/schemas/VariableFilter"
         tenantIds:
-          type: array
-          items:
-            type: string
+          type: string
     UserTaskItem:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -189,8 +189,8 @@ public final class SearchQueryRequestMapper {
       }
 
       // state
-      if (filter.getState() != null && !filter.getState().isEmpty()) {
-        builder.userTaskState(filter.getState());
+      if (filter.getTaskState() != null && !filter.getTaskState().isEmpty()) {
+        builder.userTaskState(filter.getTaskState());
       }
 
       // assignee

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -184,7 +184,7 @@ public final class SearchQueryRequestMapper {
 
     if (filter != null) {
       // key
-      if (filter.getKey() != null && !filter.getKey().isEmpty()) {
+      if (filter.getKey() != null) {
         builder.userTaskKeys(filter.getKey());
       }
 
@@ -209,17 +209,17 @@ public final class SearchQueryRequestMapper {
       }
 
       // processDefinitionKey
-      if (filter.getProcessDefinitionKey() != null && !filter.getProcessDefinitionKey().isEmpty()) {
+      if (filter.getProcessDefinitionKey() != null) {
         builder.processDefinitionKeys(filter.getProcessDefinitionKey().toString());
       }
 
       // processInstanceKey
-      if (filter.getProcessInstanceKey() != null && !filter.getProcessInstanceKey().isEmpty()) {
+      if (filter.getProcessInstanceKey() != null) {
         builder.processInstanceKeys(filter.getProcessInstanceKey());
       }
 
       // tenantIds
-      if (filter.getTenantIds() != null && !filter.getTenantIds().isEmpty()) {
+      if (filter.getTenantIds() != null) {
         builder.tenantIds(filter.getTenantIds());
       }
 

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryRequestMapper.java
@@ -7,20 +7,28 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
+import io.camunda.service.search.filter.DateValueFilter;
 import io.camunda.service.search.filter.FilterBuilders;
 import io.camunda.service.search.filter.ProcessInstanceFilter;
+import io.camunda.service.search.filter.UserTaskFilter;
 import io.camunda.service.search.filter.VariableValueFilter;
 import io.camunda.service.search.page.SearchQueryPage;
 import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.SearchQueryBuilders;
+import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.search.sort.SortOptionBuilders;
+import io.camunda.service.search.sort.UserTaskSort;
+import io.camunda.zeebe.gateway.protocol.rest.DateFilter;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceFilterRequest;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageRequest;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQuerySortRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskFilterRequest;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryRequest;
 import io.camunda.zeebe.gateway.protocol.rest.VariableValueFilterRequest;
 import io.camunda.zeebe.util.Either;
+import java.time.OffsetDateTime;
 import java.util.List;
 import org.springframework.http.ProblemDetail;
 
@@ -109,7 +117,7 @@ public final class SearchQueryRequestMapper {
     if (sorting != null && !sorting.isEmpty()) {
       final var builder = SortOptionBuilders.processInstance();
 
-      for (SearchQuerySortRequest sort : sorting) {
+      for (final SearchQuerySortRequest sort : sorting) {
         final var field = sort.getField();
         final var order = sort.getOrder();
 
@@ -138,11 +146,131 @@ public final class SearchQueryRequestMapper {
     return Either.right(null);
   }
 
+  public static Either<ProblemDetail, UserTaskSort> toUserTaskSearchQuerySort(
+      final List<SearchQuerySortRequest> sorting) {
+    if (sorting != null && !sorting.isEmpty()) {
+      final var builder = SortOptionBuilders.userTask();
+
+      for (final SearchQuerySortRequest sort : sorting) {
+        final var field = sort.getField();
+        final var order = sort.getOrder();
+
+        if ("creationTime".equals(field)) {
+          builder.creationDate();
+        } else if ("completionTime".equals(field)) {
+          builder.completionDate();
+        } else {
+          throw new RuntimeException("unkown sortBy " + field);
+        }
+
+        if ("asc".equalsIgnoreCase(order)) {
+          builder.asc();
+        } else if ("desc".equalsIgnoreCase(order)) {
+          builder.desc();
+        } else {
+          throw new RuntimeException("unkown sortOrder " + order);
+        }
+      }
+
+      return Either.right(builder.build());
+    }
+
+    return Either.right(null);
+  }
+
+  public static Either<ProblemDetail, UserTaskFilter> toUserTaskFilter(
+      final UserTaskFilterRequest filter) {
+    final var builder = FilterBuilders.userTask();
+
+    if (filter != null) {
+      // key
+      if (filter.getKey() != null && !filter.getKey().isEmpty()) {
+        builder.userTaskKeys(filter.getKey());
+      }
+
+      // state
+      if (filter.getState() != null && !filter.getState().isEmpty()) {
+        builder.userTaskState(filter.getState());
+      }
+
+      // assignee
+      if (filter.getAssignee() != null && !filter.getAssignee().isEmpty()) {
+        builder.assignees(filter.getAssignee());
+      }
+
+      // candidateGroup
+      if (filter.getCandidateGroup() != null && !filter.getCandidateGroup().isEmpty()) {
+        builder.candidateGroups(filter.getCandidateGroup());
+      }
+
+      // candidateUser
+      if (filter.getCandidateUser() != null && !filter.getCandidateUser().isEmpty()) {
+        builder.candidateUsers(filter.getCandidateUser());
+      }
+
+      // processDefinitionKey
+      if (filter.getProcessDefinitionKey() != null && !filter.getProcessDefinitionKey().isEmpty()) {
+        builder.processDefinitionKeys(filter.getProcessDefinitionKey().toString());
+      }
+
+      // processInstanceKey
+      if (filter.getProcessInstanceKey() != null && !filter.getProcessInstanceKey().isEmpty()) {
+        builder.processInstanceKeys(filter.getProcessInstanceKey());
+      }
+
+      // tenantIds
+      if (filter.getTenantIds() != null && !filter.getTenantIds().isEmpty()) {
+        builder.tenantIds(filter.getTenantIds());
+      }
+
+      // creationTime
+      if (filter.getCreationTime() != null) {
+        builder.creationDate(toDateValueFilter(filter.getCreationTime()));
+      }
+
+      // completionTime
+      if (filter.getCompletionTime() != null) {
+        builder.completionDate(toDateValueFilter(filter.getCompletionTime()));
+      }
+
+      // dueDate
+      if (filter.getDueDate() != null) {
+        builder.dueDate(toDateValueFilter(filter.getDueDate()));
+      }
+
+      // followUpDate
+      if (filter.getFollowUpDate() != null) {
+        builder.followUpDate(toDateValueFilter(filter.getFollowUpDate()));
+      }
+    }
+
+    return Either.right(builder.build());
+  }
+
+  public static Either<ProblemDetail, UserTaskQuery> toUserTaskQuery(
+      final UserTaskSearchQueryRequest request) {
+    final var page = toSearchQueryPage(request.getPage()).get();
+    final var sorting = toUserTaskSearchQuerySort(request.getSort()).get();
+    final var userTaskFilter = toUserTaskFilter(request.getFilter()).get();
+    return Either.right(
+        SearchQueryBuilders.userTaskSearchQuery()
+            .page(page)
+            .filter(userTaskFilter)
+            .sort(sorting)
+            .build());
+  }
+
   private static Object[] toArrayOrNull(final List<Object> values) {
     if (values == null || values.isEmpty()) {
       return null;
     } else {
       return values.toArray();
     }
+  }
+
+  private static DateValueFilter toDateValueFilter(final DateFilter dateFilter) {
+    return new DateValueFilter(
+        dateFilter.getFrom() != null ? OffsetDateTime.parse(dateFilter.getFrom()) : null,
+        dateFilter.getTo() != null ? OffsetDateTime.parse(dateFilter.getTo()) : null);
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -103,11 +103,15 @@ public final class SearchQueryResponseMapper {
             .tenantIds(t.tenantId())
             .key(t.key())
             .processInstanceKey(t.processInstanceId())
-            .processDefinitionKey(t.processDefinitionId().toString())
-            .state(t.state())
+            .processDefinitionKey(t.processDefinitionId())
+            .taskState(t.state())
             .assignee(t.assignee())
             .candidateUser(t.candidateUsers())
             .candidateGroup(t.candidateGroups())
+            .formKey(t.formKey())
+            .taskDefinitionId(t.flowNodeBpmnId())
+            .creationDate(t.creationTime())
+            .completionDate(t.completionTime())
             .dueDate(t.dueDate())
             .followUpDate(t.followUpDate()));
   }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/SearchQueryResponseMapper.java
@@ -8,10 +8,13 @@
 package io.camunda.zeebe.gateway.rest;
 
 import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.entities.UserTaskEntity;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceItem;
 import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.SearchQueryPageResponse;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskItem;
+import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryResponse;
 import io.camunda.zeebe.util.Either;
 import java.util.Arrays;
 import java.util.List;
@@ -64,5 +67,48 @@ public final class SearchQueryResponseMapper {
             .parentFlowNodeInstanceKey(p.parentFlowNodeInstanceKey())
             .startDate(p.startDate())
             .endDate(p.endDate()));
+  }
+
+  public static Either<ProblemDetail, UserTaskSearchQueryResponse> toUserTaskSearchQueryResponse(
+      final SearchQueryResult<UserTaskEntity> result) {
+    final var response = new UserTaskSearchQueryResponse();
+    final var total = result.total();
+    final var sortValues = result.sortValues();
+    final var items = result.items();
+
+    final var page = new SearchQueryPageResponse();
+    page.setTotalItems(total);
+    response.setPage(page);
+
+    if (sortValues != null) {
+      page.setLastSortValues(Arrays.asList(sortValues));
+    }
+
+    if (items != null) {
+      response.setItems(toUserTasks(items).get());
+    }
+
+    return Either.right(response);
+  }
+
+  public static Either<ProblemDetail, List<UserTaskItem>> toUserTasks(
+      final List<UserTaskEntity> tasks) {
+    return Either.right(
+        tasks.stream().map(SearchQueryResponseMapper::toUserTask).map(Either::get).toList());
+  }
+
+  public static Either<ProblemDetail, UserTaskItem> toUserTask(final UserTaskEntity t) {
+    return Either.right(
+        new UserTaskItem()
+            .tenantIds(t.tenantId())
+            .key(t.key())
+            .processInstanceKey(t.processInstanceId())
+            .processDefinitionKey(t.processDefinitionId().toString())
+            .state(t.state())
+            .assignee(t.assignee())
+            .candidateUser(t.candidateUsers())
+            .candidateGroup(t.candidateGroups())
+            .dueDate(t.dueDate())
+            .followUpDate(t.followUpDate()));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -7,15 +7,11 @@
  */
 package io.camunda.zeebe.gateway.rest.controller;
 
-import io.camunda.service.ProcessInstanceServices;
 import io.camunda.service.UserTaskServices;
-import io.camunda.service.search.query.ProcessInstanceQuery;
 import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRequest;
-import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryRequest;
-import io.camunda.zeebe.gateway.protocol.rest.ProcessInstanceSearchQueryResponse;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskSearchQueryRequest;
@@ -143,11 +139,12 @@ public class UserTaskController {
       @RequestBody final UserTaskSearchQueryRequest query) {
     return SearchQueryRequestMapper.toUserTaskQuery(query)
         .fold(
-            (Function<? super UserTaskQuery, ? extends ResponseEntity<UserTaskSearchQueryResponse>>) this::search, RestErrorMapper::mapProblemToResponse);
+            (Function<? super UserTaskQuery, ? extends ResponseEntity<UserTaskSearchQueryResponse>>)
+                this::search,
+            RestErrorMapper::mapProblemToResponse);
   }
 
-  private ResponseEntity<UserTaskSearchQueryResponse> search(
-      final UserTaskQuery query) {
+  private ResponseEntity<UserTaskSearchQueryResponse> search(final UserTaskQuery query) {
     try {
       final var tenantIds = TenantAttributeHolder.tenantIds();
       final var result =
@@ -157,9 +154,7 @@ public class UserTaskController {
     } catch (final Throwable e) {
       final var problemDetail =
           RestErrorMapper.createProblemDetail(
-              HttpStatus.BAD_REQUEST,
-              e.getMessage(),
-              "Failed to execute UserTask Search Query");
+              HttpStatus.BAD_REQUEST, e.getMessage(), "Failed to execute UserTask Search Query");
       return ResponseEntity.of(problemDetail)
           .headers(httpHeaders -> httpHeaders.setContentType(MediaType.APPLICATION_PROBLEM_JSON))
           .build();


### PR DESCRIPTION
## Description

This is the second of three PRs for the implementation of the Search User Task API. The goal of this PR is to set up the mappers and the controller for the User Task Context. The DTOs have been updated according to the requirements identified in the previous PR.

The overall implementation is divided into three PRs to facilitate the review process:

1. [PR 1] - https://github.com/camunda/camunda/pull/19625 - Prepare the interfaces and implementation, and set up the preparation for the API Mapper and Controller for the User Task Context.
2. **PR 2 (this PR)** - Prepare the Mappers and User Task Controller.
3. [PR 3] - https://github.com/camunda/camunda/pull/19691 - Integrate the Variables on the User Task Search Service and Controller.

From PR 2, it will be possible to conduct end-to-end tests using builders or the API call.

From this PR is already possible to test the User Task Search only over the API 

For example:
```
{
    "filter": {
        "taskState":"CREATED",
        "processInstanceKey": 2251799813685379,
    },
    "sort":[
        {
            "field":"creationTime",
            "order":"desc"
        }
    ],
    "page": {
        "limit": 20
    }
}
```


## Related issues

closes [#19211](https://github.com/camunda/camunda/issues/19211)

