### PR TITLE
fix: on auth failure send error when accessing v2 endpoint

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/BaseWebConfigurer.java
@@ -199,7 +199,9 @@ public abstract class BaseWebConfigurer {
       throws IOException {
     final String requestedUrl =
         request.getRequestURI().substring(request.getContextPath().length());
-    if (requestedUrl.contains("/api/") || requestedUrl.contains("/v1/")) {
+    if (requestedUrl.contains("/api/")
+        || requestedUrl.contains("/v1/")
+        || requestedUrl.contains("/v2/")) {
       sendError(request, response, ex);
     } else {
       storeRequestedUrlAndRedirectToLogin(request, response, requestedUrl);


### PR DESCRIPTION
## Description

When accessing any `v2` endpoint without authentication, then it should return the actual authentication failure instead of redirecting to the `login` page.

## Related issues

closes #
