### PR TITLE
Unflake `ProcessInstanceMigrationClusteredTest`

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ProcessInstanceMigrationClusteredTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ProcessInstanceMigrationClusteredTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
@@ -100,16 +99,7 @@ public class ProcessInstanceMigrationClusteredTest {
     final var secondTargetProcessDefinitionKey =
         deploymentEvent.getProcesses().get(2).getProcessDefinitionKey();
 
-    assertThat(
-            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.ACKNOWLEDGED)
-                .withDistributionPartitionId(2)
-                .findFirst())
-        .isPresent();
-    assertThat(
-            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.ACKNOWLEDGED)
-                .withDistributionPartitionId(3)
-                .findFirst())
-        .isPresent();
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
 
     final int processInstancePartitionId = 2;
     final long processInstanceKey =
@@ -237,16 +227,7 @@ public class ProcessInstanceMigrationClusteredTest {
     final var targetProcessDefinitionKey =
         deploymentEvent.getProcesses().get(1).getProcessDefinitionKey();
 
-    assertThat(
-            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.ACKNOWLEDGED)
-                .withDistributionPartitionId(2)
-                .findFirst())
-        .isPresent();
-    assertThat(
-            RecordingExporter.commandDistributionRecords(CommandDistributionIntent.ACKNOWLEDGED)
-                .withDistributionPartitionId(3)
-                .findFirst())
-        .isPresent();
+    clientRule.waitUntilDeploymentIsDone(deploymentEvent.getKey());
 
     final ProcessInstanceEvent processInstanceEvent =
         clientRule

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ProcessInstanceMigrationClusteredTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ProcessInstanceMigrationClusteredTest.java
@@ -92,8 +92,6 @@ public class ProcessInstanceMigrationClusteredTest {
             .addProcessModel(TARGET_PROCESS_2, "targetProcess2.bpmn")
             .send()
             .join();
-    final var sourceProcessDefinitionKey =
-        deploymentEvent.getProcesses().get(0).getProcessDefinitionKey();
     final var targetProcessDefinitionKey =
         deploymentEvent.getProcesses().get(1).getProcessDefinitionKey();
     final var secondTargetProcessDefinitionKey =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

The tests were flaky because it can happen that the deployment is not distributed immediately. The test doesn't wait for re-distribution to occur.

## Related issues

closes #19861
