### PR TITLE
Add `MessageCorrelation` record to ES and OS exporter

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -823,6 +823,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true
@@ -904,6 +905,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -718,6 +718,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true
@@ -799,6 +800,7 @@
         #     jobBatch: false
         #     message: true
         #     messageBatch: false
+        #     messageCorrelation: true
         #     messageStartSubscription: true
         #     messageSubscription: true
         #     process: true

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -333,6 +333,9 @@ public class ElasticsearchExporter implements Exporter {
       if (index.compensationSubscription) {
         createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION);
       }
+      if (index.messageCorrelation) {
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporterConfiguration.java
@@ -126,6 +126,8 @@ public class ElasticsearchExporterConfiguration {
         return index.userTask;
       case COMPENSATION_SUBSCRIPTION:
         return index.compensationSubscription;
+      case MESSAGE_CORRELATION:
+        return index.messageCorrelation;
       default:
         return false;
     }
@@ -201,6 +203,7 @@ public class ElasticsearchExporterConfiguration {
     public boolean form = true;
     public boolean userTask = true;
     public boolean compensationSubscription = true;
+    public boolean messageCorrelation = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -302,6 +305,8 @@ public class ElasticsearchExporterConfiguration {
           + userTask
           + ", compensationSubscription="
           + compensationSubscription
+          + ", messageCorrelation="
+          + messageCorrelation
           + '}';
     }
   }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_message-correlation_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-message-correlation": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "correlationKey": {
+              "type": "text"
+            },
+            "variables": {
+              "enabled": false
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -93,6 +93,7 @@ final class TestSupport {
       case FORM -> config.form = value;
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
+      case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporter.java
@@ -300,6 +300,9 @@ public class OpensearchExporter implements Exporter {
       if (index.compensationSubscription) {
         createValueIndexTemplate(ValueType.COMPENSATION_SUBSCRIPTION);
       }
+      if (index.messageCorrelation) {
+        createValueIndexTemplate(ValueType.MESSAGE_CORRELATION);
+      }
     }
 
     indexTemplatesCreated = true;

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchExporterConfiguration.java
@@ -125,6 +125,8 @@ public class OpensearchExporterConfiguration {
         return index.userTask;
       case COMPENSATION_SUBSCRIPTION:
         return index.compensationSubscription;
+      case MESSAGE_CORRELATION:
+        return index.messageCorrelation;
       default:
         return false;
     }
@@ -190,6 +192,7 @@ public class OpensearchExporterConfiguration {
     public boolean form = true;
     public boolean userTask = true;
     public boolean compensationSubscription = true;
+    public boolean messageCorrelation = true;
 
     // index settings
     private Integer numberOfShards = null;
@@ -289,6 +292,8 @@ public class OpensearchExporterConfiguration {
           + userTask
           + ", compensationSubscription="
           + compensationSubscription
+          + ", messageCorrelation="
+          + messageCorrelation
           + '}';
     }
   }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-message-correlation-template.json
@@ -1,0 +1,42 @@
+{
+  "index_patterns": [
+    "zeebe-record_message-correlation_*"
+  ],
+  "composed_of": ["zeebe-record"],
+  "priority": 20,
+  "version": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0,
+      "index.queries.cache.enabled": false
+    },
+    "aliases": {
+      "zeebe-record-message-correlation": {}
+    },
+    "mappings": {
+      "properties": {
+        "value": {
+          "dynamic": "strict",
+          "properties": {
+            "name": {
+              "type": "keyword"
+            },
+            "correlationKey": {
+              "type": "text"
+            },
+            "variables": {
+              "enabled": false
+            },
+            "tenantId": {
+              "type": "keyword"
+            },
+            "processInstanceKey": {
+              "type": "long"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -81,6 +81,7 @@ final class TestSupport {
       case FORM -> config.form = value;
       case USER_TASK -> config.userTask = value;
       case COMPENSATION_SUBSCRIPTION -> config.compensationSubscription = value;
+      case MESSAGE_CORRELATION -> config.messageCorrelation = value;
       default ->
           throw new IllegalArgumentException(
               "No known indexing configuration option for value type " + valueType);


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

Adds the record templates and configurations to allow `MessageCorrelation` records to be exported.

Note: this PR merges into #20164 as that one has tests failing because of this.

## Related issues

closes #20186 
