### PR TITLE
Changing default streaming timeout

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImpl.java
@@ -42,7 +42,7 @@ public final class JobWorkerBuilderImpl
 
   public static final BackoffSupplier DEFAULT_BACKOFF_SUPPLIER =
       BackoffSupplier.newBackoffBuilder().build();
-  public static final Duration DEFAULT_STREAMING_TIMEOUT = Duration.ofHours(8);
+  public static final Duration DEFAULT_STREAMING_TIMEOUT = Duration.ofHours(1);
   private final JobClient jobClient;
   private final ScheduledExecutorService executorService;
   private final List<Closeable> closeables;

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/worker/JobWorkerBuilderImplTest.java
@@ -185,7 +185,7 @@ class JobWorkerBuilderImplTest {
         .open();
 
     // then
-    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(8));
+    verify(lastStep, atLeast(1)).requestTimeout(Duration.ofHours(1));
   }
 
   @Test

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/annotation/JobWorker.java
@@ -104,7 +104,7 @@ public @interface JobWorker {
   boolean streamEnabled() default true;
 
   /** Stream timeout in ms */
-  long streamTimeout() default -1L;
+  long streamTimeout() default 3600000L;
 
   /** Set the max number of retries for a job */
   int maxRetries() default -1;

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/bean/factory/ReadZeebeWorkerValueTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/bean/factory/ReadZeebeWorkerValueTest.java
@@ -55,6 +55,7 @@ public class ReadZeebeWorkerValueTest {
     assertEquals(false, zeebeWorkerValue.get().getAutoComplete());
     assertEquals(List.of(), zeebeWorkerValue.get().getFetchVariables());
     assertEquals(methodInfo, zeebeWorkerValue.get().getMethodInfo());
+    assertEquals(Duration.ofHours(1), zeebeWorkerValue.get().getStreamTimeout());
   }
 
   @Test


### PR DESCRIPTION
Setting default streaming timeout to 1h 

## Description

Setting default streaming timeout to 1h to improve connections load balancing and solve [this issue](https://github.com/camunda/camunda/issues/19188).

## Related issues

closes #19188
