### PR TITLE
build: add distribution management to flattened pom

### DIFF
--- a/zeebe/clients/java/pom.xml
+++ b/zeebe/clients/java/pom.xml
@@ -16,4 +16,18 @@
       <artifactId>camunda-client-java</artifactId>
     </relocation>
   </distributionManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <configuration>
+          <pomElements>
+            <distributionManagement></distributionManagement>
+          </pomElements>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

We need to add `flatten-maven-plugin` to the old `zeebe-java-client` pom. In order to add the distribution management we need for the client 

## Related issues

related #19482 
