### PR TITLE
deps: downgrade Netty due to incompatibility with grpc-java

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -71,6 +71,7 @@
       "allowedVersions": "!/0.8.9/"
     },
     {
+      "description": "Do not update Netty as it is incompatible with grpc-java < 1.65; this can be removed after that",
       "matchManagers": ["maven"],
       "matchPackagePrefixes": ["io.netty"],
       "allowedVersions": "<=4.1.110.Final"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -71,6 +71,11 @@
       "allowedVersions": "!/0.8.9/"
     },
     {
+      "matchManagers": ["maven"],
+      "matchPackagePrefixes": ["io.netty"],
+      "allowedVersions": "<=4.1.110.Final"
+    },
+    {
       "description" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
       "matchManagers": ["maven"],
       "matchPackagePatterns": [".*"],

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -72,7 +72,7 @@
     <version.mockito>5.12.0</version.mockito>
     <version.model>7.7.0</version.model>
     <version.msgpack>0.9.8</version.msgpack>
-    <version.netty>4.1.111.Final</version.netty>
+    <version.netty>4.1.110.Final</version.netty>
     <version.objenesis>3.4</version.objenesis>
     <version.opensearch>2.8.0</version.opensearch>
     <version.opensearch.testcontainers>2.0.1</version.opensearch.testcontainers>


### PR DESCRIPTION
## Description

Netty 4.1.111.Final is incompatible with grpc-java < 1.65.0 and >= 1.51.0. It can introduce buffer corruption at any point, which if you're lucky is detected, but may also go unnoticed and result in garbage and waste of time.

Wait until grpc-java releases a compatible version before updating to 4.1.111.Final. Note that this also blocks Spring Boot 3.3.1 which depends on Netty 4.1.111.Final.

See:

- https://github.com/grpc/grpc-java/issues/11284#issuecomment-2168264887
- https://github.com/grpc/grpc-java/releases/tag/v1.64.0

## Related issues

blocks #19581
blocks #19265
blocks #19264 
blocks #19259
blocks #19258 
