### PR TITLE
[Backport stable/8.3] feat: allow overriding default `maxInboundMetadataSize` through config and change default to 16KB 

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -102,6 +102,11 @@ public final class ClientProperties {
   public static final String MAX_MESSAGE_SIZE = "zeebe.client.maxMessageSize";
 
   /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  public static final String MAX_METADATA_SIZE = "zeebe.client.maxMetadataSize";
+
+  /**
    * @see ZeebeClientCloudBuilderStep1#withClusterId(java.lang.String)
    */
   public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -170,6 +170,13 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder maxMessageSize(int maxSize);
 
   /**
+   * A custom maxMetadataSize allows the client to receive larger or smaller response headers from
+   * Zeebe. Technically, it specifies the maxInboundMetadataSize of the gRPC channel. The default is
+   * 16384 = 16KB .
+   */
+  ZeebeClientBuilder maxMetadataSize(int maxSize);
+
+  /**
    * A custom streamEnabled allows the client to use job stream instead of job poll. The default
    * value is set as enabled.
    */

--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -110,6 +110,11 @@ public interface ZeebeClientConfiguration {
   int getMaxMessageSize();
 
   /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  int getMaxMetadataSize();
+
+  /**
    * @see ZeebeClientBuilder#jobWorkerExecutor(ScheduledExecutorService)
    */
   ScheduledExecutorService jobWorkerExecutor();

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -20,10 +20,12 @@ import static io.camunda.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_L
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.client.ClientProperties.KEEP_ALIVE;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
+import static io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.OVERRIDE_AUTHORITY;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.BuilderUtils.appendProperty;
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 
 import io.camunda.zeebe.client.ClientProperties;
@@ -80,6 +82,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
   private String overrideAuthority;
   private int maxMessageSize = 4 * ONE_MB;
+  private int maxMetadataSize = 16 * ONE_KB;
   private boolean streamEnabled = false;
   private ScheduledExecutorService jobWorkerExecutor;
   private boolean ownsJobWorkerExecutor;
@@ -175,6 +178,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public int getMaxMetadataSize() {
+    return maxMetadataSize;
+  }
+
+  @Override
   public ScheduledExecutorService jobWorkerExecutor() {
     return jobWorkerExecutor;
   }
@@ -263,6 +271,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(MAX_MESSAGE_SIZE)) {
       maxMessageSize(DataSizeUtil.parse(properties.getProperty(MAX_MESSAGE_SIZE)));
+    }
+    if (properties.containsKey(MAX_METADATA_SIZE)) {
+      maxMetadataSize(DataSizeUtil.parse(properties.getProperty(MAX_METADATA_SIZE)));
     }
     if (properties.containsKey(STREAM_ENABLED)) {
       defaultJobWorkerStreamEnabled(Boolean.parseBoolean(properties.getProperty(STREAM_ENABLED)));
@@ -400,6 +411,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public ZeebeClientBuilder maxMetadataSize(final int maxMetadataSize) {
+    this.maxMetadataSize = maxMetadataSize;
+    return this;
+  }
+
+  @Override
   public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     this.streamEnabled = streamEnabled;
     return this;
@@ -443,6 +460,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       maxMessageSize(DataSizeUtil.parse(Environment.system().get(MAX_MESSAGE_SIZE)));
     }
 
+    if (Environment.system().isDefined(MAX_METADATA_SIZE)) {
+      maxMetadataSize(DataSizeUtil.parse(Environment.system().get(MAX_METADATA_SIZE)));
+    }
+
     if (Environment.system().isDefined(DEFAULT_TENANT_ID_VAR)) {
       defaultTenantId(Environment.system().get(DEFAULT_TENANT_ID_VAR));
     }
@@ -474,6 +495,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
     appendProperty(sb, "overrideAuthority", overrideAuthority);
     appendProperty(sb, "maxMessageSize", maxMessageSize);
+    appendProperty(sb, "maxMetadataSize", maxMetadataSize);
     appendProperty(sb, "jobWorkerExecutor", jobWorkerExecutor);
     appendProperty(sb, "ownsJobWorkerExecutor", ownsJobWorkerExecutor);
     appendProperty(sb, "streamEnabled", streamEnabled);

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -234,6 +234,11 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder maxMetadataSize(final int maxMetadataSize) {
+    return innerBuilder.maxMetadataSize(maxMetadataSize);
+  }
+
+  @Override
   public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     innerBuilder.defaultJobWorkerStreamEnabled(streamEnabled);
     return null;

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -140,6 +140,8 @@ public final class ZeebeClientImpl implements ZeebeClient {
     channelBuilder.keepAliveTime(config.getKeepAlive().toMillis(), TimeUnit.MILLISECONDS);
     channelBuilder.userAgent("zeebe-client-java/" + VersionUtil.getVersion());
     channelBuilder.maxInboundMessageSize(config.getMaxMessageSize());
+    channelBuilder.maxInboundMetadataSize(config.getMaxMetadataSize());
+
     return channelBuilder.build();
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/ZeebeClientTest.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.client.ClientProperties.CLOUD_REGION;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_TENANT_ID;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
+import static io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.CA_CERTIFICATE_VAR;
@@ -28,6 +29,7 @@ import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.KEEP_ALIVE_VAR
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.OVERRIDE_AUTHORITY_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.PLAINTEXT_CONNECTION_VAR;
 import static io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl.ZEEBE_CLIENT_WORKER_STREAM_ENABLED;
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -85,6 +87,7 @@ public final class ZeebeClientTest extends ClientTest {
       assertThat(configuration.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofHours(1));
       assertThat(configuration.getDefaultRequestTimeout()).isEqualTo(Duration.ofSeconds(10));
       assertThat(configuration.getMaxMessageSize()).isEqualTo(4 * 1024 * 1024);
+      assertThat(configuration.getMaxMetadataSize()).isEqualTo(16 * 1024);
       assertThat(configuration.getOverrideAuthority()).isNull();
       assertThat(configuration.getDefaultTenantId())
           .isEqualTo(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
@@ -287,6 +290,19 @@ public final class ZeebeClientTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetMaxMetadataSize() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.maxMetadataSize(10 * 1024);
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxMetadataSize()).isEqualTo(10 * 1024);
+  }
+
+  @Test
   public void shouldSetMaxMessageSizeWithProperty() {
     // given
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
@@ -302,6 +318,21 @@ public final class ZeebeClientTest extends ClientTest {
   }
 
   @Test
+  public void shouldSetMaxMetadataSizeWithProperty() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+
+    final Properties properties = new Properties();
+    properties.setProperty(MAX_METADATA_SIZE, "10KB");
+    builder.withProperties(properties);
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxMetadataSize()).isEqualTo(10 * ONE_KB);
+  }
+
+  @Test
   public void shouldOverrideMaxMessageSizeWithEnvVar() {
     // given
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
@@ -314,6 +345,21 @@ public final class ZeebeClientTest extends ClientTest {
 
     // then
     assertThat(builder.getMaxMessageSize()).isEqualTo(10 * ONE_MB);
+  }
+
+  @Test
+  public void shouldOverrideMaxMetadataSizeWithEnvVar() {
+    // given
+    final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
+    builder.applyEnvironmentVariableOverrides(Boolean.TRUE);
+    builder.maxMetadataSize(16 * ONE_KB);
+    Environment.system().put(MAX_METADATA_SIZE, "8KB");
+
+    // when
+    builder.build();
+
+    // then
+    assertThat(builder.getMaxMetadataSize()).isEqualTo(8 * ONE_KB);
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #20002 to `stable/8.3`.

relates to #19829 #11284 #19591
original author: @mustafadagher