### PR TITLE
[Backport stable/8.2] Checksums calculated with full file checksums

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.broker.system.monitoring.DiskSpaceUsageMonitor;
 import io.camunda.zeebe.broker.system.partitions.PartitionHealthBroadcaster;
 import io.camunda.zeebe.broker.system.partitions.ZeebePartition;
 import io.camunda.zeebe.broker.transport.commandapi.CommandApiService;
+import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
@@ -77,7 +78,8 @@ public final class PartitionManagerImpl implements PartitionManager, TopologyMan
     this.gatewayBrokerTransport = gatewayBrokerTransport;
 
     snapshotStoreFactory =
-        new FileBasedSnapshotStoreFactory(actorSchedulingService, localBroker.getNodeId());
+        new FileBasedSnapshotStoreFactory(
+            actorSchedulingService, localBroker.getNodeId(), new ChecksumProviderRocksDBImpl());
 
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,7 +80,7 @@
     <version.protobuf>3.22.5</version.protobuf>
     <version.protobuf-common>2.14.3</version.protobuf-common>
     <version.micrometer>1.10.12</version.micrometer>
-    <version.rocksdbjni>8.10.0</version.rocksdbjni>
+    <version.rocksdbjni>8.11.4</version.rocksdbjni>
     <version.sbe>1.27.1</version.sbe>
     <version.scala>2.13.14</version.scala>
     <version.slf4j>2.0.13</version.slf4j>

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/ChecksumProvider.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/ChecksumProvider.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.snapshots;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+public interface ChecksumProvider {
+
+  /**
+   * @param snapshotPath path of snapshot to get live file checksums
+   * @return Map containing fileName - checksums pairs
+   */
+  Map<String, Long> getSnapshotChecksums(final Path snapshotPath);
+}

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreFactory.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.snapshots.impl;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.SchedulingHints;
+import io.camunda.zeebe.snapshots.ChecksumProvider;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
@@ -35,6 +36,7 @@ public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotSt
   public static final String SNAPSHOTS_DIRECTORY = "snapshots";
   public static final String PENDING_DIRECTORY = "pending";
 
+  private static ChecksumProvider checksumProvider;
   private final Int2ObjectHashMap<FileBasedSnapshotStore> partitionSnapshotStores =
       new Int2ObjectHashMap<>();
   private final ActorSchedulingService actorScheduler;
@@ -42,8 +44,16 @@ public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotSt
 
   public FileBasedSnapshotStoreFactory(
       final ActorSchedulingService actorScheduler, final int nodeId) {
+    this(actorScheduler, nodeId, null);
+  }
+
+  public FileBasedSnapshotStoreFactory(
+      final ActorSchedulingService actorScheduler,
+      final int nodeId,
+      final ChecksumProvider checksumProvider) {
     this.actorScheduler = actorScheduler;
     this.nodeId = nodeId;
+    this.checksumProvider = checksumProvider;
   }
 
   public static RestorableSnapshotStore createRestorableSnapshotStore(
@@ -67,7 +77,8 @@ public final class FileBasedSnapshotStoreFactory implements ReceivableSnapshotSt
         partitionId,
         new SnapshotMetrics(Integer.toString(partitionId)),
         snapshotDirectory,
-        pendingDirectory);
+        pendingDirectory,
+        checksumProvider);
   }
 
   @Override

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.snapshots.impl;
 import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.ChecksumProvider;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
 import io.camunda.zeebe.snapshots.SnapshotId;
@@ -36,6 +37,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private final FileBasedSnapshotStore snapshotStore;
   private final FileBasedSnapshotId snapshotId;
   private final ActorFuture<Void> takenFuture = new CompletableActorFuture<>();
+  private final ChecksumProvider checksumProvider;
   private boolean isValid = false;
   private PersistedSnapshot snapshot;
   private SfvChecksum checksum;
@@ -45,11 +47,13 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
       final FileBasedSnapshotId snapshotId,
       final Path directory,
       final FileBasedSnapshotStore snapshotStore,
-      final ActorControl actor) {
+      final ActorControl actor,
+      final ChecksumProvider checksumProvider) {
     this.snapshotId = snapshotId;
     this.snapshotStore = snapshotStore;
     this.directory = directory;
     this.actor = actor;
+    this.checksumProvider = checksumProvider;
   }
 
   @Override
@@ -80,7 +84,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
                       directory)));
 
         } else {
-          checksum = SnapshotChecksum.calculate(directory);
+          checksum = SnapshotChecksum.calculateWithProvidedChecksums(directory, checksumProvider);
 
           snapshot = null;
           isValid = true;

--- a/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksum.java
+++ b/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksum.java
@@ -18,6 +18,7 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Matcher;
@@ -75,6 +76,25 @@ final class SfvChecksum {
         + ", checksums="
         + checksums
         + '}';
+  }
+
+  public SortedMap<String, Long> getChecksums() {
+    return checksums;
+  }
+
+  public void updateFromChecksum(final Path filePath, final long checksum) {
+    final String fileName = filePath.getFileName().toString();
+    checksums.put(fileName, checksum);
+  }
+
+  public boolean sameChecksums(final SfvChecksum o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null) {
+      return false;
+    }
+    return Objects.equals(checksums, o.getChecksums());
   }
 
   public void updateFromFile(final Path filePath) throws IOException {

--- a/zb-db/pom.xml
+++ b/zb-db/pom.xml
@@ -29,6 +29,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-snapshots</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
     </dependency>

--- a/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ChecksumProviderRocksDBImpl.java
+++ b/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ChecksumProviderRocksDBImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.db.impl.rocksdb;
+
+import io.camunda.zeebe.snapshots.ChecksumProvider;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.rocksdb.LiveFileMetaData;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+
+public class ChecksumProviderRocksDBImpl implements ChecksumProvider {
+
+  @Override
+  public Map<String, Long> getSnapshotChecksums(final Path snapshotPath) {
+    try (final var db = RocksDB.openReadOnly(snapshotPath.toString())) {
+      return db.getLiveFilesMetaData().stream()
+          .filter(fileMetaData -> fileMetaData.fileChecksum().length != 0)
+          .collect(Collectors.toMap(this::getMetadataName, this::rocksDBChecksumAsLong));
+    } catch (final RocksDBException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private String getMetadataName(final LiveFileMetaData fileMetaData) {
+    return fileMetaData.fileName().substring(1);
+    //        there is a leading '/' which breaks interactions with the Java Path.getFileName which
+    //     returns the file name without a leading '/'
+  }
+
+  private Long rocksDBChecksumAsLong(final LiveFileMetaData fileMetaData) {
+    final var checksum = fileMetaData.fileChecksum();
+    return Integer.toUnsignedLong(ByteBuffer.wrap(checksum).order(ByteOrder.BIG_ENDIAN).getInt());
+  }
+}


### PR DESCRIPTION
# Description
Backport of #18730 to `stable/8.2`.

relates to camunda/zeebe#17920 #18722 #18721 #17920
original author: @EuroLew