### PR TITLE
Migrate timer boundary event subscriptions

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -404,15 +404,21 @@ public final class CatchEventBehavior {
         });
   }
 
-  private void unsubscribeFromTimerEvents(
-      final long elementInstanceKey, final Predicate<DirectBuffer> elementIdFilter) {
+  public void unsubscribeFromTimerEventsByInstanceFilter(
+      final long elementInstanceKey, final Predicate<TimerInstance> timerInstanceFilter) {
     timerInstanceState.forEachTimerForElementInstance(
         elementInstanceKey,
         timer -> {
-          if (elementIdFilter.test(timer.getHandlerNodeId())) {
+          if (timerInstanceFilter.test(timer)) {
             unsubscribeFromTimerEvent(timer);
           }
         });
+  }
+
+  private void unsubscribeFromTimerEvents(
+      final long elementInstanceKey, final Predicate<DirectBuffer> elementIdFilter) {
+    unsubscribeFromTimerEventsByInstanceFilter(
+        elementInstanceKey, timer -> elementIdFilter.test(timer.getHandlerNodeId()));
   }
 
   public void unsubscribeFromTimerEvent(final TimerInstance timer) {
@@ -488,10 +494,10 @@ public final class CatchEventBehavior {
         tenantId);
   }
 
-  public record CatchEvent(ExecutableCatchEvent element, DirectBuffer messageName) {
+  public record CatchEvent(ExecutableCatchEvent element, DirectBuffer messageName, Timer timer) {
 
     private CatchEvent(final EvalResult result) {
-      this(result.event(), result.messageName());
+      this(result.event(), result.messageName(), result.timer());
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -397,7 +397,7 @@ public class ProcessInstanceMigrationMigrateProcessor
                   """
                   Expected to migrate process instance '%s' \
                   but active element with id '%s' is mapped to element with id '%s' \
-                  that must be subscribed to a message catch event. %s"""
+                  that must be subscribed to a catch event. %s"""
                       .formatted(
                           processInstanceKey, elementId, targetElementId, failure.getMessage()),
                   RejectionType.INVALID_STATE);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -495,16 +495,9 @@ public class ProcessInstanceMigrationMigrateProcessor
             // We will migrate this mapped catch event, so we don't want to unsubscribe from it.
             // Avoid reusing the subscription directly as any access to the state (e.g. #get) will
             // overwrite it
-            final TimerInstance copyTimerInstance = new TimerInstance();
-            copyTimerInstance.setProcessInstanceKey(timerInstance.getProcessInstanceKey());
-            copyTimerInstance.setElementInstanceKey(timerInstance.getElementInstanceKey());
-            copyTimerInstance.setKey(timerInstance.getKey());
-            copyTimerInstance.setDueDate(timerInstance.getDueDate());
-            copyTimerInstance.setHandlerNodeId(timerInstance.getHandlerNodeId());
-            copyTimerInstance.setRepetitions(timerInstance.getRepetitions());
-            copyTimerInstance.setProcessDefinitionKey(timerInstance.getProcessDefinitionKey());
-            copyTimerInstance.setTenantId(timerInstance.getTenantId());
-            timerInstancesToMigrate.add(copyTimerInstance);
+            final var copy = new TimerInstance();
+            copy.copyFrom(timerInstance);
+            timerInstancesToMigrate.add(copy);
 
             return false;
           }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -115,7 +115,7 @@ public final class EventAppliers implements EventApplier {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
-    register(TimerIntent.MIGRATED, NOOP_EVENT_APPLIER);
+    register(TimerIntent.MIGRATED, new TimerMigrationApplier(state.getTimerState()));
   }
 
   private void registerDeploymentAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -115,6 +115,7 @@ public final class EventAppliers implements EventApplier {
     register(TimerIntent.CREATED, new TimerCreatedApplier(state.getTimerState()));
     register(TimerIntent.CANCELED, new TimerCancelledApplier(state.getTimerState()));
     register(TimerIntent.TRIGGERED, new TimerTriggeredApplier(state.getTimerState()));
+    register(TimerIntent.MIGRATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerDeploymentAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerMigrationApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerMigrationApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.instance.TimerInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableTimerInstanceState;
+import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+
+public class TimerMigrationApplier implements TypedEventApplier<TimerIntent, TimerRecord> {
+
+  private final MutableTimerInstanceState timerInstanceState;
+
+  public TimerMigrationApplier(final MutableTimerInstanceState timerInstanceState) {
+    this.timerInstanceState = timerInstanceState;
+  }
+
+  @Override
+  public void applyState(final long key, final TimerRecord value) {
+    final TimerInstance timerInstance = timerInstanceState.get(value.getElementInstanceKey(), key);
+    timerInstanceState.update(timerInstance);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerMigrationApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/TimerMigrationApplier.java
@@ -24,6 +24,10 @@ public class TimerMigrationApplier implements TypedEventApplier<TimerIntent, Tim
   @Override
   public void applyState(final long key, final TimerRecord value) {
     final TimerInstance timerInstance = timerInstanceState.get(value.getElementInstanceKey(), key);
+    // only these fields are updated during migration
+    timerInstance.setHandlerNodeId(value.getTargetElementIdBuffer());
+    timerInstance.setProcessDefinitionKey(value.getProcessDefinitionKey());
+
     timerInstanceState.update(timerInstance);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/DbTimerInstanceState.java
@@ -84,6 +84,13 @@ public final class DbTimerInstanceState implements MutableTimerInstanceState {
   }
 
   @Override
+  public void update(final TimerInstance timer) {
+    elementInstanceKey.inner().wrapLong(timer.getElementInstanceKey());
+    timerKey.wrapLong(timer.getKey());
+    timerInstanceColumnFamily.update(elementAndTimerKey, timer);
+  }
+
+  @Override
   public long processTimersWithDueDateBefore(final long timestamp, final TimerVisitor consumer) {
     nextDueDate = -1L;
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableTimerInstanceState.java
@@ -15,4 +15,6 @@ public interface MutableTimerInstanceState extends TimerInstanceState {
   void store(TimerInstance timer);
 
   void remove(TimerInstance timer);
+
+  void update(TimerInstance timer);
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceRejectionTest.java
@@ -1018,10 +1018,72 @@ public class MigrateProcessInstanceRejectionTest {
         .hasRejectionReason(
             """
             Expected to migrate process instance '%s' but active element with id 'A' \
-            is mapped to element with id 'B' that must be subscribed to a message catch event. \
+            is mapped to element with id 'B' that must be subscribed to a catch event. \
             Failed to extract the correlation key for 'key': The value must be either a string or \
             a number, but was 'NULL'. The evaluation reported the following warnings:
             [NO_VARIABLE_FOUND] No variable found with name 'key'"""
+                .formatted(processInstanceKey));
+  }
+
+  @Test
+  public void shouldRejectWhenUnableToSubscribeToTimerBoundaryEvent() {
+    // given
+    final String processId = "process";
+    final String targetProcessId = "process2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary")
+                    .timerWithDurationExpression("invalid_timer_expression")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractTargetProcessDefinitionKey(deployment, targetProcessId);
+
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(processId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "B")
+            .expectRejection()
+            .migrate();
+
+    // then
+    Assertions.assertThat(rejection)
+        .describedAs("Expect that the message boundary event could not be subscribed")
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .hasRejectionReason(
+            """
+            Expected to migrate process instance '%s' but active element with id 'A' \
+            is mapped to element with id 'B' that must be subscribed to a catch event. \
+            Expected result of the expression 'invalid_timer_expression' to be one of \
+            '[DURATION, PERIOD, STRING]', but was 'NULL'. \
+            The evaluation reported the following warnings:
+            [NO_VARIABLE_FOUND] No variable found with name 'invalid_timer_expression'"""
                 .formatted(processInstanceKey));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateTimerInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateTimerInstanceTest.java
@@ -25,7 +25,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
 
-public class MigrateTimerSubscriptionTest {
+public class MigrateTimerInstanceTest {
 
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
@@ -33,7 +33,7 @@ public class MigrateTimerSubscriptionTest {
   @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
 
   @Test
-  public void shouldWriteTimerSubscriptionMigratedEvent() {
+  public void shouldWriteTimerMigratedEvent() {
     // given
     final String processId = helper.getBpmnProcessId();
     final String targetProcessId = helper.getBpmnProcessId() + "2";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateTimerInstanceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateTimerInstanceTest.java
@@ -371,7 +371,6 @@ public class MigrateTimerInstanceTest {
         .describedAs("Expect that the timer boundary events are migrated")
         .containsExactly(targetProcessDefinitionKey, "boundary2", migratedDueDate);
 
-    // assert that the second timer event is canceled
     assertThat(
             RecordingExporter.timerRecords(TimerIntent.CREATED)
                 .withProcessInstanceKey(processInstanceKey)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateTimerSubscriptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateTimerSubscriptionTest.java
@@ -1,0 +1,339 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.assertj.core.groups.Tuple;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateTimerSubscriptionTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldWriteTimerSubscriptionMigratedEvent() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .timerWithDuration("PT5M")
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary2")
+                    .timerWithDuration("PT1S")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final TimerRecordValue timerRecord =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst()
+            .getValue();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.timerRecords(TimerIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasProcessDefinitionKey(targetProcessDefinitionKey)
+        .describedAs("Expect that the target element id is updated")
+        .hasTargetElementId("boundary2")
+        .describedAs("Expect that the due date is not changed")
+        .hasDueDate(timerRecord.getDueDate());
+  }
+
+  @Test
+  public void shouldMigrateMultipleTimerBoundaryEvents() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .timerWithDuration("PT5M")
+                    .endEvent()
+                    .moveToActivity("A")
+                    .boundaryEvent("boundary2")
+                    .timerWithDuration("PT10M")
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary3")
+                    .timerWithDuration("PT3S")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .boundaryEvent("boundary4")
+                    .timerWithDuration("PT7S")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final List<Record<TimerRecordValue>> timerRecords =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(2)
+            .asList();
+
+    final long firstDueDate = timerRecords.getFirst().getValue().getDueDate();
+    final long secondDueDate = timerRecords.getLast().getValue().getDueDate();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary3")
+        .addMappingInstruction("boundary2", "boundary4")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(2))
+        .extracting(Record::getValue)
+        .extracting(
+            TimerRecordValue::getProcessDefinitionKey,
+            TimerRecordValue::getTargetElementId,
+            TimerRecordValue::getDueDate)
+        .describedAs("Expect that the timer boundary events are migrated")
+        .containsExactly(
+            Tuple.tuple(targetProcessDefinitionKey, "boundary4", firstDueDate),
+            Tuple.tuple(targetProcessDefinitionKey, "boundary3", secondDueDate));
+  }
+
+  @Test
+  public void shouldMigrateOneOfMultipleTimerBoundaryEventsAndUnsubscribe() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .timerWithDuration("PT5M")
+                    .endEvent()
+                    .moveToActivity("A")
+                    .boundaryEvent("boundary2")
+                    .timerWithDuration("PT10M")
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary3")
+                    .timerWithDuration("PT3S")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final List<Record<TimerRecordValue>> timerRecords =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(2)
+            .asList();
+
+    final long migratedDueDate = timerRecords.getLast().getValue().getDueDate();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary3")
+        .migrate();
+
+    // then
+    // assert that the first boundary event is migrated
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .extracting(
+            TimerRecordValue::getProcessDefinitionKey,
+            TimerRecordValue::getTargetElementId,
+            TimerRecordValue::getDueDate)
+        .describedAs("Expect that the timer boundary events are migrated")
+        .containsExactly(targetProcessDefinitionKey, "boundary3", migratedDueDate);
+
+    // assert that the second timer event is canceled
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CANCELED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withHandlerNodeId("boundary2")
+                .exists())
+        .describedAs("Expect that the second timer boundary event is canceled")
+        .isTrue();
+  }
+
+  @Test
+  public void shouldMigrateOneOfMultipleTimerBoundaryEventsAndSubscribe() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .userTask("A")
+                    .boundaryEvent("boundary1")
+                    .timerWithDuration("PT5M")
+                    .endEvent()
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .userTask("B")
+                    .boundaryEvent("boundary2")
+                    .timerWithDuration("PT3S")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .boundaryEvent("boundary3")
+                    .timerWithDuration("PT7S")
+                    .endEvent()
+                    .moveToActivity("B")
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey = engine.processInstance().ofBpmnProcessId(processId).create();
+
+    final Record<TimerRecordValue> timerRecord =
+        RecordingExporter.timerRecords(TimerIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    final long migratedDueDate = timerRecord.getValue().getDueDate();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "B")
+        .addMappingInstruction("boundary1", "boundary2")
+        .migrate();
+
+    // then
+    // assert that the first boundary event is migrated
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .getFirst()
+                .getValue())
+        .extracting(
+            TimerRecordValue::getProcessDefinitionKey,
+            TimerRecordValue::getTargetElementId,
+            TimerRecordValue::getDueDate)
+        .describedAs("Expect that the timer boundary events are migrated")
+        .containsExactly(targetProcessDefinitionKey, "boundary2", migratedDueDate);
+
+    // assert that the second timer event is canceled
+    assertThat(
+            RecordingExporter.timerRecords(TimerIntent.CREATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withHandlerNodeId("boundary3")
+                .exists())
+        .describedAs("Expect that the second timer boundary event is created")
+        .isTrue();
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/TimerIntent.java
@@ -27,7 +27,9 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
    */
   @Deprecated
   CANCEL((short) 3),
-  CANCELED((short) 4);
+  CANCELED((short) 4),
+
+  MIGRATED((short) 5);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -52,6 +54,7 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
       case CREATED:
       case TRIGGERED:
       case CANCELED:
+      case MIGRATED:
         return true;
       default:
         return false;
@@ -70,6 +73,8 @@ public enum TimerIntent implements ProcessInstanceRelatedIntent {
         return CANCEL;
       case 4:
         return CANCELED;
+      case 5:
+        return MIGRATED;
       default:
         return Intent.UNKNOWN;
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

Enables the specification of mapping instructions for timer boundary events during process instance migration. This feature ensures that the timer boundary event is migrated to the target process definition.

During migration, certain properties of the timer are adjusted using a new `MIGRATED` intent:

- `processDefinitionKey` is updated to the definition key of the target process
- `targetElementId` is updated to the ID of the target boundary event
- `interrupting` status is updated to match the interrupting type of the target boundary event (either interrupting or non-interrupting)
  - This adjustment ensures that when the timer is triggered, the boundary event will perform as defined in the target process.


During migration, the timer duration (due date) and expressions are **not** re-evaluated. This approach ensures alignment with [our documentation on expressions](https://docs.camunda.io/docs/next/components/concepts/process-instance-migration/#jobs-expressions-and-input-mappings) and provides a consistent experience across all migrations.

## Related issues

closes #15918 
