### PR TITLE
feat: measure average exporting rate

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -630,6 +630,9 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
                   LOG.error(ERROR_MESSAGE_EXPORTING_ABORTED, event, throwable);
                   onFailure();
                 } else {
+                  logStream
+                      .getFlowControl()
+                      .onExported(recordExporter.getTypedEvent().getPosition());
                   metrics.eventExported(recordExporter.getTypedEvent().getValueType());
                   inExportingPhase = false;
                   actor.submit(this::readNextEvent);

--- a/zeebe/logstreams/pom.xml
+++ b/zeebe/logstreams/pom.xml
@@ -68,6 +68,11 @@
     </dependency>
 
     <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/LogStreamMetrics.java
@@ -139,6 +139,15 @@ public final class LogStreamMetrics {
           .help("Count of records appended per partition, record type, value type, and intent")
           .register();
 
+  private static final Gauge EXPORTING_RATE =
+      Gauge.build()
+          .namespace("zeebe")
+          .subsystem("flow_control")
+          .name("exporting_rate")
+          .help("The rate of exporting records from the log appender")
+          .labelNames("partition")
+          .register();
+
   private final Counter.Child deferredAppends;
   private final Counter.Child triedAppends;
   private final Gauge.Child inflightAppends;
@@ -151,6 +160,7 @@ public final class LogStreamMetrics {
   private final Gauge.Child lastWritten;
   private final Histogram.Child commitLatency;
   private final Histogram.Child appendLatency;
+  private final Gauge.Child exportingRate;
   private final String partitionLabel;
 
   public LogStreamMetrics(final int partitionId) {
@@ -167,6 +177,7 @@ public final class LogStreamMetrics {
     lastWritten = LAST_WRITTEN_POSITION.labels(partitionLabel);
     commitLatency = COMMIT_LATENCY.labels(partitionLabel);
     appendLatency = WRITE_LATENCY.labels(partitionLabel);
+    exportingRate = EXPORTING_RATE.labels(partitionLabel);
   }
 
   public void increaseInflightAppends() {
@@ -234,6 +245,7 @@ public final class LogStreamMetrics {
     LAST_WRITTEN_POSITION.remove(partitionLabel);
     COMMIT_LATENCY.remove(partitionLabel);
     WRITE_LATENCY.remove(partitionLabel);
+    EXPORTING_RATE.remove(partitionLabel);
   }
 
   private String contextLabel(final WriteContext context) {
@@ -277,5 +289,9 @@ public final class LogStreamMetrics {
     FLOW_CONTROL_OUTCOME
         .labels(partitionLabel, contextLabel(context), reasonLabel(reason))
         .inc(batchMetadata.size());
+  }
+
+  public void setExportingRate(final long value) {
+    exportingRate.set(value);
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.logstreams.impl.flowcontrol;
 import java.time.Duration;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.function.LongSupplier;
-import javax.annotation.concurrent.ThreadSafe;
+import net.jcip.annotations.ThreadSafe;
 
 /** Measures the rate of change for monotonically increasing values. */
 @ThreadSafe

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurement.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import java.time.Duration;
+import java.util.concurrent.LinkedBlockingDeque;
+import java.util.function.LongSupplier;
+import javax.annotation.concurrent.ThreadSafe;
+
+/** Measures the rate of change for monotonically increasing values. */
+@ThreadSafe
+public final class RateMeasurement {
+  private final LongSupplier clock;
+  private final LinkedBlockingDeque<Observation> observations;
+  private final long resolution;
+  private volatile long currentValue;
+
+  public RateMeasurement(
+      final LongSupplier clock, final Duration observationWindow, final Duration resolution) {
+    if (observationWindow.isNegative() || resolution.isNegative()) {
+      throw new IllegalArgumentException("observationWindow and resolution must be positive");
+    }
+    if (observationWindow.compareTo(resolution) <= 0) {
+      throw new IllegalArgumentException("observationWindow must be greater than resolution");
+    }
+    this.clock = clock;
+    this.resolution = resolution.toMillis();
+    final var numberOfObservations = (int) (observationWindow.toMillis() / this.resolution);
+    observations = new LinkedBlockingDeque<>(numberOfObservations);
+  }
+
+  public boolean observe(final long value) {
+    final var now = clock.getAsLong();
+    currentValue = value;
+    return updateObservations(now, value);
+  }
+
+  public long rate() {
+    final var now = clock.getAsLong();
+
+    final var oldest = observations.peekFirst();
+    if (oldest == null) {
+      return 0;
+    }
+
+    final var elapsed = now - oldest.timestamp;
+    if (elapsed == 0) {
+      return 0;
+    }
+
+    final var delta = currentValue - oldest.value;
+    return delta * 1000 / elapsed;
+  }
+
+  private boolean updateObservations(final long now, final long value) {
+    final var last = observations.peekLast();
+    if (last == null || now - last.timestamp >= resolution) {
+      final var newObservation = new Observation(now, value);
+      while (!observations.offerLast(newObservation)) {
+        observations.removeFirst();
+      }
+      return true;
+    }
+    return false;
+  }
+
+  record Observation(long timestamp, long value) {}
+}

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurementTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/flowcontrol/RateMeasurementTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.logstreams.impl.flowcontrol;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.Test;
+
+class RateMeasurementTest {
+  @Test
+  void shouldMeasureZeroWithoutObservations() {
+    // given
+    final var clock = new AtomicLong(0);
+    final RateMeasurement rateMeasurement =
+        new RateMeasurement(clock::get, Duration.ofMinutes(5), Duration.ofSeconds(10));
+
+    // when
+    final double rate = rateMeasurement.rate();
+
+    // then
+    assertEquals(0, rate);
+  }
+
+  @Test
+  void shouldMeasureExpectedRate() {
+    // given
+    final var clock = new AtomicLong(0);
+    final var observationWindow = Duration.ofMinutes(5);
+    final RateMeasurement rateMeasurement =
+        new RateMeasurement(clock::get, observationWindow, Duration.ofSeconds(10));
+
+    // when
+    rateMeasurement.observe(0);
+    clock.set(observationWindow.toMillis());
+    rateMeasurement.observe(12345);
+
+    // then
+    assertEquals(12345 / observationWindow.toSeconds(), rateMeasurement.rate());
+  }
+
+  @Test
+  void shouldMeasureRate() {
+    // given
+    final var clock = new AtomicLong(0);
+    final var observationWindow = Duration.ofMinutes(5);
+    final RateMeasurement rateMeasurement =
+        new RateMeasurement(clock::get, observationWindow, Duration.ofSeconds(1));
+
+    // when
+    for (var second = 0; second <= observationWindow.toSeconds(); second++) {
+      clock.set(second * 1000L);
+      rateMeasurement.observe(second * 10L);
+    }
+
+    // then
+    assertEquals(10, rateMeasurement.rate());
+  }
+}


### PR DESCRIPTION
## Description

Measure exporting rate so that we can later adjust write rate to match. A new metric is added but not yet visualized.

## Related issues

depends on https://github.com/camunda/camunda/pull/19568
relates to https://github.com/camunda/camunda/issues/19681
