### PR TITLE
[Backport stable/8.2] fix: retry of aborted snapshot replication can succeed

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -329,6 +329,7 @@ public class PassiveRole extends InactiveRole {
   private void abortPendingSnapshots() {
     if (pendingSnapshot != null) {
       setNextExpected(null);
+      previouslyReceivedSnapshotChunkId = null;
       log.info("Rolling back snapshot {}", pendingSnapshot);
       try {
         pendingSnapshot.abort();


### PR DESCRIPTION
# Description
Backport of #19959 to `stable/8.2`.

relates to #19862
original author: @EuroLew