### PR TITLE
chore(ci): fix timeouts and memory issues brought by adding in Optimize

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
     if: needs.detect-changes.outputs.java-code-changes == 'true'
     needs: [detect-changes]
     runs-on: [ self-hosted, linux, amd64, "16" ]
-    timeout-minutes: 30
+    timeout-minutes: 60
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     steps:
@@ -218,7 +218,7 @@ jobs:
     name: Camunda docker tests
     needs: [ detect-changes ]
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 40
     services:
       # local registry is used as this job needs to push as it builds multi-platform images
       registry:

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   integration-tests:
     name: ${{ inputs.test-type }}
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on: ${{ inputs.runner-type }}
     if: ${{ !startsWith(inputs.branch, 'fe-') && !(startsWith(inputs.branch, 'renovate/') && contains(inputs.branch, '-fe-')) }}
 

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -37,8 +37,8 @@ concurrency:
 jobs:
   integration-tests:
     name: Docker container tests
-    runs-on: gcp-core-2-default
-    timeout-minutes: 20
+    runs-on: gcp-core-4-default
+    timeout-minutes: 40
     env:
       OPERATE_TEST_DOCKER_IMAGE: localhost:5000/camunda/operate:current-test
     services:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   integration-tests:
     name: "[IT] ${{ matrix.name }}"
-    timeout-minutes: 20
+    timeout-minutes: 40
     outputs:
       flakyTests: ${{ steps.analyze-test-run.outputs.flakyTests }}
     runs-on: [ self-hosted, linux, amd64, "16" ]
@@ -218,7 +218,7 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
-    timeout-minutes: 20
+    timeout-minutes: 40
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description
 
With this PR, we're increasing some job timeout, when needed, and we're using a more powerful runner for the jobs that require more memory, resolving thus:

* timeout issues
* memory issues

in the following workflows:

* `Operate Tests / Docker container tests (pull_request)`
* `CI / java-unit-tests (pull_request)`
* `Zeebe CI / [Smoke] macos with amd64 (pull_request)`
* `Zeebe CI / [Smoke] windows with amd64 (pull_request)`
* `Operate CI / Operate Backend Integration Tests / Integration Tests (pull_request)`
* `Zeebe CI / Property Tests (pull_request)`
* `CI / Camunda docker tests (pull_request)`

Although some of the workflows are still failing for other errors, once the previous problems are resolved.