### PR TITLE
chore(optimize8): increase maven plugin read timeout to 20 mins

### DIFF
--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -149,6 +149,7 @@
               <url>https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch.demo.version}-windows-x86_64.zip</url>
               <unpack>true</unpack>
               <outputDirectory>${project.build.directory}</outputDirectory>
+              <readTimeOut>1200000</readTimeOut>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
## Description

Target workflows:
* Operate Tests / Docker container tests (pull_request)
