### PR TITLE
Add client request properties to `MessageSubscriptionRecord`

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -48,6 +48,12 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "requestId": {
+              "type": "long"
+            },
+            "requestStreamId": {
+              "type": "integer"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-subscription-template.json
@@ -48,6 +48,12 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "requestId": {
+              "type": "long"
+            },
+            "requestStreamId": {
+              "type": "integer"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageSubscriptionRecord.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.DocumentProperty;
+import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
@@ -36,8 +37,12 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
+  private final LongProperty requestIdProperty = new LongProperty("requestId", -1);
+  private final IntegerProperty requestStreamIdProperty =
+      new IntegerProperty("requestStreamId", -1);
+
   public MessageSubscriptionRecord() {
-    super(9);
+    super(11);
     declareProperty(processInstanceKeyProp)
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(messageKeyProp)
@@ -46,7 +51,9 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
         .declareProperty(interruptingProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(variablesProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(requestIdProperty)
+        .declareProperty(requestStreamIdProperty);
   }
 
   public void wrap(final MessageSubscriptionRecord record) {
@@ -59,6 +66,8 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
     setBpmnProcessId(record.getBpmnProcessIdBuffer());
     setVariables(record.getVariablesBuffer());
     setTenantId(record.getTenantId());
+    setRequestId(record.getRequestId());
+    setRequestStreamId(record.getRequestStreamId());
   }
 
   @JsonIgnore
@@ -114,6 +123,26 @@ public final class MessageSubscriptionRecord extends UnifiedRecordValue
   @Override
   public boolean isInterrupting() {
     return interruptingProp.getValue();
+  }
+
+  @Override
+  public long getRequestId() {
+    return requestIdProperty.getValue();
+  }
+
+  @Override
+  public int getRequestStreamId() {
+    return requestStreamIdProperty.getValue();
+  }
+
+  public MessageSubscriptionRecord setRequestStreamId(final int requestStreamId) {
+    requestStreamIdProperty.setValue(requestStreamId);
+    return this;
+  }
+
+  public MessageSubscriptionRecord setRequestId(final long requestId) {
+    requestIdProperty.setValue(requestId);
+    return this;
   }
 
   public MessageSubscriptionRecord setInterrupting(final boolean interrupting) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -1003,6 +1003,8 @@ final class JsonSerializableToJsonTest {
               final long processInstanceKey = 2L;
               final String correlationKey = "key";
               final long messageKey = 3L;
+              final long requestId = 4L;
+              final int requestStreamId = 5;
 
               return new MessageSubscriptionRecord()
                   .setElementInstanceKey(elementInstanceKey)
@@ -1011,7 +1013,9 @@ final class JsonSerializableToJsonTest {
                   .setMessageName(wrapString(messageName))
                   .setProcessInstanceKey(processInstanceKey)
                   .setCorrelationKey(wrapString(correlationKey))
-                  .setVariables(VARIABLES_MSGPACK);
+                  .setVariables(VARIABLES_MSGPACK)
+                  .setRequestId(requestId)
+                  .setRequestStreamId(requestStreamId);
             },
         """
         {
@@ -1025,7 +1029,9 @@ final class JsonSerializableToJsonTest {
             "foo": "bar"
           },
           "interrupting": true,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "requestId": 4,
+          "requestStreamId": 5
         }
         """
       },
@@ -1054,7 +1060,9 @@ final class JsonSerializableToJsonTest {
           "messageKey": -1,
           "variables": {},
           "interrupting": true,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "requestId": -1,
+          "requestStreamId": -1
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/MessageSubscriptionRecordValue.java
@@ -66,4 +66,20 @@ public interface MessageSubscriptionRecordValue
    *     returns {@code false} if the event is non-interrupting.
    */
   boolean isInterrupting();
+
+  /**
+   * This property is used to give a response back to the client upon correlation of the message. It
+   * is only set if the message came in with a MessageCorrelation.CORRELATE command.
+   *
+   * @return the id of the request that triggered the correlation command
+   */
+  long getRequestId();
+
+  /**
+   * This property is used to give a response back to the client upon correlation of the message. It
+   * is only set if the message came in with a MessageCorrelation.CORRELATE command.
+   *
+   * @return the id of the request stream that triggered the correlation command
+   */
+  int getRequestStreamId();
 }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

In order to be able to send a response back to the client upon correlation we must keep track of the request data. This
is tricky considering multiple partitions are involved in message correlation.

Putting the request properties on this record allows us to store them in our state on the `MessageSubscription.CORRELATING` event applier. This way, once we get feedback from the other partition that correlation succeeded, we can pull these properties from the state in the `Messagesubscription.CORRELATED` command. At this point we can use them to send the response to the client.

I've added the OS and ES exporter to this PR already, as it's a very small PR anyways.

## Related issues

closes #20167 
closes #20187
