### PR TITLE
fix: do not use combined checksum for snapshot integrity

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteredSnapshotTest.java
@@ -120,6 +120,10 @@ final class ClusteredSnapshotTest {
     // then
     clusteringRule.waitForSnapshotAtBroker(clusteringRule.getBroker(followerId));
     assertThat(clusteringRule.getBroker(followerId)).havingSnapshot();
+
+    // then the broker should be able to restart with the new received snapshot
+    // Regression test for https://github.com/camunda/camunda/issues/19984
+    clusteringRule.restartBroker(followerId);
   }
 
   private void awaitUntilAsserted(final Consumer<Broker> consumer) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -209,12 +209,12 @@ public final class FileBasedSnapshotStore extends Actor
       final var expectedChecksum = SnapshotChecksum.read(checksumPath);
       final var actualChecksum =
           SnapshotChecksum.calculateWithProvidedChecksums(path, checksumProvider);
-      if (expectedChecksum.getCombinedValue() != actualChecksum.getCombinedValue()) {
+      if (!actualChecksum.sameChecksums(expectedChecksum)) {
         LOGGER.warn(
-            "Expected snapshot {} to have checksum {}, but the actual checksum is {}; the snapshot is most likely corrupted. The startup will fail if there is no other valid snapshot and the log has been compacted.",
+            "Expected snapshot {} to have checksums {}, but the actual checksums are {}; the snapshot is most likely corrupted. The startup will fail if there is no other valid snapshot and the log has been compacted.",
             path,
-            expectedChecksum.getCombinedValue(),
-            actualChecksum.getCombinedValue());
+            expectedChecksum.getChecksums(),
+            actualChecksum.getChecksums());
         return null;
       }
 


### PR DESCRIPTION
## Description

We changed the checksum calculation to use rocksdb provided per file checksum. The combine checksum calculated by the received snapshot still uses the old way. So we are comparing two incomparable values.

## Related issues

closes #19984 
