### PR TITLE
ci: add custom matcher for Playwright script

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -175,7 +175,7 @@
       "customType": "regex",
       "fileMatch": ["package\\.json"],
       "matchStrings": [
-        "mcr\\.microsoft\\.com\\\/playwright:(?<currentValue>.*?) \\\/bin\\\/bash"
+        "mcr\\.microsoft\\.com\\\/playwright:(?<currentValue>.*?)\\s"
       ],
       "depNameTemplate": "mcr.microsoft.com/playwright",
       "datasourceTemplate": "docker"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -170,6 +170,15 @@
         "renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.* '(?<currentValue>.*)'\\s"
       ],
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": ["package\\.json"],
+      "matchStrings": [
+        "mcr\\.microsoft\\.com\\\/playwright:(?<currentValue>.*?) \\\/bin\\\/bash"
+      ],
+      "depNameTemplate": "mcr.microsoft.com/playwright",
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
We have references to the Playwright docker image on [Operate](https://github.com/camunda/camunda/blob/main/operate/client/package.json#L57) and [Tasklist](https://github.com/camunda/camunda/blob/main/tasklist/client/package.json#L53)
Because they're in the `package.json` in an NPM script Renovate can't recognize it, so I'm adding a custom matcher