### PR TITLE
ci: increase timeout for java-checks

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -487,6 +487,7 @@ jobs:
   java-checks:
     name: Java checks
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe


### PR DESCRIPTION
## Description

The build fails due to timeout in the step `java-checks`. There are no particular errors. It is just too slow. https://github.com/camunda/camunda/actions/runs/9852919776/job/27202394159

Observed this a couple of times already. Not sure if we can do anything to speed up the build. So to prevent flaky builds, let's increase the timeout. 

