### PR TITLE
test: fix min-height for instance history container 

### DIFF
--- a/operate/client/e2e-playwright/tests/processInstanceVariables.spec.ts
+++ b/operate/client/e2e-playwright/tests/processInstanceVariables.spec.ts
@@ -92,7 +92,7 @@ test.describe('Process Instance Variables', () => {
     const processInstanceKey = initialData.instance.processInstanceKey;
     processInstancePage.navigateToProcessInstance({id: processInstanceKey});
 
-    expect(processInstancePage.addVariableButton).toBeEnabled();
+    await expect(processInstancePage.addVariableButton).toBeEnabled();
 
     // add a new variable
     await processInstancePage.addVariableButton.click();

--- a/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/styled.ts
+++ b/operate/client/src/App/ProcessInstance/FlowNodeInstanceLog/styled.ts
@@ -15,6 +15,7 @@ const Container = styled.div`
   background-color: var(--cds-layer-01);
   display: flex;
   flex-direction: column;
+  min-height: 0;
 `;
 
 const PanelHeader = styled(BasePanelHeader)`


### PR DESCRIPTION
## Description

Root cause: In the playwright video it is visible that the "Add variable" button is not visible for a fraction of a second. The state is the following:

- visible - disabled
- not visible
- visible - enabled

This causes some issues in the e2e test, because playwright seems to find the button, but in some cases is not able to click it, because it is not visible.

The reason for the button not to be visible is that during loading the instance history the skeletons push the button out of the viewport. The skeletons are inside a cell of a grid which extends when the content is higher than the grid itself. Setting `min-height: 0` to the grid cell solves the problem.

![add-variable-button](https://github.com/camunda/camunda/assets/2543743/49aa5abb-fc35-466d-af39-7171283a8db7)

There was also a missing await statement for the first button assertion

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

closes #19373 
