### PR TITLE
[Backport release-8.5.5] fix: apply correct license header for 8.5

### DIFF
--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamUtil.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/StreamUtil.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.camunda.zeebe.util;
 


### PR DESCRIPTION
# Description
Backport of #20008 to `release-8.5.5`.

relates to 
original author: @lenaschoenburg