### PR TITLE
feat: install jdk instead of jre [Operate]

### DIFF
--- a/operate.Dockerfile
+++ b/operate.Dockerfile
@@ -60,7 +60,7 @@ LABEL io.k8s.description="Tool for process observability and troubleshooting pro
 EXPOSE 8080
 
 RUN apk update && apk upgrade
-RUN apk add --no-cache bash openjdk21-jre tzdata
+RUN apk add --no-cache bash openjdk21-jdk tzdata
 
 ENV OPE_HOME=/usr/local/operate
 


### PR DESCRIPTION
## Description

> [!NOTE]
> This is just an proposal, feel free to reject this.

This PR changes the installation of JRE to JDK.
Installing the JDK brings us some more tools like jcmd, jmap, etc.

This can allows us during incidents, to create heap dumps, thread dumps, profile the JVM via jfr, etc. For example where it was recently needed [here](https://camunda.slack.com/archives/C077P3F763X/p1719484461257309?thread_ts=1719468455.709519&cid=C077P3F763X).

### Example:

When we have the tools installed we can do something like:

```
# find the pid of the JVM process 
jcmd

# Start flight recording; will complete after 100 seconds and write to a file
jcmd 7 JFR.start duration=100s filename=flight.jfr

# Copy from pod
k cp <pod>:/usr/local/operate/flight.jfr /tmp/flight.jfr
```

Without changing the image, nor installing separate dependencies, etc.

### Some key metadata:

 * The jdk is installed 10 mb (5 times bigger) https://pkgs.alpinelinux.org/package/edge/community/s390x/openjdk21-jdk
 * The jre which is ~2MB https://pkgs.alpinelinux.org/package/edge/community/x86_64/openjdk21-jre


### Alternatives

#### Changing deployments

We leave it as it is, but it makes it debugging investing much harder. Especially as we have to change deployments, to get root permission to install the right tools, etc.

Example (for SM):

```json
{
    "spec": {
        "template": {
            "spec": {
                "containers": [
                    {
                        "name": "operate",
                        "securityContext": {
                            "readOnlyRootFilesystem": false,
                            "runAsNonRoot": false,
                            "runAsUser": 0
                        }
                    }
                ]
            }
        }
    }
}
```

Furthermore, we need to download then the right dependencies first:

```
# exec into the pod
k exec -it <pod> -- bash

apk upgrade # upgrade packages
apk add openjdk21-jdk # install the OpenJDK to get jcmd
```

#### Building own Image

[We can do it similar to what Zeebe does and build their own image](https://github.com/camunda/camunda/blob/main/Dockerfile)


<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues
See [slack](https://camunda.slack.com/archives/C077P3F763X/p1719480283965909?thread_ts=1719468455.709519&cid=C077P3F763X) and related incident 