### PR TITLE
fix: correct Intermediate Catch/Throw events processing flow

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/event/IntermediateThrowEventProcessor.java
@@ -181,16 +181,20 @@ public class IntermediateThrowEventProcessor
     }
 
     @Override
+    public Either<Failure, ?> onActivate(
+        final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating) {
+      return element.getJobWorkerProperties() == null
+          ? SUCCESS
+          : variableMappingBehavior.applyInputMappings(activating, element);
+    }
+
+    @Override
     public Either<Failure, ?> finalizeActivation(
         final ExecutableIntermediateThrowEvent element, final BpmnElementContext activating) {
       return element.getJobWorkerProperties() == null
           ? SUCCESS
-          : variableMappingBehavior
-              .applyInputMappings(activating, element)
-              .flatMap(
-                  ok ->
-                      jobBehavior.evaluateJobExpressions(
-                          element.getJobWorkerProperties(), activating))
+          : jobBehavior
+              .evaluateJobExpressions(element.getJobWorkerProperties(), activating)
               .thenDo(
                   jobProperties -> {
                     jobBehavior.createNewJob(activating, element, jobProperties);


### PR DESCRIPTION
## Description
This pull request addresses an issue with the processing flow of Intermediate Catch/Throw events when EL are configured. The previous behavior evaluated input mappings after the execution of `start` ELs, which could lead to incorrect variable initialization. This update ensures that input mappings are evaluated before `start` ELs are executed, providing the correct context for the Execution Listeners.

### Changes
- Modified the element processing sequence for Intermediate Catch(message, signal, timer) events.
- Modified the element processing sequence for Intermediate Throw(message, signal) events.
- Added new unit tests to ensure input mappings are evaluated before `start` ELs execution.

## Related issues

closes #16536 
