### PR TITLE
fix: apply correct license header for 8.5

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamUtil.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.camunda.zeebe.util;
 


### PR DESCRIPTION
Fixes the license header introduced in backport https://github.com/camunda/camunda/pull/20004