### PR TITLE
Simplify REST data model

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -22,8 +22,8 @@ import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.response.UpdateUserTaskResponse;
 import io.camunda.zeebe.client.impl.http.HttpClient;
 import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.client.protocol.rest.Changeset;
 import io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequest;
-import io.camunda.zeebe.client.protocol.rest.UserTaskUpdateRequestChangeset;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -137,10 +137,10 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
     return this;
   }
 
-  private UserTaskUpdateRequestChangeset getChangesetEnsureInitialized() {
-    UserTaskUpdateRequestChangeset changeset = request.getChangeset();
+  private Changeset getChangesetEnsureInitialized() {
+    Changeset changeset = request.getChangeset();
     if (changeset == null) {
-      changeset = new UserTaskUpdateRequestChangeset();
+      changeset = new Changeset();
       request.setChangeset(changeset);
     }
     return changeset;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/UpdateUserTaskCommandImpl.java
@@ -74,66 +74,70 @@ public final class UpdateUserTaskCommandImpl implements UpdateUserTaskCommandSte
   @Override
   public UpdateUserTaskCommandStep1 dueDate(final String dueDate) {
     ArgumentUtil.ensureNotNull("dueDate", dueDate);
-    getChangesetEnsureInitialized().dueDate(dueDate);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_DUE_DATE, dueDate);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearDueDate() {
-    getChangesetEnsureInitialized().setDueDate("");
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_DUE_DATE, "");
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 followUpDate(final String followUpDate) {
     ArgumentUtil.ensureNotNull("followUpDate", followUpDate);
-    getChangesetEnsureInitialized().followUpDate(followUpDate);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_FOLLOW_UP_DATE, followUpDate);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearFollowUpDate() {
-    getChangesetEnsureInitialized().followUpDate("");
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_FOLLOW_UP_DATE, "");
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateGroups(final List<String> candidateGroups) {
     ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
-    getChangesetEnsureInitialized().candidateGroups(candidateGroups);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, candidateGroups);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateGroups(final String... candidateGroups) {
     ArgumentUtil.ensureNotNull("candidateGroups", candidateGroups);
-    getChangesetEnsureInitialized().candidateGroups(Arrays.asList(candidateGroups));
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, Arrays.asList(candidateGroups));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateGroups() {
-    getChangesetEnsureInitialized().setCandidateGroups(Collections.emptyList());
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_GROUPS, Collections.emptyList());
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateUsers(final List<String> candidateUsers) {
     ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
-    getChangesetEnsureInitialized().candidateUsers(candidateUsers);
+    getChangesetEnsureInitialized().put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, candidateUsers);
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 candidateUsers(final String... candidateUsers) {
     ArgumentUtil.ensureNotNull("candidateUsers", candidateUsers);
-    getChangesetEnsureInitialized().candidateUsers(Arrays.asList(candidateUsers));
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, Arrays.asList(candidateUsers));
     return this;
   }
 
   @Override
   public UpdateUserTaskCommandStep1 clearCandidateUsers() {
-    getChangesetEnsureInitialized().candidateUsers(Collections.emptyList());
+    getChangesetEnsureInitialized()
+        .put(Changeset.JSON_PROPERTY_CANDIDATE_USERS, Collections.emptyList());
     return this;
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UpdateUserTaskTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/usertask/UpdateUserTaskTest.java
@@ -19,6 +19,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 
 import io.camunda.zeebe.client.api.command.ProblemException;
 import io.camunda.zeebe.client.api.command.UpdateUserTaskCommandStep1;
@@ -69,10 +70,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     final UserTaskUpdateRequest request =
         gatewayService.getLastRequest(UserTaskUpdateRequest.class);
     assertThat(request.getAction()).isNull();
-    assertThat(request.getChangeset())
-        .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("dueDate")
-        .hasFieldOrPropertyWithValue("dueDate", TEST_TIME);
+    assertThat(request.getChangeset()).isNotNull().containsOnly(entry("dueDate", TEST_TIME));
   }
 
   @Test
@@ -84,10 +82,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     final UserTaskUpdateRequest request =
         gatewayService.getLastRequest(UserTaskUpdateRequest.class);
     assertThat(request.getAction()).isNull();
-    assertThat(request.getChangeset())
-        .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("followUpDate")
-        .hasFieldOrPropertyWithValue("followUpDate", TEST_TIME);
+    assertThat(request.getChangeset()).isNotNull().containsOnly(entry("followUpDate", TEST_TIME));
   }
 
   @Test
@@ -101,9 +96,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("followUpDate", "dueDate")
-        .hasFieldOrPropertyWithValue("followUpDate", TEST_TIME)
-        .hasFieldOrPropertyWithValue("dueDate", TEST_TIME);
+        .containsOnly(entry("followUpDate", TEST_TIME), entry("dueDate", TEST_TIME));
   }
 
   @Test
@@ -117,8 +110,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
-        .hasFieldOrPropertyWithValue("candidateGroups", singletonList("foo"));
+        .containsOnly(entry("candidateGroups", singletonList("foo")));
   }
 
   @Test
@@ -132,8 +124,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
-        .hasFieldOrPropertyWithValue("candidateGroups", Arrays.asList("foo", "bar"));
+        .containsOnly(entry("candidateGroups", Arrays.asList("foo", "bar")));
   }
 
   @Test
@@ -151,8 +142,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
-        .hasFieldOrPropertyWithValue("candidateGroups", Arrays.asList("foo", "bar"));
+        .containsOnly(entry("candidateGroups", Arrays.asList("foo", "bar")));
   }
 
   @Test
@@ -166,8 +156,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
-        .hasFieldOrPropertyWithValue("candidateUsers", singletonList("foo"));
+        .containsOnly(entry("candidateUsers", singletonList("foo")));
   }
 
   @Test
@@ -181,8 +170,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
-        .hasFieldOrPropertyWithValue("candidateUsers", Arrays.asList("foo", "bar"));
+        .containsOnly(entry("candidateUsers", Arrays.asList("foo", "bar")));
   }
 
   @Test
@@ -196,8 +184,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
-        .hasFieldOrPropertyWithValue("candidateUsers", Arrays.asList("foo", "bar"));
+        .containsOnly(entry("candidateUsers", Arrays.asList("foo", "bar")));
   }
 
   @Test
@@ -213,10 +200,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     final UserTaskUpdateRequest request =
         gatewayService.getLastRequest(UserTaskUpdateRequest.class);
     assertThat(request.getAction()).isNull();
-    assertThat(request.getChangeset())
-        .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("dueDate")
-        .hasFieldOrPropertyWithValue("dueDate", "");
+    assertThat(request.getChangeset()).isNotNull().containsOnly(entry("dueDate", ""));
   }
 
   @Test
@@ -232,10 +216,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     final UserTaskUpdateRequest request =
         gatewayService.getLastRequest(UserTaskUpdateRequest.class);
     assertThat(request.getAction()).isNull();
-    assertThat(request.getChangeset())
-        .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("followUpDate")
-        .hasFieldOrPropertyWithValue("followUpDate", "");
+    assertThat(request.getChangeset()).isNotNull().containsOnly(entry("followUpDate", ""));
   }
 
   @Test
@@ -253,8 +234,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateGroups")
-        .hasFieldOrPropertyWithValue("candidateGroups", emptyList());
+        .containsOnly(entry("candidateGroups", emptyList()));
   }
 
   @Test
@@ -272,8 +252,7 @@ public final class UpdateUserTaskTest extends ClientRestTest {
     assertThat(request.getAction()).isNull();
     assertThat(request.getChangeset())
         .isNotNull()
-        .hasAllNullFieldsOrPropertiesExcept("candidateUsers")
-        .hasFieldOrPropertyWithValue("candidateUsers", emptyList());
+        .containsOnly(entry("candidateUsers", emptyList()));
   }
 
   @Test

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1099,39 +1099,32 @@ components:
       type: object
       properties:
         changeset:
-          allOf:
-            - $ref: "#/components/schemas/Changeset"
-          description: |
-            JSON object with changed task attribute values.
-
-            The following attributes can be adjusted with this endpoint, additional attributes
-            will be ignored:
-
-            * `candidateGroups` - reset by providing an empty list
-            * `candidateUsers` - reset by providing an empty list
-            * `dueDate` - reset by providing an empty String
-            * `followUpDate` - reset by providing an empty String
-
-            Providing any of those attributes with a `null` value or omitting it preserves
-            the persisted attribute's value.
-
-            The assignee cannot be adjusted with this endpoint, use the Assign task endpoint.
-            This ensures correct event emission for assignee changes.
-          type: object
-          nullable: true
+          $ref: "#/components/schemas/Changeset"
         action:
           description: >
             A custom action value that will be accessible from user task events resulting
             from this endpoint invocation. If not provided, it will default to "update".
           type: string
           nullable: true
-    Variables:
-      description: A map of variables.
-      type: object
-      additionalProperties: true
     Changeset:
-      description: A map of changes.
+      description: |
+        JSON object with changed task attribute values.
+
+        The following attributes can be adjusted with this endpoint, additional attributes
+        will be ignored:
+
+        * `candidateGroups` - reset by providing an empty list
+        * `candidateUsers` - reset by providing an empty list
+        * `dueDate` - reset by providing an empty String
+        * `followUpDate` - reset by providing an empty String
+
+        Providing any of those attributes with a `null` value or omitting it preserves
+        the persisted attribute's value.
+
+        The assignee cannot be adjusted with this endpoint, use the Assign task endpoint.
+        This ensures correct event emission for assignee changes.
       type: object
+      nullable: true
       additionalProperties: true
       properties:
         dueDate:

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -14,11 +14,11 @@ import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.security.auth.Authentication.Builder;
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
 import io.camunda.zeebe.auth.impl.Authorization;
+import io.camunda.zeebe.gateway.protocol.rest.Changeset;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskAssignmentRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
-import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequestChangeset;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.util.Either;
 import java.time.ZonedDateTime;
@@ -138,7 +138,7 @@ public class RequestMapper {
       violations.add(ERROR_MESSAGE_EMPTY_UPDATE_CHANGESET);
     }
     if (updateRequest != null && !isEmpty(updateRequest.getChangeset())) {
-      final UserTaskUpdateRequestChangeset changeset = updateRequest.getChangeset();
+      final Changeset changeset = updateRequest.getChangeset();
       validateDate(changeset.getDueDate(), "due date", violations);
       validateDate(changeset.getFollowUpDate(), "follow-up date", violations);
     }
@@ -189,7 +189,7 @@ public class RequestMapper {
     }
   }
 
-  private static boolean isEmpty(final UserTaskUpdateRequestChangeset changeset) {
+  private static boolean isEmpty(final Changeset changeset) {
     return changeset == null
         || (changeset.getFollowUpDate() == null
             && changeset.getDueDate() == null
@@ -231,7 +231,7 @@ public class RequestMapper {
     if (updateRequest == null || updateRequest.getChangeset() == null) {
       return record;
     }
-    final UserTaskUpdateRequestChangeset changeset = updateRequest.getChangeset();
+    final Changeset changeset = updateRequest.getChangeset();
     if (changeset.getCandidateGroups() != null) {
       record.setCandidateGroupsList(changeset.getCandidateGroups()).setCandidateGroupsChanged();
     }


### PR DESCRIPTION
## Description

The user task update REST endpoint uses a data model that nests another data model. The nested data model reference is consumed as an `allOf`, indicating that we extend the original reference. However, we don't actually extend it execpt for adding more description on top and making it nullable.

This can be straightened out to moving the description and nullable attributes to the referenced data model directly and using it simply as an unaltered reference.

## Related issues

closes #19986 
