### PR TITLE
feat: Create a Spring integration for Process Testing

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -823,6 +823,20 @@
         <version>${project.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
+      <!-- Camunda Process Testing modules -->
+
+      <dependency>
+        <groupId>io.camunda</groupId>
+        <artifactId>camunda-process-test-java</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+
       <!-- sibling projects -->
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>search</module>
     <module>service</module>
     <module>testing/camunda-process-test-java</module>
+    <module>testing/camunda-process-test-spring</module>
     <module>clients/java</module>
   </modules>
 

--- a/testing/README.md
+++ b/testing/README.md
@@ -3,4 +3,5 @@
 Camunda's testing libraries for processes and process applications.
 
 - [Camunda Process Test for Java](camunda-process-test-java)
+- [Camunda Process Test for Spring](camunda-process-test-spring)
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeDefaults.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeDefaults.java
@@ -32,7 +32,8 @@ public class ContainerRuntimeDefaults {
 
   public static final String ELASTICSEARCH_DOCKER_IMAGE_VERSION =
       VERSION_UTIL.getElasticsearchVersion();
-  public static final String ZEEBE_DOCKER_IMAGE_VERSION = VERSION_UTIL.getCamundaVersion();
-  public static final String OPERATE_DOCKER_IMAGE_VERSION = VERSION_UTIL.getCamundaVersion();
-  public static final String TASKLIST_DOCKER_IMAGE_VERSION = VERSION_UTIL.getCamundaVersion();
+  public static final String CAMUNDA_VERSION = VERSION_UTIL.getCamundaVersion();
+  public static final String ZEEBE_DOCKER_IMAGE_VERSION = CAMUNDA_VERSION;
+  public static final String OPERATE_DOCKER_IMAGE_VERSION = CAMUNDA_VERSION;
+  public static final String TASKLIST_DOCKER_IMAGE_VERSION = CAMUNDA_VERSION;
 }

--- a/testing/camunda-process-test-spring/README.md
+++ b/testing/camunda-process-test-spring/README.md
@@ -1,0 +1,5 @@
+# Camunda-Process-Test-Spring
+
+Camunda's new testing library for processes and process applications with Spring.
+
+Work in progress!

--- a/testing/camunda-process-test-spring/pom.xml
+++ b/testing/camunda-process-test-spring/pom.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.camunda</groupId>
+    <artifactId>zeebe-parent</artifactId>
+    <version>8.6.0-SNAPSHOT</version>
+    <relativePath>../../parent/pom.xml</relativePath>
+  </parent>
+
+  <artifactId>camunda-process-test-spring</artifactId>
+
+  <name>Camunda Process Test Spring</name>
+  <description>Camunda's testing library for processes and process applications with Spring</description>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+    </license>
+  </licenses>
+
+  <properties>
+    <version.java>17</version.java>
+    <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-process-test-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>spring-boot-starter-camunda-sdk</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>camunda-client-java</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-beans</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.checkerframework</groupId>
+      <artifactId>checker-qual</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
+    <!--  test scope  -->
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-bpmn-model</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+  <build>
+
+    <plugins>
+
+      <plugin>
+        <groupId>org.revapi</groupId>
+        <artifactId>revapi-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <configuration>
+          <ignoredNonTestScopedDependencies>
+            <dependency>org.springframework:spring-beans</dependency>
+          </ignoredNonTestScopedDependencies>
+        </configuration>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>

--- a/testing/camunda-process-test-spring/revapi.json
+++ b/testing/camunda-process-test-spring/revapi.json
@@ -1,0 +1,23 @@
+[
+  {
+    "extension": "revapi.filter",
+    "id": "filter",
+    "configuration": {
+      "archives": {
+        "justification": "Ignore everything not included in the module itself",
+        "include": [
+          "io\\.camunda:camunda-process-test-spring:.*"
+        ]
+      },
+      "elements": {
+        "exclude": [
+          {
+            "justification": "The implementation package is not meant to be used directly, and as such does not need to maintain any backwards compatibility guarantees.",
+            "matcher": "java-package",
+            "match": "/io\\.camunda\\.process\\.test\\.impl(\\..*)?/"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.process.test.impl.configuration.CamundaContainerRuntimeConfiguration;
+import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
+import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
+import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
+import io.camunda.process.test.impl.runtime.CamundaContainerRuntime;
+import io.camunda.process.test.impl.runtime.CamundaContainerRuntimeBuilder;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.spring.client.event.ZeebeClientClosingEvent;
+import io.camunda.zeebe.spring.client.event.ZeebeClientCreatedEvent;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.core.Ordered;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.TestExecutionListener;
+
+/**
+ * A Spring test execution listener that provides the runtime for process tests.
+ *
+ * <p>Before each test method:
+ *
+ * <ul>
+ *   <li>Start the runtime
+ *   <li>Create a {@link ZeebeClient} to inject in the test class
+ *   <li>Create a {@link CamundaProcessTestContext} to inject in the test class
+ *   <li>Publish a {@link ZeebeClientCreatedEvent}
+ * </ul>
+ *
+ * <p>After each test method:
+ *
+ * <ul>
+ *   <li>Publish a {@link ZeebeClientClosingEvent}
+ *   <li>Close created {@link ZeebeClient}s
+ *   <li>Stop the runtime
+ * </ul>
+ */
+public class CamundaProcessTestExecutionListener implements TestExecutionListener, Ordered {
+
+  private final CamundaContainerRuntimeBuilder containerRuntimeBuilder;
+  private final List<ZeebeClient> createdClients = new ArrayList<>();
+
+  private CamundaContainerRuntime containerRuntime;
+  private ZeebeClient zeebeClient;
+
+  public CamundaProcessTestExecutionListener() {
+    this(CamundaContainerRuntime.newBuilder());
+  }
+
+  CamundaProcessTestExecutionListener(
+      final CamundaContainerRuntimeBuilder containerRuntimeBuilder) {
+    this.containerRuntimeBuilder = containerRuntimeBuilder;
+  }
+
+  @Override
+  public void beforeTestMethod(final TestContext testContext) throws Exception {
+    // create runtime
+    containerRuntime = buildRuntime(testContext);
+    containerRuntime.start();
+
+    final CamundaProcessTestContext camundaProcessTestContext =
+        new CamundaProcessTestContextImpl(
+            containerRuntime.getZeebeContainer(), createdClients::add);
+
+    zeebeClient = createZeebeClient(testContext, camundaProcessTestContext);
+
+    // fill proxies
+    testContext.getApplicationContext().getBean(ZeebeClientProxy.class).setZeebeClient(zeebeClient);
+    testContext
+        .getApplicationContext()
+        .getBean(CamundaProcessTestContextProxy.class)
+        .setContext(camundaProcessTestContext);
+
+    // publish Zeebe client
+    testContext
+        .getApplicationContext()
+        .publishEvent(new ZeebeClientCreatedEvent(this, zeebeClient));
+  }
+
+  @Override
+  public void afterTestMethod(final TestContext testContext) throws Exception {
+    // close Zeebe clients
+    testContext
+        .getApplicationContext()
+        .publishEvent(new ZeebeClientClosingEvent(this, zeebeClient));
+
+    createdClients.forEach(ZeebeClient::close);
+
+    // clean up proxies
+    testContext.getApplicationContext().getBean(ZeebeClientProxy.class).removeZeebeClient();
+    testContext
+        .getApplicationContext()
+        .getBean(CamundaProcessTestContextProxy.class)
+        .removeContext();
+
+    // close runtime
+    containerRuntime.close();
+  }
+
+  private CamundaContainerRuntime buildRuntime(final TestContext testContext) {
+    final CamundaContainerRuntimeConfiguration runtimeConfiguration =
+        testContext.getApplicationContext().getBean(CamundaContainerRuntimeConfiguration.class);
+
+    containerRuntimeBuilder
+        .withZeebeDockerImageVersion(runtimeConfiguration.getCamundaVersion())
+        .withOperateDockerImageVersion(runtimeConfiguration.getCamundaVersion())
+        .withTasklistDockerImageVersion(runtimeConfiguration.getCamundaVersion())
+        .withZeebeDockerImageName(runtimeConfiguration.getZeebeDockerImageName())
+        .withZeebeEnv(runtimeConfiguration.getZeebeEnvVars());
+
+    runtimeConfiguration
+        .getZeebeExposedPorts()
+        .forEach(containerRuntimeBuilder::withZeebeExposedPort);
+
+    return containerRuntimeBuilder.build();
+  }
+
+  private static ZeebeClient createZeebeClient(
+      final TestContext testContext, final CamundaProcessTestContext camundaProcessTestContext) {
+    return camundaProcessTestContext.createZeebeClient(
+        builder -> {
+          if (hasJsonMapper(testContext)) {
+            final JsonMapper jsonMapper =
+                testContext.getApplicationContext().getBean(JsonMapper.class);
+            builder.withJsonMapper(jsonMapper);
+          }
+        });
+  }
+
+  private static boolean hasJsonMapper(final TestContext testContext) {
+    return testContext.getApplicationContext().getBeanNamesForType(JsonMapper.class).length > 0;
+  }
+
+  @Override
+  public int getOrder() {
+    return Integer.MAX_VALUE;
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.process.test.impl.configuration.CamundaProcessTestAutoConfiguration;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestExecutionListeners;
+import org.springframework.test.context.TestExecutionListeners.MergeMode;
+
+/**
+ * Marks a class as a process test and adds the Spring test execution listener {@link
+ * CamundaProcessTestExecutionListener}.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ * &#064;CamundaSpringProcessTest
+ * public class MyProcessTest {
+ *
+ *   &#064;Autowired
+ *   private ZeebeClient zeebeClient;
+ *
+ *   &#064;Test
+ *   void shouldWork() {
+ *     // given
+ *     final long processInstanceKey =
+ *         zeebeClient
+ *             .newCreateInstanceCommand()
+ *             .bpmnProcessId("process")
+ *             .latestVersion()
+ *             .send()
+ *             .join()
+ *             .getProcessInstanceKey();
+ *
+ *     // when
+ *
+ *     // then
+ *
+ *   }
+ * }
+ * </pre>
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+// this pulls in the Configuration NOT as AutoConfiguration but directly creates beans, so the
+// marker is present when the normal CamundaAutoConfiguration is used by the normal
+// meta-inf/services way
+@Import({CamundaProcessTestAutoConfiguration.class})
+// this listener hooks up into test execution
+@TestExecutionListeners(
+    listeners = CamundaProcessTestExecutionListener.class,
+    mergeMode = MergeMode.MERGE_WITH_DEFAULTS)
+public @interface CamundaSpringProcessTest {}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaContainerRuntimeConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaContainerRuntimeConfiguration.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import io.camunda.process.test.impl.runtime.ContainerRuntimeDefaults;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "io.camunda.process.test")
+public class CamundaContainerRuntimeConfiguration {
+
+  private String camundaVersion = ContainerRuntimeDefaults.CAMUNDA_VERSION;
+  private String zeebeDockerImageName = ContainerRuntimeDefaults.ZEEBE_DOCKER_IMAGE_NAME;
+  private Map<String, String> zeebeEnvVars = Collections.emptyMap();
+  private List<Integer> zeebeExposedPorts = Collections.emptyList();
+
+  public String getCamundaVersion() {
+    return camundaVersion;
+  }
+
+  public void setCamundaVersion(final String camundaVersion) {
+    this.camundaVersion = camundaVersion;
+  }
+
+  public String getZeebeDockerImageName() {
+    return zeebeDockerImageName;
+  }
+
+  public void setZeebeDockerImageName(final String zeebeDockerImageName) {
+    this.zeebeDockerImageName = zeebeDockerImageName;
+  }
+
+  public Map<String, String> getZeebeEnvVars() {
+    return zeebeEnvVars;
+  }
+
+  public void setZeebeEnvVars(final Map<String, String> zeebeEnvVars) {
+    this.zeebeEnvVars = zeebeEnvVars;
+  }
+
+  public List<Integer> getZeebeExposedPorts() {
+    return zeebeExposedPorts;
+  }
+
+  public void setZeebeExposedPorts(final List<Integer> zeebeExposedPorts) {
+    this.zeebeExposedPorts = zeebeExposedPorts;
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestAutoConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration;
+import io.camunda.zeebe.spring.client.testsupport.SpringZeebeTestContext;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+@ImportAutoConfiguration({
+  CamundaProcessTestProxyConfiguration.class,
+  CamundaProcessTestDefaultConfiguration.class,
+  CamundaAutoConfiguration.class,
+  CamundaContainerRuntimeConfiguration.class
+})
+@AutoConfigureBefore(CamundaAutoConfiguration.class)
+public class CamundaProcessTestAutoConfiguration {
+
+  @Bean
+  public SpringZeebeTestContext enableTestContext() {
+    // add marker bean to Spring context that we are running in a test case
+    return new SpringZeebeTestContext();
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestDefaultConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import static io.camunda.zeebe.spring.client.configuration.CamundaAutoConfiguration.DEFAULT_OBJECT_MAPPER;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/** Fallback values if certain beans are missing */
+public class CamundaProcessTestDefaultConfiguration {
+
+  @Bean(name = "zeebeJsonMapper")
+  @ConditionalOnMissingBean
+  public JsonMapper jsonMapper(final ObjectMapper objectMapper) {
+    return new ZeebeObjectMapper(objectMapper);
+  }
+
+  @Bean
+  @ConditionalOnMissingBean
+  public ObjectMapper objectMapper() {
+    return DEFAULT_OBJECT_MAPPER;
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestProxyConfiguration.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/configuration/CamundaProcessTestProxyConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.configuration;
+
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
+import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
+import io.camunda.zeebe.client.ZeebeClient;
+import java.lang.reflect.Proxy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+
+public class CamundaProcessTestProxyConfiguration {
+
+  @Bean
+  public ZeebeClientProxy zeebeClientProxy() {
+    return new ZeebeClientProxy();
+  }
+
+  @Bean
+  @Primary
+  public ZeebeClient proxiedZeebeClient(final ZeebeClientProxy zeebeClientProxy) {
+    return (ZeebeClient)
+        Proxy.newProxyInstance(
+            getClass().getClassLoader(), new Class[] {ZeebeClient.class}, zeebeClientProxy);
+  }
+
+  @Bean
+  public CamundaProcessTestContextProxy camundaProcessTestContextProxy() {
+    return new CamundaProcessTestContextProxy();
+  }
+
+  @Bean
+  public CamundaProcessTestContext proxiedCamundaProcessTestContext(
+      final CamundaProcessTestContextProxy camundaProcessTestContextProxy) {
+    return (CamundaProcessTestContext)
+        Proxy.newProxyInstance(
+            getClass().getClassLoader(),
+            new Class[] {CamundaProcessTestContext.class},
+            camundaProcessTestContextProxy);
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/AbstractInvocationHandler.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/AbstractInvocationHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.proxy;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import javax.annotation.CheckForNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public abstract class AbstractInvocationHandler implements InvocationHandler {
+
+  private static final Object[] NO_ARGS = {};
+
+  @Override
+  @CheckForNull
+  public final Object invoke(
+      final Object proxy, final Method method, @CheckForNull @Nullable Object[] args)
+      throws Throwable {
+    if (args == null) {
+      args = NO_ARGS;
+    }
+    if (args.length == 0 && method.getName().equals("hashCode")) {
+      return hashCode();
+    }
+    if (args.length == 1
+        && method.getName().equals("equals")
+        && method.getParameterTypes()[0] == Object.class) {
+      final Object arg = args[0];
+      if (arg == null) {
+        return false;
+      }
+      if (proxy == arg) {
+        return true;
+      }
+      return isProxyOfSameInterfaces(arg, proxy.getClass())
+          && equals(Proxy.getInvocationHandler(arg));
+    }
+    if (args.length == 0 && method.getName().equals("toString")) {
+      return toString();
+    }
+    return handleInvocation(proxy, method, args);
+  }
+
+  /**
+   * {@link #invoke} delegates to this method upon any method invocation on the proxy instance,
+   * except {@link Object#equals}, {@link Object#hashCode} and {@link Object#toString}. The result
+   * will be returned as the proxied method's return value.
+   *
+   * <p>Unlike {@link #invoke}, {@code args} will never be null. When the method has no parameter,
+   * an empty array is passed in.
+   */
+  @CheckForNull
+  protected abstract Object handleInvocation(Object proxy, Method method, @Nullable Object[] args)
+      throws Throwable;
+
+  /**
+   * By default delegates to {@link Object#hashCode}. The dynamic proxies' {@code hashCode()} will
+   * delegate to this method. Subclasses can override this method to provide custom equality.
+   */
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+
+  /**
+   * By default delegates to {@link Object#equals} so instances are only equal if they are
+   * identical. {@code proxy.equals(argument)} returns true if:
+   *
+   * <ul>
+   *   <li>{@code proxy} and {@code argument} are of the same type
+   *   <li>and this method returns true for the {@link InvocationHandler} of {@code argument}
+   * </ul>
+   *
+   * <p>Subclasses can override this method to provide custom equality.
+   */
+  @Override
+  public boolean equals(@CheckForNull final Object obj) {
+    return super.equals(obj);
+  }
+
+  /**
+   * By default delegates to {@link Object#toString}. The dynamic proxies' {@code toString()} will
+   * delegate to this method. Subclasses can override this method to provide custom string
+   * representation for the proxies.
+   */
+  @Override
+  public String toString() {
+    return super.toString();
+  }
+
+  private static boolean isProxyOfSameInterfaces(final Object arg, final Class<?> proxyClass) {
+    return proxyClass.isInstance(arg)
+        // Equal proxy instances should mostly be instance of proxyClass
+        // Under some edge cases (such as the proxy of JDK types serialized and then deserialized)
+        // the proxy type may not be the same.
+        // We first check isProxyClass() so that the common case of comparing with non-proxy objects
+        // is efficient.
+        || (Proxy.isProxyClass(arg.getClass())
+            && Arrays.equals(arg.getClass().getInterfaces(), proxyClass.getInterfaces()));
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/CamundaProcessTestContextProxy.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/CamundaProcessTestContextProxy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.proxy;
+
+import io.camunda.process.test.api.CamundaProcessTestContext;
+import java.lang.reflect.Method;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Dynamic proxy to delegate to a {@link CamundaProcessTestContext} which allows to swap the context
+ * object under the hood.
+ */
+public class CamundaProcessTestContextProxy extends AbstractInvocationHandler {
+
+  private CamundaProcessTestContext delegate;
+
+  public void setContext(final CamundaProcessTestContext camundaProcessTestContext) {
+    delegate = camundaProcessTestContext;
+  }
+
+  public void removeContext() {
+    delegate = null;
+  }
+
+  @Override
+  protected Object handleInvocation(
+      final Object proxy, final Method method, @Nullable final Object[] args) throws Throwable {
+    if (delegate == null) {
+      throw new RuntimeException(
+          "Cannot invoke "
+              + method
+              + " on CamundaProcessTestContext, as CamundaProcessTestContext is currently not initialized. Maybe you run outside of a testcase?");
+    }
+    return method.invoke(delegate, args);
+  }
+}

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/ZeebeClientProxy.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/impl/proxy/ZeebeClientProxy.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.proxy;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import java.lang.reflect.Method;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Dynamic proxy to delegate to a {@link ZeebeClient} which allows to swap the ZeebeClient object
+ * under the hood.
+ */
+public class ZeebeClientProxy extends AbstractInvocationHandler {
+
+  private ZeebeClient delegate;
+
+  public void setZeebeClient(final ZeebeClient zeebeClient) {
+    delegate = zeebeClient;
+  }
+
+  public void removeZeebeClient() {
+    delegate = null;
+  }
+
+  @Override
+  protected Object handleInvocation(
+      final Object proxy, final Method method, @Nullable final Object[] args) throws Throwable {
+    if (delegate == null) {
+      throw new RuntimeException(
+          "Cannot invoke "
+              + method
+              + " on ZeebeClient, as ZeebeClient is currently not initialized. Maybe you run outside of a testcase?");
+    }
+    return method.invoke(delegate, args);
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest(classes = {CamundaSpringProcessTestListenerIT.class})
+@CamundaSpringProcessTest
+public class CamundaSpringProcessTestListenerIT {
+
+  @Autowired private ZeebeClient zeebeClient;
+
+  @Test
+  void shouldCreateProcessInstance() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .endEvent()
+            .zeebeOutputExpression("\"ok\"", "result")
+            .done();
+
+    zeebeClient.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    // when
+    final ProcessInstanceResult processInstanceResult =
+        zeebeClient
+            .newCreateInstanceCommand()
+            .bpmnProcessId("process")
+            .latestVersion()
+            .withResult()
+            .send()
+            .join();
+
+    // then
+    assertThat(processInstanceResult.getVariablesAsMap()).containsEntry("result", "ok");
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static java.util.Map.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.process.test.impl.configuration.CamundaContainerRuntimeConfiguration;
+import io.camunda.process.test.impl.containers.ZeebeContainer;
+import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
+import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
+import io.camunda.process.test.impl.runtime.CamundaContainerRuntime;
+import io.camunda.process.test.impl.runtime.CamundaContainerRuntimeBuilder;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientConfiguration;
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.spring.client.event.ZeebeClientClosingEvent;
+import io.camunda.zeebe.spring.client.event.ZeebeClientCreatedEvent;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.TestContext;
+
+@ExtendWith(MockitoExtension.class)
+public class ExecutionListenerTest {
+
+  private static final URI GRPC_API_ADDRESS = URI.create("http://my-host:100");
+  private static final URI REST_API_ADDRESS = URI.create("http://my-host:200");
+
+  @Mock(answer = Answers.RETURNS_SELF)
+  private CamundaContainerRuntimeBuilder camundaContainerRuntimeBuilder;
+
+  @Mock private CamundaContainerRuntime camundaContainerRuntime;
+  @Mock private ZeebeContainer zeebeContainer;
+
+  @Mock private ZeebeClientProxy zeebeClientProxy;
+  @Mock private CamundaProcessTestContextProxy camundaProcessTestContextProxy;
+
+  @Mock private TestContext testContext;
+
+  @Mock(answer = Answers.RETURNS_SMART_NULLS)
+  private ApplicationContext applicationContext;
+
+  @Mock private JsonMapper jsonMapper;
+
+  @Captor private ArgumentCaptor<ZeebeClient> zeebeClientArgumentCaptor;
+  @Captor private ArgumentCaptor<CamundaProcessTestContext> camundaProcessTestContextArgumentCaptor;
+  @Captor private ArgumentCaptor<ZeebeClientCreatedEvent> zeebeClientCreatedEventArgumentCaptor;
+  @Captor private ArgumentCaptor<ZeebeClientClosingEvent> zeebeClientClosingEventArgumentCaptor;
+
+  @BeforeEach
+  void configureMocks() {
+    when(camundaContainerRuntimeBuilder.build()).thenReturn(camundaContainerRuntime);
+    when(camundaContainerRuntime.getZeebeContainer()).thenReturn(zeebeContainer);
+    when(zeebeContainer.getGrpcApiAddress()).thenReturn(GRPC_API_ADDRESS);
+    when(zeebeContainer.getRestApiAddress()).thenReturn(REST_API_ADDRESS);
+
+    when(testContext.getApplicationContext()).thenReturn(applicationContext);
+    when(applicationContext.getBean(ZeebeClientProxy.class)).thenReturn(zeebeClientProxy);
+    when(applicationContext.getBean(CamundaProcessTestContextProxy.class))
+        .thenReturn(camundaProcessTestContextProxy);
+    when(applicationContext.getBean(CamundaContainerRuntimeConfiguration.class))
+        .thenReturn(new CamundaContainerRuntimeConfiguration());
+  }
+
+  @Test
+  void shouldWireZeebeClient() throws Exception {
+    // given
+    final CamundaProcessTestExecutionListener listener =
+        new CamundaProcessTestExecutionListener(camundaContainerRuntimeBuilder);
+
+    // when
+    listener.beforeTestMethod(testContext);
+
+    // then
+    verify(zeebeClientProxy).setZeebeClient(zeebeClientArgumentCaptor.capture());
+
+    final ZeebeClient zeebeClient = zeebeClientArgumentCaptor.getValue();
+    assertThat(zeebeClient).isNotNull();
+
+    final ZeebeClientConfiguration configuration = zeebeClient.getConfiguration();
+    assertThat(configuration.getGrpcAddress()).isEqualTo(GRPC_API_ADDRESS);
+    assertThat(configuration.getRestAddress()).isEqualTo(REST_API_ADDRESS);
+
+    verify(applicationContext).publishEvent(zeebeClientCreatedEventArgumentCaptor.capture());
+
+    final ZeebeClientCreatedEvent createdEvent = zeebeClientCreatedEventArgumentCaptor.getValue();
+    assertThat(createdEvent).isNotNull();
+    assertThat(createdEvent.getClient()).isEqualTo(zeebeClient);
+  }
+
+  @Test
+  void shouldWireProcessTestContext() throws Exception {
+    // given
+    final CamundaProcessTestExecutionListener listener =
+        new CamundaProcessTestExecutionListener(camundaContainerRuntimeBuilder);
+
+    // when
+    listener.beforeTestMethod(testContext);
+
+    // then
+    verify(camundaProcessTestContextProxy)
+        .setContext(camundaProcessTestContextArgumentCaptor.capture());
+
+    final CamundaProcessTestContext camundaProcessTestContext =
+        camundaProcessTestContextArgumentCaptor.getValue();
+    assertThat(camundaProcessTestContext).isNotNull();
+    assertThat(camundaProcessTestContext.getZeebeGrpcAddress()).isEqualTo(GRPC_API_ADDRESS);
+    assertThat(camundaProcessTestContext.getZeebeRestAddress()).isEqualTo(REST_API_ADDRESS);
+
+    final ZeebeClient newZeebeClient = camundaProcessTestContext.createZeebeClient();
+    assertThat(newZeebeClient).isNotNull();
+
+    final ZeebeClientConfiguration configuration = newZeebeClient.getConfiguration();
+    assertThat(configuration.getGrpcAddress()).isEqualTo(GRPC_API_ADDRESS);
+    assertThat(configuration.getRestAddress()).isEqualTo(REST_API_ADDRESS);
+  }
+
+  @Test
+  void shouldConfigureJsonMapper() throws Exception {
+    // given
+    final CamundaProcessTestExecutionListener listener =
+        new CamundaProcessTestExecutionListener(camundaContainerRuntimeBuilder);
+
+    when(applicationContext.getBeanNamesForType(JsonMapper.class))
+        .thenReturn(new String[] {"zeebeJsonMapper"});
+
+    when(applicationContext.getBean(JsonMapper.class)).thenReturn(jsonMapper);
+
+    // when
+    listener.beforeTestMethod(testContext);
+
+    // then
+    verify(zeebeClientProxy).setZeebeClient(zeebeClientArgumentCaptor.capture());
+
+    final ZeebeClient zeebeClient = zeebeClientArgumentCaptor.getValue();
+    assertThat(zeebeClient).isNotNull();
+
+    final ZeebeClientConfiguration configuration = zeebeClient.getConfiguration();
+    assertThat(configuration.getJsonMapper()).isEqualTo(jsonMapper);
+  }
+
+  @Test
+  void shouldStartAndCloseRuntime() throws Exception {
+    // given
+    final CamundaProcessTestExecutionListener listener =
+        new CamundaProcessTestExecutionListener(camundaContainerRuntimeBuilder);
+
+    // when
+    listener.beforeTestMethod(testContext);
+    listener.afterTestMethod(testContext);
+
+    // then
+    verify(camundaContainerRuntime).start();
+    verify(camundaContainerRuntime).close();
+  }
+
+  @Test
+  void shouldCloseZeebeClient() throws Exception {
+    // given
+    final CamundaProcessTestExecutionListener listener =
+        new CamundaProcessTestExecutionListener(camundaContainerRuntimeBuilder);
+
+    // when
+    listener.beforeTestMethod(testContext);
+    listener.afterTestMethod(testContext);
+
+    // then
+    verify(applicationContext).publishEvent(zeebeClientCreatedEventArgumentCaptor.capture());
+    final ZeebeClientCreatedEvent createdEvent = zeebeClientCreatedEventArgumentCaptor.getValue();
+
+    verify(applicationContext).publishEvent(zeebeClientClosingEventArgumentCaptor.capture());
+    final ZeebeClientClosingEvent closedClient = zeebeClientClosingEventArgumentCaptor.getValue();
+
+    assertThat(createdEvent.getClient()).isEqualTo(closedClient.getClient());
+
+    verify(zeebeClientProxy).removeZeebeClient();
+    verify(camundaProcessTestContextProxy).removeContext();
+  }
+
+  @Test
+  void shouldConfigureRuntime() throws Exception {
+    // given
+    final Map<String, String> zeebeEnvVars =
+        Map.ofEntries(entry("env-1", "test-1"), entry("env-2", "test-2"));
+
+    final CamundaProcessTestExecutionListener listener =
+        new CamundaProcessTestExecutionListener(camundaContainerRuntimeBuilder);
+
+    final CamundaContainerRuntimeConfiguration runtimeConfiguration =
+        new CamundaContainerRuntimeConfiguration();
+    runtimeConfiguration.setCamundaVersion("8.6.0-custom");
+    runtimeConfiguration.setZeebeDockerImageName("custom-zeebe");
+    runtimeConfiguration.setZeebeEnvVars(zeebeEnvVars);
+    runtimeConfiguration.setZeebeExposedPorts(List.of(100, 200));
+
+    when(applicationContext.getBean(CamundaContainerRuntimeConfiguration.class))
+        .thenReturn(runtimeConfiguration);
+
+    // when
+    listener.beforeTestMethod(testContext);
+
+    // then
+    verify(camundaContainerRuntimeBuilder).withZeebeDockerImageVersion("8.6.0-custom");
+    verify(camundaContainerRuntimeBuilder).withOperateDockerImageVersion("8.6.0-custom");
+    verify(camundaContainerRuntimeBuilder).withTasklistDockerImageVersion("8.6.0-custom");
+    verify(camundaContainerRuntimeBuilder).withZeebeDockerImageName("custom-zeebe");
+    verify(camundaContainerRuntimeBuilder).withZeebeEnv(zeebeEnvVars);
+    verify(camundaContainerRuntimeBuilder).withZeebeExposedPort(100);
+    verify(camundaContainerRuntimeBuilder).withZeebeExposedPort(200);
+  }
+}

--- a/testing/camunda-process-test-spring/src/test/resources/application.yml
+++ b/testing/camunda-process-test-spring/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+logging:
+  level:
+    root: info
+    io:
+      camunda:
+        process:
+          test: info
+    # Hide default logging from Testcontainers
+    org:
+      testcontainers: warn
+    tc: warn


### PR DESCRIPTION
## Description

- Create a new module `camunda-process-test-spring`
- Create a new annotation `@CamundaSpringProcessTest` to mark a test case 
- Create a new Spring Execution Test Listener to manage the runtime
    - Create a ZeebeClient and a CamundaProcessTestContext and populate to the application context
    - Publish a Zeebe Client Created Event to trigger the process application  
    - Configure the Zeebe client by a given JSON mapper
    - Configure the runtime via Spring properties 
- The runtime is based on Camunda Process Test Java
- The implementation is heavily inspired by the community project [spring-zeebe](https://github.com/camunda-community-hub/spring-zeebe/blob/main/test/testcontainer/src/main/java/io/camunda/zeebe/spring/test/ZeebeTestExecutionListener.java) 

## Related issues

closes #18999 
