### PR TITLE
[Backport stable/8.5] ci: stabilize RollingUpdateTest

### DIFF
--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -83,7 +83,7 @@ jobs:
       - name: Test snapshot
         run: >
           ./mvnw -B --no-snapshot-updates -pl zeebe/qa/update-tests
-          -D it.test=io.camunda.zeebe.test.SnapshotTest
+          -D it.test=io.camunda.zeebe.test.RollingUpdateTest
           -D failsafe.rerunFailingTestsCount=3
           -D skipChecks
           verify

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -113,3 +113,36 @@ jobs:
         with:
           name: zeebe-version-compatibility
           path: ${{ github.workspace }}/zeebe-version-compatibility
+  notify:
+    name: Notify on failure
+    runs-on: ubuntu-latest
+    needs: [released-versions, current-snapshot]
+    if: failure()
+    steps:
+      - uses: actions/checkout@v4
+      - id: slack-notify
+        uses: slackapi/slack-github-action@v1.26.0
+        with:
+          # For posting a rich message using Block Kit
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": ":warning: *Zeebe Version Compatibility checks failed:*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "Please check the related workflow execution: https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}"
+                  }
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -12,8 +12,8 @@ permissions:
   actions: read # Required to get the previous report
 
 jobs:
-  rolling-update-tests:
-    name: Rolling Update Tests
+  released-versions:
+    name: Released Versions
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -65,10 +65,36 @@ jobs:
         with:
           name: zeebe-version-compatibility-${{ strategy.job-index }}
           path: ${{ github.workspace }}/zeebe-version-compatibility
+  current-snapshot:
+    name: Current Snapshot
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+      - uses: ./.github/actions/build-platform-docker
+      - name: Test snapshot
+        run: >
+          ./mvnw -B --no-snapshot-updates -pl zeebe/qa/update-tests
+          -D it.test=io.camunda.zeebe.test.SnapshotTest
+          -D failsafe.rerunFailingTestsCount=3
+          -D skipChecks
+          verify
+        env:
+          ZEEBE_CI_CHECK_CURRENT_VERSION_COMPATIBILITY: true
+      - uses: ./.github/actions/collect-test-artifacts
+        if: always()
+        with:
+          name: "Snapshot version compatibility"
   update-shared-report:
     name: Update Report
     runs-on: ubuntu-latest
-    needs: rolling-update-tests
+    needs: released-versions
     if: always()
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -2,8 +2,8 @@ name: Zeebe Version Compatibility
 on:
   workflow_dispatch:
   schedule:
-    # Run at 10:00 on every tuesday
-    - cron: '0 10 * * 2'
+    # Run at 6:00 every day
+    - cron: '0 6 * * *'
 concurrency:
   group: zeebe-version-compatibility
   cancel-in-progress: false

--- a/.github/workflows/zeebe-version-compatibility.yml
+++ b/.github/workflows/zeebe-version-compatibility.yml
@@ -78,6 +78,8 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - uses: ./.github/actions/build-zeebe
       - uses: ./.github/actions/build-platform-docker
+        with:
+          version: current-test
       - name: Test snapshot
         run: >
           ./mvnw -B --no-snapshot-updates -pl zeebe/qa/update-tests

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamUtil.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.util;
+
+import io.camunda.zeebe.util.StreamUtil.MinMaxCollector.MinMax;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BinaryOperator;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import java.util.stream.Collector;
+
+public final class StreamUtil {
+  private StreamUtil() {}
+
+  /**
+   * Returns a collector that computes the minimum and maximum of a stream of elements according to
+   * the provided comparator.
+   */
+  public static <T> Collector<T, MinMax<T>, MinMax<T>> minMax(final Comparator<T> comparator) {
+    return new MinMaxCollector<>(comparator);
+  }
+
+  static final class MinMaxCollector<T> implements Collector<T, MinMax<T>, MinMax<T>> {
+    private final Comparator<T> comparator;
+
+    private MinMaxCollector(final Comparator<T> comparator) {
+      this.comparator = comparator;
+    }
+
+    @Override
+    public Supplier<MinMax<T>> supplier() {
+      return MinMax::new;
+    }
+
+    @Override
+    public BiConsumer<MinMax<T>, T> accumulator() {
+      return (minMax, value) -> {
+        if (minMax.min == null || comparator.compare(value, minMax.min) < 0) {
+          minMax.min = value;
+        }
+        if (minMax.max == null || comparator.compare(value, minMax.max) > 0) {
+          minMax.max = value;
+        }
+      };
+    }
+
+    @Override
+    public BinaryOperator<MinMax<T>> combiner() {
+      return (minMax1, minMax2) -> {
+        if (comparator.compare(minMax1.min, minMax2.min) < 0) {
+          minMax1.min = minMax2.min;
+        }
+        if (comparator.compare(minMax1.max, minMax2.max) > 0) {
+          minMax1.max = minMax2.max;
+        }
+        return minMax1;
+      };
+    }
+
+    @Override
+    public Function<MinMax<T>, MinMax<T>> finisher() {
+      return (minMax) -> minMax;
+    }
+
+    @Override
+    public Set<Characteristics> characteristics() {
+      return Set.of(Characteristics.IDENTITY_FINISH);
+    }
+
+    public static final class MinMax<T> {
+      private T min;
+      private T max;
+
+      /**
+       * @return the minimum value of the stream, or {@code null} if the stream was empty.
+       */
+      public T min() {
+        return min;
+      }
+
+      /**
+       * @return the maximum value of the stream, or {@code null} if the stream was empty.
+       */
+      public T max() {
+        return max;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Manual backport of https://github.com/camunda/camunda/pull/19990 to `stable/8.5.`
Only differences are that af382b44ee7b47d89827c47ca83ecf5a6189ae05 is skipped because we never disabled the test on `stable/8.5` and that I had to declare a dependency in f6dc3ce38e7afb1b652fe34489cbccb94049bdf2.

## Related issues

relates to #19910
