### PR TITLE
build: rollback java version to 17

### DIFF
--- a/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
+++ b/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
@@ -42,14 +42,21 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: '21'
-          distribution: 'adopt'
+          java-version: 21
+          distribution: temurin
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Build Java Client
         uses: ./.github/actions/build-zeebe
         with:
           maven-extra-args: -T1C -am
+
+      - name: Downgrade Java environment
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
       - name: Maven Test Build
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle

--- a/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
+++ b/.github/workflows/spring-boot-starter-camunda-sdk-ci.yml
@@ -50,13 +50,6 @@ jobs:
         uses: ./.github/actions/build-zeebe
         with:
           maven-extra-args: -T1C -am
-
-      - name: Downgrade Java environment
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
       - name: Maven Test Build
         # we use the verify goal here as flaky test extraction is bound to the post-integration-test
         # phase of Maven https://maven.apache.org/guides/introduction/introduction-to-the-lifecycle.html#default-lifecycle

--- a/spring-boot-starter-camunda-sdk/pom.xml
+++ b/spring-boot-starter-camunda-sdk/pom.xml
@@ -35,7 +35,7 @@
   </licenses>
 
   <properties>
-    <version.java>21</version.java>
+    <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
   </properties>
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

Spring Zeebe SDK should be builded with Java 17, according to our [docs](https://docs.camunda.io/docs/next/apis-tools/spring-zeebe-sdk/getting-started/#version-compatibility)

## Related issues

closes #19658 
