### PR TITLE
Add search client Query tests [OS]

### DIFF
--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/BoolQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/BoolQueryTransformerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class BoolQueryTransformerTest {
+
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchQuery.class);
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .should(
+                    List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "Query: {'bool':{'should':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.or(
+                List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar"))),
+            "Query: {'bool':{'should':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.or(
+                SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")),
+            "Query: {'bool':{'should':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .must(List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "Query: {'bool':{'must':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.and(
+                List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar"))),
+            "Query: {'bool':{'must':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.and(
+                SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")),
+            "Query: {'bool':{'must':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .mustNot(
+                    List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "Query: {'bool':{'must_not':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.not(
+                List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar"))),
+            "Query: {'bool':{'must_not':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.not(
+                SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")),
+            "Query: {'bool':{'must_not':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .filter(
+                    List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "Query: {'bool':{'filter':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.constantScore()
+                .filter(SearchQueryBuilders.exists("foo"))
+                .build()
+                .toSearchQuery(),
+            "Query: {'constant_score':{'filter':{'exists':{'field':'foo'}}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.toString()).isEqualTo(expectedQuery);
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/ConstantScoreQueryTransformerTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/query/ConstantScoreQueryTransformerTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class ConstantScoreQueryTransformerTest {
+
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchQuery.class);
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.constantScore(SearchQueryBuilders.exists("foo")),
+            "Query: {'constant_score':{'filter':{'exists':{'field':'foo'}}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.constantScore()
+                .filter(SearchQueryBuilders.exists("foo"))
+                .build()
+                .toSearchQuery(),
+            "Query: {'constant_score':{'filter':{'exists':{'field':'foo'}}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.toString()).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullFilter() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.constantScore().build())
+        .hasMessageContaining("Expected a non-null filter for the constant score query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullFieldFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.constantScore((SearchQuery) null))
+        .hasMessageContaining("Expected a non-null filter for the constant score query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/pom.xml
+++ b/search/search-client-opensearch/pom.xml
@@ -36,6 +36,11 @@
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>

--- a/search/search-client-opensearch/pom.xml
+++ b/search/search-client-opensearch/pom.xml
@@ -51,6 +51,22 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.json</groupId>
+      <artifactId>jakarta.json-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/OpensearchTransformers.java
@@ -23,6 +23,7 @@ import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchRangeQuery;
 import io.camunda.search.clients.query.SearchTermQuery;
 import io.camunda.search.clients.query.SearchTermsQuery;
+import io.camunda.search.clients.query.SearchWildcardQuery;
 import io.camunda.search.clients.sort.SearchFieldSort;
 import io.camunda.search.clients.sort.SearchSortOptions;
 import io.camunda.search.clients.types.TypedValue;
@@ -39,6 +40,7 @@ import io.camunda.search.os.transformers.query.QueryTransformer;
 import io.camunda.search.os.transformers.query.RangeQueryTransformer;
 import io.camunda.search.os.transformers.query.TermQueryTransformer;
 import io.camunda.search.os.transformers.query.TermsQueryTransformer;
+import io.camunda.search.os.transformers.query.WildcardQueryTransformer;
 import io.camunda.search.os.transformers.search.SearchQueryHitTransformer;
 import io.camunda.search.os.transformers.search.SearchRequestTransformer;
 import io.camunda.search.os.transformers.search.SearchResponseTransformer;
@@ -86,6 +88,7 @@ public final class OpensearchTransformers {
     mappers.put(SearchRangeQuery.class, new RangeQueryTransformer(mappers));
     mappers.put(SearchTermQuery.class, new TermQueryTransformer(mappers));
     mappers.put(SearchTermsQuery.class, new TermsQueryTransformer(mappers));
+    mappers.put(SearchWildcardQuery.class, new WildcardQueryTransformer(mappers));
 
     // sort
     mappers.put(SearchSortOptions.class, new SortOptionsTransformer(mappers));

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/TermQueryTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/query/TermQueryTransformer.java
@@ -24,6 +24,10 @@ public final class TermQueryTransformer extends QueryOptionTransformer<SearchTer
     final var transformer = getFieldValueTransformer();
     final var fieldValue = value.value();
     final var tranformedFieldValue = transformer.apply(fieldValue);
-    return QueryBuilders.term().field(field).value(tranformedFieldValue).build();
+    return QueryBuilders.term()
+        .field(field)
+        .value(tranformedFieldValue)
+        .caseInsensitive(value.caseInsensitive())
+        .build();
   }
 }

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/BoolQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/BoolQueryTransformerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class BoolQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .should(
+                    List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "{'bool':{'should':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.or(
+                List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar"))),
+            "{'bool':{'should':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.or(
+                SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")),
+            "{'bool':{'should':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .must(List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "{'bool':{'must':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.and(
+                List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar"))),
+            "{'bool':{'must':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.and(
+                SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")),
+            "{'bool':{'must':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .mustNot(
+                    List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "{'bool':{'must_not':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.not(
+                List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar"))),
+            "{'bool':{'must_not':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.not(
+                SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")),
+            "{'bool':{'must_not':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.bool()
+                .filter(
+                    List.of(SearchQueryBuilders.exists("foo"), SearchQueryBuilders.exists("bar")))
+                .build()
+                .toSearchQuery(),
+            "{'bool':{'filter':[{'exists':{'field':'foo'}},{'exists':{'field':'bar'}}]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.constantScore()
+                .filter(SearchQueryBuilders.exists("foo"))
+                .build()
+                .toSearchQuery(),
+            "{'constant_score':{'filter':{'exists':{'field':'foo'}}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery)
+      throws IOException {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/ConstantScoreQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/ConstantScoreQueryTransformerTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class ConstantScoreQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.constantScore(SearchQueryBuilders.exists("foo")),
+            "{'constant_score':{'filter':{'exists':{'field':'foo'}}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.constantScore()
+                .filter(SearchQueryBuilders.exists("foo"))
+                .build()
+                .toSearchQuery(),
+            "{'constant_score':{'filter':{'exists':{'field':'foo'}}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullFilter() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.constantScore().build())
+        .hasMessageContaining("Expected a non-null filter for the constant score query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullFieldFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.constantScore((SearchQuery) null))
+        .hasMessageContaining("Expected a non-null filter for the constant score query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/ExistsQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/ExistsQueryTransformerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class ExistsQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(SearchQueryBuilders.exists("foo"), "{'exists':{'field':'foo'}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.exists().field("foo").build().toSearchQuery(),
+            "{'exists':{'field':'foo'}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.exists().build())
+        .hasMessageContaining("Expected a non-null field parameter for the exists query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullFieldFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.exists((String) null))
+        .hasMessageContaining("Expected a non-null field parameter for the exists query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/HasChildQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/HasChildQueryTransformerTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class HasChildQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.hasChildQuery("fooType", SearchQueryBuilders.term("fooField", 123)),
+            "{'has_child':{'query':{'term':{'fooField':{'value':123}}},'score_mode':'none','type':'fooType'}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.hasChild()
+                .type("fooType")
+                .query(SearchQueryBuilders.term("fooField", 123))
+                .build()
+                .toSearchQuery(),
+            "{'has_child':{'query':{'term':{'fooField':{'value':123}}},'score_mode':'none','type':'fooType'}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQuery() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.hasChild().type("fooType").build())
+        .hasMessageContaining("Expected a non-null query parameter for the hasChild query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQueryFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.hasChildQuery("fooType", null))
+        .hasMessageContaining("Expected a non-null query parameter for the hasChild query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullType() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(
+            () -> SearchQueryBuilders.hasChild().query(SearchQueryBuilders.term("foo", 1)).build())
+        .hasMessageContaining(
+            "Expected a non-null type parameter for the hasChild query, with query:")
+        .hasMessageContaining("field=foo")
+        .hasMessageContaining("value=1")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullTypeFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(
+            () -> SearchQueryBuilders.hasChildQuery(null, SearchQueryBuilders.term("foo", 1)))
+        .hasMessageContaining(
+            "Expected a non-null type parameter for the hasChild query, with query:")
+        .hasMessageContaining("field=foo")
+        .hasMessageContaining("value=1")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/IdsQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/IdsQueryTransformerTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class IdsQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(SearchQueryBuilders.ids(List.of()), "{'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values(List.of()).build().toSearchQuery(),
+            "{'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().build().toSearchQuery(), "{'ids':{'values':[]}}"),
+        Arguments.arguments(SearchQueryBuilders.ids((List<String>) null), "{'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids((Collection<String>) null), "{'ids':{'values':[]}}"),
+        Arguments.arguments(SearchQueryBuilders.ids((String[]) null), "{'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values((List<String>) null).build().toSearchQuery(),
+            "{'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values((String[]) null).build().toSearchQuery(),
+            "{'ids':{'values':[]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids(List.of("value")), "{'ids':{'values':['value']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids("value1", "value2"), "{'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids((Collection<String>) List.of("value1", "value2")),
+            "{'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids(List.of("value1", "value2")),
+            "{'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values(List.of("value1", "value2")).build().toSearchQuery(),
+            "{'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids()
+                .values(List.of("value1"))
+                .values(List.of("value2"))
+                .build()
+                .toSearchQuery(),
+            "{'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values("value1").values("value2").build().toSearchQuery(),
+            "{'ids':{'values':['value1','value2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.ids().values("value1", "value2").build().toSearchQuery(),
+            "{'ids':{'values':['value1','value2']}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/MatchQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/MatchQueryTransformerTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchMatchQuery.SearchMatchQueryOperator;
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class MatchQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.match("foo", "ba", SearchMatchQueryOperator.AND),
+            "{'match':{'foo':{'operator':'and','query':'ba'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.match()
+                .field("foo")
+                .operator(SearchMatchQueryOperator.AND)
+                .query("ba")
+                .build()
+                .toSearchQuery(),
+            "{'match':{'foo':{'operator':'and','query':'ba'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.match("foo", "ba", SearchMatchQueryOperator.OR),
+            "{'match':{'foo':{'operator':'or','query':'ba'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.match()
+                .field("foo")
+                .operator(SearchMatchQueryOperator.OR)
+                .query("ba")
+                .build()
+                .toSearchQuery(),
+            "{'match':{'foo':{'operator':'or','query':'ba'}}}"),
+        Arguments.arguments(SearchQueryBuilders.matchNone(), "{'match_none':{}}"),
+        Arguments.arguments(SearchQueryBuilders.matchAll(), "{'match_all':{}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQuery() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.match().field("foo").build())
+        .hasMessageContaining(
+            "Expected a non-null query parameter for the match query, with field: 'foo'.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullQueryFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.match("foo", null, null))
+        .hasMessageContaining(
+            "Expected a non-null query parameter for the match query, with field: 'foo'.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.match().build())
+        .hasMessageContaining("Expected a non-null field for the match query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/PrefixQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/PrefixQueryTransformerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class PrefixQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> providePrefixQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.prefix("foo", "ba"), "{'prefix':{'foo':{'value':'ba'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.prefix().field("foo").value("ba").build().toSearchQuery(),
+            "{'prefix':{'foo':{'value':'ba'}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("providePrefixQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullValue() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.prefix().field("foo").build())
+        .hasMessageContaining("Expected a non-null value for the prefix query with field: 'foo'.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullValueFactoryMethod() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.prefix("foo", null))
+        .hasMessageContaining("Expected a non-null value for the prefix query with field: 'foo'.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.prefix().build())
+        .hasMessageContaining("Expected a non-null field for the prefix query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/RangeQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/RangeQueryTransformerTest.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.clients.query.SearchRangeQuery;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+
+public class RangeQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchRangeQuery, RangeQuery> transformer;
+
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchRangeQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideRangeQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(null).build(), "{'foo':{}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(Long.MAX_VALUE).build(),
+            "{'foo':{'lt':9223372036854775807}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(Long.MIN_VALUE).build(),
+            "{'foo':{'lt':-9223372036854775808}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lt(123456789L).build(),
+            "{'foo':{'lt':123456789}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").gte(123456L).build(),
+            "{'foo':{'gte':123456}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").lte(12345L).build(), "{'foo':{'lte':12345}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").gt(1234L).build(), "{'foo':{'gt':1234}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").format("format").build(),
+            "{'foo':{'format':'format'}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").to("toBar").build(), "{'foo':{'to':'toBar'}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.range().field("foo").from("fromBar").build(),
+            "{'foo':{'from':'fromBar'}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideRangeQueries")
+  public void shouldApplyTransformer(
+      final SearchRangeQuery rangeQuery, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(rangeQuery);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldCombineMultipleRangeQueries() {
+    // given
+    final SearchRangeQuery query =
+        SearchQueryBuilders.range()
+            .field("foo")
+            .lt(123456789L)
+            .lte(12345L)
+            .gte(123456L)
+            .gt(1234L)
+            .build();
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.lt().to(Long.class)).isEqualTo(123456789L);
+    assertThat(result.gt().to(Long.class)).isEqualTo(1234L);
+    assertThat(result.gte().to(Long.class)).isEqualTo(123456L);
+    assertThat(result.lte().to(Long.class)).isEqualTo(12345L);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/TermQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/TermQueryTransformerTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class TermQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideQueries() {
+    return Stream.of(
+        Arguments.arguments(SearchQueryBuilders.term("foo", 1), "{'term':{'foo':{'value':1}}}"),
+        Arguments.arguments(SearchQueryBuilders.term("foo", 1L), "{'term':{'foo':{'value':1}}}"),
+        Arguments.arguments(SearchQueryBuilders.term("foo", 1.0), "{'term':{'foo':{'value':1.0}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", true), "{'term':{'foo':{'value':true}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", "string"), "{'term':{'foo':{'value':'string'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term("foo", (String) null), "{'term':{'foo':{'value':null}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term().field("foo").value((String) null).build().toSearchQuery(),
+            "{'term':{'foo':{'value':null}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term()
+                .field("foo")
+                .value("string")
+                .caseInsensitive(true) // if not null it will be set
+                .build()
+                .toSearchQuery(),
+            "{'term':{'foo':{'value':'string','case_insensitive':true}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term()
+                .field("foo")
+                .value("string")
+                .caseInsensitive(false)
+                .build()
+                .toSearchQuery(),
+            "{'term':{'foo':{'value':'string','case_insensitive':false}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.term()
+                .field("foo")
+                .value("string")
+                .value(1)
+                .value(true) // last one wins
+                .build()
+                .toSearchQuery(),
+            "{'term':{'foo':{'value':true}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideQueries")
+  public void shouldApplyTransformer(
+      final SearchQuery rangeQuery, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(rangeQuery);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullValue() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.term().field("foo").build())
+        .hasMessageContaining("Expected non-null value for term query, for field 'foo'.")
+        .isInstanceOf(NullPointerException.class);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.term().build())
+        .hasMessageContaining("Expected non-null field for term query.")
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/TermsQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/TermsQueryTransformerTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class TermsQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideRangeQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.intTerms("foo", List.of(1, 2)), "{'terms':{'foo':[1,2]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.longTerms("foo", List.of(1L, 2L)), "{'terms':{'foo':[1,2]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.stringTerms("foo", List.of("ele1", "ele2")),
+            "{'terms':{'foo':['ele1','ele2']}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.terms()
+                .field("foo")
+                .stringTerms(Arrays.stream(new String[] {"ele1", null}).toList())
+                .build()
+                .toSearchQuery(),
+            "{'terms':{'foo':['ele1',null]}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.terms()
+                .field("foo")
+                .stringTerms(List.of("ele1", "ele2"))
+                .build()
+                .toSearchQuery(),
+            "{'terms':{'foo':['ele1','ele2']}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideRangeQueries")
+  public void shouldApplyTransformer(
+      final SearchQuery rangeQuery, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(rangeQuery);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullValue() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.terms().field("foo").stringTerms(null).build())
+        .hasMessageContaining("Expected non-null values collection, for typed values.")
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/WildcardQueryTransformerTest.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/transformers/query/WildcardQueryTransformerTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.transformers.query;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.search.clients.query.SearchQuery;
+import io.camunda.search.clients.query.SearchQueryBuilders;
+import io.camunda.search.os.transformers.OpensearchTransformers;
+import io.camunda.search.os.util.OSQuerySerializer;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class WildcardQueryTransformerTest {
+
+  private final OpensearchTransformers transformers = new OpensearchTransformers();
+  private SearchTransfomer<SearchQuery, Query> transformer;
+
+  private OSQuerySerializer osQuerySerializer;
+
+  @BeforeEach
+  public void before() throws IOException {
+    transformer = transformers.getTransformer(SearchQuery.class);
+
+    // To serialize OS queries to json
+    osQuerySerializer = new OSQuerySerializer();
+  }
+
+  @AfterEach
+  public void close() throws Exception {
+    osQuerySerializer.close();
+  }
+
+  private static Stream<Arguments> provideRangeQueries() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchQueryBuilders.wildcardQuery("foo", "*"), "{'wildcard':{'foo':{'value':'*'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.wildcard().field("foo").value("*").build().toSearchQuery(),
+            "{'wildcard':{'foo':{'value':'*'}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.wildcard().field("foo").value(null).build().toSearchQuery(),
+            "{'wildcard':{'foo':{}}}"),
+        Arguments.arguments(
+            SearchQueryBuilders.wildcardQuery("foo", null), "{'wildcard':{'foo':{}}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideRangeQueries")
+  public void shouldApplyTransformer(final SearchQuery query, final String expectedResultQuery) {
+    // given
+    final var expectedQuery = expectedResultQuery.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(query);
+
+    // then
+    assertThat(result).isNotNull();
+    Assertions.assertThat(osQuerySerializer.serialize(result)).isEqualTo(expectedQuery);
+  }
+
+  @Test
+  public void shouldThrowErrorOnNullField() {
+    // given
+
+    // when - throw
+    assertThatThrownBy(() -> SearchQueryBuilders.wildcard().build())
+        .isInstanceOf(NullPointerException.class);
+  }
+}

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/util/OSQuerySerializer.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/util/OSQuerySerializer.java
@@ -16,6 +16,7 @@ import java.io.StringWriter;
 import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 
 public class OSQuerySerializer implements AutoCloseable {
   private final JacksonJsonpMapper mapper;
@@ -34,6 +35,12 @@ public class OSQuerySerializer implements AutoCloseable {
   }
 
   public String serialize(final Query query) {
+    query.serialize(jacksonJsonpGenerator, mapper);
+    jacksonJsonpGenerator.flush();
+    return out.toString();
+  }
+
+  public String serialize(final RangeQuery query) {
     query.serialize(jacksonJsonpGenerator, mapper);
     jacksonJsonpGenerator.flush();
     return out.toString();

--- a/search/search-client-opensearch/src/test/java/io/camunda/search/os/util/OSQuerySerializer.java
+++ b/search/search-client-opensearch/src/test/java/io/camunda/search/os/util/OSQuerySerializer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.os.util;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import org.opensearch.client.json.jackson.JacksonJsonpGenerator;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+public class OSQuerySerializer implements AutoCloseable {
+  private final JacksonJsonpMapper mapper;
+  private final JacksonJsonpGenerator jacksonJsonpGenerator;
+  private final StringWriter out;
+
+  public OSQuerySerializer() throws IOException {
+
+    // To serialize OS queries to json
+    out = new StringWriter();
+    final BufferedWriter w = new BufferedWriter(out);
+    final JsonGenerator jsonGenerator = new JsonFactory().createGenerator(w);
+
+    jacksonJsonpGenerator = new JacksonJsonpGenerator(jsonGenerator);
+    mapper = new JacksonJsonpMapper(new ObjectMapper());
+  }
+
+  public String serialize(final Query query) {
+    query.serialize(jacksonJsonpGenerator, mapper);
+    jacksonJsonpGenerator.flush();
+    return out.toString();
+  }
+
+  @Override
+  public void close() throws Exception {
+    out.close();
+    jacksonJsonpGenerator.close();
+  }
+}

--- a/search/search-client/pom.xml
+++ b/search/search-client/pom.xml
@@ -37,6 +37,11 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchBoolQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchBoolQuery.java
@@ -14,18 +14,13 @@ import io.camunda.util.ObjectBuilder;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.function.Function;
 
-public final record SearchBoolQuery(
+public record SearchBoolQuery(
     List<SearchQuery> filter,
     List<SearchQuery> must,
     List<SearchQuery> mustNot,
     List<SearchQuery> should)
     implements SearchQueryOption {
-
-  static SearchBoolQuery of(final Function<Builder, ObjectBuilder<SearchBoolQuery>> fn) {
-    return SearchQueryBuilders.bool(fn);
-  }
 
   public static final class Builder implements ObjectBuilder<SearchBoolQuery> {
 
@@ -43,10 +38,6 @@ public final record SearchBoolQuery(
       return filter(collectValues(query, queries));
     }
 
-    public Builder filter(final Function<SearchQuery.Builder, ObjectBuilder<SearchQuery>> fn) {
-      return filter(SearchQueryBuilders.query(fn));
-    }
-
     public Builder must(final List<SearchQuery> queries) {
       must = addValuesToList(must, queries);
       return this;
@@ -56,21 +47,9 @@ public final record SearchBoolQuery(
       return must(collectValues(query, queries));
     }
 
-    public Builder must(final Function<SearchQuery.Builder, ObjectBuilder<SearchQuery>> fn) {
-      return must(SearchQueryBuilders.query(fn));
-    }
-
     public Builder mustNot(final List<SearchQuery> queries) {
       mustNot = addValuesToList(mustNot, queries);
       return this;
-    }
-
-    public Builder mustNot(final SearchQuery query, final SearchQuery... queries) {
-      return mustNot(collectValues(query, queries));
-    }
-
-    public Builder mustNot(final Function<SearchQuery.Builder, ObjectBuilder<SearchQuery>> fn) {
-      return mustNot(SearchQueryBuilders.query(fn));
     }
 
     public Builder should(final List<SearchQuery> queries) {
@@ -80,10 +59,6 @@ public final record SearchBoolQuery(
 
     public Builder should(final SearchQuery query, final SearchQuery... queries) {
       return should(collectValues(query, queries));
-    }
-
-    public Builder should(final Function<SearchQuery.Builder, ObjectBuilder<SearchQuery>> fn) {
-      return should(SearchQueryBuilders.query(fn));
     }
 
     @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchBoolQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchBoolQuery.java
@@ -8,7 +8,6 @@
 package io.camunda.search.clients.query;
 
 import static io.camunda.util.CollectionUtil.addValuesToList;
-import static io.camunda.util.CollectionUtil.collectValues;
 
 import io.camunda.util.ObjectBuilder;
 import java.util.Collections;
@@ -34,17 +33,9 @@ public record SearchBoolQuery(
       return this;
     }
 
-    public Builder filter(final SearchQuery query, final SearchQuery... queries) {
-      return filter(collectValues(query, queries));
-    }
-
     public Builder must(final List<SearchQuery> queries) {
       must = addValuesToList(must, queries);
       return this;
-    }
-
-    public Builder must(final SearchQuery query, final SearchQuery... queries) {
-      return must(collectValues(query, queries));
     }
 
     public Builder mustNot(final List<SearchQuery> queries) {
@@ -55,10 +46,6 @@ public record SearchBoolQuery(
     public Builder should(final List<SearchQuery> queries) {
       should = addValuesToList(should, queries);
       return this;
-    }
-
-    public Builder should(final SearchQuery query, final SearchQuery... queries) {
-      return should(collectValues(query, queries));
     }
 
     @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchConstantScoreQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchConstantScoreQuery.java
@@ -23,7 +23,9 @@ public record SearchConstantScoreQuery(SearchQuery query) implements SearchQuery
 
     @Override
     public SearchConstantScoreQuery build() {
-      return new SearchConstantScoreQuery(Objects.requireNonNull(filter));
+      return new SearchConstantScoreQuery(
+          Objects.requireNonNull(
+              filter, "Expected a non-null filter for the constant score query."));
     }
   }
 }

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchConstantScoreQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchConstantScoreQuery.java
@@ -9,14 +9,8 @@ package io.camunda.search.clients.query;
 
 import io.camunda.util.ObjectBuilder;
 import java.util.Objects;
-import java.util.function.Function;
 
-public final record SearchConstantScoreQuery(SearchQuery query) implements SearchQueryOption {
-
-  static SearchConstantScoreQuery of(
-      final Function<Builder, ObjectBuilder<SearchConstantScoreQuery>> fn) {
-    return SearchQueryBuilders.constantScore(fn);
-  }
+public record SearchConstantScoreQuery(SearchQuery query) implements SearchQueryOption {
 
   public static final class Builder implements ObjectBuilder<SearchConstantScoreQuery> {
 
@@ -25,10 +19,6 @@ public final record SearchConstantScoreQuery(SearchQuery query) implements Searc
     public Builder filter(final SearchQuery value) {
       filter = value;
       return this;
-    }
-
-    public Builder filter(final Function<SearchQuery.Builder, ObjectBuilder<SearchQuery>> fn) {
-      return filter(SearchQueryBuilders.query(fn));
     }
 
     @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
@@ -9,9 +9,7 @@ package io.camunda.search.clients.query;
 
 import io.camunda.util.CollectionUtil;
 import io.camunda.util.ObjectBuilder;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Objects;
 
 public record SearchIdsQuery(List<String> values) implements SearchQueryOption {
 
@@ -25,7 +23,7 @@ public record SearchIdsQuery(List<String> values) implements SearchQueryOption {
     }
 
     public Builder values(final String... values) {
-      return values(Arrays.stream(Objects.requireNonNullElse(values, new String[0])).toList());
+      return values(CollectionUtil.collectValuesAsList(values));
     }
 
     @Override

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
@@ -9,13 +9,14 @@ package io.camunda.search.clients.query;
 
 import io.camunda.util.CollectionUtil;
 import io.camunda.util.ObjectBuilder;
+import java.util.ArrayList;
 import java.util.List;
 
 public record SearchIdsQuery(List<String> values) implements SearchQueryOption {
 
   public static final class Builder implements ObjectBuilder<SearchIdsQuery> {
 
-    private List<String> ids;
+    private List<String> ids = new ArrayList<>();
 
     public Builder values(final List<String> values) {
       ids = CollectionUtil.addValuesToList(ids, values);

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchIdsQuery.java
@@ -7,8 +7,8 @@
  */
 package io.camunda.search.clients.query;
 
+import io.camunda.util.CollectionUtil;
 import io.camunda.util.ObjectBuilder;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -17,10 +17,10 @@ public record SearchIdsQuery(List<String> values) implements SearchQueryOption {
 
   public static final class Builder implements ObjectBuilder<SearchIdsQuery> {
 
-    private final List<String> ids = new ArrayList<>();
+    private List<String> ids;
 
     public Builder values(final List<String> values) {
-      ids.addAll(Objects.requireNonNullElse(values, List.of()));
+      ids = CollectionUtil.addValuesToList(ids, values);
       return this;
     }
 

--- a/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/query/SearchQueryBuilders.java
@@ -94,7 +94,7 @@ public final class SearchQueryBuilders {
   }
 
   public static SearchQuery constantScore(final SearchQuery query) {
-    return SearchConstantScoreQuery.of(q -> q.filter(query)).toSearchQuery();
+    return constantScore(q -> q.filter(query)).toSearchQuery();
   }
 
   public static SearchExistsQuery.Builder exists() {

--- a/search/search-client/src/main/java/io/camunda/util/CollectionUtil.java
+++ b/search/search-client/src/main/java/io/camunda/util/CollectionUtil.java
@@ -32,14 +32,28 @@ public final class CollectionUtil {
     return null;
   }
 
+  /**
+   * Adds given values to a list.
+   *
+   * <p>This method can handle null-values gracefully.
+   *
+   * <p>This means, if either one of the given list is empty, and empty ArrayList will be used
+   * instead.
+   *
+   * <p>Example:
+   *
+   * <p>* addValuesToList(null, List.of(1)) -> List(1) * addValuesToList(List.of(1), null) ->
+   * List(1) * addValuesToList(null, null) -> List() * addValuesToList(List.of(1), List.of(2)) ->
+   * List(1, 2)
+   *
+   * @param list where the values should be added to
+   * @param values the values which should be added
+   * @return the given list (when not empty) otherwise a new list containing the values
+   * @param <T> the list value type
+   */
   public static <T> List<T> addValuesToList(final List<T> list, final List<T> values) {
-    final List<T> result;
-    if (list == null) {
-      result = Objects.requireNonNull(values);
-    } else {
-      result = new ArrayList<>(list);
-      result.addAll(values);
-    }
+    final List<T> result = Objects.requireNonNullElse(list, new ArrayList<>());
+    result.addAll(Objects.requireNonNullElse(values, new ArrayList<>()));
     return result;
   }
 

--- a/search/search-client/src/main/java/io/camunda/util/CollectionUtil.java
+++ b/search/search-client/src/main/java/io/camunda/util/CollectionUtil.java
@@ -57,6 +57,21 @@ public final class CollectionUtil {
     return result;
   }
 
+  /**
+   * Collects a given values (array) as list, and handles potential null or empty values.
+   *
+   * @param values the values that needs to be collected
+   * @return an appropriate list containing the values
+   * @param <T> the type of the values
+   */
+  public static <T> List<T> collectValuesAsList(final T... values) {
+    if (values == null) {
+      return List.of();
+    }
+
+    return Arrays.stream(values).toList();
+  }
+
   public static <T> List<T> collectValues(final T value, final T... values) {
     final List<T> collectedValues = new ArrayList<>();
     collectedValues.add(value);

--- a/search/search-client/src/test/java/io/camunda/util/CollectionUtilTest.java
+++ b/search/search-client/src/test/java/io/camunda/util/CollectionUtilTest.java
@@ -46,6 +46,25 @@ public class CollectionUtilTest {
     assertThat(result).isEqualTo(expected);
   }
 
+  private static Stream<Arguments> provideArrayParams() {
+    return Stream.of(
+        Arguments.arguments(null, List.of()),
+        Arguments.arguments(new String[0], List.of()),
+        Arguments.arguments(new String[] {"1", "2"}, List.of("1", "2")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideArrayParams")
+  public void shouldCollectValuesAsList(final String[] values, final List<String> expected) {
+    // given
+
+    // when
+    final var result = CollectionUtil.collectValuesAsList(values);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
+
   @Test
   public void shouldRemoveNullValuesFromStringArray() {
     // given

--- a/search/search-client/src/test/java/io/camunda/util/CollectionUtilTest.java
+++ b/search/search-client/src/test/java/io/camunda/util/CollectionUtilTest.java
@@ -10,9 +10,9 @@ package io.camunda.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.stream.Streams;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -28,9 +28,12 @@ public class CollectionUtilTest {
         Arguments.arguments(new ArrayList<>(), null, List.of()),
         Arguments.arguments(null, List.of(), List.of()),
         Arguments.arguments(null, List.of("1"), List.of("1")),
-        Arguments.arguments(
-            new ArrayList<>(Streams.of("1").toList()), List.of("2"), List.of("1", "2")),
-        Arguments.arguments(new ArrayList<>(Streams.of("1").toList()), null, List.of("1")));
+        Arguments.arguments(asList("1"), List.of("2"), List.of("1", "2")),
+        Arguments.arguments(asList("1"), null, List.of("1")));
+  }
+
+  private static List<String> asList(final String... args) {
+    return new ArrayList<>(Arrays.stream(args).toList());
   }
 
   @ParameterizedTest

--- a/search/search-client/src/test/java/io/camunda/util/CollectionUtilTest.java
+++ b/search/search-client/src/test/java/io/camunda/util/CollectionUtilTest.java
@@ -10,9 +10,41 @@ package io.camunda.util;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.stream.Streams;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class CollectionUtilTest {
+
+  private static Stream<Arguments> provideParams() {
+    return Stream.of(
+        Arguments.arguments(new ArrayList<>(), List.of(), List.of()),
+        Arguments.arguments(new ArrayList<>(), List.of("1"), List.of("1")),
+        Arguments.arguments(null, null, List.of()),
+        Arguments.arguments(new ArrayList<>(), null, List.of()),
+        Arguments.arguments(null, List.of(), List.of()),
+        Arguments.arguments(null, List.of("1"), List.of("1")),
+        Arguments.arguments(
+            new ArrayList<>(Streams.of("1").toList()), List.of("2"), List.of("1", "2")),
+        Arguments.arguments(new ArrayList<>(Streams.of("1").toList()), null, List.of("1")));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideParams")
+  public void shouldAddValuesToList(
+      final List<String> list, final List<String> values, final List<String> expected) {
+    // given
+
+    // when
+    final var result = CollectionUtil.addValuesToList(list, values);
+
+    // then
+    assertThat(result).isEqualTo(expected);
+  }
 
   @Test
   public void shouldRemoveNullValuesFromStringArray() {


### PR DESCRIPTION
## Description

Migrates the Search Client query tests from Elasticsearch to Opensearch.

Unfortunately, we can't simply use the `toString` for the Queries as Opensearch doesn't support this (or at least doesn't implement it). We have to use some JsonSerializer magic, to get the Query in a serialized format such that we can better assert the result.


This PR covers all search client query transformations:

 * https://github.com/camunda/camunda/pull/19735
 * https://github.com/camunda/camunda/pull/19733
 * https://github.com/camunda/camunda/pull/19730
 * https://github.com/camunda/camunda/pull/19724
 * https://github.com/camunda/camunda/pull/19720
 * https://github.com/camunda/camunda/pull/19682
 * https://github.com/camunda/camunda/pull/19764
 * https://github.com/camunda/camunda/pull/19736
 * https://github.com/camunda/camunda/pull/19718
 * https://github.com/camunda/camunda/pull/19682
 * https://github.com/camunda/camunda/pull/19663
 * https://github.com/camunda/camunda/pull/19678

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

related to https://github.com/camunda/camunda/issues/19076
