### PR TITLE
fix: apply security filter chains to v2 endpoints in Tasklist

### DIFF
--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/BaseWebConfigurer.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/BaseWebConfigurer.java
@@ -92,7 +92,7 @@ public abstract class BaseWebConfigurer {
                   .permitAll()
                   .requestMatchers(
                       AntPathRequestMatcher.antMatcher(GRAPHQL_URL),
-                      AntPathRequestMatcher.antMatcher(ALL_REST_V1_API),
+                      AntPathRequestMatcher.antMatcher(ALL_REST_VERSION_API),
                       AntPathRequestMatcher.antMatcher(ERROR_URL))
                   .authenticated()
                   .requestMatchers(AntPathRequestMatcher.antMatcher("/login"))

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/TasklistURIs.java
@@ -23,7 +23,7 @@ public final class TasklistURIs {
   public static final String REST_V1_API = "/v1/";
   public static final String REST_V1_EXTERNAL_API = "/v1/external/**";
   public static final String NEW_FORM = "/new/**";
-  public static final String ALL_REST_V1_API = "/v1/**";
+  public static final String ALL_REST_VERSION_API = "/v*/**";
   public static final String TASKS_URL_V1 = "/v1/tasks";
   public static final String VARIABLES_URL_V1 = "/v1/variables";
   public static final String FORMS_URL_V1 = "/v1/forms";

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityWebSecurityConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/identity/IdentityWebSecurityConfig.java
@@ -57,7 +57,7 @@ public class IdentityWebSecurityConfig extends BaseWebConfigurer {
                   .permitAll()
                   .requestMatchers(
                       AntPathRequestMatcher.antMatcher(GRAPHQL_URL),
-                      AntPathRequestMatcher.antMatcher(ALL_REST_V1_API),
+                      AntPathRequestMatcher.antMatcher(ALL_REST_VERSION_API),
                       AntPathRequestMatcher.antMatcher(ERROR_URL))
                   .authenticated()
                   .requestMatchers(AntPathRequestMatcher.antMatcher(ROOT_URL))

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOWebSecurityConfig.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/sso/SSOWebSecurityConfig.java
@@ -70,7 +70,7 @@ public class SSOWebSecurityConfig extends BaseWebConfigurer {
                   .permitAll()
                   .requestMatchers(
                       AntPathRequestMatcher.antMatcher(GRAPHQL_URL),
-                      AntPathRequestMatcher.antMatcher(ALL_REST_V1_API),
+                      AntPathRequestMatcher.antMatcher(ALL_REST_VERSION_API),
                       AntPathRequestMatcher.antMatcher(ERROR_URL))
                   .authenticated()
                   .requestMatchers(AntPathRequestMatcher.antMatcher(ROOT_URL))


### PR DESCRIPTION
## Description

When running the single application with Tasklist (and without Operate), the `v2` endpoints require authentication.

## Related issues

closes #
