### PR TITLE
Add new tests for the SearchTermQuery (ES)

### DIFF
--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/query/TermQueryTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/query/TermQueryTransformer.java
@@ -24,6 +24,10 @@ public final class TermQueryTransformer extends QueryOptionTransformer<SearchTer
     final var transformer = getFieldValueTransformer();
     final var fieldValue = value.value();
     final var tranformedFieldValue = transformer.apply(fieldValue);
-    return QueryBuilders.term().field(field).value(tranformedFieldValue).build();
+    return QueryBuilders.term()
+        .field(field)
+        .value(tranformedFieldValue)
+        .caseInsensitive(value.caseInsensitive())
+        .build();
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TermQueryTransformerTest {
+
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchQuery.class);
+  }
+
+  private static Stream<Arguments> provideRangeQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", 1), "Query: {'term':{'foo':{'value':1}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", 1L), "Query: {'term':{'foo':{'value':1}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", 1.0), "Query: {'term':{'foo':{'value':1.0}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", true), "Query: {'term':{'foo':{'value':true}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", "string"),
+            "Query: {'term':{'foo':{'value':'string'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term()
+                .field("foo")
+                .value("string")
+                .caseInsensitive(true) // if not null it will be set
+                .build()
+                .toSearchQuery(),
+            "Query: {'term':{'foo':{'value':'string','case_insensitive':true}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term()
+                .field("foo")
+                .value("string")
+                .caseInsensitive(false)
+                .build()
+                .toSearchQuery(),
+            "Query: {'term':{'foo':{'value':'string','case_insensitive':false}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term()
+                .field("foo")
+                .value("string")
+                .value(1)
+                .value(true) // last one wins
+                .build()
+                .toSearchQuery(),
+            "Query: {'term':{'foo':{'value':true}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideRangeQueries")
+  public void shouldApplyTransformer(
+      final SearchQuery rangeQuery, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(rangeQuery);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.toString()).isEqualTo(expectedQuery);
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
@@ -8,6 +8,7 @@
 package io.camunda.search.es.transformers;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
 import io.camunda.search.clients.query.SearchQuery;
@@ -15,6 +16,7 @@ import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.transformers.SearchTransfomer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -82,5 +84,15 @@ public class TermQueryTransformerTest {
     // then
     assertThat(result).isNotNull();
     assertThat(result.toString()).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullValue() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.term().field("foo").value((String) null).build())
+        .hasMessageContaining("Expected non-null value for term query, for field 'foo'.")
+        .isInstanceOf(IllegalArgumentException.class);
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
@@ -31,7 +31,7 @@ public class TermQueryTransformerTest {
     transformer = transformers.getTransformer(SearchQuery.class);
   }
 
-  private static Stream<Arguments> provideRangeQueries() {
+  private static Stream<Arguments> provideQueries() {
     return Stream.of(
         Arguments.arguments(
             SearchQueryBuilders.term("foo", 1), "Query: {'term':{'foo':{'value':1}}}"),
@@ -72,7 +72,7 @@ public class TermQueryTransformerTest {
   }
 
   @ParameterizedTest
-  @MethodSource("provideRangeQueries")
+  @MethodSource("provideQueries")
   public void shouldApplyTransformer(
       final SearchQuery rangeQuery, final String expectedResultQuery) {
     // given
@@ -91,8 +91,18 @@ public class TermQueryTransformerTest {
     // given
 
     // when - throw
-    assertThatThrownBy(() -> SearchQueryBuilders.term().field("foo").value((String) null).build())
+    assertThatThrownBy(() -> SearchQueryBuilders.term().field("foo").build())
         .hasMessageContaining("Expected non-null value for term query, for field 'foo'.")
-        .isInstanceOf(IllegalArgumentException.class);
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.term().build())
+        .hasMessageContaining("Expected non-null field for term query.")
+        .isInstanceOf(NullPointerException.class);
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/TermQueryTransformerTest.java
@@ -45,6 +45,12 @@ public class TermQueryTransformerTest {
             SearchQueryBuilders.term("foo", "string"),
             "Query: {'term':{'foo':{'value':'string'}}}"),
         Arguments.arguments(
+            SearchQueryBuilders.term("foo", (String) null),
+            "Query: {'term':{'foo':{'value':null}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term().field("foo").value((String) null).build().toSearchQuery(),
+            "Query: {'term':{'foo':{'value':null}}}"),
+        Arguments.arguments(
             SearchQueryBuilders.term()
                 .field("foo")
                 .value("string")

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -223,23 +223,23 @@ public final class SearchQueryBuilders {
   }
 
   public static SearchQuery term(final String field, final Integer value) {
-    return SearchTermQuery.of((q) -> q.field(field).value(value)).toSearchQuery();
+    return term((q) -> q.field(field).value(value)).toSearchQuery();
   }
 
   public static SearchQuery term(final String field, final Long value) {
-    return SearchTermQuery.of((q) -> q.field(field).value(value)).toSearchQuery();
+    return term((q) -> q.field(field).value(value)).toSearchQuery();
   }
 
   public static SearchQuery term(final String field, final Double value) {
-    return SearchTermQuery.of((q) -> q.field(field).value(value)).toSearchQuery();
+    return term((q) -> q.field(field).value(value)).toSearchQuery();
   }
 
   public static SearchQuery term(final String field, final String value) {
-    return SearchTermQuery.of((q) -> q.field(field).value(value)).toSearchQuery();
+    return term((q) -> q.field(field).value(value)).toSearchQuery();
   }
 
   public static SearchQuery term(final String field, final boolean value) {
-    return SearchTermQuery.of((q) -> q.field(field).value(value)).toSearchQuery();
+    return term((q) -> q.field(field).value(value)).toSearchQuery();
   }
 
   public static SearchTermsQuery.Builder terms() {

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
@@ -10,14 +10,9 @@ package io.camunda.search.clients.query;
 import io.camunda.search.clients.types.TypedValue;
 import io.camunda.util.ObjectBuilder;
 import java.util.Objects;
-import java.util.function.Function;
 
-public final record SearchTermQuery(String field, TypedValue value, Boolean caseInsensitive)
+public record SearchTermQuery(String field, TypedValue value, Boolean caseInsensitive)
     implements SearchQueryOption {
-
-  static SearchTermQuery of(final Function<Builder, ObjectBuilder<SearchTermQuery>> fn) {
-    return SearchQueryBuilders.term(fn);
-  }
 
   public static final class Builder implements ObjectBuilder<SearchTermQuery> {
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
@@ -57,8 +57,13 @@ public record SearchTermQuery(String field, TypedValue value, Boolean caseInsens
 
     @Override
     public SearchTermQuery build() {
-      return new SearchTermQuery(
-          Objects.requireNonNull(field), Objects.requireNonNull(value), caseInsensitive);
+      Objects.requireNonNull(field);
+
+      if (value == null || value == TypedValue.NULL || value.isNull() || value.value() == null) {
+        throw new IllegalArgumentException(
+            String.format("Expected non-null value for term query, for field '%s'.", field));
+      }
+      return new SearchTermQuery(field, value, caseInsensitive);
     }
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchTermQuery.java
@@ -57,13 +57,13 @@ public record SearchTermQuery(String field, TypedValue value, Boolean caseInsens
 
     @Override
     public SearchTermQuery build() {
-      Objects.requireNonNull(field);
-
-      if (value == null || value == TypedValue.NULL || value.isNull() || value.value() == null) {
-        throw new IllegalArgumentException(
-            String.format("Expected non-null value for term query, for field '%s'.", field));
-      }
-      return new SearchTermQuery(field, value, caseInsensitive);
+      return new SearchTermQuery(
+          Objects.requireNonNull(field, "Expected non-null field for term query."),
+          Objects.requireNonNull(
+              value,
+              () ->
+                  String.format("Expected non-null value for term query, for field '%s'.", field)),
+          caseInsensitive);
     }
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/types/TypedValue.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/types/TypedValue.java
@@ -18,6 +18,10 @@ public final record TypedValue(ValueType type, Object value) {
   public static final TypedValue FALSE = new TypedValue(ValueType.BOOLEAN, Boolean.FALSE);
 
   public TypedValue(final ValueType type, final Object value) {
+    if (value == null && type != ValueType.NULL) {
+      throw new IllegalArgumentException("Expected non-null value, for value type " + type.name());
+    }
+
     this.type = type;
     this.value = type == ValueType.NULL ? null : value;
   }
@@ -66,15 +70,6 @@ public final record TypedValue(ValueType type, Object value) {
     return (String) value;
   }
 
-  public enum ValueType {
-    DOUBLE,
-    INTEGER,
-    LONG,
-    BOOLEAN,
-    STRING,
-    NULL
-  }
-
   public static TypedValue of(final int value) {
     return new TypedValue(ValueType.INTEGER, value);
   }
@@ -92,6 +87,10 @@ public final record TypedValue(ValueType type, Object value) {
   }
 
   public static TypedValue of(final String value) {
+    if (value == null) {
+      return NULL;
+    }
+
     return new TypedValue(ValueType.STRING, value);
   }
 
@@ -117,5 +116,14 @@ public final record TypedValue(ValueType type, Object value) {
       return of((Boolean) value);
     }
     throw new IllegalArgumentException("Non-supported type: " + value.getClass());
+  }
+
+  public enum ValueType {
+    DOUBLE,
+    INTEGER,
+    LONG,
+    BOOLEAN,
+    STRING,
+    NULL
   }
 }


### PR DESCRIPTION
## Description


This PR does the following:

 * Removes some indirection (reducing complexity)
 * Fix an issue with the SearchTermQuery as the caseInsensitive value was not provided to the ES client
 * Add new parameterized test for the SearchTermQuery
 * Improve a bit on the null-handling and a separate test for it
<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

related to https://github.com/camunda/camunda/issues/19076
