### PR TITLE
[Backport stable/8.4] deps: Update dependency io.grpc:grpc-bom to v1.65.0

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -268,12 +268,6 @@
 
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-testing</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>io.grpc</groupId>
       <artifactId>grpc-inprocess</artifactId>
       <scope>test</scope>
     </dependency>

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/ContextInjectingInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/ContextInjectingInterceptorTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mock;
 import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
 import io.camunda.zeebe.gateway.query.QueryApi;
 import io.grpc.Metadata;
-import io.grpc.internal.NoopServerCall;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/CustomTenantProvidingInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/CustomTenantProvidingInterceptorTest.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.gateway.interceptors.util.TestTenantProvidingInterceptor
 import io.grpc.Context;
 import io.grpc.Metadata;
 import io.grpc.Status;
-import io.grpc.internal.NoopServerCall;
 import org.assertj.core.api.ListAssert;
 import org.junit.jupiter.api.Test;
 

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/DecoratedInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/DecoratedInterceptorTest.java
@@ -14,7 +14,6 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCall.Listener;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
-import io.grpc.internal.NoopServerCall;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/IdentityInterceptorTest.java
@@ -25,7 +25,6 @@ import io.grpc.Metadata.Key;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCallHandler;
 import io.grpc.Status;
-import io.grpc.internal.NoopServerCall;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import org.assertj.core.api.ListAssert;

--- a/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/NoopServerCall.java
+++ b/gateway/src/test/java/io/camunda/zeebe/gateway/interceptors/impl/NoopServerCall.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
+ */
+package io.camunda.zeebe.gateway.interceptors.impl;
+
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.Status;
+
+public class NoopServerCall<ReqT, RespT> extends ServerCall<ReqT, RespT> {
+
+  @Override
+  public void request(final int i) {}
+
+  @Override
+  public void sendHeaders(final Metadata metadata) {}
+
+  @Override
+  public void sendMessage(final RespT respT) {}
+
+  @Override
+  public void close(final Status status, final Metadata metadata) {}
+
+  @Override
+  public boolean isCancelled() {
+    return false;
+  }
+
+  @Override
+  public MethodDescriptor<ReqT, RespT> getMethodDescriptor() {
+    return null;
+  }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
     <version.docker-java-api>3.3.6</version.docker-java-api>
     <version.elasticsearch>8.9.2</version.elasticsearch>
     <version.error-prone>2.24.1</version.error-prone>
-    <version.grpc>1.60.1</version.grpc>
+    <version.grpc>1.65.0</version.grpc>
     <version.gson>2.10.1</version.gson>
     <version.guava>33.0.0-jre</version.guava>
     <version.hamcrest>2.2</version.hamcrest>


### PR DESCRIPTION
# Description
Backport of #19858 to `stable/8.4`.

relates to 
original author: @renovate[bot]