### PR TITLE
refactor: user list call to use the search endpoint

### DIFF
--- a/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
@@ -4,7 +4,7 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignGroupMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api/hooks";
-import { postUserSearch, User } from "src/utility/api/users";
+import { searchUser, User } from "src/utility/api/users";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
@@ -27,7 +27,7 @@ const AssignMembersModal: FC<
     loading,
     reload,
     errors,
-  } = useApi(postUserSearch);
+  } = useApi(searchUser);
   const [callAssignUser] = useApiCall(assignGroupMember);
 
   const unassignedUsers =

--- a/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
+++ b/identity/client/src/pages/groups/detail/members/AssignMembersModal.tsx
@@ -4,7 +4,7 @@ import { UseEntityModalCustomProps } from "src/components/modal";
 import { assignGroupMember } from "src/utility/api/membership";
 import useTranslate from "src/utility/localization";
 import { useApi, useApiCall } from "src/utility/api/hooks";
-import { getUsers, User } from "src/utility/api/users";
+import { postUserSearch, User } from "src/utility/api/users";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import styled from "styled-components";
 import DropdownSearch from "src/components/form/DropdownSearch";
@@ -22,11 +22,16 @@ const AssignMembersModal: FC<
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
   const [loadingAssignUser, setLoadingAssignUser] = useState(false);
 
-  const { data: users, loading, reload, errors } = useApi(getUsers);
+  const {
+    data: userSearchResults,
+    loading,
+    reload,
+    errors,
+  } = useApi(postUserSearch);
   const [callAssignUser] = useApiCall(assignGroupMember);
 
   const unassignedUsers =
-    users?.filter(
+    userSearchResults?.items.filter(
       ({ id }) =>
         !assignedUsers.some((user) => user.id === id) &&
         !selectedUsers.some((user) => user.id === id),

--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -16,7 +16,7 @@ import {
   documentationHref,
   DocumentationLink,
 } from "src/components/documentation";
-import { getUsers, User } from "src/utility/api/users";
+import { postUserSearch, User } from "src/utility/api/users";
 import { useNavigate } from "react-router";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
@@ -30,14 +30,19 @@ const List: FC = () => {
   const { t, Translate } = useTranslate();
   const navigate = useNavigate();
   const [, setSearch] = useState("");
-  const { data: users, loading, reload, success } = useApi(getUsers);
+  const {
+    data: userSearchResults,
+    loading,
+    reload,
+    success,
+  } = useApi(postUserSearch);
   const [addUser, addUserModal] = useModal(AddModal, reload);
   const [editUser, editUserModal] = useEntityModal(EditModal, reload);
   const [deleteUser, deleteUserModal] = useEntityModal(DeleteModal, reload);
 
   const showDetails = ({ id }: User) => navigate(`${id}`);
 
-  if (success && !users?.length) {
+  if (success && !userSearchResults?.items?.length) {
     return (
       <Page>
         <PageTitle>
@@ -66,7 +71,7 @@ const List: FC = () => {
     <Page>
       <EntityList
         title={t("Users")}
-        data={users}
+        data={userSearchResults?.items || []}
         headers={[
           { header: t("Username"), key: "username" },
           { header: t("Name"), key: "name" },

--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -16,7 +16,7 @@ import {
   documentationHref,
   DocumentationLink,
 } from "src/components/documentation";
-import { postUserSearch, User } from "src/utility/api/users";
+import { searchUser, User } from "src/utility/api/users";
 import { useNavigate } from "react-router";
 import { TranslatedErrorInlineNotification } from "src/components/notifications/InlineNotification";
 import useModal, { useEntityModal } from "src/components/modal/useModal";
@@ -35,14 +35,14 @@ const List: FC = () => {
     loading,
     reload,
     success,
-  } = useApi(postUserSearch);
+  } = useApi(searchUser);
   const [addUser, addUserModal] = useModal(AddModal, reload);
   const [editUser, editUserModal] = useEntityModal(EditModal, reload);
   const [deleteUser, deleteUserModal] = useEntityModal(DeleteModal, reload);
 
   const showDetails = ({ id }: User) => navigate(`${id}`);
 
-  if (success && !userSearchResults?.items?.length) {
+  if (success && !userSearchResults?.items.length) {
     return (
       <Page>
         <PageTitle>
@@ -71,7 +71,7 @@ const List: FC = () => {
     <Page>
       <EntityList
         title={t("Users")}
-        data={userSearchResults?.items || []}
+        data={userSearchResults!.items}
         headers={[
           { header: t("Username"), key: "username" },
           { header: t("Name"), key: "name" },

--- a/identity/client/src/utility/api/index.ts
+++ b/identity/client/src/utility/api/index.ts
@@ -1,1 +1,5 @@
 export * from "./hooks";
+
+export type SearchResponse<R> = {
+  items: R[];
+};

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -11,7 +11,12 @@ export type User = {
   enabled: boolean;
 };
 
-export const getUsers: ApiDefinition<User[]> = () => apiGet(USERS_ENDPOINT);
+export type UserSearch = {
+  items: User[];
+};
+
+export const postUserSearch: ApiDefinition<UserSearch> = () =>
+  apiPost(`${USERS_ENDPOINT}/search`);
 
 type GetUserParams = {
   id: string;

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -12,7 +12,7 @@ export type User = {
   enabled: boolean;
 };
 
-export const postUserSearch: ApiDefinition<SearchResponse<User>> = () =>
+export const searchUser: ApiDefinition<SearchResponse<User>> = () =>
   apiPost(`${USERS_ENDPOINT}/search`);
 
 type GetUserParams = {

--- a/identity/client/src/utility/api/users/index.ts
+++ b/identity/client/src/utility/api/users/index.ts
@@ -1,4 +1,5 @@
 import { ApiDefinition, apiDelete, apiGet, apiPost, apiPut } from "../request";
+import { SearchResponse } from "src/utility/api";
 
 export const USERS_ENDPOINT = "/users";
 
@@ -11,11 +12,7 @@ export type User = {
   enabled: boolean;
 };
 
-export type UserSearch = {
-  items: User[];
-};
-
-export const postUserSearch: ApiDefinition<UserSearch> = () =>
+export const postUserSearch: ApiDefinition<SearchResponse<User>> = () =>
   apiPost(`${USERS_ENDPOINT}/search`);
 
 type GetUserParams = {


### PR DESCRIPTION
## Description

With the merging of the new `/v2` user controller endpoints the Identity client needed changing as the endpoint is not `GET /v2/users` but instead is `POST /v2/users/search`. This PR updates both the endpoint used and also the data response.


