### PR TITLE
[Backport stable/8.5] feat: allow overriding default maxInboundMetadataSize through config and change default to 16KB

### DIFF
--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationSpringImpl.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/configuration/ZeebeClientConfigurationSpringImpl.java
@@ -168,6 +168,11 @@ public class ZeebeClientConfigurationSpringImpl implements ZeebeClientConfigurat
   }
 
   @Override
+  public int getMaxMetadataSize() {
+    return properties.getMaxMetadataSize();
+  }
+
+  @Override
   public ScheduledExecutorService jobWorkerExecutor() {
     return zeebeClientExecutorService.get();
   }

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -79,6 +79,7 @@ public class ZeebeClientConfigurationProperties {
 
   private boolean defaultJobWorkerStreamEnabled = DEFAULT.getDefaultJobWorkerStreamEnabled();
   private Duration requestTimeout = DEFAULT.getDefaultRequestTimeout();
+  private int maxMetadataSize = DEFAULT.getMaxMetadataSize();
 
   @Autowired
   public ZeebeClientConfigurationProperties(
@@ -365,12 +366,17 @@ public class ZeebeClientConfigurationProperties {
   }
 
   public int getMaxMetadataSize() {
-    return DEFAULT.getMaxMetadataSize();
+    return maxMetadataSize;
+  }
+
+  public void setMaxMetadataSize(final int maxMetadataSize) {
+    this.maxMetadataSize = maxMetadataSize;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(broker, cloud, worker, message, security, job, requestTimeout);
+    return Objects.hash(
+        broker, cloud, worker, message, security, job, requestTimeout, maxMetadataSize);
   }
 
   @Override
@@ -388,7 +394,8 @@ public class ZeebeClientConfigurationProperties {
         && Objects.equals(message, that.message)
         && Objects.equals(security, that.security)
         && Objects.equals(job, that.job)
-        && Objects.equals(requestTimeout, that.requestTimeout);
+        && Objects.equals(requestTimeout, that.requestTimeout)
+        && Objects.equals(maxMetadataSize, that.maxMetadataSize);
   }
 
   @Override
@@ -426,6 +433,8 @@ public class ZeebeClientConfigurationProperties {
         + defaultJobWorkerStreamEnabled
         + ", requestTimeout="
         + requestTimeout
+        + ", maxMetadataSize="
+        + maxMetadataSize
         + '}';
   }
 

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -364,6 +364,10 @@ public class ZeebeClientConfigurationProperties {
     return message.getMaxMessageSize();
   }
 
+  public int getMaxMetadataSize() {
+    return DEFAULT.getMaxMetadataSize();
+  }
+
   @Override
   public int hashCode() {
     return Objects.hash(broker, cloud, worker, message, security, job, requestTimeout);

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientConfigurationDefaultPropertiesTest.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.spring.client.config;
 
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -68,6 +69,7 @@ public class ZeebeClientConfigurationDefaultPropertiesTest {
         .isEqualTo(new URI("https://0.0.0.0:26500"));
     assertThat(client.getConfiguration().getKeepAlive()).isEqualTo(Duration.ofSeconds(45));
     assertThat(client.getConfiguration().getMaxMessageSize()).isEqualTo(4 * ONE_MB);
+    assertThat(client.getConfiguration().getMaxMetadataSize()).isEqualTo(16 * ONE_KB);
     assertThat(client.getConfiguration().getNumJobWorkerExecutionThreads()).isEqualTo(1);
     assertThat(client.getConfiguration().getOverrideAuthority()).isNull();
     assertThat(client.getConfiguration().getRestAddress())

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/config/ZeebeClientStarterAutoConfigurationTest.java
@@ -58,6 +58,7 @@ import org.springframework.test.util.ReflectionTestUtils;
       "zeebe.client.security.plaintext=true",
       "zeebe.client.cloud.clientSecret=client-secret",
       "zeebe.client.cloud.clientId=client-id",
+      "zeebe.client.maxMetadataSize=8000",
     })
 public class ZeebeClientStarterAutoConfigurationTest {
 
@@ -107,6 +108,7 @@ public class ZeebeClientStarterAutoConfigurationTest {
     assertThat(client.getConfiguration().getDefaultJobWorkerMaxJobsActive()).isEqualTo(99);
     assertThat(client.getConfiguration().getDefaultJobPollInterval())
         .isEqualTo(Duration.ofSeconds(99));
+    assertThat(client.getConfiguration().getMaxMetadataSize()).isEqualTo(8000);
   }
 
   @Test

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ClientProperties.java
@@ -121,6 +121,11 @@ public final class ClientProperties {
   public static final String MAX_MESSAGE_SIZE = "zeebe.client.maxMessageSize";
 
   /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  public static final String MAX_METADATA_SIZE = "zeebe.client.maxMetadataSize";
+
+  /**
    * @see ZeebeClientCloudBuilderStep1#withClusterId(java.lang.String)
    */
   public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientBuilder.java
@@ -187,6 +187,13 @@ public interface ZeebeClientBuilder {
   ZeebeClientBuilder maxMessageSize(int maxSize);
 
   /**
+   * A custom maxMetadataSize allows the client to receive larger or smaller response headers from
+   * Zeebe. Technically, it specifies the maxInboundMetadataSize of the gRPC channel. The default is
+   * 16384 = 16KB .
+   */
+  ZeebeClientBuilder maxMetadataSize(int maxSize);
+
+  /**
    * A custom streamEnabled allows the client to use job stream instead of job poll. The default
    * value is set as enabled.
    */

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClientConfiguration.java
@@ -126,6 +126,11 @@ public interface ZeebeClientConfiguration {
   int getMaxMessageSize();
 
   /**
+   * @see ZeebeClientBuilder#maxMetadataSize(int)
+   */
+  int getMaxMetadataSize();
+
+  /**
    * @see ZeebeClientBuilder#jobWorkerExecutor(ScheduledExecutorService)
    */
   ScheduledExecutorService jobWorkerExecutor();

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientBuilderImpl.java
@@ -20,12 +20,14 @@ import static io.camunda.zeebe.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_L
 import static io.camunda.zeebe.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
 import static io.camunda.zeebe.client.ClientProperties.KEEP_ALIVE;
 import static io.camunda.zeebe.client.ClientProperties.MAX_MESSAGE_SIZE;
+import static io.camunda.zeebe.client.ClientProperties.MAX_METADATA_SIZE;
 import static io.camunda.zeebe.client.ClientProperties.OVERRIDE_AUTHORITY;
 import static io.camunda.zeebe.client.ClientProperties.PREFER_REST_OVER_GRPC;
 import static io.camunda.zeebe.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.zeebe.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.zeebe.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.zeebe.client.impl.BuilderUtils.appendProperty;
+import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.zeebe.client.impl.util.DataSizeUtil.ONE_MB;
 
 import io.camunda.zeebe.client.ClientProperties;
@@ -96,6 +98,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   private JsonMapper jsonMapper = new ZeebeObjectMapper();
   private String overrideAuthority;
   private int maxMessageSize = 4 * ONE_MB;
+  private int maxMetadataSize = 16 * ONE_KB;
   private boolean streamEnabled = false;
   private boolean grpcAddressUsed = false;
   private ScheduledExecutorService jobWorkerExecutor;
@@ -200,6 +203,11 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   @Override
   public int getMaxMessageSize() {
     return maxMessageSize;
+  }
+
+  @Override
+  public int getMaxMetadataSize() {
+    return maxMetadataSize;
   }
 
   @Override
@@ -312,6 +320,9 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     }
     if (properties.containsKey(MAX_MESSAGE_SIZE)) {
       maxMessageSize(DataSizeUtil.parse(properties.getProperty(MAX_MESSAGE_SIZE)));
+    }
+    if (properties.containsKey(MAX_METADATA_SIZE)) {
+      maxMetadataSize(DataSizeUtil.parse(properties.getProperty(MAX_METADATA_SIZE)));
     }
     if (properties.containsKey(STREAM_ENABLED)) {
       defaultJobWorkerStreamEnabled(Boolean.parseBoolean(properties.getProperty(STREAM_ENABLED)));
@@ -465,6 +476,12 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
   }
 
   @Override
+  public ZeebeClientBuilder maxMetadataSize(final int maxMetadataSize) {
+    this.maxMetadataSize = maxMetadataSize;
+    return this;
+  }
+
+  @Override
   public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     this.streamEnabled = streamEnabled;
     return this;
@@ -525,6 +542,10 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
       maxMessageSize(DataSizeUtil.parse(Environment.system().get(MAX_MESSAGE_SIZE)));
     }
 
+    if (Environment.system().isDefined(MAX_METADATA_SIZE)) {
+      maxMetadataSize(DataSizeUtil.parse(Environment.system().get(MAX_METADATA_SIZE)));
+    }
+
     if (Environment.system().isDefined(GRPC_ADDRESS_VAR)) {
       final URI grpcAddr = getURIFromString(Environment.system().get(GRPC_ADDRESS_VAR));
       grpcAddress(grpcAddr);
@@ -577,6 +598,7 @@ public final class ZeebeClientBuilderImpl implements ZeebeClientBuilder, ZeebeCl
     appendProperty(sb, "defaultRequestTimeout", defaultRequestTimeout);
     appendProperty(sb, "overrideAuthority", overrideAuthority);
     appendProperty(sb, "maxMessageSize", maxMessageSize);
+    appendProperty(sb, "maxMetadataSize", maxMetadataSize);
     appendProperty(sb, "jobWorkerExecutor", jobWorkerExecutor);
     appendProperty(sb, "ownsJobWorkerExecutor", ownsJobWorkerExecutor);
     appendProperty(sb, "streamEnabled", streamEnabled);

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientCloudBuilderImpl.java
@@ -248,6 +248,11 @@ public class ZeebeClientCloudBuilderImpl
   }
 
   @Override
+  public ZeebeClientBuilder maxMetadataSize(final int maxMetadataSize) {
+    return innerBuilder.maxMetadataSize(maxMetadataSize);
+  }
+
+  @Override
   public ZeebeClientBuilder defaultJobWorkerStreamEnabled(final boolean streamEnabled) {
     innerBuilder.defaultJobWorkerStreamEnabled(streamEnabled);
     return this;

--- a/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/zeebe/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -181,6 +181,7 @@ public final class ZeebeClientImpl implements ZeebeClient {
     channelBuilder.keepAliveTime(config.getKeepAlive().toMillis(), TimeUnit.MILLISECONDS);
     channelBuilder.userAgent("zeebe-client-java/" + VersionUtil.getVersion());
     channelBuilder.maxInboundMessageSize(config.getMaxMessageSize());
+    channelBuilder.maxInboundMetadataSize(config.getMaxMetadataSize());
 
     if (config.useDefaultRetryPolicy()) {
       final Map<String, Object> serviceConfig = defaultServiceConfig();


### PR DESCRIPTION
# Description
Backport of #20002 to `stable/8.5`.

relates to #19829 #11284 #19591