### PR TITLE
ci: increate tasklist and operate ci build timeout

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -40,7 +40,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -40,7 +40,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       # Setup: checkout branch
       - name: Checkout '${{ inputs.branch }}' branch


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->
tasklist and operate CI builds are timing out in `main` branch. It is caused by `Deploy nexus snapshots` job taking a longer time as we have more modules to upload than previously had
`Deploy nexus snapshots` should be later moved to a common CI, because all the project maven artifacts are being uploaded by both Tasklist and Operate CIs.

## Related issues

closes #
