### PR TITLE
[Backport stable/8.2] feat: allow overriding default `maxInboundMetadataSize` through config and change default to 16KB 

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -86,6 +86,11 @@ public final class ClientProperties {
   public static final String OVERRIDE_AUTHORITY = "zeebe.client.overrideauthority";
 
   /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  public static final String MAX_METADATA_SIZE = "zeebe.client.maxMetadataSize";
+
+  /**
    * @see ZeebeClientCloudBuilderStep1#withClusterId(java.lang.String)
    */
   public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -119,6 +119,13 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder overrideAuthority(String authority);
 
   /**
+   * A custom maxMetadataSize allows the client to receive larger or smaller response headers from
+   * Zeebe. Technically, it specifies the maxInboundMetadataSize of the gRPC channel. The default is
+   * 16384 = 16KB .
+   */
+  ZeebeClientBuilder maxMetadataSize(int maxSize);
+
+  /**
    * @return a new {@link ZeebeClient} with the provided configuration options.
    */
   ZeebeClient build();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -92,4 +92,9 @@ public interface ZeebeClientConfiguration {
    * @see ZeebeClientBuilder#overrideAuthority(String)
    */
   String getOverrideAuthority();
+
+  /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  int getMaxMetadataSize();
 }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -192,6 +192,11 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder maxMetadataSize(final int maxMetadataSize) {
+    return innerBuilder.maxMetadataSize(maxMetadataSize);
+  }
+
+  @Override
   public ZeebeClient build() {
     innerBuilder.gatewayAddress(determineGatewayAddress());
     innerBuilder.credentialsProvider(determineCredentialsProvider());

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -137,6 +137,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     configureConnectionSecurity(config, channelBuilder);
     channelBuilder.keepAliveTime(config.getKeepAlive().toMillis(), TimeUnit.MILLISECONDS);
     channelBuilder.userAgent("zeebe-client-java/" + VersionUtil.getVersion());
+    channelBuilder.maxInboundMetadataSize(config.getMaxMetadataSize());
 
     return channelBuilder.build();
   }

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/DataSizeUtil.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/util/DataSizeUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl.util;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class DataSizeUtil {
+
+  public static final int ONE_KB = 1024;
+  public static final int ONE_MB = 1024 * ONE_KB;
+  private static final Pattern PATTERN = Pattern.compile("^(\\d+)(kb|KB|mb|MB)?$");
+
+  private DataSizeUtil() {}
+
+  public static int parse(String text) {
+    if (text == null) {
+      throw new IllegalArgumentException("Text must not be null");
+    }
+    final Matcher matcher = PATTERN.matcher(text.replace(" ", ""));
+    if (!matcher.matches()) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Expected %s to be a data size, but does not match pattern %s",
+              text, PATTERN.pattern()));
+    }
+
+    final String data = matcher.group(1);
+    final String unit = matcher.group(2);
+    if (null == unit) {
+      return Integer.parseInt(data);
+    }
+    switch (matcher.group(2).toLowerCase()) {
+      case "kb":
+        return Integer.parseInt(matcher.group(1)) * ONE_KB;
+      case "mb":
+        return Integer.parseInt(matcher.group(1)) * ONE_MB;
+      default:
+        throw new IllegalArgumentException(
+            String.format("Unexpected data size unit %s, should be one of [kb, mb]", unit));
+    }
+  }
+}


### PR DESCRIPTION
# Description
Backport of #20002 to `stable/8.2`.

relates to #19829 #11284 #19591
original author: @mustafadagher