### PR TITLE
Add ids query test

### DIFF
--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/IdsQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/IdsQueryTransformerTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class IdsQueryTransformerTest {
+
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchQuery.class);
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(SearchQueryBuilders.ids(List.of()), "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values(List.of()).build().toSearchQuery(),
+            "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().build().toSearchQuery(), "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids((List<String>) null), "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids((Collection<String>) null), "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids((String[]) null), "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values((List<String>) null).build().toSearchQuery(),
+            "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values((String[]) null).build().toSearchQuery(),
+            "Query: {'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids(List.of("value")), "Query: {'ids':{'values':['value']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids("value1", "value2"),
+            "Query: {'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids((Collection<String>) List.of("value1", "value2")),
+            "Query: {'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids(List.of("value1", "value2")),
+            "Query: {'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values(List.of("value1", "value2")).build().toSearchQuery(),
+            "Query: {'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids()
+                .values(List.of("value1"))
+                .values(List.of("value2"))
+                .build()
+                .toSearchQuery(),
+            "Query: {'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values("value1").values("value2").build().toSearchQuery(),
+            "Query: {'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values("value1", "value2").build().toSearchQuery(),
+            "Query: {'ids':{'values':['value1','value2']}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.toString()).isEqualTo(expectedQuery);
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
@@ -14,13 +14,8 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
-public final record SearchIdsQuery(List<String> values) implements SearchQueryOption {
-
-  static SearchIdsQuery of(final Function<Builder, ObjectBuilder<SearchIdsQuery>> fn) {
-    return SearchQueryBuilders.ids(fn);
-  }
+public record SearchIdsQuery(List<String> values) implements SearchQueryOption {
 
   public static final class Builder implements ObjectBuilder<SearchIdsQuery> {
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
@@ -7,11 +7,9 @@
  */
 package io.camunda.search.clients.query;
 
-import static io.camunda.util.CollectionUtil.addValuesToList;
-import static io.camunda.util.CollectionUtil.collectValues;
-
 import io.camunda.util.ObjectBuilder;
-import java.util.Collections;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 
@@ -19,20 +17,20 @@ public record SearchIdsQuery(List<String> values) implements SearchQueryOption {
 
   public static final class Builder implements ObjectBuilder<SearchIdsQuery> {
 
-    private List<String> ids;
+    private final List<String> ids = new ArrayList<>();
 
     public Builder values(final List<String> values) {
-      ids = addValuesToList(ids, values);
+      ids.addAll(Objects.requireNonNullElse(values, List.of()));
       return this;
     }
 
-    public Builder values(final String value, final String... values) {
-      return values(collectValues(value, values));
+    public Builder values(final String... values) {
+      return values(Arrays.stream(Objects.requireNonNullElse(values, new String[0])).toList());
     }
 
     @Override
     public SearchIdsQuery build() {
-      return new SearchIdsQuery(Objects.requireNonNullElse(ids, Collections.emptyList()));
+      return new SearchIdsQuery(ids);
     }
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -15,6 +15,7 @@ import io.camunda.util.ObjectBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Objects;
 import java.util.function.Function;
 
 public final class SearchQueryBuilders {
@@ -132,11 +133,11 @@ public final class SearchQueryBuilders {
   }
 
   public static SearchQuery ids(final Collection<String> ids) {
-    return ids(new ArrayList<>(ids));
+    return ids(new ArrayList<>(Objects.requireNonNullElse(ids, List.of())));
   }
 
   public static SearchQuery ids(final String... ids) {
-    return ids(List.of(ids));
+    return ids(List.of(Objects.requireNonNullElse(ids, new String[0])));
   }
 
   public static SearchMatchQuery.Builder match() {

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -128,7 +128,7 @@ public final class SearchQueryBuilders {
   }
 
   public static SearchQuery ids(final List<String> ids) {
-    return SearchIdsQuery.of(q -> q.values(withoutNull(ids))).toSearchQuery();
+    return ids(q -> q.values(withoutNull(ids))).toSearchQuery();
   }
 
   public static SearchQuery ids(final Collection<String> ids) {

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -12,10 +12,10 @@ import static io.camunda.util.CollectionUtil.withoutNull;
 
 import io.camunda.search.clients.query.SearchMatchQuery.SearchMatchQueryOperator;
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 public final class SearchQueryBuilders {
 
@@ -132,7 +132,7 @@ public final class SearchQueryBuilders {
   }
 
   public static SearchQuery ids(final Collection<String> ids) {
-    return ids(ids.stream().collect(Collectors.toList()));
+    return ids(new ArrayList<>(ids));
   }
 
   public static SearchQuery ids(final String... ids) {


### PR DESCRIPTION
## Description


* Simplify implementation - remove indirection; use different method to construct list
* Make SearchIdsQuery more null tolerant, default to empty lists/values
* Add paremeterized tests covering several ways for nulls and adding values to the query
<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

related to https://github.com/camunda/camunda/issues/19076
