### PR TITLE
Add QA IT to the Unified CI

### DIFF
--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -11,8 +11,8 @@ outputs:
         github.event_name == 'push' ||
         steps.filter-common.outputs.github-actions-change == 'true'
       }}
-  java-unit-tests:
-    description: Output whether `unit-tests` (java) should be run based on GitHub event and files changed
+  java-code-changes:
+    description: Output whether `java code changes` have been detected
     value: >-
       ${{
         github.event_name == 'push' ||

--- a/.github/actions/paths-filter/action.yml
+++ b/.github/actions/paths-filter/action.yml
@@ -12,7 +12,7 @@ outputs:
         steps.filter-common.outputs.github-actions-change == 'true'
       }}
   java-code-changes:
-    description: Output whether `java code changes` have been detected
+    description: Output whether jobs depending on Java code changes should be run, related checks are based on GitHub events and java files changes
     value: >-
       ${{
         github.event_name == 'push' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
   integration-tests:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
+    needs: [detect-changes]
     timeout-minutes: 20
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
   detect-changes:
     outputs:
       actionlint: ${{ steps.filter.outputs.actionlint }}
-      java-unit-tests: ${{ steps.filter.outputs.java-unit-tests }}
+      java-code-changes: ${{ steps.filter.outputs.java-code-changes }}
       identity-frontend-tests: ${{ steps.filter.outputs.identity-frontend-tests }}
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
 
   java-unit-tests:
-    if: needs.detect-changes.outputs.java-unit-tests == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
     runs-on: [ self-hosted, linux, amd64, "16" ]
     timeout-minutes: 30
@@ -117,7 +117,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   integration-tests:
-    if: needs.detect-changes.outputs.java-unit-tests == 'true'
+    if: needs.detect-changes.outputs.java-code-changes == 'true'
     name: "[IT] ${{ matrix.name }}"
     timeout-minutes: 20
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,98 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
+  integration-tests:
+    if: needs.detect-changes.outputs.java-unit-tests == 'true'
+    name: "[IT] ${{ matrix.name }}"
+    timeout-minutes: 20
+    outputs:
+      flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
+    runs-on: [ self-hosted, linux, amd64, "16" ]
+    strategy:
+      fail-fast: false
+      matrix:
+        group: [ root, modules, qa-integration, qa-update ]
+        include:
+          - group: root
+            name: "Root Integration Tests"
+            maven-modules: "'qa/integration-tests'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+          - group: modules
+            name: "Zeebe Module Integration Tests"
+            maven-modules: "'!zeebe/qa/integration-tests,!zeebe/qa/update-tests'"
+            maven-build-threads: 2
+            maven-test-fork-count: 7
+          - group: qa-integration
+            name: "Zeebe QA - Integration Tests"
+            maven-modules: "qa/integration-tests"
+            maven-build-threads: 1
+            maven-test-fork-count: 10
+          - group: qa-update
+            name: "Zeebe QA - Update Tests"
+            maven-modules: "zeebe/qa/update-tests"
+            maven-build-threads: 1
+            maven-test-fork-count: 10
+    env:
+      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          maven-cache-key-modifier: it-${{ matrix.group }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        with:
+          repository: localhost:5000/camunda/zeebe
+          version: current-test
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}
+      - name: Create build output log file
+        run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
+      - name: Maven Test Build
+        run: >
+          ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
+          -D forkCount=${{ matrix.maven-test-fork-count }}
+          -D maven.javadoc.skip=true
+          -D skipUTs -D skipChecks
+          -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
+          -P parallel-tests,extract-flaky-tests
+          -pl ${{ matrix.maven-modules }}
+          verify
+          | tee "${BUILD_OUTPUT_FILE_PATH}"
+      - name: Analyze Test Runs
+        id: analyze-test-run
+        if: always()
+        uses: ./.github/actions/analyze-test-runs
+        with:
+          buildOutputFilePath: ${{ env.BUILD_OUTPUT_FILE_PATH }}
+      - name: Upload test artifacts
+        uses: ./.github/actions/collect-test-artifacts
+        if: ${{ failure() || cancelled() }}
+        with:
+          name: "[IT] ${{ matrix.name }}"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          job_name: "integration-tests/${{ matrix.group }}"
+          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   identity-frontend-tests:
     if: needs.detect-changes.outputs.identity-frontend-tests == 'true'
     needs: [detect-changes]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
             maven-test-fork-count: 7
           - group: modules
             name: "Zeebe Module Integration Tests"
-            maven-modules: "'!zeebe/qa/integration-tests,!zeebe/qa/update-tests'"
+            maven-modules: "'!qa/integration-tests,!qa/update-tests' -f zeebe"
             maven-build-threads: 2
             maven-test-fork-count: 7
           - group: qa-integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           ./mvnw -T2 -B --no-snapshot-updates
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
-          -P skip-random-tests,parallel-tests,extract-flaky-tests
+          -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"
       - name: Analyze Test Runs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
             maven-test-fork-count: 7
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
-            maven-modules: "qa/integration-tests"
+            maven-modules: "qa/zeebe/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
           - group: qa-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,7 +183,7 @@ jobs:
           -D maven.javadoc.skip=true
           -D skipUTs -D skipChecks
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
-          -P parallel-tests,extract-flaky-tests
+          -P parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,10 +255,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       flakyUnitTests: ${{ needs.java-unit-tests.outputs.flakyTests }}
+      flakyITs: ${{ needs.integration-tests.outputs.flakyTests }}
     needs:
       - actionlint
       - java-unit-tests
       - identity-frontend-tests
+      - integration-tests
     steps:
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 
@@ -300,6 +302,13 @@ jobs:
                     "type": "mrkdwn",
                     "text": "*Detected flaky unit tests:* \n ${{ env.FLAKY_UNIT_TESTS }}"
                   }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Detected flaky integration tests:* \n ${{ env.FLAKY_ITS }}"
+                  }
                 }
               ]
             }
@@ -307,3 +316,4 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
           FLAKY_UNIT_TESTS: ${{needs.check-results.outputs.flakyUnitTests}}
+          FLAKY_ITS: ${{needs.check-results.outputs.flakyITs}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,7 +141,7 @@ jobs:
             maven-test-fork-count: 7
           - group: qa-integration
             name: "Zeebe QA - Integration Tests"
-            maven-modules: "qa/zeebe/integration-tests"
+            maven-modules: "zeebe/qa/integration-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
           - group: qa-update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           job_name: "integration-tests/${{ matrix.group }}"
-          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
+          build_status: ${{ job.status }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

With #19757 we added an new QA module containing integration tests on the root level. This PR should add the execution of such tests to the unified CI. Furthermore, it adds the integrations tests from the Zeebe CI already also to the job, which can be seen as a blue print to add more such integration tests.

Probably useful for Operate, Tasklist and other components that have separate component related integration tests. 

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

related to #19757 