### PR TITLE
[Backport stable/8.3] fix: Allow single deployment of multiple BPMN processes with the same resource name

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -181,7 +181,9 @@ public final class DeploymentCreateProcessor
         .forEach(
             metadata -> {
               for (final DeploymentResource resource : deploymentEvent.getResources()) {
-                if (resource.getResourceName().equals(metadata.getResourceName())) {
+                final var resourceChecksum =
+                    deploymentTransformer.getChecksum(resource.getResource());
+                if (resourceChecksum.equals(metadata.getChecksumBuffer())) {
                   stateWriter.appendFollowUpEvent(
                       metadata.getKey(),
                       ProcessIntent.CREATED,

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -41,7 +41,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
 
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
-  private final Function<DeploymentResource, DirectBuffer> checksumGenerator;
+  private final Function<byte[], DirectBuffer> checksumGenerator;
 
   private final BpmnValidator validator;
   private final ProcessState processState;
@@ -50,7 +50,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
   public BpmnResourceTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
-      final Function<DeploymentResource, DirectBuffer> checksumGenerator,
+      final Function<byte[], DirectBuffer> checksumGenerator,
       final ProcessState processState,
       final ExpressionProcessor expressionProcessor,
       final boolean enableStraightThroughProcessingLoopDetector) {
@@ -158,7 +158,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
 
         final DirectBuffer lastDigest =
             processState.getLatestVersionDigest(wrapString(bpmnProcessId), tenantId);
-        final DirectBuffer resourceDigest = checksumGenerator.apply(deploymentResource);
+        final DirectBuffer resourceDigest =
+            checksumGenerator.apply(deploymentResource.getResource());
 
         // adds process record to deployment record
         final var processMetadata = deploymentEvent.processesMetadata().add();

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -85,8 +85,8 @@ public final class DeploymentTransformer {
             entry(".form", formResourceTransformer));
   }
 
-  private DirectBuffer getChecksum(final DeploymentResource resource) {
-    return wrapArray(digestGenerator.digest(resource.getResource()));
+  public DirectBuffer getChecksum(final byte[] resource) {
+    return wrapArray(digestGenerator.digest(resource));
   }
 
   public Either<Failure, Void> transform(final DeploymentRecord deploymentEvent) {

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -49,13 +49,13 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
 
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
-  private final Function<DeploymentResource, DirectBuffer> checksumGenerator;
+  private final Function<byte[], DirectBuffer> checksumGenerator;
   private final DecisionState decisionState;
 
   public DmnResourceTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
-      final Function<DeploymentResource, DirectBuffer> checksumGenerator,
+      final Function<byte[], DirectBuffer> checksumGenerator,
       final DecisionState decisionState) {
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
@@ -160,7 +160,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
       final DeploymentRecord deploymentEvent) {
 
     final LongSupplier newDecisionRequirementsKey = keyGenerator::nextKey;
-    final DirectBuffer checksum = checksumGenerator.apply(resource);
+    final DirectBuffer checksum = checksumGenerator.apply(resource.getResource());
     final var drgRecord = deploymentEvent.decisionRequirementsMetadata().add();
 
     drgRecord

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -37,13 +37,13 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
 
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
-  private final Function<DeploymentResource, DirectBuffer> checksumGenerator;
+  private final Function<byte[], DirectBuffer> checksumGenerator;
   private final FormState formState;
 
   public FormResourceTransformer(
       final KeyGenerator keyGenerator,
       final StateWriter stateWriter,
-      final Function<DeploymentResource, DirectBuffer> checksumGenerator,
+      final Function<byte[], DirectBuffer> checksumGenerator,
       final FormState formState) {
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
@@ -111,7 +111,7 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
       final DeploymentResource resource,
       final String tenantId) {
     final LongSupplier newFormKey = keyGenerator::nextKey;
-    final DirectBuffer checksum = checksumGenerator.apply(resource);
+    final DirectBuffer checksum = checksumGenerator.apply(resource.getResource());
 
     formRecord.setFormId(formId);
     formRecord.setChecksum(checksum);


### PR DESCRIPTION
# Description
Backport of #20026 to `stable/8.3`.

relates to #19834
original author: @remcowesterhoud