### PR TITLE
Add build backend and frontend to unified ci

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -45,7 +45,8 @@ outputs:
       ${{
         github.event_name == 'push' ||
         steps.filter-common.outputs.github-actions-change == 'true' ||
-        steps.filter-identity.outputs.identity-frontend-change == 'true'
+        steps.filter-common.outputs.frontend-change == 'true' ||
+        steps.filter-identity.outputs.frontend-identity == 'true'
       }}
 
 

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -39,6 +39,14 @@ outputs:
         steps.filter-common.outputs.dockerfile-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true'
       }}
+  frontend-change:
+    description: Output whether any frontend has changed
+    value: >-
+      ${{
+        github.event_name == 'push' ||
+        steps.filter-common.outputs.github-actions-change == 'true' ||
+        steps.filter-identity.outputs.identity-frontend-change == 'true'
+      }}
 
 
 runs:

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -39,7 +39,7 @@ outputs:
         steps.filter-common.outputs.dockerfile-change == 'true' ||
         steps.filter-common.outputs.frontend-change == 'true'
       }}
-  frontend-change:
+  frontend-changes:
     description: Output whether any frontend has changed
     value: >-
       ${{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         with:
           directory: ./tasklist/client
       - uses: ./.github/actions/build-frontend
-        id: build-tasklist-fe
+        id: build-identity-fe
         with:
           directory: ./identity/client
       - name: Observe build status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -423,6 +423,8 @@ jobs:
       - docker-checks
       - identity-frontend-tests
       - integration-tests
+      - build-platform-backend
+      - build-platform-frontend
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
     if: needs.detect-changes.outputs.java-unit-tests == 'true'
     needs: [detect-changes]
     name: Java checks
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,25 +65,21 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
-  build-platform-backend:
+  java-checks:
     if: needs.detect-changes.outputs.java-unit-tests == 'true'
     needs: [ detect-changes ]
+    name: Java checks
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-    outputs:
-      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
         with:
-          go: true
+          go: false
+          maven-cache-key-modifier: java-checks
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-      - uses: ./.github/actions/build-zeebe
-        with:
-          go: false
-          maven-extra-args: -T1C -PskipFrontendBuild
+      - run: ./mvnw -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -93,7 +89,6 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-
 
   build-platform-frontend:
     if: needs.detect-changes.outputs.frontend-changes == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       java-code-changes: ${{ steps.filter.outputs.java-code-changes }}
       camunda-docker-tests: ${{ steps.filter.outputs.camunda-docker-tests}}
       identity-frontend-tests: ${{ steps.filter.outputs.identity-frontend-tests }}
+      frontend-changes: ${{ steps.filter.output.frontend-changes }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,7 @@ jobs:
       - docker-checks
       - identity-frontend-tests
       - integration-tests
+      - java-checks
       - build-platform-frontend
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,36 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
+  build-platform-backend:
+    if: needs.detect-changes.outputs.java-unit-tests == 'true'
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          go: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        with:
+          go: false
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+
   java-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       java-code-changes: ${{ steps.filter.outputs.java-code-changes }}
       camunda-docker-tests: ${{ steps.filter.outputs.camunda-docker-tests}}
       identity-frontend-tests: ${{ steps.filter.outputs.identity-frontend-tests }}
-      frontend-changes: ${{ steps.filter.output.frontend-changes }}
+      frontend-changes: ${{ steps.filter.outputs.frontend-changes }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   java-checks:
     if: needs.detect-changes.outputs.java-unit-tests == 'true'
-    needs: [ detect-changes ]
+    needs: [detect-changes]
     name: Java checks
     runs-on: ubuntu-latest
     steps:
@@ -92,11 +92,9 @@ jobs:
 
   build-platform-frontend:
     if: needs.detect-changes.outputs.frontend-changes == 'true'
-    needs: [ detect-changes ]
+    needs: [detect-changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    outputs:
-      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe
@@ -418,7 +416,6 @@ jobs:
       - docker-checks
       - identity-frontend-tests
       - integration-tests
-      - build-platform-backend
       - build-platform-frontend
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   java-checks:
-    if: needs.detect-changes.outputs.java-unit-tests == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
     name: Java checks
     timeout-minutes: 15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,43 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
 
+  build-platform-frontend:
+    if: needs.detect-changes.outputs.frontend-changes == 'true'
+    needs: [ detect-changes ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          go: true
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-frontend
+        id: build-operate-fe
+        with:
+          directory: ./operate/client
+      - uses: ./.github/actions/build-frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./tasklist/client
+      - uses: ./.github/actions/build-frontend
+        id: build-tasklist-fe
+        with:
+          directory: ./identity/client
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   java-unit-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]


### PR DESCRIPTION
## Description

> [!NOTE] 
> This is just an proposal


We havew previously added merge CIs for Operate and Tasklist, which were mostly only building the apps.

I think this can be merged into the Unified CI, and we can get rid of these extra merge workflows. With that, we can also have one place where we build the frontends together.

Additionally, here we can do the java checks (checking for google styleguide and spotbugs) which was previously done in Zeebe CI. This inherently also builds the backend, so we need no extra step for this.

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

Related to https://github.com/camunda/camunda/issues/17721