### PR TITLE
ci: remove GH comments for Operate CI

### DIFF
--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -98,14 +98,6 @@ jobs:
           ${{ inputs.command }}
 
       # Reports: publish test metrics results
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.16.1
-        if: ${{ (success() || failure()) }}
-        with:
-          check_name: "Operate ${{ inputs.test-type }} Results"
-          files: |
-            operate/**/target/*-reports/*.xml
-            !operate/**/target/*-reports/*-summary.xml
       - name: Upload Test Report
         if: ${{ (success() || failure()) }}
         uses: ./.github/actions/collect-operate-test-artifacts

--- a/.github/workflows/operate-run-tests.yml
+++ b/.github/workflows/operate-run-tests.yml
@@ -47,16 +47,6 @@ jobs:
         run: mvn -B -T1C -DskipChecks -DskipTests -P skipFrontendBuild clean install
       - name: Run Tests
         run: ${{ inputs.command }}
-      - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2.16.1
-        if: always()
-        with:
-          comment_mode: off
-          report_individual_runs: true
-          report_suite_logs: error
-          check_name: "Operate Test Results"
-          files: |
-            operate/**/target/surefire-reports/*.xml
       - name: Send Slack notification on failure
         if: failure()
         uses: slackapi/slack-github-action@v1.26.0


### PR DESCRIPTION
## Description

 Adding github comments on the executed Test count, brings no
 additional value. Teams are not consuming it, and it is polluting
 the PR conversations with unnecessary data that is also accessible via
 PR status checks.
<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues
related slack conv https://camunda.slack.com/archives/C9B5270DA/p1719477984701329
