### PR TITLE
fix: ignore large RocksDB .sst and frontend .yarn files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ faces-config.NavData
 work/
 public/
 tngp-data
+*.sst
 
 .flattened-pom.xml
 
@@ -52,3 +53,4 @@ hs_err*.log
 .vscode
 .eslintcache
 els-snapshots
+.yarn


### PR DESCRIPTION
## Description

Outcome of https://camunda.slack.com/archives/C05DH1F5TAR/p1719909724298809 to make repeating this more unlikely.