### PR TITLE
feat: Add CPT assertions for a process instance

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -57,6 +57,32 @@
       <artifactId>camunda-client-java</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>compile</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.client5</groupId>
+      <artifactId>httpclient5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.httpcomponents.core5</groupId>
+      <artifactId>httpcore5</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
     <!--  test scope  -->
 
     <dependency>
@@ -78,12 +104,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
@@ -96,12 +116,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
       <scope>test</scope>
@@ -110,18 +124,6 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j2-impl</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents.client5</groupId>
-      <artifactId>httpclient5</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.httpcomponents.core5</groupId>
-      <artifactId>httpcore5</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/BpmnAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/BpmnAssert.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.impl.assertions.ProcessInstanceAssertj;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import java.time.Duration;
+import org.awaitility.Awaitility;
+
+public class BpmnAssert {
+
+  public static final Duration DEFAULT_ASSERTION_TIMEOUT = Duration.ofSeconds(10);
+  public static final Duration DEFAULT_ASSERTION_INTERVAL = Duration.ofMillis(100);
+
+  private static final ThreadLocal<CamundaDataSource> DATA_SOURCE = new ThreadLocal<>();
+
+  static {
+    Awaitility.setDefaultTimeout(DEFAULT_ASSERTION_TIMEOUT);
+    Awaitility.setDefaultPollInterval(DEFAULT_ASSERTION_INTERVAL);
+  }
+
+  // ======== Configuration options ========
+
+  public static void setAssertionTimeout(final Duration assertionTimeout) {
+    Awaitility.setDefaultTimeout(assertionTimeout);
+  }
+
+  public static void setAssertionInterval(final Duration assertionInterval) {
+    Awaitility.setDefaultPollInterval(assertionInterval);
+  }
+
+  // ======== Assertions ========
+
+  public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent processInstanceEvent) {
+    return new ProcessInstanceAssertj(
+        getDataSource(), processInstanceEvent.getProcessInstanceKey());
+  }
+
+  public static ProcessInstanceAssert assertThat(
+      final ProcessInstanceResult processInstanceResult) {
+    return new ProcessInstanceAssertj(
+        getDataSource(), processInstanceResult.getProcessInstanceKey());
+  }
+
+  // ======== Internal ========
+
+  private static CamundaDataSource getDataSource() {
+    if (DATA_SOURCE.get() == null) {
+      throw new IllegalStateException(
+          "No data source is set. Maybe you run outside of a testcase?");
+    }
+    return DATA_SOURCE.get();
+  }
+
+  /**
+   * Initializes the assertions by setting the data source. Must be called before the assertions are
+   * used.
+   */
+  static void initialize(final CamundaDataSource dataSource) {
+    BpmnAssert.DATA_SOURCE.set(dataSource);
+  }
+
+  /**
+   * Resets the assertions by removing the data source. Must call {@link
+   * #initialize(CamundaDataSource)} before the assertions can be used again.
+   */
+  static void reset() {
+    BpmnAssert.DATA_SOURCE.remove();
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/BpmnAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/BpmnAssert.java
@@ -23,9 +23,39 @@ import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 
+/**
+ * The entry point for all assertions.
+ *
+ * <p>Example usage:
+ *
+ * <pre>
+ *   &#064;Test
+ *   void shouldWork() {
+ *     // given
+ *     final ProcessInstanceEvent processInstance =
+ *         zeebeClient
+ *             .newCreateInstanceCommand()
+ *             .bpmnProcessId("process")
+ *             .latestVersion()
+ *             .send()
+ *             .join();
+ *
+ *     // when
+ *
+ *     // then
+ *     BpmnAssert.assertThat(processInstance)
+ *         .isCompleted()
+ *         .hasCompletedElements("A", "B");
+ *   }
+ * }
+ * </pre>
+ */
 public class BpmnAssert {
 
+  /** The default time how long an assertion waits until the expected state is reached. */
   public static final Duration DEFAULT_ASSERTION_TIMEOUT = Duration.ofSeconds(10);
+
+  /** The default time between two assertion attempts until the expected state is reached. */
   public static final Duration DEFAULT_ASSERTION_INTERVAL = Duration.ofMillis(100);
 
   private static final ThreadLocal<CamundaDataSource> DATA_SOURCE = new ThreadLocal<>();
@@ -37,21 +67,45 @@ public class BpmnAssert {
 
   // ======== Configuration options ========
 
+  /**
+   * Configures the time how long an assertion waits until the expected state is reached.
+   *
+   * @param assertionTimeout the maximum time of an assertion
+   * @see #DEFAULT_ASSERTION_TIMEOUT
+   */
   public static void setAssertionTimeout(final Duration assertionTimeout) {
     Awaitility.setDefaultTimeout(assertionTimeout);
   }
 
+  /**
+   * Configures the time between two assertion attempts until the expected state is reached.
+   *
+   * @param assertionInterval time between two assertion attempts
+   * @see #DEFAULT_ASSERTION_INTERVAL
+   */
   public static void setAssertionInterval(final Duration assertionInterval) {
     Awaitility.setDefaultPollInterval(assertionInterval);
   }
 
   // ======== Assertions ========
 
+  /**
+   * To verify a process instance.
+   *
+   * @param processInstanceEvent the event of the process instance to verify
+   * @return the assertion object
+   */
   public static ProcessInstanceAssert assertThat(final ProcessInstanceEvent processInstanceEvent) {
     return new ProcessInstanceAssertj(
         getDataSource(), processInstanceEvent.getProcessInstanceKey());
   }
 
+  /**
+   * To verify a process instance.
+   *
+   * @param processInstanceResult the result of the process instance to verify
+   * @return the assertion object
+   */
   public static ProcessInstanceAssert assertThat(
       final ProcessInstanceResult processInstanceResult) {
     return new ProcessInstanceAssertj(

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaAssert.java
@@ -43,14 +43,14 @@ import org.awaitility.Awaitility;
  *     // when
  *
  *     // then
- *     BpmnAssert.assertThat(processInstance)
+ *     CamundaAssert.assertThat(processInstance)
  *         .isCompleted()
  *         .hasCompletedElements("A", "B");
  *   }
  * }
  * </pre>
  */
-public class BpmnAssert {
+public class CamundaAssert {
 
   /** The default time how long an assertion waits until the expected state is reached. */
   public static final Duration DEFAULT_ASSERTION_TIMEOUT = Duration.ofSeconds(10);
@@ -127,7 +127,7 @@ public class BpmnAssert {
    * used.
    */
   static void initialize(final CamundaDataSource dataSource) {
-    BpmnAssert.DATA_SOURCE.set(dataSource);
+    CamundaAssert.DATA_SOURCE.set(dataSource);
   }
 
   /**
@@ -135,6 +135,6 @@ public class BpmnAssert {
    * #initialize(CamundaDataSource)} before the assertions can be used again.
    */
   static void reset() {
-    BpmnAssert.DATA_SOURCE.remove();
+    CamundaAssert.DATA_SOURCE.remove();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Marks a class as a process test and adds the JUnit extension {@link CamundaProcessTestExtension}.
- * Use {@link BpmnAssert} to verify the expected result of a test.
+ * Use {@link CamundaAssert} to verify the expected result of a test.
  *
  * <p>Example usage:
  *
@@ -49,7 +49,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *     // when
  *
  *     // then
- *     BpmnAssert.assertThat(processInstance)
+ *     CamundaAssert.assertThat(processInstance)
  *         .isCompleted()
  *         .hasCompletedElements("A", "B");
  *   }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Marks a class as a process test and adds the JUnit extension {@link CamundaProcessTestExtension}.
+ * Use {@link BpmnAssert} to verify the expected result of a test.
  *
  * <p>Example usage:
  *
@@ -37,19 +38,20 @@ import org.junit.jupiter.api.extension.ExtendWith;
  *   &#064;Test
  *   void shouldWork() {
  *     // given
- *     final long processInstanceKey =
+ *     final ProcessInstanceEvent processInstance =
  *         zeebeClient
  *             .newCreateInstanceCommand()
  *             .bpmnProcessId("process")
  *             .latestVersion()
  *             .send()
- *             .join()
- *             .getProcessInstanceKey();
+ *             .join();
  *
  *     // when
  *
  *     // then
- *
+ *     BpmnAssert.assertThat(processInstance)
+ *         .isCompleted()
+ *         .hasCompletedElements("A", "B");
  *   }
  * }
  * </pre>

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestExtension.java
@@ -120,7 +120,7 @@ public class CamundaProcessTestExtension implements BeforeEachCallback, AfterEac
 
     // initialize assertions
     final CamundaDataSource dataSource = createDataSource(containerRuntime);
-    BpmnAssert.initialize(dataSource);
+    CamundaAssert.initialize(dataSource);
   }
 
   private <T> void injectField(
@@ -161,7 +161,7 @@ public class CamundaProcessTestExtension implements BeforeEachCallback, AfterEac
   @Override
   public void afterEach(final ExtensionContext extensionContext) throws Exception {
     // reset assertions
-    BpmnAssert.reset();
+    CamundaAssert.reset();
     // close all created clients
     createdClients.forEach(ZeebeClient::close);
     // close the runtime

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api.assertions;
+
+public interface ProcessInstanceAssert {
+
+  ProcessInstanceAssert isActive();
+
+  ProcessInstanceAssert isCompleted();
+
+  ProcessInstanceAssert isTerminated();
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -15,17 +15,69 @@
  */
 package io.camunda.process.test.api.assertions;
 
+/** The assertion object to verify a process instance. */
 public interface ProcessInstanceAssert {
 
+  /**
+   * Verifies that the process instance is active. The verification fails if the process instance is
+   * completed, terminated, or not created.
+   *
+   * <p>The assertion waits until the process instance is created.
+   *
+   * @return the assertion object
+   */
   ProcessInstanceAssert isActive();
 
+  /**
+   * Verifies that the process instance is completed. The verification fails if the process instance
+   * is active, terminated, or not created.
+   *
+   * <p>The assertion waits until the process instance is ended.
+   *
+   * @return the assertion object
+   */
   ProcessInstanceAssert isCompleted();
 
+  /**
+   * Verifies that the process instance is terminated. The verification fails if the process
+   * instance is active, completed, or not created.
+   *
+   * <p>The assertion waits until the process instance is ended.
+   *
+   * @return the assertion object
+   */
   ProcessInstanceAssert isTerminated();
 
+  /**
+   * Verifies that the given BPMN elements are active. The verification fails if at least one
+   * element is completed, terminated, or not entered.
+   *
+   * <p>The assertion waits until all elements are created.
+   *
+   * @param elementNames the BPMN element names
+   * @return the assertion object
+   */
   ProcessInstanceAssert hasActiveElements(String... elementNames);
 
+  /**
+   * Verifies that the given BPMN elements are completed. The verification fails if at least one
+   * element is active, terminated, or not entered.
+   *
+   * <p>The assertion waits until all elements are left.
+   *
+   * @param elementNames the BPMN element names
+   * @return the assertion object
+   */
   ProcessInstanceAssert hasCompletedElements(String... elementNames);
 
+  /**
+   * Verifies that the given BPMN elements are terminated. The verification fails if at least one
+   * element is active, completed, or not entered.
+   *
+   * <p>The assertion waits until all elements are left.
+   *
+   * @param elementNames the BPMN element names
+   * @return the assertion object
+   */
   ProcessInstanceAssert hasTerminatedElements(String... elementNames);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import io.camunda.process.test.impl.client.OperateApiClient;
+import io.camunda.process.test.impl.client.ProcessInstanceDto;
+import java.io.IOException;
+
+public class CamundaDataSource {
+
+  private final OperateApiClient operateApiClient;
+
+  public CamundaDataSource(final String operateApiEndpoint) {
+    operateApiClient = new OperateApiClient(operateApiEndpoint);
+  }
+
+  public ProcessInstanceDto getProcessInstance(final long processInstanceKey) throws IOException {
+    return operateApiClient.getProcessInstanceByKey(processInstanceKey);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -15,9 +15,11 @@
  */
 package io.camunda.process.test.impl.assertions;
 
+import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
 import io.camunda.process.test.impl.client.OperateApiClient;
 import io.camunda.process.test.impl.client.ProcessInstanceDto;
 import java.io.IOException;
+import java.util.List;
 
 public class CamundaDataSource {
 
@@ -29,5 +31,12 @@ public class CamundaDataSource {
 
   public ProcessInstanceDto getProcessInstance(final long processInstanceKey) throws IOException {
     return operateApiClient.getProcessInstanceByKey(processInstanceKey);
+  }
+
+  public List<FlowNodeInstanceDto> getFlowNodeInstancesByProcessInstanceKey(
+      final long processInstanceKey) throws IOException {
+    return operateApiClient
+        .findFlowNodeInstancesByProcessInstanceKey(processInstanceKey)
+        .getItems();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -20,8 +20,15 @@ import static org.assertj.core.api.Assertions.fail;
 
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.impl.client.CamundaClientNotFoundException;
+import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
+import io.camunda.process.test.impl.client.FlowNodeInstanceState;
 import io.camunda.process.test.impl.client.ProcessInstanceDto;
 import io.camunda.process.test.impl.client.ProcessInstanceState;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
@@ -59,6 +66,26 @@ public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssert
     return this;
   }
 
+  @Override
+  public ProcessInstanceAssert hasActiveElements(final String... elementNames) {
+    hasElementsInState(elementNames, FlowNodeInstanceState.ACTIVE, Objects::nonNull);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasCompletedElements(final String... elementNames) {
+    hasElementsInState(
+        elementNames, FlowNodeInstanceState.COMPLETED, ProcessInstanceAssertj::isEnded);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert hasTerminatedElements(final String... elementNames) {
+    hasElementsInState(
+        elementNames, FlowNodeInstanceState.TERMINATED, ProcessInstanceAssertj::isEnded);
+    return this;
+  }
+
   private void hasProcessInstanceInState(
       final ProcessInstanceState expectedState, final Predicate<ProcessInstanceDto> waitCondition) {
 
@@ -92,15 +119,93 @@ public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssert
     }
   }
 
+  private void hasElementsInState(
+      final String[] elementNames,
+      final FlowNodeInstanceState expectedState,
+      final Predicate<FlowNodeInstanceDto> waitCondition) {
+
+    final AtomicReference<List<FlowNodeInstanceDto>> reference =
+        new AtomicReference<>(Collections.emptyList());
+
+    try {
+      Awaitility.await()
+          .ignoreException(CamundaClientNotFoundException.class)
+          .failFast(
+              () ->
+                  reference.get().stream()
+                      .filter(waitCondition)
+                      .map(FlowNodeInstanceDto::getFlowNodeName)
+                      .collect(Collectors.toSet())
+                      .containsAll(Arrays.asList(elementNames)))
+          .untilAsserted(
+              () -> {
+                final List<FlowNodeInstanceDto> flowNodeInstances =
+                    dataSource.getFlowNodeInstancesByProcessInstanceKey(actual);
+                reference.set(flowNodeInstances);
+
+                assertThat(flowNodeInstances)
+                    .filteredOn(FlowNodeInstanceDto::getState, expectedState)
+                    .extracting(FlowNodeInstanceDto::getFlowNodeName)
+                    .contains(elementNames);
+              });
+
+    } catch (final ConditionTimeoutException | TerminalFailureException e) {
+
+      final Map<String, FlowNodeInstanceState> elementStateByName =
+          reference.get().stream()
+              .collect(
+                  Collectors.toMap(
+                      FlowNodeInstanceDto::getFlowNodeName, FlowNodeInstanceDto::getState));
+
+      final String elementsNotInState =
+          Arrays.stream(elementNames)
+              .filter(elementName -> !expectedState.equals(elementStateByName.get(elementName)))
+              .map(
+                  elementName ->
+                      String.format(
+                          "\t- '%s': %s",
+                          elementName, formatState(elementStateByName.get(elementName))))
+              .collect(Collectors.joining("\n"));
+
+      final String failureMessage =
+          String.format(
+              "%s should have %s elements %s but the following elements were not %s:\n%s",
+              formatProcessInstance(),
+              formatState(expectedState),
+              formatElementNames(elementNames),
+              formatState(expectedState),
+              elementsNotInState);
+      fail(failureMessage);
+    }
+  }
+
   private static boolean isEnded(final ProcessInstanceDto processInstance) {
     return processInstance != null && processInstance.getEndDate() != null;
+  }
+
+  private static boolean isEnded(final FlowNodeInstanceDto flowNodeInstance) {
+    return flowNodeInstance.getEndDate() != null;
   }
 
   private String formatProcessInstance() {
     return String.format("Process instance [key: %s]", actual);
   }
 
+  private static String formatElementNames(final String[] elementNames) {
+    return Arrays.stream(elementNames)
+        .map(elementName -> String.format("'%s'", elementName))
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+
   private static String formatState(final ProcessInstanceState state) {
+    if (state == null) {
+      return "not activated";
+    } else {
+      return state.name().toLowerCase();
+    }
+  }
+
+  private static String formatState(final FlowNodeInstanceState state) {
     if (state == null) {
       return "not activated";
     } else {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
+import io.camunda.process.test.impl.client.CamundaClientNotFoundException;
+import io.camunda.process.test.impl.client.ProcessInstanceDto;
+import io.camunda.process.test.impl.client.ProcessInstanceState;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractAssert;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.TerminalFailureException;
+
+public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssertj, Long>
+    implements ProcessInstanceAssert {
+
+  private final CamundaDataSource dataSource;
+
+  public ProcessInstanceAssertj(final CamundaDataSource dataSource, final long processInstanceKey) {
+    super(processInstanceKey, ProcessInstanceAssertj.class);
+    this.dataSource = dataSource;
+  }
+
+  @Override
+  public ProcessInstanceAssert isActive() {
+    hasProcessInstanceInState(ProcessInstanceState.ACTIVE, Objects::nonNull);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert isCompleted() {
+    hasProcessInstanceInState(ProcessInstanceState.COMPLETED, ProcessInstanceAssertj::isEnded);
+    return this;
+  }
+
+  @Override
+  public ProcessInstanceAssert isTerminated() {
+    hasProcessInstanceInState(ProcessInstanceState.TERMINATED, ProcessInstanceAssertj::isEnded);
+    return this;
+  }
+
+  private void hasProcessInstanceInState(
+      final ProcessInstanceState expectedState, final Predicate<ProcessInstanceDto> waitCondition) {
+
+    final AtomicReference<ProcessInstanceDto> reference = new AtomicReference<>();
+
+    try {
+      Awaitility.await()
+          .ignoreException(CamundaClientNotFoundException.class)
+          .failFast(() -> waitCondition.test(reference.get()))
+          .untilAsserted(
+              () -> {
+                final ProcessInstanceDto processInstance = dataSource.getProcessInstance(actual);
+                reference.set(processInstance);
+
+                assertThat(processInstance.getState()).isEqualTo(expectedState);
+              });
+
+    } catch (final ConditionTimeoutException | TerminalFailureException e) {
+
+      final String actualState =
+          Optional.ofNullable(reference.get())
+              .map(ProcessInstanceDto::getState)
+              .map(ProcessInstanceAssertj::formatState)
+              .orElse("not activated");
+
+      final String failureMessage =
+          String.format(
+              "%s should be %s but was %s.",
+              formatProcessInstance(), formatState(expectedState), actualState);
+      fail(failureMessage);
+    }
+  }
+
+  private static boolean isEnded(final ProcessInstanceDto processInstance) {
+    return processInstance != null && processInstance.getEndDate() != null;
+  }
+
+  private String formatProcessInstance() {
+    return String.format("Process instance [key: %s]", actual);
+  }
+
+  private static String formatState(final ProcessInstanceState state) {
+    if (state == null) {
+      return "not activated";
+    } else {
+      return state.name().toLowerCase();
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaClientNotFoundException.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/CamundaClientNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public class CamundaClientNotFoundException extends RuntimeException {
+
+  public CamundaClientNotFoundException() {
+    super();
+  }
+
+  public CamundaClientNotFoundException(final String message) {
+    super(message);
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/FlowNodeInstanceDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/FlowNodeInstanceDto.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public class FlowNodeInstanceDto {
+
+  private long key;
+  private long processInstanceKey;
+  private long processDefinitionKey;
+  private String startDate;
+  private String endDate;
+  private String flowNodeId;
+  private String flowNodeName;
+  private long incidentKey;
+  private String type;
+  private FlowNodeInstanceState state;
+  private boolean incident;
+  private String tenantId;
+
+  public long getKey() {
+    return key;
+  }
+
+  public void setKey(final long key) {
+    this.key = key;
+  }
+
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final String startDate) {
+    this.startDate = startDate;
+  }
+
+  public String getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final String endDate) {
+    this.endDate = endDate;
+  }
+
+  public String getFlowNodeId() {
+    return flowNodeId;
+  }
+
+  public void setFlowNodeId(final String flowNodeId) {
+    this.flowNodeId = flowNodeId;
+  }
+
+  public String getFlowNodeName() {
+    return flowNodeName;
+  }
+
+  public void setFlowNodeName(final String flowNodeName) {
+    this.flowNodeName = flowNodeName;
+  }
+
+  public long getIncidentKey() {
+    return incidentKey;
+  }
+
+  public void setIncidentKey(final long incidentKey) {
+    this.incidentKey = incidentKey;
+  }
+
+  public String getType() {
+    return type;
+  }
+
+  public void setType(final String type) {
+    this.type = type;
+  }
+
+  public FlowNodeInstanceState getState() {
+    return state;
+  }
+
+  public void setState(final FlowNodeInstanceState state) {
+    this.state = state;
+  }
+
+  public boolean isIncident() {
+    return incident;
+  }
+
+  public void setIncident(final boolean incident) {
+    this.incident = incident;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/FlowNodeInstanceState.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/FlowNodeInstanceState.java
@@ -13,19 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.process.test.api.assertions;
+package io.camunda.process.test.impl.client;
 
-public interface ProcessInstanceAssert {
-
-  ProcessInstanceAssert isActive();
-
-  ProcessInstanceAssert isCompleted();
-
-  ProcessInstanceAssert isTerminated();
-
-  ProcessInstanceAssert hasActiveElements(String... elementNames);
-
-  ProcessInstanceAssert hasCompletedElements(String... elementNames);
-
-  ProcessInstanceAssert hasTerminatedElements(String... elementNames);
+public enum FlowNodeInstanceState {
+  ACTIVE,
+  COMPLETED,
+  TERMINATED
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/FlowNodeInstancesResponseDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/FlowNodeInstancesResponseDto.java
@@ -13,19 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.camunda.process.test.api.assertions;
+package io.camunda.process.test.impl.client;
 
-public interface ProcessInstanceAssert {
+import java.util.List;
 
-  ProcessInstanceAssert isActive();
+public class FlowNodeInstancesResponseDto {
 
-  ProcessInstanceAssert isCompleted();
+  private List<FlowNodeInstanceDto> items;
+  private long total;
 
-  ProcessInstanceAssert isTerminated();
+  public List<FlowNodeInstanceDto> getItems() {
+    return items;
+  }
 
-  ProcessInstanceAssert hasActiveElements(String... elementNames);
+  public void setItems(final List<FlowNodeInstanceDto> items) {
+    this.items = items;
+  }
 
-  ProcessInstanceAssert hasCompletedElements(String... elementNames);
+  public long getTotal() {
+    return total;
+  }
 
-  ProcessInstanceAssert hasTerminatedElements(String... elementNames);
+  public void setTotal(final long total) {
+    this.total = total;
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.cookie.BasicCookieStore;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.HttpEntities;
+
+public class OperateApiClient {
+
+  private static final String LOGIN_ENDPOINT = "/api/login?username=%s&password=%s";
+  private static final String LOGIN_USERNAME = "demo";
+  private static final String LOGIN_PASSWORD = "demo";
+
+  private static final String PROCESS_INSTANCE_GET_ENDPOINT = "/v1/process-instances/%d";
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  private boolean isLoggedIn = false;
+
+  private final String operateRestApi;
+
+  private final CloseableHttpClient httpClient;
+
+  public OperateApiClient(final String operateRestApi) {
+    this.operateRestApi = operateRestApi;
+
+    final BasicCookieStore cookieStore = new BasicCookieStore();
+    httpClient = HttpClientBuilder.create().setDefaultCookieStore(cookieStore).build();
+  }
+
+  private void ensureAuthenticated() throws IOException {
+    if (!isLoggedIn) {
+      sendLoginRequest();
+      isLoggedIn = true;
+    }
+  }
+
+  private void sendLoginRequest() throws IOException {
+    httpClient.execute(
+        new HttpPost(
+            String.format(operateRestApi + LOGIN_ENDPOINT, LOGIN_USERNAME, LOGIN_PASSWORD)),
+        response -> {
+          if (response.getCode() != 204) {
+            throw new IllegalStateException(
+                String.format(
+                    "Failed to login. [code: %d, message: %s]",
+                    response.getCode(), getReponseAsString(response)));
+          }
+          return null;
+        });
+  }
+
+  private static void verifyStatusCode(final ClassicHttpResponse response) {
+    if (response.getCode() == 404) {
+      throw new CamundaClientNotFoundException(
+          String.format(
+              "Failed send request. Object not found. [code: %d, message: %s]",
+              response.getCode(), getReponseAsString(response)));
+    }
+    if (response.getCode() != 200) {
+      throw new RuntimeException(
+          String.format(
+              "Failed send request. [code: %d, message: %s]",
+              response.getCode(), getReponseAsString(response)));
+    }
+  }
+
+  public ProcessInstanceDto getProcessInstanceByKey(final long processInstanceKey)
+      throws IOException {
+    ensureAuthenticated();
+
+    final String body =
+        sendGetRequest(String.format(PROCESS_INSTANCE_GET_ENDPOINT, processInstanceKey));
+    return objectMapper.readValue(body, ProcessInstanceDto.class);
+  }
+
+  private static String getReponseAsString(final ClassicHttpResponse response) {
+    return Optional.ofNullable(response.getEntity())
+        .map(
+            entity -> {
+              try {
+                return EntityUtils.toString(entity);
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .orElse("?");
+  }
+
+  private String sendGetRequest(final String endpoint) throws IOException {
+    return httpClient.execute(
+        new HttpGet(operateRestApi + endpoint),
+        response -> {
+          verifyStatusCode(response);
+          return getReponseAsString(response);
+        });
+  }
+
+  private String sendPostRequest(final String endpoint, final String body) throws IOException {
+
+    final HttpPost request = new HttpPost(operateRestApi + endpoint);
+    request.setEntity(HttpEntities.create(body, ContentType.APPLICATION_JSON));
+
+    return httpClient.execute(
+        request,
+        response -> {
+          verifyStatusCode(response);
+          return getReponseAsString(response);
+        });
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
@@ -36,6 +36,7 @@ public class OperateApiClient {
   private static final String LOGIN_PASSWORD = "demo";
 
   private static final String PROCESS_INSTANCE_GET_ENDPOINT = "/v1/process-instances/%d";
+  private static final String FLOW_NODE_INSTANCES_SEARCH_ENDPOINT = "/v1/flownode-instances/search";
 
   private final ObjectMapper objectMapper =
       new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
@@ -97,6 +98,16 @@ public class OperateApiClient {
     final String body =
         sendGetRequest(String.format(PROCESS_INSTANCE_GET_ENDPOINT, processInstanceKey));
     return objectMapper.readValue(body, ProcessInstanceDto.class);
+  }
+
+  public FlowNodeInstancesResponseDto findFlowNodeInstancesByProcessInstanceKey(
+      final long processInstanceKey) throws IOException {
+    ensureAuthenticated();
+
+    final String requestBody =
+        String.format("{\"filter\": {\"processInstanceKey\":%d}}", processInstanceKey);
+    final String responseBody = sendPostRequest(FLOW_NODE_INSTANCES_SEARCH_ENDPOINT, requestBody);
+    return objectMapper.readValue(responseBody, FlowNodeInstancesResponseDto.class);
   }
 
   private static String getReponseAsString(final ClassicHttpResponse response) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ProcessInstanceDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ProcessInstanceDto.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public class ProcessInstanceDto {
+
+  private long key;
+  private int processVersion;
+  private String bpmnProcessId;
+  private long parentKey;
+  private long parentFlowNodeInstanceKey;
+  private String startDate;
+  private String endDate;
+  private ProcessInstanceState state;
+  private long processDefinitionKey;
+  private String tenantId;
+  private long parentProcessInstanceKey;
+
+  public long getKey() {
+    return key;
+  }
+
+  public void setKey(final long key) {
+    this.key = key;
+  }
+
+  public int getProcessVersion() {
+    return processVersion;
+  }
+
+  public void setProcessVersion(final int processVersion) {
+    this.processVersion = processVersion;
+  }
+
+  public String getBpmnProcessId() {
+    return bpmnProcessId;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  public long getParentKey() {
+    return parentKey;
+  }
+
+  public void setParentKey(final long parentKey) {
+    this.parentKey = parentKey;
+  }
+
+  public long getParentFlowNodeInstanceKey() {
+    return parentFlowNodeInstanceKey;
+  }
+
+  public void setParentFlowNodeInstanceKey(final long parentFlowNodeInstanceKey) {
+    this.parentFlowNodeInstanceKey = parentFlowNodeInstanceKey;
+  }
+
+  public String getStartDate() {
+    return startDate;
+  }
+
+  public void setStartDate(final String startDate) {
+    this.startDate = startDate;
+  }
+
+  public String getEndDate() {
+    return endDate;
+  }
+
+  public void setEndDate(final String endDate) {
+    this.endDate = endDate;
+  }
+
+  public ProcessInstanceState getState() {
+    return state;
+  }
+
+  public void setState(final ProcessInstanceState state) {
+    this.state = state;
+  }
+
+  public long getProcessDefinitionKey() {
+    return processDefinitionKey;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+
+  public long getParentProcessInstanceKey() {
+    return parentProcessInstanceKey;
+  }
+
+  public void setParentProcessInstanceKey(final long parentProcessInstanceKey) {
+    this.parentProcessInstanceKey = parentProcessInstanceKey;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ProcessInstanceState.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ProcessInstanceState.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public enum ProcessInstanceState {
+  ACTIVE,
+  COMPLETED,
+  TERMINATED
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/OperateContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/OperateContainer.java
@@ -39,6 +39,7 @@ public class OperateContainer extends GenericContainer<OperateContainer> {
   private void applyDefaultConfiguration() {
     withNetwork(Network.SHARED)
         .waitingFor(newDefaultWaitStrategy())
+        .withEnv(ContainerRuntimeEnvs.CAMUNDA_OPERATE_IMPORTER_READERBACKOFF, "1000")
         .addExposedPorts(ContainerRuntimePorts.OPERATE_REST_API);
   }
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeEnvs.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/runtime/ContainerRuntimeEnvs.java
@@ -35,6 +35,8 @@ public class ContainerRuntimeEnvs {
   public static final String OPERATE_ENV_ELASTICSEARCH_URL = "CAMUNDA_OPERATE_ELASTICSEARCH_URL";
   public static final String OPERATE_ENV_ZEEBEELASTICSEARCH_URL =
       "CAMUNDA_OPERATE_ZEEBEELASTICSEARCH_URL";
+  public static final String CAMUNDA_OPERATE_IMPORTER_READERBACKOFF =
+      "CAMUNDA_OPERATE_IMPORTER_READERBACKOFF";
 
   // Tasklist
   public static final String TASKLIST_ENV_ZEEBE_GATEWAYADDRESS =

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/BpmnAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/BpmnAssertTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.impl.client.ProcessInstanceDto;
+import io.camunda.process.test.impl.client.ProcessInstanceState;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class BpmnAssertTest {
+
+  @Mock private CamundaDataSource camundaDataSource;
+
+  @Mock private ProcessInstanceEvent processInstanceEvent;
+
+  @Test
+  void shouldFailIfNotInitialized() {
+    // given
+    BpmnAssert.reset();
+
+    // when/then
+    assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("No data source is set. Maybe you run outside of a testcase?");
+  }
+
+  @Test
+  void shouldUseDataSource() throws IOException {
+    // given
+    final long processInstanceKey = 100L;
+    when(processInstanceEvent.getProcessInstanceKey()).thenReturn(processInstanceKey);
+
+    final ProcessInstanceDto processInstanceDto = new ProcessInstanceDto();
+    processInstanceDto.setState(ProcessInstanceState.ACTIVE);
+    when(camundaDataSource.getProcessInstance(processInstanceKey)).thenReturn(processInstanceDto);
+
+    // when
+    BpmnAssert.initialize(camundaDataSource);
+    BpmnAssert.assertThat(processInstanceEvent).isActive();
+
+    // then
+    verify(camundaDataSource).getProcessInstance(processInstanceKey);
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaAssertTest.java
@@ -30,7 +30,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public class BpmnAssertTest {
+public class CamundaAssertTest {
 
   @Mock private CamundaDataSource camundaDataSource;
 
@@ -39,10 +39,10 @@ public class BpmnAssertTest {
   @Test
   void shouldFailIfNotInitialized() {
     // given
-    BpmnAssert.reset();
+    CamundaAssert.reset();
 
     // when/then
-    assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+    assertThatThrownBy(() -> CamundaAssert.assertThat(processInstanceEvent).isActive())
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("No data source is set. Maybe you run outside of a testcase?");
   }
@@ -58,8 +58,8 @@ public class BpmnAssertTest {
     when(camundaDataSource.getProcessInstance(processInstanceKey)).thenReturn(processInstanceDto);
 
     // when
-    BpmnAssert.initialize(camundaDataSource);
-    BpmnAssert.assertThat(processInstanceEvent).isActive();
+    CamundaAssert.initialize(camundaDataSource);
+    CamundaAssert.assertThat(processInstanceEvent).isActive();
 
     // then
     verify(camundaDataSource).getProcessInstance(processInstanceKey);

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -53,7 +53,7 @@ public class CamundaProcessTestExtensionIT {
             .join();
 
     // then
-    BpmnAssert.assertThat(processInstance)
+    CamundaAssert.assertThat(processInstance)
         .isActive()
         .hasCompletedElements("start")
         .hasActiveElements("task");

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -15,10 +15,8 @@
  */
 package io.camunda.process.test.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import io.camunda.zeebe.client.ZeebeClient;
-import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import org.junit.jupiter.api.Test;
@@ -35,23 +33,29 @@ public class CamundaProcessTestExtensionIT {
     final BpmnModelInstance process =
         Bpmn.createExecutableProcess("process")
             .startEvent()
+            .name("start")
+            .userTask()
+            .name("task")
             .endEvent()
+            .name("end")
             .zeebeOutputExpression("\"ok\"", "result")
             .done();
 
     zeebeClient.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
 
     // when
-    final ProcessInstanceResult processInstanceResult =
+    final ProcessInstanceEvent processInstance =
         zeebeClient
             .newCreateInstanceCommand()
             .bpmnProcessId("process")
             .latestVersion()
-            .withResult()
             .send()
             .join();
 
     // then
-    assertThat(processInstanceResult.getVariablesAsMap()).containsEntry("result", "ok");
+    BpmnAssert.assertThat(processInstance)
+        .isActive()
+        .hasCompletedElements("start")
+        .hasActiveElements("task");
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/JunitExtensionTest.java
@@ -20,6 +20,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import io.camunda.process.test.impl.containers.OperateContainer;
 import io.camunda.process.test.impl.containers.ZeebeContainer;
 import io.camunda.process.test.impl.runtime.CamundaContainerRuntime;
 import io.camunda.process.test.impl.runtime.CamundaContainerRuntimeBuilder;
@@ -50,6 +51,7 @@ public class JunitExtensionTest {
 
   @Mock private CamundaContainerRuntime camundaContainerRuntime;
   @Mock private ZeebeContainer zeebeContainer;
+  @Mock private OperateContainer operateContainer;
 
   @Mock private ExtensionContext extensionContext;
   @Mock private TestInstances testInstances;
@@ -65,6 +67,10 @@ public class JunitExtensionTest {
     when(camundaContainerRuntime.getZeebeContainer()).thenReturn(zeebeContainer);
     when(zeebeContainer.getGrpcApiAddress()).thenReturn(GRPC_API_ADDRESS);
     when(zeebeContainer.getRestApiAddress()).thenReturn(REST_API_ADDRESS);
+
+    when(camundaContainerRuntime.getOperateContainer()).thenReturn(operateContainer);
+    when(operateContainer.getHost()).thenReturn("my-host");
+    when(operateContainer.getRestApiPort()).thenReturn(100);
 
     when(extensionContext.getRequiredTestInstances()).thenReturn(testInstances);
     when(testInstances.getAllInstances()).thenReturn(Collections.singletonList(this));

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -1,0 +1,370 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.impl.client.CamundaClientNotFoundException;
+import io.camunda.process.test.impl.client.ProcessInstanceDto;
+import io.camunda.process.test.impl.client.ProcessInstanceState;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
+import java.io.IOException;
+import java.time.Duration;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class ProcessInstanceAssertTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 1L;
+  private static final String BPMN_PROCESS_ID = "process";
+  private static final String START_DATE = "2024-07-01T09:45:00";
+  private static final String END_DATE = "2024-07-01T10:00:00";
+
+  @Mock private CamundaDataSource camundaDataSource;
+  @Mock private ProcessInstanceEvent processInstanceEvent;
+
+  @BeforeEach
+  void configureAssertions() {
+    BpmnAssert.initialize(camundaDataSource);
+    BpmnAssert.setAssertionInterval(Duration.ZERO);
+    BpmnAssert.setAssertionTimeout(Duration.ofMillis(100));
+  }
+
+  @AfterEach
+  void resetAssertions() {
+    BpmnAssert.setAssertionInterval(BpmnAssert.DEFAULT_ASSERTION_INTERVAL);
+    BpmnAssert.setAssertionTimeout(BpmnAssert.DEFAULT_ASSERTION_TIMEOUT);
+  }
+
+  private static ProcessInstanceDto newActiveProcessInstance(final long processInstanceKey) {
+    final ProcessInstanceDto processInstance = new ProcessInstanceDto();
+    processInstance.setKey(processInstanceKey);
+    processInstance.setBpmnProcessId(BPMN_PROCESS_ID);
+    processInstance.setState(ProcessInstanceState.ACTIVE);
+    processInstance.setStartDate(START_DATE);
+    return processInstance;
+  }
+
+  private static ProcessInstanceDto newCompletedProcessInstance(final long processInstanceKey) {
+    final ProcessInstanceDto processInstance = newActiveProcessInstance(processInstanceKey);
+    processInstance.setState(ProcessInstanceState.COMPLETED);
+    processInstance.setEndDate(END_DATE);
+    return processInstance;
+  }
+
+  private static ProcessInstanceDto newTerminatedProcessInstance(final long processInstanceKey) {
+    final ProcessInstanceDto processInstance = newActiveProcessInstance(processInstanceKey);
+    processInstance.setState(ProcessInstanceState.TERMINATED);
+    processInstance.setEndDate(END_DATE);
+    return processInstance;
+  }
+
+  @Nested
+  class ProcessInstanceSource {
+
+    @Mock private ProcessInstanceResult processInstanceResult;
+
+    @BeforeEach
+    void configureMocks() throws IOException {
+      final ProcessInstanceDto processInstance = newActiveProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+    }
+
+    @Test
+    void shouldUseProcessInstanceEvent() throws IOException {
+      // given
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when
+      BpmnAssert.assertThat(processInstanceEvent).isActive();
+
+      // then
+      verify(camundaDataSource).getProcessInstance(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldUseProcessInstanceResult() throws IOException {
+      // given
+      when(processInstanceResult.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // when
+      BpmnAssert.assertThat(processInstanceResult).isActive();
+
+      // then
+      verify(camundaDataSource).getProcessInstance(PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
+  class IsActive {
+
+    @Test
+    void shouldBeActive() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newActiveProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).isActive();
+    }
+
+    @Test
+    void shouldFailIfCompleted() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newCompletedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+          .hasMessage(
+              "Process instance [key: %d] should be active but was completed.",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfTerminated() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newTerminatedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+          .hasMessage(
+              "Process instance [key: %d] should be active but was terminated.",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfNotFound() throws IOException {
+      // given
+      doThrow(new CamundaClientNotFoundException())
+          .when(camundaDataSource)
+          .getProcessInstance(PROCESS_INSTANCE_KEY);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+          .hasMessage(
+              "Process instance [key: %d] should be active but was not activated.",
+              PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
+  class IsCompleted {
+
+    @Test
+    void shouldBeCompleted() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newCompletedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).isCompleted();
+    }
+
+    @Test
+    void shouldFailIfTerminated() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newTerminatedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isCompleted())
+          .hasMessage(
+              "Process instance [key: %d] should be completed but was terminated.",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldWaitUntilCompleted() throws IOException {
+      // given
+      final ProcessInstanceDto processInstanceActive =
+          newActiveProcessInstance(PROCESS_INSTANCE_KEY);
+      final ProcessInstanceDto processInstanceCompleted =
+          newCompletedProcessInstance(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY))
+          .thenReturn(processInstanceActive, processInstanceCompleted);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).isCompleted();
+
+      verify(camundaDataSource, times(2)).getProcessInstance(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfActive() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newActiveProcessInstance(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isCompleted())
+          .hasMessage(
+              "Process instance [key: %d] should be completed but was active.",
+              PROCESS_INSTANCE_KEY);
+
+      verify(camundaDataSource, atLeast(2)).getProcessInstance(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfNotFound() throws IOException {
+      // given
+      doThrow(new CamundaClientNotFoundException())
+          .when(camundaDataSource)
+          .getProcessInstance(PROCESS_INSTANCE_KEY);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isCompleted())
+          .hasMessage(
+              "Process instance [key: %d] should be completed but was not activated.",
+              PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
+  class IsTerminated {
+
+    @Test
+    void shouldBeTerminated() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newTerminatedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).isTerminated();
+    }
+
+    @Test
+    void shouldFailIfCompleted() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newCompletedProcessInstance(PROCESS_INSTANCE_KEY);
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).isTerminated())
+          .hasMessage(
+              "Process instance [key: %d] should be terminated but was completed.",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldWaitUntilTerminated() throws IOException {
+      // given
+      final ProcessInstanceDto processInstanceActive =
+          newActiveProcessInstance(PROCESS_INSTANCE_KEY);
+      final ProcessInstanceDto processInstanceTerminated =
+          newTerminatedProcessInstance(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY))
+          .thenReturn(processInstanceActive, processInstanceTerminated);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).isTerminated();
+
+      verify(camundaDataSource, times(2)).getProcessInstance(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfActive() throws IOException {
+      // given
+      final ProcessInstanceDto processInstance = newActiveProcessInstance(PROCESS_INSTANCE_KEY);
+
+      when(camundaDataSource.getProcessInstance(PROCESS_INSTANCE_KEY)).thenReturn(processInstance);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).isTerminated())
+          .hasMessage(
+              "Process instance [key: %d] should be terminated but was active.",
+              PROCESS_INSTANCE_KEY);
+
+      verify(camundaDataSource, atLeast(2)).getProcessInstance(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfNotFound() throws IOException {
+      // given
+      doThrow(new CamundaClientNotFoundException())
+          .when(camundaDataSource)
+          .getProcessInstance(PROCESS_INSTANCE_KEY);
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).isTerminated())
+          .hasMessage(
+              "Process instance [key: %d] should be terminated but was not activated.",
+              PROCESS_INSTANCE_KEY);
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -55,15 +55,15 @@ public class ProcessInstanceAssertTest {
 
   @BeforeEach
   void configureAssertions() {
-    BpmnAssert.initialize(camundaDataSource);
-    BpmnAssert.setAssertionInterval(Duration.ZERO);
-    BpmnAssert.setAssertionTimeout(Duration.ofMillis(100));
+    CamundaAssert.initialize(camundaDataSource);
+    CamundaAssert.setAssertionInterval(Duration.ZERO);
+    CamundaAssert.setAssertionTimeout(Duration.ofMillis(100));
   }
 
   @AfterEach
   void resetAssertions() {
-    BpmnAssert.setAssertionInterval(BpmnAssert.DEFAULT_ASSERTION_INTERVAL);
-    BpmnAssert.setAssertionTimeout(BpmnAssert.DEFAULT_ASSERTION_TIMEOUT);
+    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
+    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
   }
 
   private static ProcessInstanceDto newActiveProcessInstance(final long processInstanceKey) {
@@ -129,7 +129,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // when
-      BpmnAssert.assertThat(processInstanceEvent).isActive();
+      CamundaAssert.assertThat(processInstanceEvent).isActive();
 
       // then
       verify(camundaDataSource).getProcessInstance(PROCESS_INSTANCE_KEY);
@@ -141,7 +141,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceResult.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // when
-      BpmnAssert.assertThat(processInstanceResult).isActive();
+      CamundaAssert.assertThat(processInstanceResult).isActive();
 
       // then
       verify(camundaDataSource).getProcessInstance(PROCESS_INSTANCE_KEY);
@@ -161,7 +161,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).isActive();
+      CamundaAssert.assertThat(processInstanceEvent).isActive();
     }
 
     @Test
@@ -174,7 +174,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+      Assertions.assertThatThrownBy(() -> CamundaAssert.assertThat(processInstanceEvent).isActive())
           .hasMessage(
               "Process instance [key: %d] should be active but was completed.",
               PROCESS_INSTANCE_KEY);
@@ -190,7 +190,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+      Assertions.assertThatThrownBy(() -> CamundaAssert.assertThat(processInstanceEvent).isActive())
           .hasMessage(
               "Process instance [key: %d] should be active but was terminated.",
               PROCESS_INSTANCE_KEY);
@@ -207,7 +207,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isActive())
+      Assertions.assertThatThrownBy(() -> CamundaAssert.assertThat(processInstanceEvent).isActive())
           .hasMessage(
               "Process instance [key: %d] should be active but was not activated.",
               PROCESS_INSTANCE_KEY);
@@ -227,7 +227,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).isCompleted();
+      CamundaAssert.assertThat(processInstanceEvent).isCompleted();
     }
 
     @Test
@@ -240,7 +240,8 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isCompleted())
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).isCompleted())
           .hasMessage(
               "Process instance [key: %d] should be completed but was terminated.",
               PROCESS_INSTANCE_KEY);
@@ -261,7 +262,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).isCompleted();
+      CamundaAssert.assertThat(processInstanceEvent).isCompleted();
 
       verify(camundaDataSource, times(2)).getProcessInstance(PROCESS_INSTANCE_KEY);
     }
@@ -277,7 +278,8 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isCompleted())
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).isCompleted())
           .hasMessage(
               "Process instance [key: %d] should be completed but was active.",
               PROCESS_INSTANCE_KEY);
@@ -296,7 +298,8 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      Assertions.assertThatThrownBy(() -> BpmnAssert.assertThat(processInstanceEvent).isCompleted())
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).isCompleted())
           .hasMessage(
               "Process instance [key: %d] should be completed but was not activated.",
               PROCESS_INSTANCE_KEY);
@@ -316,7 +319,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).isTerminated();
+      CamundaAssert.assertThat(processInstanceEvent).isTerminated();
     }
 
     @Test
@@ -330,7 +333,7 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).isTerminated())
+              () -> CamundaAssert.assertThat(processInstanceEvent).isTerminated())
           .hasMessage(
               "Process instance [key: %d] should be terminated but was completed.",
               PROCESS_INSTANCE_KEY);
@@ -351,7 +354,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).isTerminated();
+      CamundaAssert.assertThat(processInstanceEvent).isTerminated();
 
       verify(camundaDataSource, times(2)).getProcessInstance(PROCESS_INSTANCE_KEY);
     }
@@ -368,7 +371,7 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).isTerminated())
+              () -> CamundaAssert.assertThat(processInstanceEvent).isTerminated())
           .hasMessage(
               "Process instance [key: %d] should be terminated but was active.",
               PROCESS_INSTANCE_KEY);
@@ -388,7 +391,7 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).isTerminated())
+              () -> CamundaAssert.assertThat(processInstanceEvent).isTerminated())
           .hasMessage(
               "Process instance [key: %d] should be terminated but was not activated.",
               PROCESS_INSTANCE_KEY);
@@ -411,7 +414,23 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
+      CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
+    }
+
+    @Test
+    void shouldHasTwoActiveElements() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceActive = newActiveFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceCompleted = newCompletedFlowNodeInstance("A");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceCompleted, flowNodeInstanceActive));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A", "A");
     }
 
     @Test
@@ -428,7 +447,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
+      CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
 
       verify(camundaDataSource, times(2))
           .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
@@ -448,7 +467,7 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "C", "D"))
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A", "C", "D"))
           .hasMessage(
               "Process instance [key: %d] should have active elements ['A', 'C', 'D'] but the following elements were not active:\n"
                   + "\t- 'C': not activated\n"
@@ -471,7 +490,7 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B", "C"))
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B", "C"))
           .hasMessage(
               "Process instance [key: %d] should have active elements ['A', 'B', 'C'] but the following elements were not active:\n"
                   + "\t- 'B': completed\n"
@@ -498,7 +517,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B");
+      CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B");
     }
 
     @Test
@@ -516,7 +535,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B");
+      CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B");
 
       verify(camundaDataSource, times(2))
           .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
@@ -536,7 +555,9 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "C", "D"))
+              () ->
+                  CamundaAssert.assertThat(processInstanceEvent)
+                      .hasCompletedElements("A", "C", "D"))
           .hasMessage(
               "Process instance [key: %d] should have completed elements ['A', 'C', 'D'] but the following elements were not completed:\n"
                   + "\t- 'C': not activated\n"
@@ -558,7 +579,7 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B"))
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B"))
           .hasMessage(
               "Process instance [key: %d] should have completed elements ['A', 'B'] but the following elements were not completed:\n"
                   + "\t- 'B': terminated",
@@ -584,7 +605,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B");
+      CamundaAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B");
     }
 
     @Test
@@ -602,7 +623,7 @@ public class ProcessInstanceAssertTest {
       when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
 
       // then
-      BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B");
+      CamundaAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B");
 
       verify(camundaDataSource, times(2))
           .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
@@ -623,7 +644,8 @@ public class ProcessInstanceAssertTest {
       // then
       Assertions.assertThatThrownBy(
               () ->
-                  BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "C", "D"))
+                  CamundaAssert.assertThat(processInstanceEvent)
+                      .hasTerminatedElements("A", "C", "D"))
           .hasMessage(
               "Process instance [key: %d] should have terminated elements ['A', 'C', 'D'] but the following elements were not terminated:\n"
                   + "\t- 'C': not activated\n"
@@ -645,7 +667,7 @@ public class ProcessInstanceAssertTest {
 
       // then
       Assertions.assertThatThrownBy(
-              () -> BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B"))
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B"))
           .hasMessage(
               "Process instance [key: %d] should have terminated elements ['A', 'B'] but the following elements were not terminated:\n"
                   + "\t- 'A': completed",

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -23,12 +23,16 @@ import static org.mockito.Mockito.when;
 
 import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.client.CamundaClientNotFoundException;
+import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
+import io.camunda.process.test.impl.client.FlowNodeInstanceState;
 import io.camunda.process.test.impl.client.ProcessInstanceDto;
 import io.camunda.process.test.impl.client.ProcessInstanceState;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.client.api.response.ProcessInstanceResult;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -83,6 +87,29 @@ public class ProcessInstanceAssertTest {
     processInstance.setState(ProcessInstanceState.TERMINATED);
     processInstance.setEndDate(END_DATE);
     return processInstance;
+  }
+
+  private static FlowNodeInstanceDto newActiveFlowNodeInstance(final String elementName) {
+    final FlowNodeInstanceDto flowNodeInstance = new FlowNodeInstanceDto();
+    flowNodeInstance.setFlowNodeName(elementName);
+    flowNodeInstance.setProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    flowNodeInstance.setState(FlowNodeInstanceState.ACTIVE);
+    flowNodeInstance.setStartDate(START_DATE);
+    return flowNodeInstance;
+  }
+
+  private static FlowNodeInstanceDto newCompletedFlowNodeInstance(final String elementName) {
+    final FlowNodeInstanceDto flowNodeInstance = newActiveFlowNodeInstance(elementName);
+    flowNodeInstance.setState(FlowNodeInstanceState.COMPLETED);
+    flowNodeInstance.setEndDate(END_DATE);
+    return flowNodeInstance;
+  }
+
+  private static FlowNodeInstanceDto newTerminatedFlowNodeInstance(final String elementName) {
+    final FlowNodeInstanceDto flowNodeInstance = newActiveFlowNodeInstance(elementName);
+    flowNodeInstance.setState(FlowNodeInstanceState.TERMINATED);
+    flowNodeInstance.setEndDate(END_DATE);
+    return flowNodeInstance;
   }
 
   @Nested
@@ -365,6 +392,266 @@ public class ProcessInstanceAssertTest {
           .hasMessage(
               "Process instance [key: %d] should be terminated but was not activated.",
               PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
+  class HasActiveElements {
+
+    @Test
+    void shouldHasActiveElements() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newActiveFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newActiveFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
+    }
+
+    @Test
+    void shouldWaitUntilHasActiveElements() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newActiveFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newActiveFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(flowNodeInstanceA))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B");
+
+      verify(camundaDataSource, times(2))
+          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfElementsNotFound() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newActiveFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newActiveFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "C", "D"))
+          .hasMessage(
+              "Process instance [key: %d] should have active elements ['A', 'C', 'D'] but the following elements were not active:\n"
+                  + "\t- 'C': not activated\n"
+                  + "\t- 'D': not activated",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfElementsNotActive() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newActiveFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newCompletedFlowNodeInstance("B");
+      final FlowNodeInstanceDto flowNodeInstanceC = newTerminatedFlowNodeInstance("C");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB, flowNodeInstanceC));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).hasActiveElements("A", "B", "C"))
+          .hasMessage(
+              "Process instance [key: %d] should have active elements ['A', 'B', 'C'] but the following elements were not active:\n"
+                  + "\t- 'B': completed\n"
+                  + "\t- 'C': terminated",
+              PROCESS_INSTANCE_KEY);
+
+      verify(camundaDataSource).getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
+  class HasCompletedElements {
+
+    @Test
+    void shouldHasCompletedElements() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newCompletedFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newCompletedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B");
+    }
+
+    @Test
+    void shouldWaitUntilHasCompletedElements() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newCompletedFlowNodeInstance("A");
+      final FlowNodeInstanceDto activeFlowNodeInstanceB = newActiveFlowNodeInstance("B");
+      final FlowNodeInstanceDto completedFlowNodeInstanceB = newCompletedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, activeFlowNodeInstanceB))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, completedFlowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B");
+
+      verify(camundaDataSource, times(2))
+          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfElementsNotFound() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newCompletedFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newCompletedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "C", "D"))
+          .hasMessage(
+              "Process instance [key: %d] should have completed elements ['A', 'C', 'D'] but the following elements were not completed:\n"
+                  + "\t- 'C': not activated\n"
+                  + "\t- 'D': not activated",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfElementsNotCompleted() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newCompletedFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).hasCompletedElements("A", "B"))
+          .hasMessage(
+              "Process instance [key: %d] should have completed elements ['A', 'B'] but the following elements were not completed:\n"
+                  + "\t- 'B': terminated",
+              PROCESS_INSTANCE_KEY);
+
+      verify(camundaDataSource).getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
+  class HasTerminatedElements {
+
+    @Test
+    void shouldHasTerminatedElements() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newTerminatedFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B");
+    }
+
+    @Test
+    void shouldWaitUntilHasTerminatedElements() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newTerminatedFlowNodeInstance("A");
+      final FlowNodeInstanceDto activeFlowNodeInstanceB = newActiveFlowNodeInstance("B");
+      final FlowNodeInstanceDto terminatedFlowNodeInstanceB = newTerminatedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, activeFlowNodeInstanceB))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, terminatedFlowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B");
+
+      verify(camundaDataSource, times(2))
+          .getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfElementsNotFound() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newTerminatedFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "C", "D"))
+          .hasMessage(
+              "Process instance [key: %d] should have terminated elements ['A', 'C', 'D'] but the following elements were not terminated:\n"
+                  + "\t- 'C': not activated\n"
+                  + "\t- 'D': not activated",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfElementsNotTerminated() throws IOException {
+      // given
+      final FlowNodeInstanceDto flowNodeInstanceA = newCompletedFlowNodeInstance("A");
+      final FlowNodeInstanceDto flowNodeInstanceB = newTerminatedFlowNodeInstance("B");
+
+      when(camundaDataSource.getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(flowNodeInstanceA, flowNodeInstanceB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> BpmnAssert.assertThat(processInstanceEvent).hasTerminatedElements("A", "B"))
+          .hasMessage(
+              "Process instance [key: %d] should have terminated elements ['A', 'B'] but the following elements were not terminated:\n"
+                  + "\t- 'A': completed",
+              PROCESS_INSTANCE_KEY);
+
+      verify(camundaDataSource).getFlowNodeInstancesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
     }
   }
 }

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -96,13 +96,13 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
 
     // initialize assertions
     final CamundaDataSource dataSource = createDataSource(containerRuntime);
-    BpmnAssert.initialize(dataSource);
+    CamundaAssert.initialize(dataSource);
   }
 
   @Override
   public void afterTestMethod(final TestContext testContext) throws Exception {
     // reset assertions
-    BpmnAssert.reset();
+    CamundaAssert.reset();
 
     // close Zeebe clients
     testContext

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaProcessTestExecutionListener.java
@@ -15,7 +15,9 @@
  */
 package io.camunda.process.test.api;
 
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
 import io.camunda.process.test.impl.configuration.CamundaContainerRuntimeConfiguration;
+import io.camunda.process.test.impl.containers.OperateContainer;
 import io.camunda.process.test.impl.extension.CamundaProcessTestContextImpl;
 import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
 import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
@@ -91,10 +93,17 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
     testContext
         .getApplicationContext()
         .publishEvent(new ZeebeClientCreatedEvent(this, zeebeClient));
+
+    // initialize assertions
+    final CamundaDataSource dataSource = createDataSource(containerRuntime);
+    BpmnAssert.initialize(dataSource);
   }
 
   @Override
   public void afterTestMethod(final TestContext testContext) throws Exception {
+    // reset assertions
+    BpmnAssert.reset();
+
     // close Zeebe clients
     testContext
         .getApplicationContext()
@@ -145,6 +154,13 @@ public class CamundaProcessTestExecutionListener implements TestExecutionListene
 
   private static boolean hasJsonMapper(final TestContext testContext) {
     return testContext.getApplicationContext().getBeanNamesForType(JsonMapper.class).length > 0;
+  }
+
+  private CamundaDataSource createDataSource(final CamundaContainerRuntime containerRuntime) {
+    final OperateContainer operateContainer = containerRuntime.getOperateContainer();
+    final String operateApiEndpoint =
+        "http://" + operateContainer.getHost() + ":" + operateContainer.getRestApiPort();
+    return new CamundaDataSource(operateApiEndpoint);
   }
 
   @Override

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
@@ -27,8 +27,8 @@ import org.springframework.test.context.TestExecutionListeners.MergeMode;
 
 /**
  * Marks a class as a process test and adds the Spring test execution listener {@link
- * CamundaProcessTestExecutionListener}. Use {@link BpmnAssert} to verify the expected result of a
- * test.
+ * CamundaProcessTestExecutionListener}. Use {@link CamundaAssert} to verify the expected result of
+ * a test.
  *
  * <p>Example usage:
  *
@@ -53,7 +53,7 @@ import org.springframework.test.context.TestExecutionListeners.MergeMode;
  *     // when
  *
  *     // then
- *     BpmnAssert.assertThat(processInstance)
+ *     CamundaAssert.assertThat(processInstance)
  *         .isCompleted()
  *         .hasCompletedElements("A", "B");
  *   }

--- a/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
+++ b/testing/camunda-process-test-spring/src/main/java/io/camunda/process/test/api/CamundaSpringProcessTest.java
@@ -27,7 +27,8 @@ import org.springframework.test.context.TestExecutionListeners.MergeMode;
 
 /**
  * Marks a class as a process test and adds the Spring test execution listener {@link
- * CamundaProcessTestExecutionListener}.
+ * CamundaProcessTestExecutionListener}. Use {@link BpmnAssert} to verify the expected result of a
+ * test.
  *
  * <p>Example usage:
  *
@@ -41,19 +42,20 @@ import org.springframework.test.context.TestExecutionListeners.MergeMode;
  *   &#064;Test
  *   void shouldWork() {
  *     // given
- *     final long processInstanceKey =
+ *     final ProcessInstanceEvent processInstance =
  *         zeebeClient
  *             .newCreateInstanceCommand()
  *             .bpmnProcessId("process")
  *             .latestVersion()
  *             .send()
- *             .join()
- *             .getProcessInstanceKey();
+ *             .join();
  *
  *     // when
  *
  *     // then
- *
+ *     BpmnAssert.assertThat(processInstance)
+ *         .isCompleted()
+ *         .hasCompletedElements("A", "B");
  *   }
  * }
  * </pre>

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
@@ -55,7 +55,7 @@ public class CamundaSpringProcessTestListenerIT {
             .join();
 
     // then
-    BpmnAssert.assertThat(processInstance)
+    CamundaAssert.assertThat(processInstance)
         .isActive()
         .hasCompletedElements("start")
         .hasActiveElements("task");

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/ExecutionListenerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import io.camunda.process.test.impl.configuration.CamundaContainerRuntimeConfiguration;
+import io.camunda.process.test.impl.containers.OperateContainer;
 import io.camunda.process.test.impl.containers.ZeebeContainer;
 import io.camunda.process.test.impl.proxy.CamundaProcessTestContextProxy;
 import io.camunda.process.test.impl.proxy.ZeebeClientProxy;
@@ -56,6 +57,7 @@ public class ExecutionListenerTest {
 
   @Mock private CamundaContainerRuntime camundaContainerRuntime;
   @Mock private ZeebeContainer zeebeContainer;
+  @Mock private OperateContainer operateContainer;
 
   @Mock private ZeebeClientProxy zeebeClientProxy;
   @Mock private CamundaProcessTestContextProxy camundaProcessTestContextProxy;
@@ -78,6 +80,10 @@ public class ExecutionListenerTest {
     when(camundaContainerRuntime.getZeebeContainer()).thenReturn(zeebeContainer);
     when(zeebeContainer.getGrpcApiAddress()).thenReturn(GRPC_API_ADDRESS);
     when(zeebeContainer.getRestApiAddress()).thenReturn(REST_API_ADDRESS);
+
+    when(camundaContainerRuntime.getOperateContainer()).thenReturn(operateContainer);
+    when(operateContainer.getHost()).thenReturn("my-host");
+    when(operateContainer.getRestApiPort()).thenReturn(100);
 
     when(testContext.getApplicationContext()).thenReturn(applicationContext);
     when(applicationContext.getBean(ZeebeClientProxy.class)).thenReturn(zeebeClientProxy);


### PR DESCRIPTION
## Description

- Add new assertions to:
    - Verify the state of a process instance: active/completed/terminated
    - Verify the state of BPMN elements: active/completed/terminated
- The assertions are inspired by [zeebe-process-test](https://docs.camunda.io/docs/apis-tools/java-client/zeebe-process-test/#process-instance-assertions) with noticeable differences:
    - Use different naming for `hasActiveElements()` vs. `isWaitingAtElements()` and `hasCompletedElements()` vs. `hasPassedElement()` to align the wording and distinguish completed from terminated
    - Use BPMN element names vs. element ids to make it easier/powerful under the assumption that element names are not important and visible in the BPMN. We will add support for ids later.
    - The assertions wait implicitly until the expected state is reached to ease the asynchronous of the engine
- The assertions follow the style of AssertJ 
- The implementation is based on AssertJ and [Awaitility](https://github.com/awaitility/awaitility)
    - Awaitility is used to wait until the process instance reaches the expected state 
- Build a small client to access the (old) APIs. We will replace this client later with the official SDK.   

This PR adds the first assertions to CPT. We will add more assertions later. 

## Related issues

contributes to #19175 
