### PR TITLE
ci: fix build-platform-docker action to provide image output again

### DIFF
--- a/.github/actions/build-platform-docker/action.yml
+++ b/.github/actions/build-platform-docker/action.yml
@@ -38,7 +38,7 @@ inputs:
 outputs:
   image:
     description: "Fully qualified image name available in your local Docker daemon"
-    value: ${{ steps.get-image.outputs.result }}
+    value: ${{ steps.get-image-output.outputs.result }}
   date:
     description: "The ISO 8601 date at which the image was created"
     value: ${{ steps.get-date.outputs.result }}
@@ -51,6 +51,7 @@ runs:
   steps:
     - name: Set up multi-platform support
       uses: docker/setup-qemu-action@v3
+
     # Creating a context is required when installing buildx on self-hosted runners
     - name: Create context
       shell: bash
@@ -58,6 +59,7 @@ runs:
         if ! docker context ls --format '{{.Name}}' | grep -q "^zeebe-context$"; then
           docker context create zeebe-context
         fi
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
@@ -65,25 +67,37 @@ runs:
         driver-opts: network=host
         endpoint: zeebe-context
         install: true
+
     - name: Set semantic version from Maven project
       id: get-version
       if: ${{ inputs.version == ''}}
       shell: bash
       run: echo "result=$(./mvnw -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)" >> $GITHUB_OUTPUT
+
     - name: Set image build label from ISO 8601 DATE
       id: get-date
       shell: bash
       run: echo "result=$(date --iso-8601=seconds)" >> $GITHUB_OUTPUT
+
     - name: Build image names from params and/or project version
       id: get-image
       uses: docker/metadata-action@v5
       with:
         images: ${{ inputs.repository }}
         tags: ${{ inputs.version || steps.get-version.outputs.result }}
+
+    # Pick one (the first) out of multiple tags for the image name out, all
+    # should work equally well in a local Docker daemon
+    - name: Set fully qualified image name for output
+      id: get-image-output
+      shell: bash
+      run: echo "result=$(echo '${{ steps.get-image.outputs.tags }}' | head -n 1)" >> $GITHUB_OUTPUT
+
     - name: Set DISTBALL path relative to the build context
       id: get-distball
       shell: bash
       run: echo "result=$(realpath --relative-to="${PWD}" ${{ inputs.distball }})" >> $GITHUB_OUTPUT
+
     - name: Build Docker image
       uses: docker/build-push-action@v6
       with:


### PR DESCRIPTION
## Description

The `image` output of the `build-platform-docker` action is empty since the change done in https://github.com/camunda/camunda/pull/19521 which extended the action to handle multiple tags.

This PR fixes the `image` output so it provides a valid tag (if multiple are given it picks the first, all tags should be interchangeably usable in local Docker daemon) again.

## Related issues

Fixes #20001 
