### PR TITLE
[Backport stable/8.2] fix: limit validation result output to a certain size and print the number of remaining errors

### DIFF
--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/EngineCfg.java
@@ -16,12 +16,14 @@ public final class EngineCfg implements ConfigurationEntry {
   private MessagesCfg messages = new MessagesCfg();
   private CachesCfg caches = new CachesCfg();
   private JobsCfg jobs = new JobsCfg();
+  private ValidatorsCfg validators = new ValidatorsCfg();
 
   @Override
   public void init(final BrokerCfg globalConfig, final String brokerBase) {
     messages.init(globalConfig, brokerBase);
     caches.init(globalConfig, brokerBase);
     jobs.init(globalConfig, brokerBase);
+    validators.init(globalConfig, brokerBase);
   }
 
   public MessagesCfg getMessages() {
@@ -48,9 +50,26 @@ public final class EngineCfg implements ConfigurationEntry {
     this.jobs = jobs;
   }
 
+  public ValidatorsCfg getValidators() {
+    return validators;
+  }
+
+  public void setValidators(final ValidatorsCfg validators) {
+    this.validators = validators;
+  }
+
   @Override
   public String toString() {
-    return "EngineCfg{" + "messages=" + messages + ", caches=" + caches + ", jobs=" + jobs + '}';
+    return "EngineCfg{"
+        + "messages="
+        + messages
+        + ", caches="
+        + caches
+        + ", jobs="
+        + jobs
+        + ", validators="
+        + validators
+        + '}';
   }
 
   public EngineConfiguration createEngineConfiguration() {
@@ -59,6 +78,7 @@ public final class EngineCfg implements ConfigurationEntry {
         .setMessagesTtlCheckerInterval(messages.getTtlCheckerInterval())
         .setDrgCacheCapacity(caches.getDrgCacheCapacity())
         .setJobsTimeoutCheckerPollingInterval(jobs.getTimeoutCheckerPollingInterval())
-        .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit());
+        .setJobsTimeoutCheckerBatchLimit(jobs.getTimeoutCheckerBatchLimit())
+        .setValidatorsResultsOutputMaxSize(validators.getResultsOutputMaxSize());
   }
 }

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ValidatorsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ValidatorsCfg.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.broker.system.configuration.engine;
+
+import io.camunda.zeebe.broker.system.configuration.ConfigurationEntry;
+import io.camunda.zeebe.engine.EngineConfiguration;
+
+public class ValidatorsCfg implements ConfigurationEntry {
+
+  private int resultsOutputMaxSize = EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
+
+  public int getResultsOutputMaxSize() {
+    return resultsOutputMaxSize;
+  }
+
+  public void setResultsOutputMaxSize(final int resultsOutputMaxSize) {
+    this.resultsOutputMaxSize = resultsOutputMaxSize;
+  }
+
+  @Override
+  public String toString() {
+    return "BpmnValidatorsCfg{" + "resultsOutputMaxSize=" + resultsOutputMaxSize + '}';
+  }
+}

--- a/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ValidatorsCfg.java
+++ b/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/engine/ValidatorsCfg.java
@@ -2,8 +2,8 @@
  * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
  * one or more contributor license agreements. See the NOTICE file distributed
  * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Licensed under the Zeebe Community License 1.1. You may not use this file
+ * except in compliance with the Zeebe Community License 1.1.
  */
 package io.camunda.zeebe.broker.system.configuration.engine;
 

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -33,6 +33,8 @@ final class EngineCfgTest {
     assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
         .isEqualTo(Duration.ofSeconds(1));
     assertThat(configuration.getJobsTimeoutCheckerBatchLimit()).isEqualTo(Integer.MAX_VALUE);
+    assertThat(configuration.getValidatorsResultsOutputMaxSize())
+        .isEqualTo(EngineConfiguration.DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE);
   }
 
   @Test
@@ -50,5 +52,6 @@ final class EngineCfgTest {
     assertThat(configuration.getJobsTimeoutCheckerPollingInterval())
         .isEqualTo(Duration.ofSeconds(15));
     assertThat(configuration.getJobsTimeoutCheckerBatchLimit()).isEqualTo(1000);
+    assertThat(configuration.getValidatorsResultsOutputMaxSize()).isEqualTo(2000);
   }
 }

--- a/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
+++ b/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/EngineCfgTest.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.broker.system.configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;

--- a/broker/src/test/resources/system/engine.yaml
+++ b/broker/src/test/resources/system/engine.yaml
@@ -10,3 +10,5 @@ zeebe:
         jobs:
           timeoutCheckerPollingInterval: 15s
           timeoutCheckerBatchLimit: 1000
+        validators:
+          resultsOutputMaxSize: 2000

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1084,7 +1084,7 @@
           # timeoutCheckerBatchLimit: 0x7fffffff
 
         # validators:
-          # Allows to configure the maximum output size for BPMN validator results.
+          # Allows to configure the maximum output size (in bytes) for BPMN validator results.
           # These results details are typically returned in our gRPC endpoint responses and can cause issues in proxy servers if they are too long to be contained in proxy-headers.
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_VALIDATORS_RESULTSOUTPUTMAXSIZE
           # resultsOutputMaxSize: 0x7fffffff

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1087,7 +1087,8 @@
           # Allows to configure the maximum output size (in bytes) for BPMN validator results.
           # These results details are typically returned in our gRPC endpoint responses and can cause issues in proxy servers if they are too long to be contained in proxy-headers.
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_VALIDATORS_RESULTSOUTPUTMAXSIZE
-          # resultsOutputMaxSize: 0x7fffffff
+          # PS: The default value is 12kb. Increasing it to a higher value introduces a risk that it will be throttled by NGINX proxy configs or the zeebe client configs.
+          # resultsOutputMaxSize: 12288
 
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1083,6 +1083,12 @@
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERBATCHLIMIT
           # timeoutCheckerBatchLimit: 0x7fffffff
 
+        # validators:
+          # Allows to configure the maximum output size for BPMN validator results.
+          # These results details are typically returned in our gRPC endpoint responses and can cause issues in proxy servers if they are too long to be contained in proxy-headers.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_VALIDATORS_RESULTSOUTPUTMAXSIZE
+          # resultsOutputMaxSize: 0x7fffffff
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -993,7 +993,7 @@
           # timeoutCheckerBatchLimit: 0x7fffffff
 
         # validators:
-          # Allows to configure the maximum output size for BPMN validator results.
+          # Allows to configure the maximum output size (in bytes) for BPMN validator results.
           # These results details are typically returned in our gRPC endpoint responses and can cause issues in proxy servers if they are too long to be contained in proxy-headers.
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_VALIDATORS_RESULTSOUTPUTMAXSIZE
           # resultsOutputMaxSize: 0x7fffffff

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -996,7 +996,8 @@
           # Allows to configure the maximum output size (in bytes) for BPMN validator results.
           # These results details are typically returned in our gRPC endpoint responses and can cause issues in proxy servers if they are too long to be contained in proxy-headers.
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_VALIDATORS_RESULTSOUTPUTMAXSIZE
-          # resultsOutputMaxSize: 0x7fffffff
+          # PS: The default value is 12kb. Increasing it to a higher value introduces a risk that it will be throttled by NGINX proxy configs or the zeebe client configs.
+          # resultsOutputMaxSize: 12288
 
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -992,6 +992,12 @@
           # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_JOBS_TIMEOUTCHECKERBATCHLIMIT
           # timeoutCheckerBatchLimit: 0x7fffffff
 
+        # validators:
+          # Allows to configure the maximum output size for BPMN validator results.
+          # These results details are typically returned in our gRPC endpoint responses and can cause issues in proxy servers if they are too long to be contained in proxy-headers.
+          # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_ENGINE_VALIDATORS_RESULTSOUTPUTMAXSIZE
+          # resultsOutputMaxSize: 0x7fffffff
+
       # Allows to configure feature flags. These are used to test new features in dev and int environments prior
       # to rolling them out to production
       # features:

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -23,12 +23,15 @@ public final class EngineConfiguration {
   public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
+  public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = Integer.MAX_VALUE;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;
   private int drgCacheCapacity = DEFAULT_DRG_CACHE_CAPACITY;
   private Duration jobsTimeoutCheckerPollingInterval = DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
   private int jobsTimeoutCheckerBatchLimit = DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT;
+
+  private int validatorsResultsOutputMaxSize = DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE;
 
   public int getMessagesTtlCheckerBatchLimit() {
     return messagesTtlCheckerBatchLimit;
@@ -76,6 +79,15 @@ public final class EngineConfiguration {
   public EngineConfiguration setJobsTimeoutCheckerBatchLimit(
       final int jobsTimeoutCheckerBatchLimit) {
     this.jobsTimeoutCheckerBatchLimit = jobsTimeoutCheckerBatchLimit;
+    return this;
+  }
+
+  public int getValidatorsResultsOutputMaxSize() {
+    return validatorsResultsOutputMaxSize;
+  }
+
+  public EngineConfiguration setValidatorsResultsOutputMaxSize(final int maxSize) {
+    validatorsResultsOutputMaxSize = maxSize;
     return this;
   }
 }

--- a/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/EngineConfiguration.java
@@ -23,7 +23,7 @@ public final class EngineConfiguration {
   public static final int DEFAULT_DRG_CACHE_CAPACITY = 1000;
   public static final Duration DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL = Duration.ofSeconds(1);
   public static final int DEFAULT_JOBS_TIMEOUT_CHECKER_BATCH_LIMIT = Integer.MAX_VALUE;
-  public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = Integer.MAX_VALUE;
+  public static final int DEFAULT_VALIDATORS_RESULTS_OUTPUT_MAX_SIZE = 12 * 1024;
 
   private int messagesTtlCheckerBatchLimit = DEFAULT_MESSAGES_TTL_CHECKER_BATCH_LIMIT;
   private Duration messagesTtlCheckerInterval = DEFAULT_MESSAGES_TTL_CHECKER_INTERVAL;

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -124,7 +124,8 @@ public final class EngineProcessors {
         partitionsCount,
         deploymentDistributionCommandSender,
         processingState.getKeyGenerator(),
-        featureFlags);
+        featureFlags,
+        config);
     addMessageProcessors(
         bpmnBehaviors,
         subscriptionCommandSender,
@@ -199,7 +200,8 @@ public final class EngineProcessors {
       final int partitionsCount,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
       final KeyGenerator keyGenerator,
-      final FeatureFlags featureFlags) {
+      final FeatureFlags featureFlags,
+      final EngineConfiguration config) {
 
     // on deployment partition CREATE Command is received and processed
     // it will cause a distribution to other partitions
@@ -211,7 +213,8 @@ public final class EngineProcessors {
             writers,
             deploymentDistributionCommandSender,
             keyGenerator,
-            featureFlags);
+            featureFlags,
+            config);
     typedRecordProcessors.onCommand(ValueType.DEPLOYMENT, CREATE, processor);
 
     // periodically retries deployment distribution

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment;
 
 import static io.camunda.zeebe.engine.state.instance.TimerInstance.NO_ELEMENT_INSTANCE;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
@@ -66,7 +67,8 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       final Writers writers,
       final DeploymentDistributionCommandSender deploymentDistributionCommandSender,
       final KeyGenerator keyGenerator,
-      final FeatureFlags featureFlags) {
+      final FeatureFlags featureFlags,
+      final EngineConfiguration config) {
     processState = processingState.getProcessState();
     decisionState = processingState.getDecisionState();
     timerInstanceState = processingState.getTimerState();
@@ -78,7 +80,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
     expressionProcessor = bpmnBehaviors.expressionBehavior();
     deploymentTransformer =
         new DeploymentTransformer(
-            stateWriter, processingState, expressionProcessor, keyGenerator, featureFlags);
+            stateWriter, processingState, expressionProcessor, keyGenerator, featureFlags, config);
     startEventSubscriptionManager =
         new StartEventSubscriptionManager(processingState, keyGenerator);
     deploymentDistributionBehavior =
@@ -130,7 +132,7 @@ public final class DeploymentCreateProcessor implements TypedRecordProcessor<Dep
       decisionState.clearCache();
     }
 
-    if (error instanceof ResourceTransformationFailedException exception) {
+    if (error instanceof final ResourceTransformationFailedException exception) {
       rejectionWriter.appendRejection(
           command, RejectionType.INVALID_ARGUMENT, exception.getMessage());
       responseWriter.writeRejectionOnCommand(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -21,8 +21,8 @@ public final class BpmnFactory {
 
   public static BpmnValidator createValidator(
       final ExpressionProcessor expressionProcessor, final int validatorResultsOutputMaxSize) {
-    return new BpmnValidator(createExpressionLanguage(), expressionProcessor,
-        validatorResultsOutputMaxSize);
+    return new BpmnValidator(
+        createExpressionLanguage(), expressionProcessor, validatorResultsOutputMaxSize);
   }
 
   private static ExpressionLanguage createExpressionLanguage() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -19,8 +19,10 @@ public final class BpmnFactory {
     return new BpmnTransformer(createExpressionLanguage());
   }
 
-  public static BpmnValidator createValidator(final ExpressionProcessor expressionProcessor) {
-    return new BpmnValidator(createExpressionLanguage(), expressionProcessor);
+  public static BpmnValidator createValidator(
+      final ExpressionProcessor expressionProcessor, final int validatorResultsOutputMaxSize) {
+    return new BpmnValidator(createExpressionLanguage(), expressionProcessor,
+        validatorResultsOutputMaxSize);
   }
 
   private static ExpressionLanguage createExpressionLanguage() {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.BpmnFactory;
@@ -52,12 +53,15 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final Function<DeploymentResource, DirectBuffer> checksumGenerator,
       final ProcessState processState,
       final ExpressionProcessor expressionProcessor,
-      final boolean enableStraightThroughProcessingLoopDetector) {
+      final boolean enableStraightThroughProcessingLoopDetector,
+      final EngineConfiguration config) {
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;
     this.processState = processState;
-    validator = BpmnFactory.createValidator(expressionProcessor);
+    validator =
+        BpmnFactory.createValidator(
+            expressionProcessor, config.getValidatorsResultsOutputMaxSize());
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
   }
 

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidator.java
@@ -15,10 +15,12 @@ import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
 import io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebeDesignTimeValidators;
 import java.io.StringWriter;
+import org.camunda.bpm.model.xml.impl.validation.ModelValidationResultsImpl;
 import org.camunda.bpm.model.xml.validation.ValidationResults;
 
 public final class BpmnValidator {
-
+  // 2kb is half of the default nginx ingress proxy header size
+  public static final int VALIDATION_RESULTS_OUTPUT_MAX_SIZE = 2000;
   private final ValidationVisitor designTimeAspectValidator;
   private final ValidationVisitor runtimeAspectValidator;
 
@@ -45,8 +47,8 @@ public final class BpmnValidator {
 
     if (results1.hasErrors() || results2.hasErrors()) {
       final StringWriter writer = new StringWriter();
-      results1.write(writer, formatter);
-      results2.write(writer, formatter);
+      final var results = new ModelValidationResultsImpl(results1, results2);
+      results.write(writer, formatter, VALIDATION_RESULTS_OUTPUT_MAX_SIZE);
 
       return writer.toString();
     } else {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnValidator.java
@@ -19,19 +19,20 @@ import org.camunda.bpm.model.xml.impl.validation.ModelValidationResultsImpl;
 import org.camunda.bpm.model.xml.validation.ValidationResults;
 
 public final class BpmnValidator {
-  // 2kb is half of the default nginx ingress proxy header size
-  public static final int VALIDATION_RESULTS_OUTPUT_MAX_SIZE = 2000;
   private final ValidationVisitor designTimeAspectValidator;
   private final ValidationVisitor runtimeAspectValidator;
-
   private final ValidationErrorFormatter formatter = new ValidationErrorFormatter();
+  private final int validatorResultsOutputMaxSize;
 
   public BpmnValidator(
-      final ExpressionLanguage expressionLanguage, final ExpressionProcessor expressionProcessor) {
+      final ExpressionLanguage expressionLanguage,
+      final ExpressionProcessor expressionProcessor,
+      final int validatorResultsOutputMaxSize) {
     designTimeAspectValidator = new ValidationVisitor(ZeebeDesignTimeValidators.VALIDATORS);
     runtimeAspectValidator =
         new ValidationVisitor(
             ZeebeRuntimeValidators.getValidators(expressionLanguage, expressionProcessor));
+    this.validatorResultsOutputMaxSize = validatorResultsOutputMaxSize;
   }
 
   public String validate(final BpmnModelInstance modelInstance) {
@@ -48,7 +49,7 @@ public final class BpmnValidator {
     if (results1.hasErrors() || results2.hasErrors()) {
       final StringWriter writer = new StringWriter();
       final var results = new ModelValidationResultsImpl(results1, results2);
-      results.write(writer, formatter, VALIDATION_RESULTS_OUTPUT_MAX_SIZE);
+      results.write(writer, formatter, validatorResultsOutputMaxSize);
 
       return writer.toString();
     } else {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.engine.processing.deployment.transform;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapArray;
 import static java.util.Map.entry;
 
+import io.camunda.zeebe.engine.EngineConfiguration;
 import io.camunda.zeebe.engine.Loggers;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
@@ -48,7 +49,8 @@ public final class DeploymentTransformer {
       final ProcessingState processingState,
       final ExpressionProcessor expressionProcessor,
       final KeyGenerator keyGenerator,
-      final FeatureFlags featureFlags) {
+      final FeatureFlags featureFlags,
+      final EngineConfiguration config) {
 
     try {
       // We get an alert by LGTM, since MD5 is a weak cryptographic hash function,
@@ -68,7 +70,8 @@ public final class DeploymentTransformer {
             this::getChecksum,
             processingState.getProcessState(),
             expressionProcessor,
-            featureFlags.enableStraightThroughProcessingLoopDetector());
+            featureFlags.enableStraightThroughProcessingLoopDetector(),
+            config);
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
             keyGenerator, stateWriter, this::getChecksum, processingState.getDecisionState());

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/ValidationErrorFormatter.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/ValidationErrorFormatter.java
@@ -16,6 +16,7 @@ import org.camunda.bpm.model.xml.validation.ValidationResult;
 import org.camunda.bpm.model.xml.validation.ValidationResultFormatter;
 
 public final class ValidationErrorFormatter implements ValidationResultFormatter {
+  public static final String OMITTED_RESULTS_SUFFIX_FORMAT = "and %d more errors and/or warnings";
 
   @Override
   public void formatElement(final StringWriter writer, final ModelElementInstance element) {
@@ -31,6 +32,16 @@ public final class ValidationErrorFormatter implements ValidationResultFormatter
     writer.append(": ");
     writer.append(result.getMessage());
     writer.append("\n");
+  }
+
+  @Override
+  public void formatSuffixWithOmittedResultsCount(final StringWriter writer, final int count) {
+    writer.append(String.format(OMITTED_RESULTS_SUFFIX_FORMAT, count));
+  }
+
+  @Override
+  public int getFormattedSuffixWithOmittedResultsSize(final int count) {
+    return String.format(OMITTED_RESULTS_SUFFIX_FORMAT, count).getBytes().length;
   }
 
   /**

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -40,7 +40,7 @@
     <version.assertj>3.24.2</version.assertj>
     <version.awaitility>4.2.1</version.awaitility>
     <version.bouncycastle>1.78.1</version.bouncycastle>
-    <version.camunda>7.18.0</version.camunda>
+    <version.camunda>7.22.0-SNAPSHOT</version.camunda>
     <version.checkstyle>10.9.3</version.checkstyle>
     <version.commons-lang>3.14.0</version.commons-lang>
     <version.commons-logging>1.2</version.commons-logging>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -40,7 +40,7 @@
     <version.assertj>3.24.2</version.assertj>
     <version.awaitility>4.2.1</version.awaitility>
     <version.bouncycastle>1.78.1</version.bouncycastle>
-    <version.camunda>7.22.0-SNAPSHOT</version.camunda>
+    <version.camunda>7.22.0-alpha3</version.camunda>
     <version.checkstyle>10.9.3</version.checkstyle>
     <version.commons-lang>3.14.0</version.commons-lang>
     <version.commons-logging>1.2</version.commons-logging>


### PR DESCRIPTION
# Description
Backport of #19600 to `stable/8.2`.

relates to camunda/camunda-bpm-platform#4443 #19595 #11284
original author: @mustafadagher