### PR TITLE
ci: prevent merge queue bypass of cancelled jobs

### DIFF
--- a/.github/workflows/operate-merge-ci.yaml
+++ b/.github/workflows/operate-merge-ci.yaml
@@ -25,4 +25,4 @@ jobs:
     needs:
       - run-build
     steps:
-      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+      - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}

--- a/.github/workflows/tasklist-merge-ci.yml
+++ b/.github/workflows/tasklist-merge-ci.yml
@@ -33,4 +33,4 @@ jobs:
       - run-build
       - run-fe-ci
     steps:
-      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+      - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -590,7 +590,7 @@ jobs:
       - go-apidiff
       - docker-checks
     steps:
-      - run: exit ${{ ((contains(needs.*.result, 'skipped') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+      - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ test-summary ]


### PR DESCRIPTION
## Description

Reusing the expression that is already used in the Unified CI in https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml also in the other jobs. Checking for "cancelled" is definitely more useful and confirmed by build status info in CI health data:

![image](https://github.com/camunda/camunda/assets/800933/404c5f67-167b-49cb-809b-3884b98b7e74)

## Related issues

Closes #18796 
