### PR TITLE
Chunk reader retry test

### DIFF
--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkId.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkId.java
@@ -35,6 +35,8 @@ public record SnapshotChunkId(ByteBuffer id) {
 
   @Override
   public String toString() {
-    return ID_CHARSET.decode(id).toString();
+    final String idStr = ID_CHARSET.decode(id).toString();
+    id.clear();
+    return idStr;
   }
 }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -313,6 +313,27 @@ public final class FileBasedSnapshotChunkReaderTest {
                 .collect(Collectors.toUnmodifiableList()));
   }
 
+  @Test
+  public void shouldSeekSameByteBufferTwiceWithNoError() throws IOException {
+    // given
+
+    final var buffer = ByteBuffer.wrap("file3__0".getBytes(StandardCharsets.UTF_8));
+    final var snapshotChunkReader = newReader();
+
+    // when
+    snapshotChunkReader.seek(buffer);
+    final var chunkFromFirstSeek = snapshotChunkReader.next();
+
+    snapshotChunkReader.seek(buffer);
+    final var chunkFromSecondSeek = snapshotChunkReader.next();
+
+    // then
+    assertThat(chunkFromFirstSeek.getChunkName()).isEqualTo(chunkFromSecondSeek.getChunkName());
+    assertThat(chunkFromFirstSeek.getContent()).isEqualTo(chunkFromSecondSeek.getContent());
+    assertThat(chunkFromFirstSeek.getChecksum()).isEqualTo(chunkFromSecondSeek.getChecksum());
+  }
+
+
   private List<SnapshotChunk> getAllChunks(final FileBasedSnapshotChunkReader reader) {
     final var snapshotChunks = new ArrayList<SnapshotChunk>();
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -333,7 +333,6 @@ public final class FileBasedSnapshotChunkReaderTest {
     assertThat(chunkFromFirstSeek.getChecksum()).isEqualTo(chunkFromSecondSeek.getChecksum());
   }
 
-
   private List<SnapshotChunk> getAllChunks(final FileBasedSnapshotChunkReader reader) {
     final var snapshotChunks = new ArrayList<SnapshotChunk>();
 


### PR DESCRIPTION
## Description

Adds test and fixes bug with regards to not calling `clear` on buffer after usage to allow for future usage.

## Related issues

closes #19642 
