### PR TITLE
[Backport stable/8.5] deps: Update dependency io.grpc:grpc-bom to v1.65.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -53,7 +53,7 @@
     <version.docker-java-api>3.3.6</version.docker-java-api>
     <version.elasticsearch>8.9.2</version.elasticsearch>
     <version.error-prone>2.26.1</version.error-prone>
-    <version.grpc>1.62.2</version.grpc>
+    <version.grpc>1.65.0</version.grpc>
     <version.gson>2.10.1</version.gson>
     <version.guava>33.1.0-jre</version.guava>
     <version.hamcrest>2.2</version.hamcrest>


### PR DESCRIPTION
# Description
Backport of #19858 to `stable/8.5`.

relates to 
original author: @renovate[bot]