### PR TITLE
Stream processor failure proper rejection

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/PartitionInactiveException.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/PartitionInactiveException.java
@@ -12,7 +12,8 @@ package io.camunda.zeebe.broker.client.api;
  * partition.
  */
 public class PartitionInactiveException extends BrokerClientException {
-  private static final String DEFAULT_ERROR_MESSAGE = "The partition %d is currently INACTIVE";
+  private static final String DEFAULT_ERROR_MESSAGE =
+      "The partition %d is currently INACTIVE with no leader.";
   private final int partitionId;
 
   public PartitionInactiveException(final int partitionId) {

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/PartitionInactiveException.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/api/PartitionInactiveException.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.client.api;
+
+/**
+ * Represents an exceptional error that occurs when a request is trying to be sent to an inactive
+ * partition.
+ */
+public class PartitionInactiveException extends BrokerClientException {
+  private static final String DEFAULT_ERROR_MESSAGE = "The partition %d is currently INACTIVE";
+  private final int partitionId;
+
+  public PartitionInactiveException(final int partitionId) {
+    this(String.format(DEFAULT_ERROR_MESSAGE, partitionId), partitionId);
+  }
+
+  public PartitionInactiveException(final String message, final int partitionId) {
+    super(message);
+    this.partitionId = partitionId;
+  }
+
+  public int getPartitionId() {
+    return partitionId;
+  }
+}

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -222,7 +222,6 @@ final class BrokerRequestManager extends Actor {
 
       // select next partition id for request
       int partitionId = strategy.determinePartition(topologyManager);
-
       if (partitionId == BrokerClusterState.PARTITION_ID_NULL) {
         // could happen if the topology is not set yet, let's just try with partition 0 but we
         // should find a better solution

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -242,7 +242,11 @@ final class BrokerRequestManager extends Actor {
 
   private void throwIfPartitionInactive(final int partitionId) {
     final BrokerClusterState topology = topologyManager.getTopology();
-    if (topology != null && topology.getInactiveNodesForPartition(partitionId) != null) {
+    final var inactiveNodes = topology.getInactiveNodesForPartition(partitionId);
+    final var someNodesInactive = inactiveNodes != null && !inactiveNodes.isEmpty();
+    final var noPartitionLeader =
+        topology.getLeaderForPartition(partitionId) == BrokerClusterState.NODE_ID_NULL;
+    if (topology != null && someNodesInactive && noPartitionLeader) {
       throw new PartitionInactiveException(partitionId);
     }
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -241,11 +241,15 @@ final class BrokerRequestManager extends Actor {
 
   private void throwIfPartitionInactive(final int partitionId) {
     final BrokerClusterState topology = topologyManager.getTopology();
+    if (topology == null) {
+      throw new NoTopologyAvailableException();
+    }
+
     final var inactiveNodes = topology.getInactiveNodesForPartition(partitionId);
     final var someNodesInactive = inactiveNodes != null && !inactiveNodes.isEmpty();
     final var noPartitionLeader =
         topology.getLeaderForPartition(partitionId) == BrokerClusterState.NODE_ID_NULL;
-    if (topology != null && someNodesInactive && noPartitionLeader) {
+    if (someNodesInactive && noPartitionLeader) {
       throw new PartitionInactiveException(partitionId);
     }
   }

--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/BrokerRequestManager.java
@@ -223,8 +223,6 @@ final class BrokerRequestManager extends Actor {
       // select next partition id for request
       int partitionId = strategy.determinePartition(topologyManager);
 
-      throwIfPartitionInactive(partitionId);
-
       if (partitionId == BrokerClusterState.PARTITION_ID_NULL) {
         // could happen if the topology is not set yet, let's just try with partition 0 but we
         // should find a better solution
@@ -232,6 +230,8 @@ final class BrokerRequestManager extends Actor {
         partitionId = Protocol.DEPLOYMENT_PARTITION;
       }
       request.setPartitionId(partitionId);
+
+      throwIfPartitionInactive(partitionId);
 
       return new BrokerAddressProvider(request.getPartitionId());
     } else {

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/api/BrokerClientTest.java
@@ -341,7 +341,7 @@ public final class BrokerClientTest {
   }
 
   @Test
-  public void shouldThrowCorrectErrorForInactivePartitionRequest() {
+  public void shouldThrowCorrectErrorForInactivePartitionAndNoLeaderRequest() {
     // given
     final var partitionId = 1;
     final var request = new TestCommand(1, topologyManager -> partitionId);

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -27,7 +27,6 @@ import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import io.camunda.zeebe.stream.impl.state.StreamProcessorDbState;
-import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
@@ -433,13 +432,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             openFuture.completeExceptionally(throwable);
           }
 
-          if (throwable instanceof UnrecoverableException) {
-            final var report = HealthReport.dead(this).withIssue(throwable);
-            failureListeners.forEach(l -> l.onUnrecoverableFailure(report));
-          } else {
-            final var report = HealthReport.unhealthy(this).withIssue(throwable);
-            failureListeners.forEach(l -> l.onFailure(report));
-          }
+          final var report = HealthReport.dead(this).withIssue(throwable);
+          failureListeners.forEach(l -> l.onUnrecoverableFailure(report));
         });
   }
 


### PR DESCRIPTION
## Description

If a partition's stream processor dies it is now set to `DEAD` and corresponding error messages now inform the user that the partition is inactive.

## Related issues

closes #16180 
