### PR TITLE
fix: use and spring profile operator

### DIFF
--- a/dist/src/main/java/io/camunda/tasklist/TasklistSecurityStubsConfiguration.java
+++ b/dist/src/main/java/io/camunda/tasklist/TasklistSecurityStubsConfiguration.java
@@ -38,7 +38,7 @@ import org.springframework.security.core.Authentication;
  * service layer of Tasklist.
  */
 @Configuration(proxyBeanMethods = false)
-@Profile("tasklist && operate")
+@Profile("tasklist & operate")
 public class TasklistSecurityStubsConfiguration {
 
   /** UserReader that gets user details using Operate's UserService */


### PR DESCRIPTION
The AND operator in Spring profile expression is `&` and not `&&`https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/env/Profiles.html

## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

closes #
