### PR TITLE
chore(ci): update node to version 20 in operate's CIs

### DIFF
--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup yarn cache
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "yarn"
           cache-dependency-path: operate/client/yarn.lock
       - name: Install node dependencies

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Setup yarn
         run: npm install -g yarn
       - name: Install node dependencies

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
       - name: Install node dependencies
         working-directory: ./operate/client
         run: yarn


### PR DESCRIPTION
## Description

Fixes incompatibilities between some modules and the version of node used in some CIs

## Related issues

closes #
