### PR TITLE
Ensure instance migration can't detach boundary event from element instance

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -228,6 +228,13 @@ public class ProcessInstanceMigrationMigrateProcessor
         targetElementId,
         elementInstanceRecord,
         EnumSet.of(BpmnEventType.MESSAGE));
+    requireMappedBoundaryEventsToStayAttachedToSameElement(
+        processInstanceKey,
+        sourceProcessDefinition,
+        targetProcessDefinition,
+        elementId,
+        targetElementId,
+        sourceElementIdToTargetElementId);
     requireNoConcurrentCommand(eventScopeInstanceState, elementInstance, processInstanceKey);
 
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -53,16 +53,16 @@ public final class ProcessInstanceMigrationPreconditions {
       "Expected to migrate process instance '%s' but the mapping instructions contain duplicate source element ids '%s'.";
   private static final String ERROR_SOURCE_ELEMENT_ID_NOT_FOUND =
       """
-              Expected to migrate process instance '%s' \
-              but mapping instructions contain a non-existing source element id '%s'. \
-              Elements provided in mapping instructions must exist \
-              in the source process definition.""";
+      Expected to migrate process instance '%s' \
+      but mapping instructions contain a non-existing source element id '%s'. \
+      Elements provided in mapping instructions must exist \
+      in the source process definition.""";
   private static final String ERROR_TARGET_ELEMENT_ID_NOT_FOUND =
       """
-              Expected to migrate process instance '%s' \
-              but mapping instructions contain a non-existing target element id '%s'. \
-              Elements provided in mapping instructions must exist \
-              in the target process definition.""";
+      Expected to migrate process instance '%s' \
+      but mapping instructions contain a non-existing target element id '%s'. \
+      Elements provided in mapping instructions must exist \
+      in the target process definition.""";
   private static final String ERROR_MESSAGE_EVENT_SUBPROCESS_NOT_SUPPORTED_IN_PROCESS_INSTANCE =
       "Expected to migrate process instance but process instance has an event subprocess. Process instances with event subprocesses cannot be migrated yet.";
   private static final String ERROR_MESSAGE_EVENT_SUBPROCESS_NOT_SUPPORTED_IN_TARGET_PROCESS =
@@ -73,45 +73,44 @@ public final class ProcessInstanceMigrationPreconditions {
       "Expected to migrate process instance '%s' but no mapping instruction defined for active element with id '%s'. Elements cannot be migrated without a mapping.";
   private static final String ERROR_ELEMENT_TYPE_CHANGED =
       """
-              Expected to migrate process instance '%s' \
-              but active element with id '%s' and type '%s' is mapped to \
-              an element with id '%s' and different type '%s'. \
-              Elements must be mapped to elements of the same type.""";
-
+      Expected to migrate process instance '%s' \
+      but active element with id '%s' and type '%s' is mapped to \
+      an element with id '%s' and different type '%s'. \
+      Elements must be mapped to elements of the same type.""";
   private static final String ERROR_USER_TASK_IMPLEMENTATION_CHANGED =
       """
-              Expected to migrate process instance '%s' \
-              but active user task with id '%s' and implementation '%s' is mapped to \
-              an user task with id '%s' and different implementation '%s'. \
-              Elements must be mapped to elements of the same implementation.""";
+      Expected to migrate process instance '%s' \
+      but active user task with id '%s' and implementation '%s' is mapped to \
+      an user task with id '%s' and different implementation '%s'. \
+      Elements must be mapped to elements of the same implementation.""";
   private static final String ERROR_MESSAGE_ELEMENT_FLOW_SCOPE_CHANGED =
       """
-              Expected to migrate process instance '%s' \
-              but the flow scope of active element with id '%s' is changed. \
-              The flow scope of the active element is expected to be '%s' but was '%s'. \
-              The flow scope of an element cannot be changed during migration yet.""";
+      Expected to migrate process instance '%s' \
+      but the flow scope of active element with id '%s' is changed. \
+      The flow scope of the active element is expected to be '%s' but was '%s'. \
+      The flow scope of an element cannot be changed during migration yet.""";
   private static final String ERROR_ACTIVE_ELEMENT_WITH_BOUNDARY_EVENT =
       """
-              Expected to migrate process instance '%s' \
-              but active element with id '%s' has one or more boundary events of types '%s'. \
-              Migrating active elements with boundary events of these types is not possible yet.""";
+      Expected to migrate process instance '%s' \
+      but active element with id '%s' has one or more boundary events of types '%s'. \
+      Migrating active elements with boundary events of these types is not possible yet.""";
   private static final String ERROR_TARGET_ELEMENT_WITH_BOUNDARY_EVENT =
       """
-              Expected to migrate process instance '%s' \
-              but target element with id '%s' has one or more boundary events of types '%s'. \
-              Migrating target elements with boundary events of these types is not possible yet.""";
+      Expected to migrate process instance '%s' \
+      but target element with id '%s' has one or more boundary events of types '%s'. \
+      Migrating target elements with boundary events of these types is not possible yet.""";
   private static final String ERROR_BOUNDARY_EVENT_DETACHED =
       """
-              Expected to migrate process instance '%s' \
-              but active element with id '%s' is mapped to an element with id '%s' and \
-              has a boundary event with id '%s' that is mapped to an element with id '%s'. \
-              These mappings detach the boundary event from the element in the target process. \
-              Boundary events must stay attached to the same element instance.""";
+      Expected to migrate process instance '%s' \
+      but active element with id '%s' is mapped to an element with id '%s' and \
+      has a boundary event with id '%s' that is mapped to an element with id '%s'. \
+      These mappings detach the boundary event from the element in the target process. \
+      Boundary events must stay attached to the same element instance.""";
   private static final String ERROR_PENDING_DISTRIBUTION =
       """
-              Expected to migrate process instance '%s' \
-              but active element with id '%s' has a pending message subscription \
-              migration distribution for event with id '%s'.""";
+      Expected to migrate process instance '%s' \
+      but active element with id '%s' has a pending message subscription \
+      migration distribution for event with id '%s'.""";
   private static final String ERROR_CONCURRENT_COMMAND =
       "Expected to migrate process instance '%s' but a concurrent command was executed on the process instance. Please retry the migration.";
   private static final long NO_PARENT = -1L;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -48,9 +48,13 @@ public final class ProcessInstanceMigrationPreconditions {
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to migrate process instance but no process instance found with key '%d'";
   private static final String ERROR_MESSAGE_PROCESS_DEFINITION_NOT_FOUND =
-      "Expected to migrate process instance to process definition but no process definition found with key '%d'";
+      """
+      Expected to migrate process instance to process definition \
+      but no process definition found with key '%d'""";
   private static final String ERROR_MESSAGE_DUPLICATE_SOURCE_ELEMENT_IDS =
-      "Expected to migrate process instance '%s' but the mapping instructions contain duplicate source element ids '%s'.";
+      """
+      Expected to migrate process instance '%s' \
+      but the mapping instructions contain duplicate source element ids '%s'.""";
   private static final String ERROR_SOURCE_ELEMENT_ID_NOT_FOUND =
       """
       Expected to migrate process instance '%s' \
@@ -64,13 +68,23 @@ public final class ProcessInstanceMigrationPreconditions {
       Elements provided in mapping instructions must exist \
       in the target process definition.""";
   private static final String ERROR_MESSAGE_EVENT_SUBPROCESS_NOT_SUPPORTED_IN_PROCESS_INSTANCE =
-      "Expected to migrate process instance but process instance has an event subprocess. Process instances with event subprocesses cannot be migrated yet.";
+      """
+      Expected to migrate process instance but process instance has an event subprocess. \
+      Process instances with event subprocesses cannot be migrated yet.""";
   private static final String ERROR_MESSAGE_EVENT_SUBPROCESS_NOT_SUPPORTED_IN_TARGET_PROCESS =
-      "Expected to migrate process instance but target process has an event subprocess. Target processes with event subprocesses cannot be migrated yet.";
+      """
+      Expected to migrate process instance but target process has an event subprocess. \
+      Target processes with event subprocesses cannot be migrated yet.""";
   private static final String ERROR_UNSUPPORTED_ELEMENT_TYPE =
-      "Expected to migrate process instance '%s' but active element with id '%s' has an unsupported type. The migration of a %s is not supported.";
+      """
+      Expected to migrate process instance '%s' \
+      but active element with id '%s' has an unsupported type. \
+      The migration of a %s is not supported.""";
   private static final String ERROR_UNMAPPED_ACTIVE_ELEMENT =
-      "Expected to migrate process instance '%s' but no mapping instruction defined for active element with id '%s'. Elements cannot be migrated without a mapping.";
+      """
+      Expected to migrate process instance '%s' \
+      but no mapping instruction defined for active element with id '%s'. \
+      Elements cannot be migrated without a mapping.""";
   private static final String ERROR_ELEMENT_TYPE_CHANGED =
       """
       Expected to migrate process instance '%s' \
@@ -112,7 +126,10 @@ public final class ProcessInstanceMigrationPreconditions {
       but active element with id '%s' has a pending message subscription \
       migration distribution for event with id '%s'.""";
   private static final String ERROR_CONCURRENT_COMMAND =
-      "Expected to migrate process instance '%s' but a concurrent command was executed on the process instance. Please retry the migration.";
+      """
+      Expected to migrate process instance '%s' \
+      but a concurrent command was executed on the process instance. \
+      Please retry the migration.""";
   private static final long NO_PARENT = -1L;
   private static final String ZEEBE_USER_TASK_IMPLEMENTATION = "zeebe user task";
   private static final String JOB_WORKER_IMPLEMENTATION = "job worker";

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -130,7 +130,7 @@ public final class ProcessInstanceMigrationPreconditions {
       Expected to migrate process instance '%s' \
       but a concurrent command was executed on the process instance. \
       Please retry the migration.""";
-  private static final long NO_PARENT = -1L;
+
   private static final String ZEEBE_USER_TASK_IMPLEMENTATION = "zeebe user task";
   private static final String JOB_WORKER_IMPLEMENTATION = "job worker";
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBoundaryEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBoundaryEventTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -415,5 +416,129 @@ public class MigrateBoundaryEventTest {
         .hasElementId("sub2")
         .describedAs("Expect that version number did not change")
         .hasVersion(1);
+  }
+
+  @Test
+  public void shouldMigrateMappedBoundaryEventAttachedToTheSameMappedElement() {
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("boundary")
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .boundaryEvent("boundary")
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent("end")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVariable("key", "key").create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementId("A")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary", "boundary")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .hasBpmnProcessId(targetProcessId);
+  }
+
+  @Test
+  public void shouldRejectCommandWhenMappedBoundaryEventIsAttachedToDifferentElement() {
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent("boundary")
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .serviceTask("B", t -> t.zeebeJobType("B"))
+                    .boundaryEvent("boundary")
+                    .message(m -> m.name("message").zeebeCorrelationKeyExpression("key"))
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent("end")
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVariable("key", "key").create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .addMappingInstruction("boundary", "boundary")
+            .expectRejection()
+            .migrate();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .extracting(Record::getRejectionReason)
+        .asString()
+        .contains("Expected to migrate process instance '2251799813685252'")
+        .contains("active element with id 'A' is mapped to an element with id 'A'")
+        .contains(
+            "and has a boundary event with id 'boundary' that is mapped to an element with id 'boundary'")
+        .contains("These mappings detach the boundary event from the element in the target process")
+        .contains("Boundary events must stay attached to the same element instance");
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -954,6 +954,7 @@ service Gateway {
         - not all active elements in the given process instance are mapped to the elements in the target process definition
         - a mapping instruction changes the type of an element or event
         - a mapping instruction changes the implementation of a task
+        - a mapping instruction detaches a boundary event from an active element
         - a mapping instruction refers to an unsupported element (i.e. some elements will be supported later on)
         - a mapping instruction refers to element in unsupported scenarios.
           (i.e. migration is not supported when process instance or target process elements contains event subscriptions)

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -953,6 +953,7 @@ service Gateway {
       FAILED_PRECONDITION:
         - not all active elements in the given process instance are mapped to the elements in the target process definition
         - a mapping instruction changes the type of an element or event
+        - a mapping instruction changes the implementation of a task
         - a mapping instruction refers to an unsupported element (i.e. some elements will be supported later on)
         - a mapping instruction refers to element in unsupported scenarios.
           (i.e. migration is not supported when process instance or target process elements contains event subscriptions)


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

Adds an additional validation to instance migration.

If boundary event would become detached from element instance, the `MIGRATE` command is rejected with [`GRPC_STATUS_FAILED_PRECONDITION`](https://docs.camunda.io/docs/next/apis-tools/zeebe-api/gateway-service/#grpc_status_failed_precondition-3).

I've taken the liberty to clean up some precondition error templates.

The `gateway.proto` documentation is adjusted accordingly. We'll also need to update the docs at https://docs.camunda.io.

> [!NOTE]
> The `gateway.proto` file was not completely synced with https://docs.camunda.io. To align them, I've added:
> - a mapping instruction changes the implementation of a task

## Related issues

closes #19956