### PR TITLE
Increate testbench workflow timeout for 8.5

### DIFF
--- a/.github/workflows/zeebe-testbench.yaml
+++ b/.github/workflows/zeebe-testbench.yaml
@@ -20,7 +20,7 @@ jobs:
   testbench:
     name: Start a test in testbench
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
## Description

The `build-zeebe` step requires more time in `8.5`, resulting in timeouts in the CI. Extending the timeout to 30mins should fix the issue.
