### PR TITLE
ci: disable flaky test to avoid CI disruption until flakiness resolved

### DIFF
--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -228,6 +229,8 @@ public final class OAuthCredentialsCacheTest {
     assertThat(copy.size()).isEqualTo(2);
   }
 
+  @Ignore(
+      "Can be enabled when not flaky anymore, see https://github.com/camunda/camunda/issues/20136")
   @Test
   public void shouldBeThreadSafe() throws InterruptedException {
     // given


### PR DESCRIPTION
## Description

See https://github.com/camunda/camunda/issues/20136#issuecomment-2222231245 for reasoning. We should first seek to mitigate impact on CI health due to flaky tests and then take time to fully resolve them so other engineers in the monorepo are not blocked during the resolution process.

## Related issues

Related to #20136
