### PR TITLE
Do not evaluate target boundary event correlation key expression on migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -148,7 +148,7 @@ public final class CatchEventBehavior {
    */
   public Either<Failure, Void> subscribeToEvents(
       final BpmnElementContext context, final ExecutableCatchEventSupplier supplier) {
-    return subscribeToEvents(context, supplier, catchEvent -> true);
+    return subscribeToEvents(context, supplier, executableCatchEvent -> true, catchEvent -> true);
   }
 
   /**
@@ -161,19 +161,26 @@ public final class CatchEventBehavior {
    * @param context the context of the element instance that subscribes to events
    * @param supplier the supplier of catch events to subscribe to, typically the element of the
    *     element instance that subscribes to events
-   * @param filter the filter for catch events to subscribe to, only events that match the filter
-   *     are subscribed to.
+   * @param filterBeforeEvaluation the filter apply for catch events before applying any
+   *     evaluations. This is especially useful for filtering catch events that doesn't require an
+   *     expression evaluation.
+   * @param filterAfterEvaluation the filter for catch events to subscribe to, only events that
+   *     match the filter are subscribed to.
    * @return either a failure or nothing
    */
   public Either<Failure, Void> subscribeToEvents(
       final BpmnElementContext context,
       final ExecutableCatchEventSupplier supplier,
-      final Predicate<CatchEvent> filter) {
+      final Predicate<ExecutableCatchEvent> filterBeforeEvaluation,
+      final Predicate<CatchEvent> filterAfterEvaluation) {
     final var evaluationResults =
         supplier.getEvents().stream()
             .filter(event -> event.isTimer() || event.isMessage() || event.isSignal())
+            .filter(filterBeforeEvaluation)
             .map(event -> evalExpressions(expressionProcessor, event, context))
-            .filter(result -> result.map(CatchEvent::new).map(filter::test).getOrElse(true))
+            .filter(
+                result ->
+                    result.map(CatchEvent::new).map(filterAfterEvaluation::test).getOrElse(true))
             .collect(Either.collectorFoldingLeft());
 
     evaluationResults.ifRight(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -161,11 +161,13 @@ public final class CatchEventBehavior {
    * @param context the context of the element instance that subscribes to events
    * @param supplier the supplier of catch events to subscribe to, typically the element of the
    *     element instance that subscribes to events
-   * @param filterBeforeEvaluation the filter apply for catch events before applying any
-   *     evaluations. This is especially useful for filtering catch events that doesn't require an
-   *     expression evaluation.
-   * @param filterAfterEvaluation the filter for catch events to subscribe to, only events that
-   *     match the filter are subscribed to.
+   * @param filterBeforeEvaluation the filter for catch events to subscribe to. Only events that
+   *     match the filter are subscribed to. This filter is applied before evaluating the catch
+   *     event's expressions. This is especially useful for filtering catch events that doesn't
+   *     require an expression evaluation.
+   * @param filterAfterEvaluation the filter for catch events to subscribe to. Only events that
+   *     match the filter are subscribed to. This filter is applied after evaluating the catch
+   *     event's expressions.
    * @return either a failure or nothing
    */
   public Either<Failure, Void> subscribeToEvents(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -351,16 +351,23 @@ public class ProcessInstanceMigrationMigrateProcessor
         .subscribeToEvents(
             context,
             targetElement,
-            catchEvent -> {
-              final var element = catchEvent.element();
-              final String targetCatchEventId = BufferUtil.bufferAsString(element.getId());
+            executableCatchEvent -> {
+              final String targetCatchEventId =
+                  BufferUtil.bufferAsString(executableCatchEvent.getId());
               if (sourceElementIdToTargetElementId.containsValue(targetCatchEventId)) {
                 // We will migrate this mapped catch event, so we don't want to subscribe to it
                 // Store interrupting status, we will use it to update the interrupting status of
                 // the migrated subscription
-                targetCatchEventIdToInterrupting.put(targetCatchEventId, element.isInterrupting());
+                targetCatchEventIdToInterrupting.put(
+                    targetCatchEventId, executableCatchEvent.isInterrupting());
                 return false;
               }
+
+              return true;
+            },
+            catchEvent -> {
+              final var element = catchEvent.element();
+              final String targetCatchEventId = BufferUtil.bufferAsString(element.getId());
 
               if (element.isMessage()) {
                 requireNoSubscriptionForMessage(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageSubscriptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateMessageSubscriptionTest.java
@@ -68,7 +68,7 @@ public class MigrateMessageSubscriptionTest {
         engine
             .processInstance()
             .ofBpmnProcessId(processId)
-            .withVariables(Map.of("key1", "key1", "key2", "key2"))
+            .withVariables(Map.of("key1", "key1"))
             .create();
 
     RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
@@ -148,7 +148,7 @@ public class MigrateMessageSubscriptionTest {
         engine
             .processInstance()
             .ofBpmnProcessId(processId)
-            .withVariables(Map.of("key1", "key1", "key2", "key2"))
+            .withVariables(Map.of("key1", "key1"))
             .create();
 
     RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
@@ -246,7 +246,7 @@ public class MigrateMessageSubscriptionTest {
         engine
             .processInstance()
             .ofBpmnProcessId(processId)
-            .withVariables(Map.of("key1", "key1", "key2", "key2"))
+            .withVariables(Map.of("key1", "key1"))
             .create();
 
     Assertions.assertThat(
@@ -383,7 +383,7 @@ public class MigrateMessageSubscriptionTest {
         engine
             .processInstance()
             .ofBpmnProcessId(processId)
-            .withVariables(Map.of("key1", "key1", "key2", "key2"))
+            .withVariables(Map.of("key1", "key1"))
             .create();
 
     Assertions.assertThat(
@@ -529,7 +529,7 @@ public class MigrateMessageSubscriptionTest {
         engine
             .processInstance()
             .ofBpmnProcessId(processId)
-            .withVariables(Map.of("key1", "key1", "key2", "key2", "key3", "key3", "key4", "key4"))
+            .withVariables(Map.of("key1", "key1", "key2", "key2"))
             .create();
 
     RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
@@ -680,7 +680,7 @@ public class MigrateMessageSubscriptionTest {
         engine
             .processInstance()
             .ofBpmnProcessId(processId)
-            .withVariables(Map.of("key1", "key1", "key2", "key2", "key3", "key3"))
+            .withVariables(Map.of("key1", "key1", "key2", "key2"))
             .create();
 
     RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
@@ -804,7 +804,7 @@ public class MigrateMessageSubscriptionTest {
         engine
             .processInstance()
             .ofBpmnProcessId(processId)
-            .withVariables(Map.of("key1", "key1", "key2", "key2", "key3", "key3"))
+            .withVariables(Map.of("key1", "key1", "key3", "key3"))
             .create();
 
     RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ProcessInstanceMigrationClusteredTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ProcessInstanceMigrationClusteredTest.java
@@ -114,9 +114,7 @@ public class ProcessInstanceMigrationClusteredTest {
     final int processInstancePartitionId = 2;
     final long processInstanceKey =
         clusteringRule.createProcessInstanceOnPartition(
-            processInstancePartitionId,
-            "sourceProcess",
-            Map.of("key1", "key1", "key2", "key2", "key3", "key3"));
+            processInstancePartitionId, "sourceProcess", Map.of("key1", "key1"));
 
     // always partition 1
     final var subscriptionPartitionId =
@@ -255,7 +253,7 @@ public class ProcessInstanceMigrationClusteredTest {
             .getClient()
             .newCreateInstanceCommand()
             .processDefinitionKey(sourceProcessDefinitionKey)
-            .variables(Map.of("key1", "key1", "key2", "key2", "key3", "key3", "key4", "key4"))
+            .variables(Map.of("key1", "key1", "key2", "key2", "key4", "key4"))
             .send()
             .join();
     final var processInstanceKey = processInstanceEvent.getProcessInstanceKey();


### PR DESCRIPTION
## Description
A filter added to `CatchEventBehavior.subscribeToEvents` method to filter out events of an element instance before executing any expression evaluations. This is used to prevent evaluating expressions on events that are migrated. Because, we are currently not supporting expression evaluation on migration. This will become optional (e.g. allowing correlation key or message name re-evaluation) in further migration improvements.

## Related issues
closes #19527 
