### PR TITLE
refactor: apply auth profile only if other auth profiles are not enabled

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -166,17 +166,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>operate-common</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>operate-archiver</artifactId>
     </dependency>
 

--- a/dist/src/main/java/io/camunda/application/Profile.java
+++ b/dist/src/main/java/io/camunda/application/Profile.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.application;
 
+import java.util.Set;
+
 /**
  * A fixed set of Spring profiles. Some are application specific (broker, gateway), and others
  * environment specific (dev, test ,prod). Here to avoid littering the code base with different hard
@@ -26,9 +28,12 @@ public enum Profile {
   DEVELOPMENT("dev"),
   PRODUCTION("prod"),
 
-  // other
+  // authentication profiles
+  AUTH_BASIC("auth-basic"),
   IDENTITY_AUTH("identity-auth"),
   SSO_AUTH("sso-auth"),
+  DEFAULT_AUTH_PROFILE("auth"),
+  LDAP_AUTH_PROFILE("ldap-auth"),
 
   // indicating legacy standalone application
   STANDALONE("standalone");
@@ -41,6 +46,14 @@ public enum Profile {
 
   public String getId() {
     return id;
+  }
+
+  public static Set<Profile> getAuthProfiles() {
+    return Set.of(AUTH_BASIC, DEFAULT_AUTH_PROFILE, IDENTITY_AUTH, LDAP_AUTH_PROFILE, SSO_AUTH);
+  }
+
+  public static Set<Profile> getWebappProfiles() {
+    return Set.of(TASKLIST, IDENTITY, OPERATE);
   }
 
   @Override

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.application.initializers;
 
+import static io.camunda.application.Profile.AUTH_BASIC;
 import static io.camunda.application.Profile.IDENTITY;
 import static io.camunda.application.Profile.IDENTITY_AUTH;
 import static io.camunda.application.Profile.OPERATE;
@@ -34,7 +35,7 @@ public class WebappsConfigurationInitializer
   private static final Set<String> WEBAPPS_PROFILES =
       Set.of(OPERATE.getId(), TASKLIST.getId(), IDENTITY.getId());
   private static final Set<String> LOGIN_DELEGATED_PROFILES =
-      Set.of(IDENTITY_AUTH.getId(), SSO_AUTH.getId());
+      Set.of(IDENTITY_AUTH.getId(), SSO_AUTH.getId(), AUTH_BASIC.getId());
 
   @Override
   public void initialize(final ConfigurableApplicationContext context) {

--- a/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/WebappsConfigurationInitializer.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.application.initializers;
 
-import static io.camunda.application.Profile.AUTH_BASIC;
 import static io.camunda.application.Profile.IDENTITY;
 import static io.camunda.application.Profile.IDENTITY_AUTH;
 import static io.camunda.application.Profile.OPERATE;
@@ -35,7 +34,7 @@ public class WebappsConfigurationInitializer
   private static final Set<String> WEBAPPS_PROFILES =
       Set.of(OPERATE.getId(), TASKLIST.getId(), IDENTITY.getId());
   private static final Set<String> LOGIN_DELEGATED_PROFILES =
-      Set.of(IDENTITY_AUTH.getId(), SSO_AUTH.getId(), AUTH_BASIC.getId());
+      Set.of(IDENTITY_AUTH.getId(), SSO_AUTH.getId());
 
   @Override
   public void initialize(final ConfigurableApplicationContext context) {

--- a/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
+++ b/operate/common/src/main/java/io/camunda/operate/OperateProfileService.java
@@ -21,10 +21,7 @@ public class OperateProfileService {
   public static final String IDENTITY_AUTH_PROFILE = "identity-auth";
   public static final String AUTH_BASIC = "auth-basic";
   public static final String AUTH_PROFILE = "auth";
-  public static final String DEFAULT_AUTH = AUTH_PROFILE;
   public static final String LDAP_AUTH_PROFILE = "ldap-auth";
-  public static final Set<String> AUTH_PROFILES =
-      Set.of(AUTH_PROFILE, LDAP_AUTH_PROFILE, SSO_AUTH_PROFILE, IDENTITY_AUTH_PROFILE, AUTH_BASIC);
 
   private static final Set<String> CANT_LOGOUT_AUTH_PROFILES = Set.of(SSO_AUTH_PROFILE);
 


### PR DESCRIPTION
## Description
I would like to start making progress on integrating the webapps (starting with Operate) into the new central auth layer. This PR is a small refactor to the logic around when the default auth profile is applied.

Essentially I wanted to centralise that logic and remove the dependency on the Operate specific classes.
