### PR TITLE
Add new unit tests for SearchRange queries (ES)

### DIFF
--- a/search/search-client-elasticsearch/pom.xml
+++ b/search/search-client-elasticsearch/pom.xml
@@ -39,6 +39,11 @@
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>org.assertj</groupId>

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
@@ -15,6 +15,7 @@ import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.transformers.SearchTransfomer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -68,5 +69,28 @@ public class RangeQueryTransformerTest {
     assertThat(result).isNotNull();
     assertThat(result._toQuery()).isNotNull();
     assertThat(result._toQuery().toString()).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldCombineMultipleRangeQueries() {
+    // given
+    final SearchRangeQuery query =
+        SearchQueryBuilders.range()
+            .field("foo")
+            .lt(123456789L)
+            .lte(12345L)
+            .gte(123456L)
+            .gt(1234L)
+            .build();
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.lt().to(Long.class)).isEqualTo(123456789L);
+    assertThat(result.gt().to(Long.class)).isEqualTo(1234L);
+    assertThat(result.gte().to(Long.class)).isEqualTo(123456L);
+    assertThat(result.lte().to(Long.class)).isEqualTo(12345L);
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
@@ -33,6 +33,15 @@ public class RangeQueryTransformerTest {
   private static Stream<Arguments> provideRangeQueries() {
     return Stream.of(
         Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(null).build(),
+            "Query: {'range':{'foo':{}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(Long.MAX_VALUE).build(),
+            "Query: {'range':{'foo':{'lt':9223372036854775807}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(Long.MIN_VALUE).build(),
+            "Query: {'range':{'foo':{'lt':-9223372036854775808}}}"),
+        Arguments.arguments(
             SearchQueryBuilders.range().field("foo").lt(123456789L).build(),
             "Query: {'range':{'foo':{'lt':123456789}}}"),
         Arguments.arguments(

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/RangeQueryTransformerTest.java
@@ -13,8 +13,11 @@ import co.elastic.clients.elasticsearch._types.query_dsl.RangeQuery;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.transformers.SearchTransfomer;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class RangeQueryTransformerTest {
 
@@ -26,16 +29,44 @@ public class RangeQueryTransformerTest {
     transformer = transformers.getTransformer(SearchRangeQuery.class);
   }
 
-  @Test
-  public void shouldApplyTransformer() {
+  private static Stream<Arguments> provideRangeQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(123456789L).build(),
+            "Query: {'range':{'foo':{'lt':123456789}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").gte(123456L).build(),
+            "Query: {'range':{'foo':{'gte':123456}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lte(12345L).build(),
+            "Query: {'range':{'foo':{'lte':12345}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").gt(1234L).build(),
+            "Query: {'range':{'foo':{'gt':1234}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").format("format").build(),
+            "Query: {'range':{'foo':{'format':'format'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").to("toBar").build(),
+            "Query: {'range':{'foo':{'to':'toBar'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").from("fromBar").build(),
+            "Query: {'range':{'foo':{'from':'fromBar'}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideRangeQueries")
+  public void shouldApplyTransformer(
+      final SearchRangeQuery rangeQuery, final String expectedResultQuery) {
     // given
-    final var query = SearchQueryBuilders.range().field("foo").lt(12456L).build();
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
 
     // when
-    final var result = transformer.apply(query);
+    final var result = transformer.apply(rangeQuery);
 
     // then
-    assertThat(result).isInstanceOf(RangeQuery.class);
-    assertThat(result.lt().to(Long.class)).isEqualTo(12456L);
+    assertThat(result).isNotNull();
+    assertThat(result._toQuery()).isNotNull();
+    assertThat(result._toQuery().toString()).isEqualTo(expectedQuery);
   }
 }


### PR DESCRIPTION
## Description

I wrote some new tests for the search range queries (ES implementation). I thought about how to do it with less effort and having a good coverage, and thought might make sense to use parameterized tests here.

So I added a parameterized test for SearchRange query (ES) that allows us to easily test and extend tests for different range queries. 

I kind of like it as it checks the actual query which will be sent to ES (it is kind of decoupled from the actual client API/usage). I would like to discuss this approach first with you @romansmirnov  before I continue here. 


<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

related to https://github.com/camunda/camunda/issues/19076
