### PR TITLE
Add `MessageCorrelation` record and intent

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -823,6 +823,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true
@@ -904,6 +905,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -718,6 +718,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true
@@ -799,6 +800,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceCreationRecord;
@@ -64,6 +65,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.USER_TASK, UserTaskRecord::new);
     RECORDS_BY_TYPE.put(ValueType.PROCESS_INSTANCE_MIGRATION, ProcessInstanceMigrationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -46,7 +46,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.COMPENSATION_SUBSCRIPTION);
+      EnumSet.range(ValueType.JOB, ValueType.MESSAGE_CORRELATION);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -76,6 +77,7 @@ public final class EventAppliers implements EventApplier {
     registerDeploymentAppliers(state);
 
     registerMessageAppliers(state);
+    registerMessageCorrelationAppliers(state);
     registerMessageSubscriptionAppliers(state);
     registerMessageStartEventSubscriptionAppliers(state);
 
@@ -219,6 +221,11 @@ public final class EventAppliers implements EventApplier {
   private void registerMessageAppliers(final MutableProcessingState state) {
     register(MessageIntent.PUBLISHED, new MessagePublishedApplier(state.getMessageState()));
     register(MessageIntent.EXPIRED, new MessageExpiredApplier(state.getMessageState()));
+  }
+
+  private void registerMessageCorrelationAppliers(final MutableProcessingState state) {
+    register(MessageCorrelationIntent.CORRELATED, NOOP_EVENT_APPLIER);
+    register(MessageCorrelationIntent.NOT_CORRELATED, NOOP_EVENT_APPLIER);
   }
 
   private void registerMessageSubscriptionAppliers(final MutableProcessingState state) {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -333,6 +333,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.compensationSubscription) {
         createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION);
       }
+      if (index.messageCorrelation) {
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -126,6 +126,8 @@ public class ElasticsearchExporterConfiguration {
         return index.userTask;
       case COMPENSATION_SUBSCRIPTION:
         return index.compensationSubscription;
+      case MESSAGE_CORRELATION:
+        return index.messageCorrelation;
       default:
         return false;
     }
@@ -201,6 +203,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean form = true;
     public boolean userTask = true;
     public boolean compensationSubscription = true;
+    public boolean messageCorrelation = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -302,6 +305,8 @@ public class ElasticsearchExporterConfiguration {
           + userTask
           + ", compensationSubscription="
           + compensationSubscription
+          + ", messageCorrelation="
+          + messageCorrelation
           + '}';
     }
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_message-correlation_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-message-correlation": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "correlationKey": {
+              "type": "text"
+            },
+            "variables": {
+              "enabled": false
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -93,6 +93,7 @@ final class TestSupport {
       case FORM -> config.form = value;
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
+      case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -300,6 +300,9 @@ public class OpensearchExporter implements Exporter {
       if (index.compensationSubscription) {
         createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION);
       }
+      if (index.messageCorrelation) {
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -125,6 +125,8 @@ public class OpensearchExporterConfiguration {
         return index.userTask;
       case COMPENSATION_SUBSCRIPTION:
         return index.compensationSubscription;
+      case MESSAGE_CORRELATION:
+        return index.messageCorrelation;
       default:
         return false;
     }
@@ -190,6 +192,7 @@ public class OpensearchExporterConfiguration {
     public boolean form = true;
     public boolean userTask = true;
     public boolean compensationSubscription = true;
+    public boolean messageCorrelation = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -289,6 +292,8 @@ public class OpensearchExporterConfiguration {
           + userTask
           + ", compensationSubscription="
           + compensationSubscription
+          + ", messageCorrelation="
+          + messageCorrelation
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_message-correlation_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-message-correlation": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "correlationKey": {
+              "type": "text"
+            },
+            "variables": {
+              "enabled": false
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -81,6 +81,7 @@ final class TestSupport {
       case FORM -> config.form = value;
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
+      case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.message;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.util.Map;
+import org.agrona.DirectBuffer;
+
+public final class MessageCorrelationRecord extends UnifiedRecordValue
+    implements MessageCorrelationRecordValue {
+
+  private final StringProperty nameProp = new StringProperty("name");
+  private final StringProperty correlationKeyProp = new StringProperty("correlationKey");
+  private final DocumentProperty variablesProp = new DocumentProperty("variables");
+  private final StringProperty tenantIdProp =
+      new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty processInstanceKeyProp = new LongProperty("processInstanceKey", -1L);
+
+  public MessageCorrelationRecord() {
+    super(5);
+    declareProperty(nameProp)
+        .declareProperty(correlationKeyProp)
+        .declareProperty(variablesProp)
+        .declareProperty(tenantIdProp)
+        .declareProperty(processInstanceKeyProp);
+  }
+
+  public void wrap(final MessageCorrelationRecord record) {
+    setName(record.getName());
+    setCorrelationKey(record.getCorrelationKey());
+    setVariables(record.getVariablesBuffer());
+    setTenantId(record.getTenantId());
+    setProcessInstanceKey(record.getProcessInstanceKey());
+  }
+
+  @Override
+  public String getName() {
+    return bufferAsString(nameProp.getValue());
+  }
+
+  @Override
+  public String getCorrelationKey() {
+    return bufferAsString(correlationKeyProp.getValue());
+  }
+
+  public MessageCorrelationRecord setCorrelationKey(final String correlationKey) {
+    correlationKeyProp.setValue(correlationKey);
+    return this;
+  }
+
+  public MessageCorrelationRecord setName(final String name) {
+    nameProp.setValue(name);
+    return this;
+  }
+
+  @Override
+  public Map<String, Object> getVariables() {
+    return MsgPackConverter.convertToMap(variablesProp.getValue());
+  }
+
+  public MessageCorrelationRecord setVariables(final DirectBuffer variables) {
+    variablesProp.setValue(variables);
+    return this;
+  }
+
+  @JsonIgnore
+  public DirectBuffer getVariablesBuffer() {
+    return variablesProp.getValue();
+  }
+
+  @Override
+  public String getTenantId() {
+    return bufferAsString(tenantIdProp.getValue());
+  }
+
+  public MessageCorrelationRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  @Override
+  public long getProcessInstanceKey() {
+    return processInstanceKeyProp.getValue();
+  }
+
+  public MessageCorrelationRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -2318,6 +2319,60 @@ final class JsonSerializableToJsonTest {
           "compensableActivityScopeKey": -1,
           "compensableActivityInstanceKey": -1,
           "variables": {}
+        }
+        """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////// MessageCorrelationRecord ///////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "MessageCorrelationRecord",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String correlationKey = "test-key";
+              final String messageName = "test-message";
+              final long processInstanceKey = 1L;
+
+              return new MessageCorrelationRecord()
+                  .setCorrelationKey(correlationKey)
+                  .setName(messageName)
+                  .setVariables(VARIABLES_MSGPACK)
+                  .setTenantId("foo")
+                  .setProcessInstanceKey(processInstanceKey);
+            },
+        """
+        {
+          "correlationKey": "test-key",
+          "variables": {
+            "foo": "bar"
+          },
+          "name": "test-message",
+          "tenantId": "foo",
+          "processInstanceKey": 1
+        }
+        """
+      },
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////// Empty MessageCorrelationRecord /////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "Empty MessageCorrelationRecord",
+        (Supplier<MessageCorrelationRecord>)
+            () -> {
+              final String correlationKey = "test-key";
+              final String messageName = "test-message";
+
+              return new MessageCorrelationRecord()
+                  .setCorrelationKey(correlationKey)
+                  .setName(messageName);
+            },
+        """
+        {
+          "correlationKey": "test-key",
+          "variables": {},
+          "name": "test-message",
+          "tenantId": "<default>",
+          "processInstanceKey": -1
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -61,6 +62,7 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -223,6 +225,9 @@ public final class ValueTypeMapping {
         ValueType.COMPENSATION_SUBSCRIPTION,
         new Mapping<>(
             CompensationSubscriptionRecordValue.class, CompensationSubscriptionIntent.class));
+    mapping.put(
+        ValueType.MESSAGE_CORRELATION,
+        new Mapping<>(MessageCorrelationRecordValue.class, MessageCorrelationIntent.class));
 
     return mapping;
   }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.zeebe.protocol.record.intent;
 
+import static io.camunda.zeebe.protocol.record.ValueType.MESSAGE_CORRELATION;
+
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import java.util.Arrays;
@@ -56,7 +58,8 @@ public interface Intent {
           FormIntent.class,
           UserTaskIntent.class,
           ProcessInstanceMigrationIntent.class,
-          CompensationSubscriptionIntent.class);
+          CompensationSubscriptionIntent.class,
+          MessageCorrelationIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 
@@ -215,6 +218,8 @@ public interface Intent {
         return ProcessInstanceMigrationIntent.valueOf(intent);
       case COMPENSATION_SUBSCRIPTION:
         return CompensationSubscriptionIntent.valueOf(intent);
+      case MESSAGE_CORRELATION:
+        return MessageCorrelationIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageCorrelationIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/MessageCorrelationIntent.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum MessageCorrelationIntent implements Intent {
+  CORRELATE(1),
+  CORRELATED(2),
+  NOT_CORRELATED(3);
+
+  private final short value;
+
+  MessageCorrelationIntent(final int value) {
+    this.value = (short) value;
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    switch (this) {
+      case CORRELATED:
+      case NOT_CORRELATED:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 1:
+        return CORRELATE;
+      case 2:
+        return CORRELATED;
+      case 3:
+        return NOT_CORRELATED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageCorrelationRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageCorrelationRecordValue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValueWithVariables;
+import org.immutables.value.Value;
+
+/**
+ * Represents a message correlation event or command.
+ *
+ * <p>See {@link io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent} for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableMessageCorrelationRecordValue.Builder.class)
+public interface MessageCorrelationRecordValue
+    extends RecordValueWithVariables, TenantOwned, ProcessInstanceRelated {
+
+  /**
+   * @return the name of the message
+   */
+  String getName();
+
+  /**
+   * @return the correlation key of the message
+   */
+  String getCorrelationKey();
+}

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -54,6 +54,7 @@
       <validValue name="USER_TASK">37</validValue>
       <validValue name="PROCESS_INSTANCE_MIGRATION">38</validValue>
       <validValue name="COMPENSATION_SUBSCRIPTION">39</validValue>
+      <validValue name="MESSAGE_CORRELATION">40</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
@@ -92,6 +93,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.FORM, FormRecord.class);
     registry.put(ValueType.USER_TASK, UserTaskRecord.class);
     registry.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord.class);
+    registry.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -144,6 +145,7 @@ public class CompactRecordLogger {
     valueLoggers.put(ValueType.SIGNAL_SUBSCRIPTION, this::summarizeSignalSubscription);
     valueLoggers.put(ValueType.USER_TASK, this::summarizeUserTask);
     valueLoggers.put(ValueType.COMMAND_DISTRIBUTION, this::summarizeCommandDistribution);
+    valueLoggers.put(ValueType.MESSAGE_CORRELATION, this::summarizeMessageCorrelation);
   }
 
   public CompactRecordLogger(final Collection<Record<?>> records) {
@@ -828,6 +830,22 @@ public class CompactRecordLogger {
     return stringBuilder
         .append("%s partition %d".formatted(targetPartitionWord, value.getPartitionId()))
         .toString();
+  }
+
+  private String summarizeMessageCorrelation(final Record<?> record) {
+    final var value = (MessageCorrelationRecordValue) record.getValue();
+
+    final var result = new StringBuilder().append("\"").append(value.getName()).append("\"");
+
+    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
+      result.append(" correlationKey: ").append(value.getCorrelationKey());
+    }
+
+    result.append(" processInstanceKey: ").append(value.getProcessInstanceKey());
+
+    result.append(summarizeVariables(value.getVariables()));
+
+    return result.toString();
   }
 
   /**

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/CompactRecordLogger.java
@@ -834,16 +834,18 @@ public class CompactRecordLogger {
 
   private String summarizeMessageCorrelation(final Record<?> record) {
     final var value = (MessageCorrelationRecordValue) record.getValue();
+    final var correlationKey = value.getCorrelationKey();
 
     final var result = new StringBuilder().append("\"").append(value.getName()).append("\"");
 
-    if (!StringUtils.isEmpty(value.getCorrelationKey())) {
-      result.append(" correlationKey: ").append(value.getCorrelationKey());
+    if (correlationKey != null && !correlationKey.isEmpty()) {
+      result.append(" correlationKey: ").append(correlationKey);
     }
 
-    result.append(" processInstanceKey: ").append(value.getProcessInstanceKey());
-
-    result.append(summarizeVariables(value.getVariables()));
+    result
+        .append(" processInstanceKey: ")
+        .append(value.getProcessInstanceKey())
+        .append(summarizeVariables(value.getVariables()));
 
     return result.toString();
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

This PR introduces the `MessageCorrelation` value type and intents. The record is similar to the `MessageRecord` except it has a few fields less. It shall be used for the purpose of a "synchronous" message publication.

## Related issues

closes #20164
closes #20189 
closes #20186
