### PR TITLE
ci: fix actions/paths-filter condition expressions from bool to string

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -9,24 +9,24 @@ outputs:
     value: >-
       ${{
         github.event_name == 'push' ||
-        steps.filter-common.outputs.github-actions-change
+        steps.filter-common.outputs.github-actions-change == 'true'
       }}
   java-unit-tests:
     description: Output whether `unit-tests` (java) should be run based on GitHub event and files changed
     value: >-
       ${{
         github.event_name == 'push' ||
-        steps.filter-common.outputs.github-actions-change ||
-        steps.filter-common.outputs.java-code-change ||
-        steps.filter-common.outputs.maven-change
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-common.outputs.java-code-change == 'true' ||
+        steps.filter-common.outputs.maven-change == 'true'
       }}
   identity-frontend-tests:
     description: Output whether Identity frontend tests should be run based on GitHub event and files changed
     value: >-
       ${{
         github.event_name == 'push' ||
-        steps.filter-common.outputs.github-actions-change ||
-        steps.filter-identity.outputs.identity-frontend-change
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-identity.outputs.identity-frontend-change == 'true'
       }}
 
 runs:


### PR DESCRIPTION
## Description

Address the problem reported [via Slack](https://camunda.slack.com/archives/C071KP5BTHB/p1719235453069919) where `java-unit-tests` did not get executed although Java files where touched.

Works now with only Java code changes and without GHA changes: https://github.com/camunda/camunda/actions/runs/9649777741?pr=19694