### PR TITLE
feat: allow overriding default `maxInboundMetadataSize` through config and change default to 16KB 

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -121,6 +121,11 @@ public final class ClientProperties {
   public static final String MAX_MESSAGE_SIZE = "zeebe.client.maxMessageSize";
 
   /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  public static final String MAX_METADATA_SIZE = "zeebe.client.maxMetadataSize";
+
+  /**
    * @see ZeebeClientCloudBuilderStep1#withClusterId(java.lang.String)
    */
   public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -187,6 +187,13 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder maxMessageSize(int maxSize);
 
   /**
+   * A custom maxMetadataSize allows the client to receive larger or smaller response headers from
+   * Zeebe. Technically, it specifies the maxInboundMetadataSize of the gRPC channel. The default is
+   * 16384 = 16KB .
+   */
+  ZeebeClientBuilder maxMetadataSize(int maxSize);
+
+  /**
    * A custom streamEnabled allows the client to use job stream instead of job poll. The default
    * value is set as enabled.
    */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -126,6 +126,11 @@ public interface ZeebeClientConfiguration {
   int getMaxMessageSize();
 
   /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  int getMaxMetadataSize();
+
+  /**
    * @see ZeebeClientBuilder#jobWorkerExecutor(ScheduledExecutorService)
    */
   ScheduledExecutorService jobWorkerExecutor();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -20,12 +20,14 @@ import static io.camunda.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_L
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.client.ClientProperties.KEEP_ALIVE;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
+import static io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.OVERRIDE_AUTHORITY;
 import static io.camunda.zeebe.client.ClientProperties.PREFER_REST_OVER_GRPC;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.BuilderUtils.appendProperty;
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 
 import io.camunda.zeebe.client.ClientProperties;
@@ -96,6 +98,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
   private String overrideAuthority;
   private int maxMessageSize = 4 * ONE_MB;
+  private int maxMetadataSize = 16 * ONE_KB;
   private boolean streamEnabled = false;
   private boolean grpcAddressUsed = false;
   private ScheduledExecutorService jobWorkerExecutor;
@@ -200,6 +203,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public int getMaxMessageSize() {
     return maxMessageSize;
+  }
+
+  @Override
+  public int getMaxMetadataSize() {
+    return maxMetadataSize;
   }
 
   @Override
@@ -312,6 +320,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(MAX_MESSAGE_SIZE)) {
       maxMessageSize(DataSizeUtil.parse(properties.getProperty(MAX_MESSAGE_SIZE)));
+    }
+    if (properties.containsKey(MAX_METADATA_SIZE)) {
+      maxMetadataSize(DataSizeUtil.parse(properties.getProperty(MAX_METADATA_SIZE)));
     }
     if (properties.containsKey(STREAM_ENABLED)) {
       defaultJobWorkerStreamEnabled(Boolean.parseBoolean(properties.getProperty(STREAM_ENABLED)));
@@ -465,6 +476,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public ZeebeClientBuilder maxMetadataSize(final int maxMetadataSize) {
+    this.maxMetadataSize = maxMetadataSize;
+    return this;
+  }
+
+  @Override
   public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     this.streamEnabled = streamEnabled;
     return this;
@@ -525,6 +542,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       maxMessageSize(DataSizeUtil.parse(Environment.system().get(MAX_MESSAGE_SIZE)));
     }
 
+    if (Environment.system().isDefined(MAX_METADATA_SIZE)) {
+      maxMetadataSize(DataSizeUtil.parse(Environment.system().get(MAX_METADATA_SIZE)));
+    }
+
     if (Environment.system().isDefined(GRPC_ADDRESS_VAR)) {
       final URI grpcAddr = getURIFromString(Environment.system().get(GRPC_ADDRESS_VAR));
       grpcAddress(grpcAddr);
@@ -577,6 +598,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
     appendProperty(sb, "overrideAuthority", overrideAuthority);
     appendProperty(sb, "maxMessageSize", maxMessageSize);
+    appendProperty(sb, "maxMetadataSize", maxMetadataSize);
     appendProperty(sb, "jobWorkerExecutor", jobWorkerExecutor);
     appendProperty(sb, "ownsJobWorkerExecutor", ownsJobWorkerExecutor);
     appendProperty(sb, "streamEnabled", streamEnabled);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -248,6 +248,11 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder maxMetadataSize(final int maxMetadataSize) {
+    return innerBuilder.maxMetadataSize(maxMetadataSize);
+  }
+
+  @Override
   public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     innerBuilder.defaultJobWorkerStreamEnabled(streamEnabled);
     return this;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -183,6 +183,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     channelBuilder.keepAliveTime(config.getKeepAlive().toMillis(), TimeUnit.MILLISECONDS);
     channelBuilder.userAgent("camunda-client-java/" + VersionUtil.getVersion());
     channelBuilder.maxInboundMessageSize(config.getMaxMessageSize());
+    channelBuilder.maxInboundMetadataSize(config.getMaxMetadataSize());
 
     if (config.useDefaultRetryPolicy()) {
       final Map<String, Object> serviceConfig = defaultServiceConfig();
@@ -470,6 +471,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
     return new UnassignUserTaskCommandImpl(httpClient, userTaskKey);
   }
 
+  @Override
+  public ProcessInstanceQuery newProcessInstanceQuery() {
+    return new ProcessInstanceQueryImpl(httpClient, jsonMapper);
+  }
+
   private JobClient newJobClient() {
     return new JobClientImpl(
         asyncStub, httpClient, config, jsonMapper, credentialsProvider::shouldRetryRequest);
@@ -514,10 +520,5 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public StreamJobsCommandStep1 newStreamJobsCommand() {
     return new StreamJobsCommandImpl(
         asyncStub, jsonMapper, credentialsProvider::shouldRetryRequest, config);
-  }
-
-  @Override
-  public ProcessInstanceQuery newProcessInstanceQuery() {
-    return new ProcessInstanceQueryImpl(httpClient, jsonMapper);
   }
 }

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/PropertyUtil.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/PropertyUtil.java
@@ -49,7 +49,6 @@ public class PropertyUtil {
       return (T) propertyValue;
     }
     T property = getPropertyFromSupplier(legacyPropertySupplier, propertyName, "legacy");
-
     if (property == null || property.equals(defaultProperty)) {
       property = getPropertyFromSupplier(propertySupplier, propertyName, "property");
     }
@@ -63,6 +62,29 @@ public class PropertyUtil {
 
     LOG.debug("Property {} set to {}", propertyName, property);
     return property;
+  }
+
+  /**
+   * Returns the property in the given relevance: property, defaultProperty
+   *
+   * @param propertyName the name of the property, used for logging
+   * @param propertySupplier a function to supply the property, may throw
+   * @param defaultProperty the default to apply if nothing else suits, may be null
+   * @param configCache the cache to save the property to, may be null
+   * @return the property resolved
+   * @param <T> the type of the property
+   */
+  public static <T> T getOrDefault(
+      final String propertyName,
+      final Supplier<T> propertySupplier,
+      final T defaultProperty,
+      final Map<String, Object> configCache) {
+    return getOrLegacyOrDefault(
+        propertyName, propertySupplier, noPropertySupplier(), defaultProperty, configCache);
+  }
+
+  private static <T> Supplier<T> noPropertySupplier() {
+    return () -> null;
   }
 
   private static <T> T getPropertyFromSupplier(

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationImpl.java
@@ -278,6 +278,15 @@ public class ZeebeClientConfigurationImpl
   }
 
   @Override
+  public int getMaxMetadataSize() {
+    return getOrDefault(
+        "MaxMetadataSize",
+        () -> camundaClientProperties.getZeebe().getMaxMessageSize(),
+        DEFAULT.getMaxMetadataSize(),
+        configCache);
+  }
+
+  @Override
   public ScheduledExecutorService jobWorkerExecutor() {
     return zeebeClientExecutorService.get();
   }

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/common/ZeebeClientProperties.java
@@ -24,6 +24,7 @@ public class ZeebeClientProperties extends ApiProperties {
   private Integer executionThreads;
   private Duration messageTimeToLive;
   private Integer maxMessageSize;
+  private Integer maxMetadataSize;
   private Duration requestTimeout;
   private String caCertificatePath;
   private Duration keepAlive;
@@ -104,6 +105,14 @@ public class ZeebeClientProperties extends ApiProperties {
 
   public void setMaxMessageSize(final Integer maxMessageSize) {
     this.maxMessageSize = maxMessageSize;
+  }
+
+  public Integer getMaxMetadataSize() {
+    return maxMetadataSize;
+  }
+
+  public void setMaxMetadataSize(final Integer maxMetadataSize) {
+    this.maxMetadataSize = maxMetadataSize;
   }
 
   public boolean isPreferRestOverGrpc() {

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.config;
 
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -69,6 +70,7 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
         .isEqualTo(new URI("https://0.0.0.0:26500"));
     assertThat(client.getConfiguration().getKeepAlive()).isEqualTo(Duration.ofSeconds(45));
     assertThat(client.getConfiguration().getMaxMessageSize()).isEqualTo(4 * ONE_MB);
+    assertThat(client.getConfiguration().getMaxMetadataSize()).isEqualTo(16 * ONE_KB);
     assertThat(client.getConfiguration().getNumJobWorkerExecutionThreads()).isEqualTo(1);
     assertThat(client.getConfiguration().getOverrideAuthority()).isNull();
     assertThat(client.getConfiguration().getRestAddress())

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSaasTest.java
@@ -157,6 +157,12 @@ public class ZeebeClientConfigurationImplSaasTest {
   }
 
   @Test
+  void shouldHaveMaxMetadataSize() {
+    assertThat(zeebeClientConfiguration.getMaxMetadataSize())
+        .isEqualTo(DEFAULT.getMaxMetadataSize());
+  }
+
+  @Test
   void shouldHaveJobWorkerExecutor() {
     assertThat(zeebeClientConfiguration.jobWorkerExecutor())
         .isEqualTo(zeebeClientExecutorService.get());

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationImplSelfManagedTest.java
@@ -151,6 +151,12 @@ public class ZeebeClientConfigurationImplSelfManagedTest {
   }
 
   @Test
+  void shouldHaveMaxMetadataSize() {
+    assertThat(zeebeClientConfiguration.getMaxMetadataSize())
+        .isEqualTo(DEFAULT.getMaxMetadataSize());
+  }
+
+  @Test
   void shouldHaveJobWorkerExecutor() {
     assertThat(zeebeClientConfiguration.jobWorkerExecutor())
         .isEqualTo(zeebeClientExecutorService.get());


### PR DESCRIPTION
## Description

Allows overriding default `maxInboundMetadataSize` through config and change default to 16KB 
This is a followup to changing default NGINX proxy buffer size to 16kb to allow returning more BPMN validation errors

## Related issues

closes #19829 
related to #11284 
related to #19591