### PR TITLE
ci: increase timeouts for acquiring locks during build

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -137,6 +137,7 @@ runs:
         -D aether.enhancedLocalRepository.splitRemote=true
         -D aether.syncContext.named.nameMapper=file-gav
         -D aether.syncContext.named.factory=file-lock
+        -D aether.syncContext.named.time=120
         -D maven.artifact.threads=32
         EOF
     - name: Determine if running on GH infra or self-hosted


### PR DESCRIPTION
## Description

This is an attempt to workaround the frequent failures caused by 'Could not acquire read lock for ..' 
This change helped to merge #19613. I'm not sure if it really improves the situation, though. But makes sense to apply this changes to main and other stable branches.

## Related issues

closes #19619 
