### PR TITLE
[Backport stable/8.2] Limit client request retries to three attempts

### DIFF
--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -114,6 +114,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/clients/java/src/test/java/io/camunda/zeebe/client/CredentialsTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/CredentialsTest.java
@@ -150,7 +150,8 @@ public final class CredentialsTest {
 
               @Override
               public boolean shouldRetryRequest(final Throwable throwable) {
-                return retryCounter-- > 0;
+                retryCounter--;
+                return true;
               }
             });
     builder.usePlaintext().credentialsProvider(provider);
@@ -160,7 +161,7 @@ public final class CredentialsTest {
     assertThatThrownBy(() -> client.newTopologyRequest().send().join())
         .isInstanceOf(ClientException.class);
 
-    Mockito.verify(provider, times(retries + 1)).shouldRetryRequest(any(Throwable.class));
+    Mockito.verify(provider, times(retries)).shouldRetryRequest(any(Throwable.class));
     assertThat(recordingInterceptor.getCapturedHeaders().get(AUTH_KEY)).isEqualTo("Bearer token-0");
   }
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/RetriableClientFutureImplTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/RetriableClientFutureImplTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.client.impl;
+
+import io.camunda.zeebe.client.api.command.ClientException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class RetriableClientFutureImplTest {
+
+  public static final Predicate<Throwable> SHOULD_RETRY_ALWAYS = ignore -> true;
+
+  @Test
+  void shouldNotRetryOnNext() {
+    // given
+    final RetriableClientFutureImpl<Object, Object> future =
+        new RetriableClientFutureImpl<>(
+            // even when instructed to retry
+            SHOULD_RETRY_ALWAYS,
+            ignore ->
+                // then
+                Assertions.fail("Expect to not retry"));
+
+    // when
+    future.onNext(null);
+  }
+
+  @Test
+  void shouldRetryOnError() {
+    // given
+    final AtomicBoolean isRetried = new AtomicBoolean(false);
+    final RetriableClientFutureImpl<Object, Object> future =
+        new RetriableClientFutureImpl<>(
+            SHOULD_RETRY_ALWAYS,
+            observer -> {
+              isRetried.set(true);
+              observer.onError(new ClientException("An error occurred again"));
+            });
+
+    // when
+    future.onError(new ClientException("An error occurred"));
+
+    // then
+    Assertions.assertThat(isRetried).isTrue();
+  }
+
+  @Test
+  void shouldRetryOnErrorOnlyTwice() {
+    // given
+    final AtomicInteger numberOfRetries = new AtomicInteger(0);
+    final RetriableClientFutureImpl<Object, Object> future =
+        new RetriableClientFutureImpl<>(
+            // even when instructed to always retry
+            SHOULD_RETRY_ALWAYS,
+            observer -> {
+              numberOfRetries.incrementAndGet();
+              observer.onError(new ClientException("An error occurred again"));
+            });
+
+    // when
+    future.onError(new ClientException("An error occurred"));
+
+    // then
+    Assertions.assertThat(numberOfRetries.get())
+        .describedAs("Expected to retry twice")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void shouldRetryOnErrorOnlyWhenRetryPrecidateTestsTrue() {
+    // given
+    final AtomicInteger numberOfRetries = new AtomicInteger(0);
+    final RetriableClientFutureImpl<Object, Object> future =
+        new RetriableClientFutureImpl<>(
+            // when instructed to retry only once
+            ignore -> numberOfRetries.get() < 1,
+            observer -> {
+              numberOfRetries.incrementAndGet();
+              observer.onError(new ClientException("An error occurred again"));
+            });
+
+    // when
+    future.onError(new ClientException("An error occurred"));
+
+    // then
+    Assertions.assertThat(numberOfRetries.get())
+        .describedAs("Expected to retry only once")
+        .isEqualTo(1);
+  }
+}


### PR DESCRIPTION
# Description
Backport of #20088 to `stable/8.2`.

relates to #13832
original author: @korthout