### PR TITLE
ci: remove GH comments for Tasklist CI

### DIFF
--- a/.github/workflows/tasklist-backup-restore-tests-reusable.yml
+++ b/.github/workflows/tasklist-backup-restore-tests-reusable.yml
@@ -74,18 +74,6 @@ jobs:
         run: |
           mvn -B -pl tasklist/qa/backup-restore-tests -DskipChecks -DtasklistDatabase=${{ inputs.database }} -P -docker,-skipTests verify
 
-      # Reports: publish test results
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.16.1
-        if: always()
-        with:
-          check_name: "Tasklist BackupRestore test results with '${{ inputs.database }}'"
-          comment_mode: off
-          report_individual_runs: true
-          report_suite_logs: error
-          files: |
-            tasklist/**/target/surefire-reports/*.xml
-
       # Notify: send Slack notification on tests failure
       - name: Send Slack notification on failure
         if: failure()

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -88,16 +88,6 @@ jobs:
         run: |
           mvn -f tasklist -T${{ env.LIMITS_CPU }} verify -P ${{ matrix.testProfile }},skipFrontendBuild -B --fail-at-end -Dfailsafe.rerunFailingTestsCount=2 -Dcamunda.tasklist.database=${{ matrix.database }}
 
-      # Reports: publish test metrics results
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.16.1
-        if: ${{ (success() || failure()) }}
-        with:
-          check_name: "Tasklist Test Results"
-          files: |
-            tasklist/**/target/surefire-reports/*.xml
-            tasklist/**/target/failsafe-reports/TEST-*.xml
-
       # Sanitize the branch name to replace non alphanumeric characters with `-`
       - id: sanitize
         uses: camunda/infra-global-github-actions/sanitize-branch-name@main

--- a/.github/workflows/tasklist-migrate-elasticsearch-data.yml
+++ b/.github/workflows/tasklist-migrate-elasticsearch-data.yml
@@ -71,18 +71,6 @@ jobs:
         run: |
           mvn -B -f tasklist/qa/migration-tests -DskipTests=false -DskipChecks verify
 
-      # Reports: publish test results
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.16.1
-        if: always()
-        with:
-          comment_mode: off
-          report_individual_runs: true
-          report_suite_logs: error
-          check_name: "Tasklist Migration Test Results"
-          files: |
-            tasklist/**/target/surefire-reports/*.xml
-
       # Notify: send Slack notification on tests failure
       - name: Send Slack notification on failure
         if: failure()


### PR DESCRIPTION


## Description

Removing the usage of https://github.com/EnricoMi/publish-unit-test-result-action which adds GH comment for executed Tests.

**Why:**

Adding GitHub comments on the executed Test count brings no
additional value. Teams are not consuming it, and it is polluting the PR conversations with unnecessary data that is also accessible via PR status checks.

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues
See slack conv https://camunda.slack.com/archives/C043W5V88M7/p1719478030055259