### PR TITLE
fix: increase Spring Boot starter pluging timeout

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -2652,6 +2652,9 @@
           <groupId>org.springframework.boot</groupId>
           <artifactId>spring-boot-maven-plugin</artifactId>
           <version>${version.spring-boot}</version>
+          <configuration>
+            <wait>40000</wait>
+          </configuration>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
Increase timeout from 30 sec (default) to 40 seconds to improve E2E tests stability.
