### PR TITLE
feat: add new binding type attribute to BPMN model API

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 
 /**
@@ -78,6 +79,19 @@ public abstract class AbstractBusinessRuleTaskBuilder<B extends AbstractBusiness
     final ZeebeCalledDecision calledDecision =
         getCreateSingleExtensionElement(ZeebeCalledDecision.class);
     calledDecision.setResultVariable(resultVariable);
+    return myself;
+  }
+
+  /**
+   * Sets the binding type for the decision that is called.
+   *
+   * @param bindingType the binding type for the decision
+   * @return the builder object
+   */
+  public B zeebeBindingType(final ZeebeBindingType bindingType) {
+    final ZeebeCalledDecision calledDecision =
+        getCreateSingleExtensionElement(ZeebeCalledDecision.class);
+    calledDecision.setBindingType(bindingType);
     return myself;
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.builder;
 
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.CallActivity;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 
 /**
@@ -67,6 +68,13 @@ public class AbstractCallActivityBuilder<B extends AbstractCallActivityBuilder<B
     final ZeebeCalledElement calledElement =
         getCreateSingleExtensionElement(ZeebeCalledElement.class);
     calledElement.setPropagateAllParentVariablesEnabled(propagateAllParentVariables);
+    return myself;
+  }
+
+  public B zeebeBindingType(final ZeebeBindingType bindingType) {
+    final ZeebeCalledElement calledElement =
+        getCreateSingleExtensionElement(ZeebeCalledElement.class);
+    calledElement.setBindingType(bindingType);
     return myself;
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -22,6 +22,7 @@ import static io.camunda.zeebe.model.bpmn.impl.ZeebeConstants.USER_TASK_FORM_KEY
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.UserTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeHeader;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskHeaders;
@@ -173,6 +174,14 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
   @Override
   public B zeebeExternalFormReferenceExpression(final String expression) {
     return zeebeExternalFormReference(asZeebeExpression(expression));
+  }
+
+  @Override
+  public B zeebeFormBindingType(final ZeebeBindingType bindingType) {
+    final ZeebeFormDefinition formDefinition =
+        getCreateSingleExtensionElement(ZeebeFormDefinition.class);
+    formDefinition.setBindingType(bindingType);
+    return myself;
   }
 
   public B zeebeTaskHeader(final String key, final String value) {

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.model.bpmn.builder;
 
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+
 /** A fluent builder for zeebe specific user task related properties. */
 public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertiesBuilder<B>> {
 
@@ -166,4 +168,12 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
    * @return the builder object
    */
   B zeebeExternalFormReferenceExpression(String expression);
+
+  /**
+   * Sets the binding type for the user task's form.
+   *
+   * @param bindingType the binding type to set
+   * @return the builder object
+   */
+  B zeebeFormBindingType(final ZeebeBindingType bindingType);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -59,6 +59,8 @@ public class ZeebeConstants {
 
   public static final String ATTRIBUTE_RESULT_VARIABLE = "resultVariable";
 
+  public static final String ATTRIBUTE_BINDING_TYPE = "bindingType";
+
   public static final String ELEMENT_HEADER = "header";
   public static final String ELEMENT_INPUT = "input";
   public static final String ELEMENT_IO_MAPPING = "ioMapping";

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledDecisionImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledDecisionImpl.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
@@ -29,6 +30,7 @@ public class ZeebeCalledDecisionImpl extends BpmnModelElementInstanceImpl
 
   private static Attribute<String> decisionIdAttribute;
   private static Attribute<String> resultVariableAttribute;
+  private static Attribute<ZeebeBindingType> bindingTypeAttribute;
 
   public ZeebeCalledDecisionImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -55,6 +57,13 @@ public class ZeebeCalledDecisionImpl extends BpmnModelElementInstanceImpl
             .required()
             .build();
 
+    bindingTypeAttribute =
+        typeBuilder
+            .enumAttribute(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, ZeebeBindingType.class)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .defaultValue(ZeebeBindingType.latest)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -76,5 +85,15 @@ public class ZeebeCalledDecisionImpl extends BpmnModelElementInstanceImpl
   @Override
   public void setResultVariable(final String resultVariable) {
     resultVariableAttribute.setValue(this, resultVariable);
+  }
+
+  @Override
+  public ZeebeBindingType getBindingType() {
+    return bindingTypeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setBindingType(final ZeebeBindingType bindingType) {
+    bindingTypeAttribute.setValue(this, bindingType);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
@@ -30,6 +31,7 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
   private static Attribute<String> processIdAttribute;
   private static Attribute<Boolean> propagateAllChildVariablesAttribute;
   private static Attribute<Boolean> propagateAllParentVariablesAttribute;
+  private static Attribute<ZeebeBindingType> bindingTypeAttribute;
 
   public ZeebeCalledElementImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -62,8 +64,19 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
   }
 
   @Override
-  public void setPropagateAllParentVariablesEnabled(boolean propagateAllParentVariablesEnabled) {
+  public void setPropagateAllParentVariablesEnabled(
+      final boolean propagateAllParentVariablesEnabled) {
     propagateAllParentVariablesAttribute.setValue(this, propagateAllParentVariablesEnabled);
+  }
+
+  @Override
+  public ZeebeBindingType getBindingType() {
+    return bindingTypeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setBindingType(final ZeebeBindingType bindingType) {
+    bindingTypeAttribute.setValue(this, bindingType);
   }
 
   public static void registerType(final ModelBuilder modelBuilder) {
@@ -91,6 +104,13 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
             .booleanAttribute(ZeebeConstants.ATTRIBUTE_PROPAGATE_ALL_PARENT_VARIABLES)
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .defaultValue(true)
+            .build();
+
+    bindingTypeAttribute =
+        typeBuilder
+            .enumAttribute(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, ZeebeBindingType.class)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .defaultValue(ZeebeBindingType.latest)
             .build();
 
     typeBuilder.build();

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import org.camunda.bpm.model.xml.ModelBuilder;
 import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
@@ -30,6 +31,7 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
   protected static Attribute<String> formKeyAttribute;
   protected static Attribute<String> formIdAttribute;
   protected static Attribute<String> externalReferenceAttribute;
+  private static Attribute<ZeebeBindingType> bindingTypeAttribute;
 
   public ZeebeFormDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -65,6 +67,16 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
     externalReferenceAttribute.setValue(this, externalReference);
   }
 
+  @Override
+  public ZeebeBindingType getBindingType() {
+    return bindingTypeAttribute.getValue(this);
+  }
+
+  @Override
+  public void setBindingType(final ZeebeBindingType bindingType) {
+    bindingTypeAttribute.setValue(this, bindingType);
+  }
+
   public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
@@ -88,6 +100,13 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
         typeBuilder
             .stringAttribute(ZeebeConstants.ATTRIBUTE_EXTERNAL_REFERENCE)
             .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
+    bindingTypeAttribute =
+        typeBuilder
+            .enumAttribute(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, ZeebeBindingType.class)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .defaultValue(ZeebeBindingType.latest)
             .build();
 
     typeBuilder.build();

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeBindingType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeBindingType.java
@@ -15,23 +15,7 @@
  */
 package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
-import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
-
-public interface ZeebeFormDefinition extends BpmnModelElementInstance {
-
-  String getFormKey();
-
-  void setFormKey(String formKey);
-
-  String getFormId();
-
-  void setFormId(String formId);
-
-  String getExternalReference();
-
-  void setExternalReference(String externalReference);
-
-  ZeebeBindingType getBindingType();
-
-  void setBindingType(ZeebeBindingType bindingType);
+public enum ZeebeBindingType {
+  deployment,
+  latest
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
@@ -43,4 +43,16 @@ public interface ZeebeCalledDecision extends BpmnModelElementInstance {
    * @param resultVariable the name of the result variable
    */
   void setResultVariable(String resultVariable);
+
+  /**
+   * @return the binding type for the decision that is called
+   */
+  ZeebeBindingType getBindingType();
+
+  /**
+   * Sets the binding type for the decision that is called.
+   *
+   * @param bindingType the binding type for the decision
+   */
+  void setBindingType(ZeebeBindingType bindingType);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
@@ -30,4 +30,8 @@ public interface ZeebeCalledElement extends BpmnModelElementInstance {
   boolean isPropagateAllParentVariablesEnabled();
 
   void setPropagateAllParentVariablesEnabled(boolean propagateAllParentVariablesEnabled);
+
+  ZeebeBindingType getBindingType();
+
+  void setBindingType(ZeebeBindingType bindingType);
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
@@ -21,9 +21,12 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class BusinessRuleTaskBuilderTest {
 
@@ -104,5 +107,25 @@ public class BusinessRuleTaskBuilderTest {
         .hasSize(1)
         .extracting(ZeebeCalledDecision::getDecisionId, ZeebeCalledDecision::getResultVariable)
         .containsExactly(tuple("decision-id-1", "result"));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ZeebeBindingType.class)
+  void shouldSetBindingType(final ZeebeBindingType bindingType) {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", task -> task.zeebeBindingType(bindingType))
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledDecision.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledDecision::getBindingType)
+        .containsExactly(bindingType);
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.builder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class CallActivityBuilderTest {
+
+  @Test
+  void shouldSetProcessId() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("callActivity", c -> c.zeebeProcessId("process-id-1"))
+            .done();
+
+    // then
+    final ModelElementInstance callActivity = instance.getModelElementById("callActivity");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) callActivity.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledElement.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledElement::getProcessId)
+        .containsExactly("process-id-1");
+  }
+
+  @Test
+  void shouldSetProcessIdExpression() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("callActivity", c -> c.zeebeProcessIdExpression("processIdExpr"))
+            .done();
+
+    // then
+    final ModelElementInstance callActivity = instance.getModelElementById("callActivity");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) callActivity.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledElement.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledElement::getProcessId)
+        .containsExactly("=processIdExpr");
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldSetPropagateAllChildVariables(final boolean propagateAllChildVariables) {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "callActivity", c -> c.zeebePropagateAllChildVariables(propagateAllChildVariables))
+            .done();
+
+    // then
+    final ModelElementInstance callActivity = instance.getModelElementById("callActivity");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) callActivity.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledElement.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledElement::isPropagateAllChildVariablesEnabled)
+        .containsExactly(propagateAllChildVariables);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void shouldSetPropagateAllParentVariables(final boolean propagateAllParentVariables) {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "callActivity",
+                c -> c.zeebePropagateAllParentVariables(propagateAllParentVariables))
+            .done();
+
+    // then
+    final ModelElementInstance callActivity = instance.getModelElementById("callActivity");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) callActivity.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledElement.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledElement::isPropagateAllParentVariablesEnabled)
+        .containsExactly(propagateAllParentVariables);
+  }
+
+  @ParameterizedTest
+  @EnumSource(ZeebeBindingType.class)
+  void shouldSetBindingType(final ZeebeBindingType bindingType) {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("callActivity", c -> c.zeebeBindingType(bindingType))
+            .done();
+
+    // then
+    final ModelElementInstance callActivity = instance.getModelElementById("callActivity");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) callActivity.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledElement.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledElement::getBindingType)
+        .containsExactly(bindingType);
+  }
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
@@ -22,12 +22,16 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.ExtensionElements;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeAssignmentDefinition;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 import java.util.Collection;
 import org.camunda.bpm.model.xml.instance.ModelElementInstance;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 class UserTaskBuilderTest {
 
@@ -257,5 +261,27 @@ class UserTaskBuilderTest {
         .hasSize(1)
         .extracting(ZeebeTaskSchedule::getDueDate, ZeebeTaskSchedule::getFollowUpDate)
         .containsExactly(tuple(dueDate, followUpDate));
+  }
+
+  @ParameterizedTest
+  @EnumSource(ZeebeBindingType.class)
+  void shouldSetFormBindingType(final ZeebeBindingType bindingType) {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask1")
+            .zeebeFormBindingType(bindingType)
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance userTask = instance.getModelElementById("userTask1");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeFormDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeFormDefinition::getBindingType)
+        .containsExactly(bindingType);
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecisionTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecisionTest.java
@@ -15,11 +15,19 @@
  */
 package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import org.junit.Test;
 
 public class ZeebeCalledDecisionTest extends BpmnModelElementInstanceTest {
 
@@ -40,5 +48,52 @@ public class ZeebeCalledDecisionTest extends BpmnModelElementInstanceTest {
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "resultVariable", false, true),
         new AttributeAssumption(
             BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest));
+  }
+
+  @Test
+  public void shouldReadValidBindingTypeFromXml() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .businessRuleTask("task", task -> task.zeebeBindingType(ZeebeBindingType.deployment))
+            .done();
+    final String modelXml = Bpmn.convertToString(modelInstance);
+
+    // when
+    final BusinessRuleTask businessRuleTask =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("task");
+    final ZeebeCalledDecision calledDecision =
+        businessRuleTask.getSingleExtensionElement(ZeebeCalledDecision.class);
+
+    // then
+    assertThat(calledDecision.getBindingType()).isEqualTo(ZeebeBindingType.deployment);
+  }
+
+  @Test
+  public void shouldThrowExceptionForInvalidBindingTypeInXml() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .businessRuleTask("task", task -> task.zeebeBindingType(ZeebeBindingType.deployment))
+            .done();
+    final String modelXml =
+        Bpmn.convertToString(modelInstance)
+            .replace("bindingType=\"deployment\"", "bindingType=\"foo\"");
+
+    // when
+    final BusinessRuleTask businessRuleTask =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("task");
+    final ZeebeCalledDecision calledDecision =
+        businessRuleTask.getSingleExtensionElement(ZeebeCalledDecision.class);
+
+    // then
+    assertThatThrownBy(calledDecision::getBindingType)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "No enum constant io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType.foo");
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElementTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElementTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-public class ZeebeCalledDecisionTest extends BpmnModelElementInstanceTest {
+public class ZeebeCalledElementTest extends BpmnModelElementInstanceTest {
 
   @Override
   public TypeAssumption getTypeAssumption() {
@@ -36,8 +36,11 @@ public class ZeebeCalledDecisionTest extends BpmnModelElementInstanceTest {
   @Override
   public Collection<AttributeAssumption> getAttributesAssumptions() {
     return Arrays.asList(
-        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "decisionId", false, true),
-        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "resultVariable", false, true),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "processId", false, false),
+        new AttributeAssumption(
+            BpmnModelConstants.ZEEBE_NS, "propagateAllChildVariables", false, false, true),
+        new AttributeAssumption(
+            BpmnModelConstants.ZEEBE_NS, "propagateAllParentVariables", false, false, true),
         new AttributeAssumption(
             BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest));
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
@@ -38,6 +38,8 @@ public class ZeebeFormDefinitionTest extends BpmnModelElementInstanceTest {
     return Arrays.asList(
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "formKey", false, false),
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "formId", false, false),
-        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "externalReference", false, false));
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "externalReference", false, false),
+        new AttributeAssumption(
+            BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest));
   }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
@@ -15,11 +15,19 @@
  */
 package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
 import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import io.camunda.zeebe.model.bpmn.instance.UserTask;
+import java.io.ByteArrayInputStream;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import org.junit.Test;
 
 public class ZeebeFormDefinitionTest extends BpmnModelElementInstanceTest {
 
@@ -41,5 +49,52 @@ public class ZeebeFormDefinitionTest extends BpmnModelElementInstanceTest {
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "externalReference", false, false),
         new AttributeAssumption(
             BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest));
+  }
+
+  @Test
+  public void shouldReadValidBindingTypeFromXml() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .userTask("task", task -> task.zeebeFormBindingType(ZeebeBindingType.deployment))
+            .done();
+    final String modelXml = Bpmn.convertToString(modelInstance);
+
+    // when
+    final UserTask userTask =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("task");
+    final ZeebeFormDefinition formDefinition =
+        userTask.getSingleExtensionElement(ZeebeFormDefinition.class);
+
+    // then
+    assertThat(formDefinition.getBindingType()).isEqualTo(ZeebeBindingType.deployment);
+  }
+
+  @Test
+  public void shouldThrowExceptionForInvalidBindingTypeInXml() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess()
+            .startEvent()
+            .userTask("task", task -> task.zeebeFormBindingType(ZeebeBindingType.deployment))
+            .done();
+    final String modelXml =
+        Bpmn.convertToString(modelInstance)
+            .replace("bindingType=\"deployment\"", "bindingType=\"foo\"");
+
+    // when
+    final UserTask userTask =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("task");
+    final ZeebeFormDefinition formDefinition =
+        userTask.getSingleExtensionElement(ZeebeFormDefinition.class);
+
+    // then
+    assertThatThrownBy(formDefinition::getBindingType)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "No enum constant io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType.foo");
   }
 }


### PR DESCRIPTION
## Description
Adds support for a new `bindingType` attribute (that can be `latest` or `deployment`) to the `ZeebeCalledElement`, `ZeebeCalledDecision`, and `ZeebeFormDefinition` extension elements in the BPMN Model API.
This should allow Zeebe to determine the binding type for such elements when a deployed BPMN diagram is processed.

## Related issues

closes #19461
