### PR TITLE
[Backport stable/8.3] ci: increase timeouts for acquiring locks during build

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -137,6 +137,7 @@ runs:
         -D aether.enhancedLocalRepository.splitRemote=true
         -D aether.syncContext.named.nameMapper=file-gav
         -D aether.syncContext.named.factory=file-lock
+        -D aether.syncContext.named.time=120
         -D maven.artifact.threads=32
         EOF
     - name: Determine if running on GH infra or self-hosted


### PR DESCRIPTION
# Description
Backport of #19679 to `stable/8.3`.

relates to #19619
original author: @deepthidevaki