### PR TITLE
test: snapshot false negative corruption unit test

### DIFF
--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -11,7 +11,6 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.Assert.assertTrue;
 
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -19,7 +18,6 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
 import io.camunda.zeebe.snapshots.SnapshotChunkWrapper;
-import io.camunda.zeebe.snapshots.TestChecksumProvider;
 import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -28,10 +26,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.zip.CRC32C;
 import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Rule;
@@ -338,48 +334,6 @@ public class FileBasedReceivedSnapshotTest {
         .isDirectoryContaining(
             name ->
                 name.getFileName().toString().equals(FileBasedSnapshotStore.METADATA_FILE_NAME));
-  }
-
-  @Test
-  public void shouldNotFlagAsCorruptedIfFileChecksumsMatchButCombinedChecksumMismatch() {
-    // given
-    final Map<String, Long> fileChecksums = new HashMap<>();
-    for (final var entry : SNAPSHOT_FILE_CONTENTS.entrySet()) {
-      final var fileContentChecksum = new CRC32C();
-      fileContentChecksum.update(entry.getValue().getBytes(StandardCharsets.UTF_8));
-      fileChecksums.put(entry.getKey(), fileContentChecksum.getValue());
-    }
-
-    final var store =
-        new FileBasedSnapshotStore(
-            PARTITION_ID,
-            temporaryFolder.getRoot().toPath().resolve("receiver"),
-            new TestChecksumProvider(fileChecksums));
-    scheduler.submitActor(store);
-
-    // when
-    final var persistedSnapshot = takePersistedSnapshot(1L);
-    final var receivedSnapshot = store.newReceivedSnapshot(persistedSnapshot.getId()).join();
-    try (final var reader = persistedSnapshot.newChunkReader()) {
-      while (reader.hasNext()) {
-        receivedSnapshot.apply(reader.next()).join();
-      }
-    }
-
-    receivedSnapshot.persist().join();
-
-    // simulate restart, store will attempt to update the latest snapshot to the most recent one.
-    store.onActorStarting();
-
-    // then
-    final AtomicReference<PersistedSnapshot> snapshot = new AtomicReference<>();
-    store.getLatestSnapshot().ifPresent(snapshot::set);
-
-    // The snapshot which is generated from received snapshot with the provider is DIFFERENT to
-    // the persisted checksum but a file corruption has not been detected. If a file corruption is
-    // detected the store.getLatestSnapshot() all will return null and the .get() call will return
-    // an NPE.
-    assertTrue(snapshot.get().getChecksum() != persistedSnapshot.getChecksum());
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -371,6 +371,7 @@ public class FileBasedReceivedSnapshotTest {
     // simulate restart, store will attempt to update the latest snapshot to the most recent one.
     store.onActorStarting();
 
+    // then
     final AtomicReference<PersistedSnapshot> snapshot = new AtomicReference<>();
     store.getLatestSnapshot().ifPresent(snapshot::set);
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -368,7 +368,7 @@ public class FileBasedSnapshotStoreTest {
 
     final var store =
         new FileBasedSnapshotStore(
-            PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
+            0, PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
     scheduler.submitActor(store);
 
     // when
@@ -388,7 +388,7 @@ public class FileBasedSnapshotStoreTest {
 
     final var restartedStore =
         new FileBasedSnapshotStore(
-            PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
+            0, PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
     scheduler.submitActor(restartedStore).join();
 
     assertThat(restartedStore.getLatestSnapshot())

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -19,11 +19,13 @@ import io.camunda.zeebe.test.util.asserts.DirectoryAssert;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.zip.CRC32C;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,6 +36,8 @@ public class FileBasedSnapshotStoreTest {
   private static final String PENDING_DIRECTORY = "pending";
 
   private static final String SNAPSHOT_CONTENT_FILE_NAME = "file1.txt";
+  private static final String SNAPSHOT_CONTENT = "this is the content";
+  private static final Integer PARTITION_ID = 1;
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
   @Rule public ActorSchedulerRule scheduler = new ActorSchedulerRule();
@@ -353,12 +357,52 @@ public class FileBasedSnapshotStoreTest {
     assertThat(newSnapshot.getPath()).exists();
   }
 
+  @Test
+  public void shouldRestartWithAReceivedSnapshot() throws IOException {
+    // given
+    final Map<String, Long> fileChecksums = new HashMap<>();
+    final var fileContentChecksum = new CRC32C();
+    fileContentChecksum.update(SNAPSHOT_CONTENT.getBytes(StandardCharsets.UTF_8));
+    fileChecksums.put(SNAPSHOT_CONTENT_FILE_NAME, fileContentChecksum.getValue());
+    final var receiverStorePath = temporaryFolder.newFolder("receiver").toPath();
+
+    final var store =
+        new FileBasedSnapshotStore(
+            PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
+    scheduler.submitActor(store);
+
+    // when
+    final var persistedSnapshot = takeTransientSnapshot().persist().join();
+    final var receivedSnapshot = store.newReceivedSnapshot(persistedSnapshot.getId()).join();
+    try (final var reader = persistedSnapshot.newChunkReader()) {
+      while (reader.hasNext()) {
+        receivedSnapshot.apply(reader.next()).join();
+      }
+    }
+
+    receivedSnapshot.persist().join();
+
+    // restart store will attempt to update the latest snapshot to the most recent one and check for
+    // corruption.
+    store.close();
+
+    final var restartedStore =
+        new FileBasedSnapshotStore(
+            PARTITION_ID, receiverStorePath, new TestChecksumProvider(fileChecksums));
+    scheduler.submitActor(restartedStore).join();
+
+    assertThat(restartedStore.getLatestSnapshot())
+        .describedAs(
+            "The latest snapshot is not detected as corrupted and should be loaded after restart")
+        .hasValueSatisfying(s -> assertThat(s.getId()).isEqualTo(persistedSnapshot.getId()));
+  }
+
   private boolean createSnapshotDir(final Path path) {
     try {
       FileUtil.ensureDirectoryExists(path);
       Files.write(
           path.resolve(SNAPSHOT_CONTENT_FILE_NAME),
-          "This is the content".getBytes(),
+          SNAPSHOT_CONTENT.getBytes(),
           CREATE_NEW,
           StandardOpenOption.WRITE);
     } catch (final IOException e) {


### PR DESCRIPTION
## Description

When a snapshot which has been received from a leader is persisted, eventually the snapshot will have to be read say during a restore or actor start. When the snapshot is read a corruption check must occur, it therefore generates the individual file checksums and a combined checksum from the files on disk. Due to the nature of how the combined checksum is generated by reading the full file and RocksDB full file checksums does not read the file, equal combined checksums are not achieved from the same files.

The test ensures that even if combined checksums are different no errors occur (as long as the individual file checksums are equal).

The aim is to eventually remove combined checksum as it is only used in test code currently.

## Related issues

Relates to #19984 
