### PR TITLE
test: disable RollingUpdateTest

### DIFF
--- a/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
+++ b/zeebe/qa/update-tests/src/test/java/io/camunda/zeebe/test/RollingUpdateTest.java
@@ -39,6 +39,7 @@ import org.agrona.CloseHelper;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -53,6 +54,8 @@ import org.testcontainers.utility.DockerImageName;
  * <p>The important part is that we should be aware whether rolling update is possible between
  * versions.
  */
+@Disabled(
+    "Was detected as flaky, see https://camunda.slack.com/archives/C013MEVQ4M9/p1719835052167879")
 final class RollingUpdateTest {
 
   private static final BpmnModelInstance PROCESS =


### PR DESCRIPTION
## Description

Was detected RollingUpdate as flaky/failing and causing issues on the main branch, especially blocking further merging. The test issue needs further investigation by the respective teams.


<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

Related https://github.com/camunda/camunda/issues/19910
See https://camunda.slack.com/archives/C013MEVQ4M9/p1719835052167879