### PR TITLE
ci: automatically set zeebe test image name

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -93,6 +93,10 @@ runs:
       shell: bash
       run: echo "result=$(echo '${{ steps.get-image.outputs.tags }}' | head -n 1)" >> $GITHUB_OUTPUT
 
+    - name: Set Zeebe test image
+      shell: bash
+      run: echo "ZEEBE_TEST_DOCKER_IMAGE=${{ steps.get-image-output.outputs.result }}" >> $GITHUB_ENV
+
     - name: Set DISTBALL path relative to the build context
       id: get-distball
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,6 @@ jobs:
             maven-modules: "zeebe/qa/update-tests"
             maven-build-threads: 1
             maven-test-fork-count: 10
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
       registry:
         image: registry:2
@@ -241,9 +239,6 @@ jobs:
           maven-extra-args: -T1C -PskipFrontendBuild
       - uses: ./.github/actions/build-platform-docker
         with:
-          repository: localhost:5000/camunda/zeebe
-          version: current-test
-          push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -86,8 +86,6 @@ jobs:
             maven-test-fork-count: 10
             tcc-enabled: ${{ vars.TCC_ENABLED }}
             tcc-concurrency: 2
-    env:
-      ZEEBE_TEST_DOCKER_IMAGE: localhost:5000/camunda/zeebe:current-test
     services:
       registry:
         image: registry:2
@@ -108,7 +106,6 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         with:
           repository: localhost:5000/camunda/zeebe
-          version: current-test
           push: true
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Setup TCC
@@ -263,7 +260,6 @@ jobs:
         # Currently only Linux runners support building docker images without further ado
         if: ${{ runner.os == 'Linux' }}
         with:
-          version: current-test
           distball: ${{ steps.build-zeebe.outputs.distball }}
           platforms: linux/${{ matrix.arch }}
           push: false
@@ -421,8 +417,6 @@ jobs:
       - uses: ./.github/actions/build-platform-docker
         id: build-zeebe-docker
         with:
-          repository: camunda/zeebe
-          version: current-test
           distball: ${{ steps.build-zeebe.outputs.distball }}
       - name: Run Go tests
         working-directory: clients/go


### PR DESCRIPTION
## Description

Don't hard-code `current-test` everywhere, instead we just set the `ZEEBE_TEST_DOCKER_IMAGE` env var to whatever was built by the `build-platform-docker` action.

## Related issues
follow-up of https://github.com/camunda/camunda/pull/19990
blocked by https://github.com/camunda/camunda/issues/20001
