### PR TITLE
deps: bump zeebe-test-container for compatibility with httpcore5

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -90,7 +90,7 @@
     <version.asm>9.3</version.asm>
     <version.testcontainers>1.19.8</version.testcontainers>
     <version.netflix.concurrency>0.4.1</version.netflix.concurrency>
-    <version.zeebe-test-container>3.6.3</version.zeebe-test-container>
+    <version.zeebe-test-container>3.6.5</version.zeebe-test-container>
     <version.feel-scala>1.17.7</version.feel-scala>
     <version.dmn-scala>1.9.0</version.dmn-scala>
     <version.rest-assured>5.4.0</version.rest-assured>


### PR DESCRIPTION
## Description

This PR bumps zeebe-test-container to fix an issue introduced in a shared transitive dependency, httpcore5 5.2.5. This breaks the `DebugExporter` as the server receiving exported records now (since 5.2.5) checks the hostname authority, even when TLS is not enabled. This breaks several container based tests such as the disk filling ones.
