### PR TITLE
fix: retry of aborted snapshot replication can succeed

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -521,6 +521,7 @@ public class PassiveRole extends InactiveRole {
   private void abortPendingSnapshots() {
     if (pendingSnapshot != null) {
       setNextExpected(null);
+      previouslyReceivedSnapshotChunkId = null;
       log.info("Rolling back snapshot {}", pendingSnapshot);
       try {
         pendingSnapshot.abort();


### PR DESCRIPTION
## Description

fix test flake.

If a snapshot replication aborts after the first chunk is received, the `previouslyReceivedSnapshotChunkId` is not reset to null therefore in the next snapshot that is retried it skips over the first chunk (assuming it has already been received) and for all subsequent chunks since the pending snapshot has not been created it fails a check as non initial chunks cannot be processed if no pending snapshot has been created.

- System assumes because no pending snapshot it is waiting for the first chunk, it rejects all non initial chunks.
- first chunk arrives and is skipped due to `previouslyReceivedSnapshotChunkId` not being reset
- all subsequent chunks are rejected for being non initial

The fix was to reset the `previouslyReceivedSnapshotChunkId` if a snapshot is aborted.
## Related issues

closes #19862 
