### PR TITLE
test: simplify REST error mapper test

### DIFF
--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -146,12 +146,6 @@
       <scope>test</scope>
     </dependency>
 
-    <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-config</artifactId>
-      <scope>test</scope>
-    </dependency>
-
     <!-- dependencies required for OpenAPI model generation -->
     <dependency>
       <groupId>jakarta.validation</groupId>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/TestApplication.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/TestApplication.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+
+@SpringBootApplication(
+    exclude = {
+      SecurityAutoConfiguration.class,
+      HibernateJpaAutoConfiguration.class,
+      DataSourceAutoConfiguration.class
+    })
+public class TestApplication {
+  // required to provide the web server context
+}


### PR DESCRIPTION
## Description

Removes unnecessary context from the ErrorMapperTest in the REST gateway. This way, the test class needs no adjustments anymore for controller dependency adjustments.

Moves the test application required by all REST controller tests out of the ErrorMapperTest.

## Related issues

closes #19977 
