### PR TITLE
fix: check concurrency mode per batch instead of per record

### DIFF
--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/EventZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/EventZeebeRecordProcessor.java
@@ -44,7 +44,6 @@ import io.camunda.operate.entities.ErrorType;
 import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.schema.templates.EventTemplate;
 import io.camunda.operate.store.BatchRequest;
-import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.util.DateUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -96,10 +95,10 @@ public class EventZeebeRecordProcessor {
 
   @Autowired private EventTemplate eventTemplate;
 
-  @Autowired private ImportStore importStore;
-
   public void processIncidentRecords(
-      final Map<Long, List<Record<IncidentRecordValue>>> records, final BatchRequest batchRequest)
+      final Map<Long, List<Record<IncidentRecordValue>>> records,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<IncidentRecordValue>> incidentRecords : records.values()) {
       processLastRecord(
@@ -108,13 +107,15 @@ public class EventZeebeRecordProcessor {
           rethrowConsumer(
               record -> {
                 final IncidentRecordValue recordValue = (IncidentRecordValue) record.getValue();
-                processIncident(record, recordValue, batchRequest);
+                processIncident(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
 
   public void processJobRecords(
-      final Map<Long, List<Record<JobRecordValue>>> records, final BatchRequest batchRequest)
+      final Map<Long, List<Record<JobRecordValue>>> records,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<JobRecordValue>> jobRecords : records.values()) {
       processLastRecord(
@@ -123,14 +124,15 @@ public class EventZeebeRecordProcessor {
           rethrowConsumer(
               record -> {
                 final JobRecordValue recordValue = (JobRecordValue) record.getValue();
-                processJob(record, recordValue, batchRequest);
+                processJob(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
 
   public void processProcessMessageSubscription(
       final Map<Long, List<Record<ProcessMessageSubscriptionRecordValue>>> records,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<ProcessMessageSubscriptionRecordValue>> pmsRecords : records.values()) {
       processLastRecord(
@@ -140,14 +142,15 @@ public class EventZeebeRecordProcessor {
               record -> {
                 final ProcessMessageSubscriptionRecordValue recordValue =
                     (ProcessMessageSubscriptionRecordValue) record.getValue();
-                processMessage(record, recordValue, batchRequest);
+                processMessage(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
 
   public void processProcessInstanceRecords(
       final Map<Long, List<Record<ProcessInstanceRecordValue>>> records,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<ProcessInstanceRecordValue>> piRecords : records.values()) {
       processLastRecord(
@@ -157,7 +160,7 @@ public class EventZeebeRecordProcessor {
               record -> {
                 final ProcessInstanceRecordValue recordValue =
                     (ProcessInstanceRecordValue) record.getValue();
-                processProcessInstance(record, recordValue, batchRequest);
+                processProcessInstance(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
@@ -180,7 +183,8 @@ public class EventZeebeRecordProcessor {
   private void processProcessInstance(
       final Record record,
       final ProcessInstanceRecordValue recordValue,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     if (!isProcessEvent(recordValue)) { // we do not need to store process level events
       final EventEntity eventEntity =
@@ -205,14 +209,16 @@ public class EventZeebeRecordProcessor {
         eventEntity.setFlowNodeInstanceKey(record.getKey());
       }
 
-      persistEvent(eventEntity, EventTemplate.POSITION, record.getPosition(), batchRequest);
+      persistEvent(
+          eventEntity, EventTemplate.POSITION, record.getPosition(), batchRequest, concurrencyMode);
     }
   }
 
   private void processMessage(
       final Record record,
       final ProcessMessageSubscriptionRecordValue recordValue,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final EventEntity eventEntity =
         new EventEntity()
@@ -247,11 +253,19 @@ public class EventZeebeRecordProcessor {
 
     eventEntity.setMetadata(eventMetadata);
 
-    persistEvent(eventEntity, EventTemplate.POSITION_MESSAGE, record.getPosition(), batchRequest);
+    persistEvent(
+        eventEntity,
+        EventTemplate.POSITION_MESSAGE,
+        record.getPosition(),
+        batchRequest,
+        concurrencyMode);
   }
 
   private void processJob(
-      final Record record, final JobRecordValue recordValue, final BatchRequest batchRequest)
+      final Record record,
+      final JobRecordValue recordValue,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final EventEntity eventEntity =
         new EventEntity()
@@ -301,11 +315,19 @@ public class EventZeebeRecordProcessor {
 
     eventEntity.setMetadata(eventMetadata);
 
-    persistEvent(eventEntity, EventTemplate.POSITION_JOB, record.getPosition(), batchRequest);
+    persistEvent(
+        eventEntity,
+        EventTemplate.POSITION_JOB,
+        record.getPosition(),
+        batchRequest,
+        concurrencyMode);
   }
 
   private void processIncident(
-      final Record record, final IncidentRecordValue recordValue, final BatchRequest batchRequest)
+      final Record record,
+      final IncidentRecordValue recordValue,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final EventEntity eventEntity =
         new EventEntity()
@@ -336,7 +358,12 @@ public class EventZeebeRecordProcessor {
             recordValue.getErrorType() == null ? null : recordValue.getErrorType().name()));
     eventEntity.setMetadata(eventMetadata);
 
-    persistEvent(eventEntity, EventTemplate.POSITION_INCIDENT, record.getPosition(), batchRequest);
+    persistEvent(
+        eventEntity,
+        EventTemplate.POSITION_INCIDENT,
+        record.getPosition(),
+        batchRequest,
+        concurrencyMode);
   }
 
   private boolean isProcessEvent(final ProcessInstanceRecordValue recordValue) {
@@ -366,7 +393,8 @@ public class EventZeebeRecordProcessor {
       final EventEntity entity,
       final String positionFieldName,
       final long positionFieldValue,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     LOGGER.debug(
         "Event: id {}, eventSourceType {}, eventType {}, processInstanceKey {}",
@@ -407,7 +435,6 @@ public class EventZeebeRecordProcessor {
       }
     }
 
-    final boolean concurrencyMode = importStore.getConcurrencyMode();
     // write event
     if (concurrencyMode) {
       batchRequest.upsertWithScript(

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/IncidentZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/IncidentZeebeRecordProcessor.java
@@ -30,7 +30,6 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.IncidentTemplate;
 import io.camunda.operate.schema.templates.PostImporterQueueTemplate;
 import io.camunda.operate.store.BatchRequest;
-import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
 import io.camunda.operate.util.OperationsManager;
@@ -60,19 +59,18 @@ public class IncidentZeebeRecordProcessor {
 
   @Autowired private IncidentTemplate incidentTemplate;
 
-  @Autowired private ImportStore importStore;
-
   @Autowired private PostImporterQueueTemplate postImporterQueueTemplate;
 
   @Autowired private OperationsManager operationsManager;
 
   @Autowired private IncidentNotifier incidentNotifier;
 
-  public void processIncidentRecord(final List<Record> records, final BatchRequest batchRequest)
+  public void processIncidentRecord(
+      final List<Record> records, final BatchRequest batchRequest, final boolean concurrencyMode)
       throws PersistenceException {
     final List<IncidentEntity> newIncidents = new ArrayList<>();
     for (final Record record : records) {
-      processIncidentRecord(record, batchRequest, newIncidents::add);
+      processIncidentRecord(record, batchRequest, newIncidents::add, concurrencyMode);
     }
     if (operateProperties.getAlert().getWebhook() != null) {
       incidentNotifier.notifyOnIncidents(newIncidents);
@@ -82,11 +80,12 @@ public class IncidentZeebeRecordProcessor {
   public void processIncidentRecord(
       final Record record,
       final BatchRequest batchRequest,
-      final Consumer<IncidentEntity> newIncidentHandler)
+      final Consumer<IncidentEntity> newIncidentHandler,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final IncidentRecordValue recordValue = (IncidentRecordValue) record.getValue();
 
-    persistIncident(record, recordValue, batchRequest, newIncidentHandler);
+    persistIncident(record, recordValue, batchRequest, newIncidentHandler, concurrencyMode);
 
     persistPostImportQueueEntry(record, recordValue, batchRequest);
   }
@@ -117,7 +116,8 @@ public class IncidentZeebeRecordProcessor {
       final Record record,
       final IncidentRecordValue recordValue,
       final BatchRequest batchRequest,
-      final Consumer<IncidentEntity> newIncidentHandler)
+      final Consumer<IncidentEntity> newIncidentHandler,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final String intentStr = record.getIntent().name();
     final Long incidentKey = record.getKey();
@@ -167,7 +167,6 @@ public class IncidentZeebeRecordProcessor {
 
       final Map<String, Object> updateFields = getUpdateFieldsMapByIntent(intentStr, incident);
       updateFields.put(POSITION, incident.getPosition());
-      final boolean concurrencyMode = importStore.getConcurrencyMode();
       if (concurrencyMode) {
         batchRequest.upsertWithScript(
             incidentTemplate.getFullQualifiedName(),

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/ListViewZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/ListViewZeebeRecordProcessor.java
@@ -50,7 +50,6 @@ import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.ListViewTemplate;
 import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.FlowNodeStore;
-import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.store.ListViewStore;
 import io.camunda.operate.store.MetricsStore;
 import io.camunda.operate.util.*;
@@ -105,8 +104,6 @@ public class ListViewZeebeRecordProcessor {
 
   @Autowired private MetricsStore metricsStore;
 
-  @Autowired private ImportStore importStore;
-
   // treePath by processInstanceKey cache
   private Map<String, String> treePathCache;
   // flowNodeId by flowNodeInstanceId cache for call activities
@@ -135,7 +132,8 @@ public class ListViewZeebeRecordProcessor {
     return callActivityIdCache;
   }
 
-  public void processIncidentRecord(final Record record, final BatchRequest batchRequest)
+  public void processIncidentRecord(
+      final Record record, final BatchRequest batchRequest, final boolean concurrencyMode)
       throws PersistenceException {
 
     final String intentStr = record.getIntent().name();
@@ -166,8 +164,6 @@ public class ListViewZeebeRecordProcessor {
     updateFields.put(ERROR_MSG, entity.getErrorMessage());
     updateFields.put(INCIDENT_POSITION, entity.getPositionIncident());
 
-    final boolean concurrencyMode = importStore.getConcurrencyMode();
-
     if (concurrencyMode) {
       batchRequest.upsertWithScriptAndRouting(
           listViewTemplate.getFullQualifiedName(),
@@ -188,7 +184,8 @@ public class ListViewZeebeRecordProcessor {
 
   public void processVariableRecords(
       final Map<Long, List<Record<VariableRecordValue>>> variablesGroupedByScopeKey,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final var variableRecords : variablesGroupedByScopeKey.entrySet()) {
       final var temporaryVariableCache =
@@ -222,8 +219,6 @@ public class ListViewZeebeRecordProcessor {
         updateFields.put(VAR_VALUE, variableEntity.getVarValue());
         updateFields.put(POSITION, variableEntity.getPosition());
 
-        final boolean concurrencyMode = importStore.getConcurrencyMode();
-
         if (concurrencyMode) {
           batchRequest.upsertWithScriptAndRouting(
               listViewTemplate.getFullQualifiedName(),
@@ -247,10 +242,9 @@ public class ListViewZeebeRecordProcessor {
   public void processProcessInstanceRecord(
       final Map<Long, List<Record<ProcessInstanceRecordValue>>> records,
       final BatchRequest batchRequest,
-      final ImportBatch importBatch)
+      final ImportBatch importBatch,
+      final boolean concurrencyMode)
       throws PersistenceException {
-
-    final boolean concurrencyMode = importStore.getConcurrencyMode();
 
     final Map<String, String> treePathMap = new HashMap<>();
     for (final Map.Entry<Long, List<Record<ProcessInstanceRecordValue>>> wiRecordsEntry :
@@ -444,14 +438,16 @@ public class ListViewZeebeRecordProcessor {
   }
 
   public void processJobRecords(
-      final Map<Long, List<Record<JobRecordValue>>> records, final BatchRequest batchRequest)
+      final Map<Long, List<Record<JobRecordValue>>> records,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<JobRecordValue>> jobRecords : records.values()) {
       processLastRecord(
           jobRecords,
           rethrowConsumer(
               record -> {
-                updateFlowNodeInstanceFromJob(record, batchRequest);
+                updateFlowNodeInstanceFromJob(record, batchRequest, concurrencyMode);
               }));
     }
   }
@@ -615,7 +611,9 @@ public class ListViewZeebeRecordProcessor {
   }
 
   private void updateFlowNodeInstanceFromJob(
-      final Record<JobRecordValue> record, final BatchRequest batchRequest)
+      final Record<JobRecordValue> record,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final FlowNodeInstanceForListViewEntity entity = new FlowNodeInstanceForListViewEntity();
 
@@ -645,7 +643,7 @@ public class ListViewZeebeRecordProcessor {
     updateFields.put(JOB_FAILED_WITH_RETRIES_LEFT, entity.isJobFailedWithRetriesLeft());
     updateFields.put(JOB_POSITION, entity.getPositionJob());
 
-    if (importStore.getConcurrencyMode()) {
+    if (concurrencyMode) {
       batchRequest.upsertWithScriptAndRouting(
           listViewTemplate.getFullQualifiedName(),
           entity.getId(),

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/VariableZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/VariableZeebeRecordProcessor.java
@@ -30,7 +30,6 @@ import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.VariableTemplate;
 import io.camunda.operate.store.BatchRequest;
-import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.util.Tuple;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -49,13 +48,12 @@ public class VariableZeebeRecordProcessor {
 
   @Autowired private VariableTemplate variableTemplate;
 
-  @Autowired private ImportStore importStore;
-
   @Autowired private OperateProperties operateProperties;
 
   public void processVariableRecords(
       final Map<Long, List<Record<VariableRecordValue>>> variablesGroupedByScopeKey,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final var variableRecords : variablesGroupedByScopeKey.entrySet()) {
       final var temporaryVariableCache = new HashMap<String, Tuple<Intent, VariableEntity>>();
@@ -94,7 +92,6 @@ public class VariableZeebeRecordProcessor {
           updateFields.put(BPMN_PROCESS_ID, variableEntity.getBpmnProcessId());
         }
 
-        final boolean concurrencyMode = importStore.getConcurrencyMode();
         if (concurrencyMode) {
           batchRequest.upsertWithScript(
               variableTemplate.getFullQualifiedName(),

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/EventZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/EventZeebeRecordProcessor.java
@@ -44,7 +44,6 @@ import io.camunda.operate.entities.ErrorType;
 import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.schema.templates.EventTemplate;
 import io.camunda.operate.store.BatchRequest;
-import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.util.DateUtil;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
@@ -96,10 +95,16 @@ public class EventZeebeRecordProcessor {
 
   @Autowired private EventTemplate eventTemplate;
 
-  @Autowired private ImportStore importStore;
-
   public void processIncidentRecords(
       final Map<Long, List<Record<IncidentRecordValue>>> records, final BatchRequest batchRequest)
+      throws PersistenceException {
+    processIncidentRecords(records, batchRequest, false);
+  }
+
+  public void processIncidentRecords(
+      final Map<Long, List<Record<IncidentRecordValue>>> records,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<IncidentRecordValue>> incidentRecords : records.values()) {
       processLastRecord(
@@ -108,13 +113,21 @@ public class EventZeebeRecordProcessor {
           rethrowConsumer(
               record -> {
                 final IncidentRecordValue recordValue = (IncidentRecordValue) record.getValue();
-                processIncident(record, recordValue, batchRequest);
+                processIncident(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
 
   public void processJobRecords(
       final Map<Long, List<Record<JobRecordValue>>> records, final BatchRequest batchRequest)
+      throws PersistenceException {
+    processJobRecords(records, batchRequest, false);
+  }
+
+  public void processJobRecords(
+      final Map<Long, List<Record<JobRecordValue>>> records,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<JobRecordValue>> jobRecords : records.values()) {
       processLastRecord(
@@ -123,7 +136,7 @@ public class EventZeebeRecordProcessor {
           rethrowConsumer(
               record -> {
                 final JobRecordValue recordValue = (JobRecordValue) record.getValue();
-                processJob(record, recordValue, batchRequest);
+                processJob(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
@@ -131,6 +144,14 @@ public class EventZeebeRecordProcessor {
   public void processProcessMessageSubscription(
       final Map<Long, List<Record<ProcessMessageSubscriptionRecordValue>>> records,
       final BatchRequest batchRequest)
+      throws PersistenceException {
+    processProcessMessageSubscription(records, batchRequest, false);
+  }
+
+  public void processProcessMessageSubscription(
+      final Map<Long, List<Record<ProcessMessageSubscriptionRecordValue>>> records,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<ProcessMessageSubscriptionRecordValue>> pmsRecords : records.values()) {
       processLastRecord(
@@ -140,7 +161,7 @@ public class EventZeebeRecordProcessor {
               record -> {
                 final ProcessMessageSubscriptionRecordValue recordValue =
                     (ProcessMessageSubscriptionRecordValue) record.getValue();
-                processMessage(record, recordValue, batchRequest);
+                processMessage(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
@@ -148,6 +169,14 @@ public class EventZeebeRecordProcessor {
   public void processProcessInstanceRecords(
       final Map<Long, List<Record<ProcessInstanceRecordValue>>> records,
       final BatchRequest batchRequest)
+      throws PersistenceException {
+    processProcessInstanceRecords(records, batchRequest, false);
+  }
+
+  public void processProcessInstanceRecords(
+      final Map<Long, List<Record<ProcessInstanceRecordValue>>> records,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final List<Record<ProcessInstanceRecordValue>> piRecords : records.values()) {
       processLastRecord(
@@ -157,7 +186,7 @@ public class EventZeebeRecordProcessor {
               record -> {
                 final ProcessInstanceRecordValue recordValue =
                     (ProcessInstanceRecordValue) record.getValue();
-                processProcessInstance(record, recordValue, batchRequest);
+                processProcessInstance(record, recordValue, batchRequest, concurrencyMode);
               }));
     }
   }
@@ -180,7 +209,8 @@ public class EventZeebeRecordProcessor {
   private void processProcessInstance(
       final Record record,
       final ProcessInstanceRecordValue recordValue,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     if (!isProcessEvent(recordValue)) { // we do not need to store process level events
       final EventEntity eventEntity =
@@ -205,14 +235,16 @@ public class EventZeebeRecordProcessor {
         eventEntity.setFlowNodeInstanceKey(record.getKey());
       }
 
-      persistEvent(eventEntity, EventTemplate.POSITION, record.getPosition(), batchRequest);
+      persistEvent(
+          eventEntity, EventTemplate.POSITION, record.getPosition(), batchRequest, concurrencyMode);
     }
   }
 
   private void processMessage(
       final Record record,
       final ProcessMessageSubscriptionRecordValue recordValue,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final EventEntity eventEntity =
         new EventEntity()
@@ -247,11 +279,19 @@ public class EventZeebeRecordProcessor {
 
     eventEntity.setMetadata(eventMetadata);
 
-    persistEvent(eventEntity, EventTemplate.POSITION_MESSAGE, record.getPosition(), batchRequest);
+    persistEvent(
+        eventEntity,
+        EventTemplate.POSITION_MESSAGE,
+        record.getPosition(),
+        batchRequest,
+        concurrencyMode);
   }
 
   private void processJob(
-      final Record record, final JobRecordValue recordValue, final BatchRequest batchRequest)
+      final Record record,
+      final JobRecordValue recordValue,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final EventEntity eventEntity =
         new EventEntity()
@@ -301,11 +341,19 @@ public class EventZeebeRecordProcessor {
 
     eventEntity.setMetadata(eventMetadata);
 
-    persistEvent(eventEntity, EventTemplate.POSITION_JOB, record.getPosition(), batchRequest);
+    persistEvent(
+        eventEntity,
+        EventTemplate.POSITION_JOB,
+        record.getPosition(),
+        batchRequest,
+        concurrencyMode);
   }
 
   private void processIncident(
-      final Record record, final IncidentRecordValue recordValue, final BatchRequest batchRequest)
+      final Record record,
+      final IncidentRecordValue recordValue,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final EventEntity eventEntity =
         new EventEntity()
@@ -336,7 +384,12 @@ public class EventZeebeRecordProcessor {
             recordValue.getErrorType() == null ? null : recordValue.getErrorType().name()));
     eventEntity.setMetadata(eventMetadata);
 
-    persistEvent(eventEntity, EventTemplate.POSITION_INCIDENT, record.getPosition(), batchRequest);
+    persistEvent(
+        eventEntity,
+        EventTemplate.POSITION_INCIDENT,
+        record.getPosition(),
+        batchRequest,
+        concurrencyMode);
   }
 
   private boolean isProcessEvent(final ProcessInstanceRecordValue recordValue) {
@@ -366,7 +419,8 @@ public class EventZeebeRecordProcessor {
       final EventEntity entity,
       final String positionFieldName,
       final long positionFieldValue,
-      final BatchRequest batchRequest)
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     LOGGER.debug(
         "Event: id {}, eventSourceType {}, eventType {}, processInstanceKey {}",
@@ -407,7 +461,6 @@ public class EventZeebeRecordProcessor {
       }
     }
 
-    final boolean concurrencyMode = importStore.getConcurrencyMode();
     // write event
     if (concurrencyMode) {
       batchRequest.upsertWithScript(

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/ImportBulkProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/ImportBulkProcessor.java
@@ -26,6 +26,7 @@ import io.camunda.operate.entities.HitEntity;
 import io.camunda.operate.exceptions.OperateRuntimeException;
 import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.store.BatchRequest;
+import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.util.CollectionUtil;
 import io.camunda.operate.zeebe.ImportValueType;
 import io.camunda.operate.zeebeimport.AbstractImportBatchProcessor;
@@ -79,6 +80,8 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
 
   @Autowired private ObjectMapper objectMapper;
 
+  @Autowired private ImportStore importStore;
+
   private ObjectMapper localObjectMapper;
 
   private static <T> T fromSearchHit(
@@ -117,6 +120,8 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
         importBatch.getImportValueType(),
         importBatch.getPartitionId());
 
+    final boolean concurrencyMode = importStore.getConcurrencyMode();
+
     final ImportValueType importValueType = importBatch.getImportValueType();
     switch (importValueType) {
       case DECISION:
@@ -129,13 +134,13 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
         processDecisionEvaluationRecords(batchRequest, zeebeRecords);
         break;
       case PROCESS_INSTANCE:
-        processProcessInstanceRecords(importBatch, batchRequest, zeebeRecords);
+        processProcessInstanceRecords(importBatch, batchRequest, zeebeRecords, concurrencyMode);
         break;
       case INCIDENT:
-        processIncidentRecords(batchRequest, zeebeRecords);
+        processIncidentRecords(batchRequest, zeebeRecords, concurrencyMode);
         break;
       case VARIABLE:
-        processVariableRecords(batchRequest, zeebeRecords);
+        processVariableRecords(batchRequest, zeebeRecords, concurrencyMode);
         break;
       case VARIABLE_DOCUMENT:
         processVariableDocumentRecords(batchRequest, zeebeRecords);
@@ -144,10 +149,10 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
         processProcessRecords(batchRequest, zeebeRecords);
         break;
       case JOB:
-        processJobRecords(batchRequest, zeebeRecords);
+        processJobRecords(batchRequest, zeebeRecords, concurrencyMode);
         break;
       case PROCESS_MESSAGE_SUBSCRIPTION:
-        processProcessMessageSubscription(batchRequest, zeebeRecords);
+        processProcessMessageSubscription(batchRequest, zeebeRecords, concurrencyMode);
         break;
       case USER_TASK:
         processUserTask(batchRequest, zeebeRecords);
@@ -175,7 +180,9 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
   }
 
   private void processProcessMessageSubscription(
-      final BatchRequest batchRequest, final List<Record> zeebeRecords)
+      final BatchRequest batchRequest,
+      final List<Record> zeebeRecords,
+      final boolean concurrencyMode)
       throws PersistenceException {
     // per flow node instance
     final Map<Long, List<Record<ProcessMessageSubscriptionRecordValue>>>
@@ -184,7 +191,7 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
                 .map(obj -> (Record<ProcessMessageSubscriptionRecordValue>) obj)
                 .collect(Collectors.groupingBy(obj -> obj.getValue().getElementInstanceKey()));
     eventZeebeRecordProcessor.processProcessMessageSubscription(
-        groupedRecordsPerFlowNodeInst, batchRequest);
+        groupedRecordsPerFlowNodeInst, batchRequest, concurrencyMode);
   }
 
   private ObjectMapper getLocalObjectMapper() {
@@ -221,15 +228,20 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
     }
   }
 
-  private void processJobRecords(final BatchRequest batchRequest, final List<Record> zeebeRecords)
+  private void processJobRecords(
+      final BatchRequest batchRequest,
+      final List<Record> zeebeRecords,
+      final boolean concurrencyMode)
       throws PersistenceException {
     // per activity
     final Map<Long, List<Record<JobRecordValue>>> groupedJobRecordsPerActivityInst =
         zeebeRecords.stream()
             .map(obj -> (Record<JobRecordValue>) obj)
             .collect(Collectors.groupingBy(obj -> obj.getValue().getElementInstanceKey()));
-    listViewZeebeRecordProcessor.processJobRecords(groupedJobRecordsPerActivityInst, batchRequest);
-    eventZeebeRecordProcessor.processJobRecords(groupedJobRecordsPerActivityInst, batchRequest);
+    listViewZeebeRecordProcessor.processJobRecords(
+        groupedJobRecordsPerActivityInst, batchRequest, concurrencyMode);
+    eventZeebeRecordProcessor.processJobRecords(
+        groupedJobRecordsPerActivityInst, batchRequest, concurrencyMode);
   }
 
   private void processProcessRecords(
@@ -250,7 +262,9 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
   }
 
   private void processVariableRecords(
-      final BatchRequest batchRequest, final List<Record> zeebeRecords)
+      final BatchRequest batchRequest,
+      final List<Record> zeebeRecords,
+      final boolean concurrencyMode)
       throws PersistenceException {
 
     final var variablesGroupedByScopeKey =
@@ -258,17 +272,21 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
             .map(obj -> (Record<VariableRecordValue>) obj)
             .collect(Collectors.groupingBy(obj -> obj.getValue().getScopeKey()));
 
-    listViewZeebeRecordProcessor.processVariableRecords(variablesGroupedByScopeKey, batchRequest);
-    variableZeebeRecordProcessor.processVariableRecords(variablesGroupedByScopeKey, batchRequest);
+    listViewZeebeRecordProcessor.processVariableRecords(
+        variablesGroupedByScopeKey, batchRequest, concurrencyMode);
+    variableZeebeRecordProcessor.processVariableRecords(
+        variablesGroupedByScopeKey, batchRequest, concurrencyMode);
   }
 
   private void processIncidentRecords(
-      final BatchRequest batchRequest, final List<Record> zeebeRecords)
+      final BatchRequest batchRequest,
+      final List<Record> zeebeRecords,
+      final boolean concurrencyMode)
       throws PersistenceException {
     // old style
-    incidentZeebeRecordProcessor.processIncidentRecord(zeebeRecords, batchRequest);
+    incidentZeebeRecordProcessor.processIncidentRecord(zeebeRecords, batchRequest, concurrencyMode);
     for (final Record record : zeebeRecords) {
-      listViewZeebeRecordProcessor.processIncidentRecord(record, batchRequest);
+      listViewZeebeRecordProcessor.processIncidentRecord(record, batchRequest, concurrencyMode);
       flowNodeInstanceZeebeRecordProcessor.processIncidentRecord(record, batchRequest);
     }
     final Map<Long, List<Record<IncidentRecordValue>>> groupedIncidentRecordsPerActivityInst =
@@ -276,13 +294,14 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
             .map(obj -> (Record<IncidentRecordValue>) obj)
             .collect(Collectors.groupingBy(obj -> obj.getValue().getElementInstanceKey()));
     eventZeebeRecordProcessor.processIncidentRecords(
-        groupedIncidentRecordsPerActivityInst, batchRequest);
+        groupedIncidentRecordsPerActivityInst, batchRequest, concurrencyMode);
   }
 
   private void processProcessInstanceRecords(
       final ImportBatch importBatch,
       final BatchRequest batchRequest,
-      final List<Record> zeebeRecords)
+      final List<Record> zeebeRecords,
+      final boolean concurrencyMode)
       throws PersistenceException {
     final Map<Long, List<Record<ProcessInstanceRecordValue>>> groupedWIRecords =
         zeebeRecords.stream()
@@ -293,7 +312,7 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
                     CollectionUtil.addToMap(map, item.getValue().getProcessInstanceKey(), item),
                 Map::putAll);
     listViewZeebeRecordProcessor.processProcessInstanceRecord(
-        groupedWIRecords, batchRequest, importBatch);
+        groupedWIRecords, batchRequest, importBatch, concurrencyMode);
     final Map<Long, List<Record<ProcessInstanceRecordValue>>> groupedWIRecordsPerActivityInst =
         zeebeRecords.stream()
             .map(obj -> (Record<ProcessInstanceRecordValue>) obj)
@@ -303,7 +322,7 @@ public class ImportBulkProcessor extends AbstractImportBatchProcessor {
     flowNodeInstanceZeebeRecordProcessor.processProcessInstanceRecord(
         groupedWIRecordsPerActivityInst, flowNodeInstanceKeysOrdered, batchRequest);
     eventZeebeRecordProcessor.processProcessInstanceRecords(
-        groupedWIRecordsPerActivityInst, batchRequest);
+        groupedWIRecordsPerActivityInst, batchRequest, concurrencyMode);
     for (final Record record : zeebeRecords) {
       sequenceFlowZeebeRecordProcessor.processSequenceFlowRecord(record, batchRequest);
     }

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/VariableZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/VariableZeebeRecordProcessor.java
@@ -30,7 +30,6 @@ import io.camunda.operate.exceptions.PersistenceException;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.templates.VariableTemplate;
 import io.camunda.operate.store.BatchRequest;
-import io.camunda.operate.store.ImportStore;
 import io.camunda.operate.util.Tuple;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.Intent;
@@ -49,13 +48,19 @@ public class VariableZeebeRecordProcessor {
 
   @Autowired private VariableTemplate variableTemplate;
 
-  @Autowired private ImportStore importStore;
-
   @Autowired private OperateProperties operateProperties;
 
   public void processVariableRecords(
       final Map<Long, List<Record<VariableRecordValue>>> variablesGroupedByScopeKey,
       final BatchRequest batchRequest)
+      throws PersistenceException {
+    processVariableRecords(variablesGroupedByScopeKey, batchRequest, false);
+  }
+
+  public void processVariableRecords(
+      final Map<Long, List<Record<VariableRecordValue>>> variablesGroupedByScopeKey,
+      final BatchRequest batchRequest,
+      final boolean concurrencyMode)
       throws PersistenceException {
     for (final var variableRecords : variablesGroupedByScopeKey.entrySet()) {
       final var temporaryVariableCache = new HashMap<String, Tuple<Intent, VariableEntity>>();
@@ -94,7 +99,6 @@ public class VariableZeebeRecordProcessor {
           updateFields.put(BPMN_PROCESS_ID, variableEntity.getBpmnProcessId());
         }
 
-        final boolean concurrencyMode = importStore.getConcurrencyMode();
         if (concurrencyMode) {
           batchRequest.upsertWithScript(
               variableTemplate.getFullQualifiedName(),

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/EventZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/EventZeebeRecordProcessorIT.java
@@ -50,7 +50,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +65,6 @@ public class EventZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   @Autowired private BeanFactory beanFactory;
   @MockBean private PartitionHolder partitionHolder;
   @Autowired private ImportPositionHolder importPositionHolder;
-  private boolean concurrencyModeBefore;
   private final String jobType = "createOrder";
   private final String jobWorker = "someWorker";
   private final int jobRetries = 2;
@@ -78,15 +76,6 @@ public class EventZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   @Override
   protected void runAdditionalBeforeAllSetup() throws Exception {
     when(partitionHolder.getPartitionIds()).thenReturn(List.of(1));
-    concurrencyModeBefore = importPositionHolder.getConcurrencyMode();
-    importPositionHolder.setConcurrencyMode(true);
-  }
-
-  @Override
-  @AfterAll
-  public void afterAllTeardown() {
-    importPositionHolder.setConcurrencyMode(concurrencyModeBefore);
-    super.afterAllTeardown();
   }
 
   @Test
@@ -583,7 +572,9 @@ public class EventZeebeRecordProcessorIT extends OperateSearchAbstractIT {
       throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
     eventZeebeRecordProcessor.processIncidentRecords(
-        Map.of(zeebeRecord.getValue().getElementInstanceKey(), List.of(zeebeRecord)), batchRequest);
+        Map.of(zeebeRecord.getValue().getElementInstanceKey(), List.of(zeebeRecord)),
+        batchRequest,
+        true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(eventTemplate.getFullQualifiedName());
   }
@@ -592,7 +583,9 @@ public class EventZeebeRecordProcessorIT extends OperateSearchAbstractIT {
       throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
     eventZeebeRecordProcessor.processJobRecords(
-        Map.of(zeebeRecord.getValue().getElementInstanceKey(), List.of(zeebeRecord)), batchRequest);
+        Map.of(zeebeRecord.getValue().getElementInstanceKey(), List.of(zeebeRecord)),
+        batchRequest,
+        true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(eventTemplate.getFullQualifiedName());
   }
@@ -601,7 +594,9 @@ public class EventZeebeRecordProcessorIT extends OperateSearchAbstractIT {
       final Record<ProcessMessageSubscriptionRecordValue> zeebeRecord) throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
     eventZeebeRecordProcessor.processProcessMessageSubscription(
-        Map.of(zeebeRecord.getValue().getElementInstanceKey(), List.of(zeebeRecord)), batchRequest);
+        Map.of(zeebeRecord.getValue().getElementInstanceKey(), List.of(zeebeRecord)),
+        batchRequest,
+        true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(eventTemplate.getFullQualifiedName());
   }
@@ -610,7 +605,7 @@ public class EventZeebeRecordProcessorIT extends OperateSearchAbstractIT {
       final Record<ProcessInstanceRecordValue> zeebeRecord) throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
     eventZeebeRecordProcessor.processProcessInstanceRecords(
-        Map.of(zeebeRecord.getKey(), List.of(zeebeRecord)), batchRequest);
+        Map.of(zeebeRecord.getKey(), List.of(zeebeRecord)), batchRequest, true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(eventTemplate.getFullQualifiedName());
   }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/IncidentZeebeRecordProcessorIT.java
@@ -36,7 +36,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,20 +51,10 @@ public class IncidentZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   @Autowired private BeanFactory beanFactory;
   @MockBean private PartitionHolder partitionHolder;
   @Autowired private ImportPositionHolder importPositionHolder;
-  private boolean concurrencyModeBefore;
 
   @Override
   protected void runAdditionalBeforeAllSetup() throws Exception {
     when(partitionHolder.getPartitionIds()).thenReturn(List.of(1));
-    concurrencyModeBefore = importPositionHolder.getConcurrencyMode();
-    importPositionHolder.setConcurrencyMode(true);
-  }
-
-  @Override
-  @AfterAll
-  public void afterAllTeardown() {
-    importPositionHolder.setConcurrencyMode(concurrencyModeBefore);
-    super.afterAllTeardown();
   }
 
   @Test
@@ -185,7 +174,7 @@ public class IncidentZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   private void importIncidentZeebeRecord(final Record<IncidentRecordValue> zeebeRecord)
       throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
-    incidentZeebeRecordProcessor.processIncidentRecord(List.of(zeebeRecord), batchRequest);
+    incidentZeebeRecordProcessor.processIncidentRecord(List.of(zeebeRecord), batchRequest, true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(incidentTemplate.getFullQualifiedName());
   }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/ListViewZeebeRecordProcessorIT.java
@@ -739,7 +739,8 @@ public class ListViewZeebeRecordProcessorIT extends OperateSearchAbstractIT {
     listViewZeebeRecordProcessor.processProcessInstanceRecord(
         (Map) Map.of(zeebeRecord.getKey(), List.of(zeebeRecord)),
         batchRequest,
-        mock(ImportBatch.class));
+        mock(ImportBatch.class),
+        true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(listViewTemplate.getFullQualifiedName());
   }
@@ -747,7 +748,7 @@ public class ListViewZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   private void importIncidentZeebeRecord(final Record<IncidentRecordValue> zeebeRecord)
       throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
-    listViewZeebeRecordProcessor.processIncidentRecord(zeebeRecord, batchRequest);
+    listViewZeebeRecordProcessor.processIncidentRecord(zeebeRecord, batchRequest, true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(listViewTemplate.getFullQualifiedName());
   }
@@ -756,7 +757,7 @@ public class ListViewZeebeRecordProcessorIT extends OperateSearchAbstractIT {
       throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
     listViewZeebeRecordProcessor.processVariableRecords(
-        (Map) Map.of(zeebeRecord.getKey(), List.of(zeebeRecord)), batchRequest);
+        (Map) Map.of(zeebeRecord.getKey(), List.of(zeebeRecord)), batchRequest, true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(listViewTemplate.getFullQualifiedName());
   }
@@ -765,7 +766,7 @@ public class ListViewZeebeRecordProcessorIT extends OperateSearchAbstractIT {
       throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
     listViewZeebeRecordProcessor.processJobRecords(
-        (Map) Map.of(zeebeRecord.getKey(), List.of(zeebeRecord)), batchRequest);
+        (Map) Map.of(zeebeRecord.getKey(), List.of(zeebeRecord)), batchRequest, true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(listViewTemplate.getFullQualifiedName());
   }

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/VariableZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/VariableZeebeRecordProcessorIT.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,21 +48,11 @@ public class VariableZeebeRecordProcessorIT extends OperateSearchAbstractIT {
   @Autowired private BeanFactory beanFactory;
   @MockBean private PartitionHolder partitionHolder;
   @Autowired private ImportPositionHolder importPositionHolder;
-  private boolean concurrencyModeBefore;
   private final String newVarValue = "newVarValue";
 
   @Override
   protected void runAdditionalBeforeAllSetup() throws Exception {
     when(partitionHolder.getPartitionIds()).thenReturn(List.of(1));
-    concurrencyModeBefore = importPositionHolder.getConcurrencyMode();
-    importPositionHolder.setConcurrencyMode(true);
-  }
-
-  @Override
-  @AfterAll
-  public void afterAllTeardown() {
-    importPositionHolder.setConcurrencyMode(concurrencyModeBefore);
-    super.afterAllTeardown();
   }
 
   @Test
@@ -176,7 +165,7 @@ public class VariableZeebeRecordProcessorIT extends OperateSearchAbstractIT {
       throws PersistenceException {
     final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
     variableZeebeRecordProcessor.processVariableRecords(
-        Map.of(zeebeRecord.getValue().getScopeKey(), List.of(zeebeRecord)), batchRequest);
+        Map.of(zeebeRecord.getValue().getScopeKey(), List.of(zeebeRecord)), batchRequest, true);
     batchRequest.execute();
     searchContainerManager.refreshIndices(variableTemplate.getFullQualifiedName());
   }


### PR DESCRIPTION
fix: check concurrency mode per batch instead of per record

related with #19840

This PR is based on version 8.5.4 and will be used for hotfixing one specific cluster. The fix for the patch version will follow.