### PR TITLE
fix: do not close snapshot store in RaftContext

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/impl/RaftContext.java
@@ -810,13 +810,6 @@ public class RaftContext implements AutoCloseable, HealthMonitorable {
       log.error("Failed to close metastore", e);
     }
 
-    // Close the snapshot store.
-    try {
-      persistedSnapshotStore.close();
-    } catch (final Exception e) {
-      log.error("Failed to close snapshot store", e);
-    }
-
     // close thread contexts
     threadContext.close();
   }


### PR DESCRIPTION
## Description

`SnapshotStore` lifecycle is managed by the `Partition` outside of raft. It is closed by  the `Partition` as defined by its startup and shutdown sequence. 

## Related issues

closes #17452 
