### PR TITLE
[Backport stable/8.2] test: fix flaky raft heartbeat test

### DIFF
--- a/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
+++ b/atomix/cluster/src/test/java/io/atomix/raft/RaftTest.java
@@ -19,6 +19,7 @@ package io.atomix.raft;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -451,7 +452,11 @@ public class RaftTest extends ConcurrentTestCase {
 
   @Test
   public void shouldTriggerHeartbeatTimeouts() throws Throwable {
+    // given
     final List<RaftServer> servers = createServers(3);
+    Awaitility.await("A leader exists")
+        .until(() -> servers.stream().filter(server -> server.isLeader()).findAny().isPresent());
+
     final List<RaftServer> followers = getFollowers(servers);
     final RaftServer follower = followers.get(0);
     final MemberId followerId = follower.getContext().getCluster().getLocalMember().memberId();
@@ -474,7 +479,9 @@ public class RaftTest extends ConcurrentTestCase {
     final var timeout = follower.getContext().getElectionTimeout().multipliedBy(4).toMillis();
 
     // should send poll requests to 2 nodes
-    Awaitility.await().timeout(Duration.ofMillis(timeout)).untilAdder(pollCount, greaterThan(2L));
+    Awaitility.await()
+        .timeout(Duration.ofMillis(timeout))
+        .untilAdder(pollCount, greaterThanOrEqualTo(2L));
   }
 
   @Test


### PR DESCRIPTION
# Description
Backport of #20079 to `stable/8.2`.

relates to #19574
original author: @deepthidevaki