### PR TITLE
feat: Enable `end` EL support for escalation Intermediate Throw and End events

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBoundaryEventBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBoundaryEventBuilder.java
@@ -41,7 +41,7 @@ public abstract class AbstractBoundaryEventBuilder<B extends AbstractBoundaryEve
   /**
    * Set if the boundary event cancels the attached activity.
    *
-   * @param cancelActivity true if the boundary event cancels the activiy, false otherwise
+   * @param cancelActivity true if the boundary event cancels the activity, false otherwise
    * @return the builder object
    */
   public B cancelActivity(final Boolean cancelActivity) {

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/EndEventValidator.java
@@ -70,8 +70,7 @@ public class EndEventValidator implements ModelElementValidator<EndEvent> {
               .findFirst()
               .ifPresent(
                   eventDefinition -> {
-                    if (eventDefinition instanceof ErrorEventDefinition
-                        || eventDefinition instanceof EscalationEventDefinition) {
+                    if (eventDefinition instanceof ErrorEventDefinition) {
                       final boolean endExecutionListenersDefined =
                           listeners.stream()
                               .map(ZeebeExecutionListener::getEventType)
@@ -79,7 +78,7 @@ public class EndEventValidator implements ModelElementValidator<EndEvent> {
                       if (endExecutionListenersDefined) {
                         validationResultCollector.addError(
                             0,
-                            "Execution listeners of type 'end' are not supported by [escalation, error] end events");
+                            "Execution listeners of type 'end' are not supported by [error] end events");
                       }
                     }
                   });

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/IntermediateThrowEventValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/IntermediateThrowEventValidator.java
@@ -16,16 +16,10 @@
 package io.camunda.zeebe.model.bpmn.validation.zeebe;
 
 import static io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants.BPMN_ATTRIBUTE_WAIT_FOR_COMPLETION;
-import static io.camunda.zeebe.model.bpmn.util.ModelUtil.validateExecutionListenersDefinitionForElement;
 
 import io.camunda.zeebe.model.bpmn.impl.QueryImpl;
 import io.camunda.zeebe.model.bpmn.instance.CompensateEventDefinition;
-import io.camunda.zeebe.model.bpmn.instance.EscalationEventDefinition;
-import io.camunda.zeebe.model.bpmn.instance.EventDefinition;
 import io.camunda.zeebe.model.bpmn.instance.IntermediateThrowEvent;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
-import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListenerEventType;
-import java.util.Collection;
 import java.util.Optional;
 import org.camunda.bpm.model.xml.validation.ModelElementValidator;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
@@ -56,29 +50,6 @@ public class IntermediateThrowEventValidator
             "A compensation intermediate throwing event waitForCompletion attribute must be true or not present");
       }
     }
-
-    validateExecutionListenersDefinitionForElement(
-        element,
-        validationResultCollector,
-        listeners -> {
-          final Collection<EventDefinition> eventDefinitions = element.getEventDefinitions();
-          eventDefinitions.stream()
-              .findFirst()
-              .ifPresent(
-                  eventDefinition -> {
-                    if (eventDefinition instanceof EscalationEventDefinition) {
-                      final boolean endExecutionListenersDefined =
-                          listeners.stream()
-                              .map(ZeebeExecutionListener::getEventType)
-                              .anyMatch(ZeebeExecutionListenerEventType.end::equals);
-                      if (endExecutionListenersDefined) {
-                        validationResultCollector.addError(
-                            0,
-                            "Execution listeners of type 'end' are not supported by [escalation] intermediate throw events");
-                      }
-                    }
-                  });
-        });
   }
 
   private Optional<CompensateEventDefinition> getEventDefinition(


### PR DESCRIPTION
## Description
This pull request introduces support for `end` Execution Listeners for escalation Intermediate Throw and End events. By enabling this feature, we enhance the flexibility and control over workflow processes, allowing custom logic execution.

### Changes included:
1. Implementation:
   - Enabled `end` Execution Listener support for escalation intermediate throw events.
   - Enabled `end` Execution Listener support for escalation end events.
2. Testing:
   - Added unit tests to ensure the correct behaviour of `end` Execution Listeners for escalation Intermediate Throw and End events.
   - Verified that the `end` listeners are not executed in scenarios where the escalation catch event is interrupting.

### Limitations:
   - `End` listeners for escalation Intermediate Throw and End events will not be executed if the escalation catch event is configured as interrupting. In such cases, the processing of these event elements will be terminated immediately after activation.

## Related issues
closes #19813 
