### PR TITLE
feat: validate binding type attribute

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeBindingTypeValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeBindingTypeValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.validation.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+import org.camunda.bpm.model.xml.validation.ModelElementValidator;
+import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
+
+public class ZeebeBindingTypeValidator<T extends ModelElementInstance>
+    implements ModelElementValidator<T> {
+
+  private static final List<String> ALLOWED_BINDING_TYPES =
+      Arrays.stream(ZeebeBindingType.values())
+          .map(ZeebeBindingType::toString)
+          .collect(Collectors.toList());
+
+  private final Class<T> elementType;
+
+  public ZeebeBindingTypeValidator(final Class<T> elementType) {
+    this.elementType = elementType;
+  }
+
+  @Override
+  public Class<T> getElementType() {
+    return elementType;
+  }
+
+  @Override
+  public void validate(final T element, final ValidationResultCollector validationResultCollector) {
+    final String bindingType = element.getAttributeValue(ZeebeConstants.ATTRIBUTE_BINDING_TYPE);
+    if (bindingType != null && !ALLOWED_BINDING_TYPES.contains(bindingType)) {
+      final String message =
+          String.format(
+              "Attribute '%s' must be one of: %s",
+              ZeebeConstants.ATTRIBUTE_BINDING_TYPE, String.join(", ", ALLOWED_BINDING_TYPES));
+      validationResultCollector.addError(0, message);
+    }
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebeDesignTimeValidators.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.model.bpmn.instance.ServiceTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeExecutionListener;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeLoopCharacteristics;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebePublishMessage;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeScript;
@@ -123,6 +124,9 @@ public final class ZeebeDesignTimeValidators {
     validators.add(new IntermediateThrowEventValidator());
     validators.add(new CompensationTaskValidator());
     validators.add(new CompensationEventDefinitionValidator());
+    validators.add(new ZeebeBindingTypeValidator<>(ZeebeCalledDecision.class));
+    validators.add(new ZeebeBindingTypeValidator<>(ZeebeCalledElement.class));
+    validators.add(new ZeebeBindingTypeValidator<>(ZeebeFormDefinition.class));
 
     VALIDATORS = Collections.unmodifiableList(validators);
   }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
@@ -20,6 +20,7 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.BusinessRuleTask;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledDecision;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskDefinition;
@@ -65,6 +66,26 @@ class BusinessRuleTaskValidatorTest {
         process,
         ExpectedValidationResult.expect(
             ZeebeCalledDecision.class, "Attribute 'resultVariable' must be present and not empty"));
+  }
+
+  @Test
+  void invalidBindingType() {
+    // when
+    final BpmnModelInstance process =
+        process(
+            task ->
+                task.zeebeCalledDecisionId("decisionId")
+                    .zeebeResultVariable("result")
+                    .getElement()
+                    .getSingleExtensionElement(ZeebeCalledDecision.class)
+                    .setAttributeValue(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, "foo"));
+
+    // then
+    ProcessValidationUtil.assertThatProcessHasViolations(
+        process,
+        ExpectedValidationResult.expect(
+            ZeebeCalledDecision.class,
+            "Attribute 'bindingType' must be one of: deployment, latest"));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeCallActivityTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeCallActivityTest.java
@@ -19,6 +19,7 @@ import static io.camunda.zeebe.model.bpmn.validation.ExpectedValidationResult.ex
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeCalledElement;
 import org.junit.runners.Parameterized.Parameters;
 
@@ -40,6 +41,23 @@ public class ZeebeCallActivityTest extends AbstractZeebeValidationTest {
             .done(),
         singletonList(
             expect(ZeebeCalledElement.class, "Attribute 'processId' must be present and not empty"))
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity(
+                "call",
+                c ->
+                    c.zeebeProcessId("x")
+                        .getElement()
+                        .getSingleExtensionElement(ZeebeCalledElement.class)
+                        .setAttributeValue(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, "foo"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeCalledElement.class,
+                "Attribute 'bindingType' must be one of: deployment, latest"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskValidatorFormTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskValidatorFormTest.java
@@ -20,6 +20,7 @@ import static java.util.Collections.EMPTY_LIST;
 import static java.util.Collections.singletonList;
 
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeFormDefinition;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeUserTaskForm;
 import java.util.Arrays;
@@ -349,6 +350,23 @@ public class ZeebeTaskValidatorFormTest extends AbstractZeebeValidationTest {
                 ZeebeFormDefinition.class,
                 "Exactly one of the attributes 'formId, formKey' must be present and not blank"))
       },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeFormId("formId")
+                        .getElement()
+                        .getSingleExtensionElement(ZeebeFormDefinition.class)
+                        .setAttributeValue(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, "foo"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'bindingType' must be one of: deployment, latest"))
+      },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ////////////////////////////////// Native user tasks ////////////////////////////////////////
       /////////////////////////////////////////////////////////////////////////////////////////////
@@ -625,6 +643,24 @@ public class ZeebeTaskValidatorFormTest extends AbstractZeebeValidationTest {
             .endEvent()
             .done(),
         EMPTY_LIST
+      },
+      {
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask(
+                "task",
+                task ->
+                    task.zeebeUserTask()
+                        .zeebeFormId("formId")
+                        .getElement()
+                        .getSingleExtensionElement(ZeebeFormDefinition.class)
+                        .setAttributeValue(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, "foo"))
+            .endEvent()
+            .done(),
+        singletonList(
+            expect(
+                ZeebeFormDefinition.class,
+                "Attribute 'bindingType' must be one of: deployment, latest"))
       }
     };
   }


### PR DESCRIPTION
## Description
Adds validation for the `bindingType` attribute of `ZeebeCalledElement`, `ZeebeCalledDecision`, and `ZeebeFormDefinition`: If the BPMN model contains an invalid/unknown value for this attribute, a validation error will be thrown.

This will prevent an `IllegalArgumentException` when the attribute is accessed later on by the Zeebe engine during model transformation.

_Note_: Currently, the binding type is not yet used; this will change with #19710.

## Related issues
closes #20054