### PR TITLE
Properly handle connection closed error in the gRPC server

### DIFF
--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -12,6 +12,7 @@ import com.google.protobuf.Any;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import com.google.rpc.Status.Builder;
+import io.atomix.cluster.messaging.MessagingException;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.BrokerRejectionException;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
@@ -135,6 +136,12 @@ public final class GrpcErrorMapper {
         builder.setCode(Code.UNAVAILABLE_VALUE).setMessage(error.getMessage());
         logger.warn(
             "Expected to handle gRPC request, but there was a connection error with one of the brokers",
+            rootError);
+      }
+      case final MessagingException.ConnectionClosed ignored -> {
+        builder.setCode(Code.ABORTED_VALUE).setMessage(error.getMessage());
+        logger.warn(
+            "Expected to handle gRPC request, but the connection was cut between with the broker",
             rootError);
       }
       default -> {

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapper.java
@@ -141,7 +141,8 @@ public final class GrpcErrorMapper {
       case final MessagingException.ConnectionClosed ignored -> {
         builder.setCode(Code.ABORTED_VALUE).setMessage(error.getMessage());
         logger.warn(
-            "Expected to handle gRPC request, but the connection was cut between with the broker",
+            "Expected to handle gRPC request, but the connection was cut prematurely with the broker; "
+                + "the request may or may not have been accepted, and may not be safe to retry.",
             rootError);
       }
       default -> {

--- a/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
+++ b/zeebe/gateway-grpc/src/test/java/io/camunda/zeebe/gateway/grpc/GrpcErrorMapperTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.fail;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Status;
+import io.atomix.cluster.messaging.MessagingException.ConnectionClosed;
 import io.camunda.zeebe.broker.client.api.BrokerErrorException;
 import io.camunda.zeebe.broker.client.api.RequestRetriesExhaustedException;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
@@ -165,5 +166,18 @@ final class GrpcErrorMapperTest {
       final LogEvent event = recorder.getAppendedEvents().get(0);
       assertThat(event.getLevel()).isEqualTo(Level.DEBUG);
     }
+  }
+
+  @Test
+  void shouldReturnAbortedOnConnectionClosed() {
+    // given
+    final var error = new ConnectionClosed("Closed");
+
+    // when
+    log.setLevel(Level.DEBUG);
+    final StatusRuntimeException statusException = errorMapper.mapError(error, logger);
+
+    // then
+    assertThat(statusException.getStatus().getCode()).isEqualTo(Code.ABORTED);
   }
 }


### PR DESCRIPTION
## Description

This PR maps the `ConnectionClosed` error - which is returned by the `BrokerClient` when the broker has forcefully closed the connection before the gateway request was completed - as ABORTED, since it's unclear whether or not the request is safe to retry (i.e. is it idempotent?).

Also includes a little bit of refactoring as the first commit.

## Related issues

closes #18339 
