### PR TITLE
Detect duplicate InstallRequests correctly

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -120,7 +120,31 @@ public class PassiveRole extends InactiveRole {
     logRequest(request);
     updateTermAndLeader(request.currentTerm(), request.leader());
 
-    log.debug("Received snapshot {} chunk from {}", request.index(), request.leader());
+    final var snapshotChunk = new SnapshotChunkImpl();
+    final var snapshotChunkBuffer = new UnsafeBuffer(request.data());
+    if (!snapshotChunk.tryWrap(snapshotChunkBuffer)) {
+      abortPendingSnapshots();
+      return CompletableFuture.completedFuture(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(RaftResponse.Status.ERROR)
+                  .withError(RaftError.Type.APPLICATION_ERROR, "Failed to parse request data")
+                  .build()));
+    }
+
+    log.debug(
+        "Received snapshot chunk {} of snapshot {} from {}",
+        snapshotChunk.getChunkName(),
+        snapshotChunk.getSnapshotId(),
+        request.leader());
+
+    if (pendingSnapshot != null
+        && !pendingSnapshot
+            .snapshotId()
+            .getSnapshotIdAsString()
+            .equals(snapshotChunk.getSnapshotId())) {
+      abortPendingSnapshots();
+    }
 
     if (Objects.equals(request.chunkId(), previouslyReceivedSnapshotChunkId)) {
       return CompletableFuture.completedFuture(
@@ -207,18 +231,6 @@ public class PassiveRole extends InactiveRole {
                   .withError(
                       RaftError.Type.PROTOCOL_ERROR,
                       "Snapshot installation is not complete but did not provide any next expected chunk")
-                  .build()));
-    }
-
-    final var snapshotChunk = new SnapshotChunkImpl();
-    final var snapshotChunkBuffer = new UnsafeBuffer(request.data());
-    if (!snapshotChunk.tryWrap(snapshotChunkBuffer)) {
-      abortPendingSnapshots();
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.ERROR)
-                  .withError(RaftError.Type.APPLICATION_ERROR, "Failed to parse request data")
                   .build()));
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
 import io.camunda.zeebe.snapshots.impl.SnapshotChunkId;
+import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -138,6 +139,12 @@ public class PassiveRole extends InactiveRole {
         snapshotChunk.getSnapshotId(),
         request.leader());
 
+    // If a snapshot is currently being received and the snapshot versions don't match, simply
+    // close the existing snapshot. This is a naive implementation that assumes that the leader
+    // will be responsible in sending the correct snapshot to this server. Leaders must dictate
+    // where snapshots must be sent since entries can still legitimately exist prior to the
+    // snapshot, and so snapshots aren't simply sent at the beginning of the follower's log, but
+    // rather the leader dictates when a snapshot needs to be sent.
     if (pendingSnapshot != null
         && !pendingSnapshot
             .snapshotId()
@@ -146,93 +153,14 @@ public class PassiveRole extends InactiveRole {
       abortPendingSnapshots();
     }
 
-    if (Objects.equals(request.chunkId(), previouslyReceivedSnapshotChunkId)) {
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.OK)
-                  .withPreferredChunkSize(snapshotChunkSize)
-                  .build()));
+    // Validate the request and return if the request should not be processed further.
+    final var preProcessed = preProcessInstallRequest(request);
+    if (preProcessed.isLeft()) {
+      // The request is either rejected or skip processing with a success response
+      return CompletableFuture.completedFuture(preProcessed.getLeft());
     }
 
-    // if null assume it is first chunk of file
-    if (nextPendingSnapshotChunkId != null
-        && !nextPendingSnapshotChunkId.equals(request.chunkId())) {
-      final var errMsg =
-          "Expected chunkId of ["
-              + new SnapshotChunkId(nextPendingSnapshotChunkId)
-              + "] got ["
-              + new SnapshotChunkId(request.chunkId())
-              + "].";
-      abortPendingSnapshots();
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(Status.ERROR)
-                  .withError(Type.ILLEGAL_MEMBER_STATE, errMsg)
-                  .build()));
-    }
-
-    // If the request is for a lesser term, reject the request.
-    if (request.currentTerm() < raft.getTerm()) {
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.ERROR)
-                  .withError(
-                      RaftError.Type.ILLEGAL_MEMBER_STATE,
-                      "Request term is less than the local term " + request.currentTerm())
-                  .build()));
-    }
-
-    // If the index has already been applied, we have enough state to populate the state machine up
-    // to this index.
-    // Skip the snapshot and response successfully.
-    if (raft.getCommitIndex() > request.index()) {
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.OK)
-                  .withPreferredChunkSize(snapshotChunkSize)
-                  .build()));
-    }
-
-    // If a snapshot is currently being received and the snapshot versions don't match, simply
-    // close the existing snapshot. This is a naive implementation that assumes that the leader
-    // will be responsible in sending the correct snapshot to this server. Leaders must dictate
-    // where snapshots must be sent since entries can still legitimately exist prior to the
-    // snapshot,
-    // and so snapshots aren't simply sent at the beginning of the follower's log, but rather the
-    // leader dictates when a snapshot needs to be sent.
-    if (pendingSnapshot != null && request.index() != pendingSnapshot.index()) {
-      abortPendingSnapshots();
-    }
-
-    // If the snapshot already exists locally, do not overwrite it with a replicated snapshot.
-    // Simply reply to the request successfully.
-    final var latestIndex = raft.getCurrentSnapshotIndex();
-    if (latestIndex >= request.index()) {
-      abortPendingSnapshots();
-
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.OK)
-                  .withPreferredChunkSize(snapshotChunkSize)
-                  .build()));
-    }
-
-    if (!request.complete() && request.nextChunkId() == null) {
-      abortPendingSnapshots();
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.ERROR)
-                  .withError(
-                      RaftError.Type.PROTOCOL_ERROR,
-                      "Snapshot installation is not complete but did not provide any next expected chunk")
-                  .build()));
-    }
+    // Process the request
 
     // If there is no pending snapshot, create a new snapshot.
     if (pendingSnapshot == null) {
@@ -491,6 +419,89 @@ public class PassiveRole extends InactiveRole {
                 .withError(
                     RaftError.Type.ILLEGAL_MEMBER_STATE, "Cannot request vote from RESERVE member")
                 .build()));
+  }
+
+  // validates install request and returns a response if the request should not be processed
+  // further.
+  private Either<InstallResponse, Void> preProcessInstallRequest(final InstallRequest request) {
+    if (Objects.equals(request.chunkId(), previouslyReceivedSnapshotChunkId)) {
+      // Duplicate request for the same chunk that was previously processed
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.OK)
+                  .withPreferredChunkSize(snapshotChunkSize)
+                  .build()));
+    }
+
+    // if null assume it is first chunk of file
+    if (nextPendingSnapshotChunkId != null
+        && !nextPendingSnapshotChunkId.equals(request.chunkId())) {
+      final var errMsg =
+          "Expected chunkId of ["
+              + new SnapshotChunkId(nextPendingSnapshotChunkId)
+              + "] got ["
+              + new SnapshotChunkId(request.chunkId())
+              + "].";
+      abortPendingSnapshots();
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(Type.ILLEGAL_MEMBER_STATE, errMsg)
+                  .build()));
+    }
+
+    // If the request is for a lesser term, reject the request.
+    if (request.currentTerm() < raft.getTerm()) {
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(
+                      Type.ILLEGAL_MEMBER_STATE,
+                      "Request term is less than the local term " + request.currentTerm())
+                  .build()));
+    }
+
+    // If the index has already been applied, we have enough state to populate the state machine up
+    // to this index.
+    // Skip the snapshot and response successfully.
+    if (raft.getCommitIndex() > request.index()) {
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.OK)
+                  .withPreferredChunkSize(snapshotChunkSize)
+                  .build()));
+    }
+
+    // If the snapshot already exists locally, do not overwrite it with a replicated snapshot.
+    // Simply reply to the request successfully.
+    final var latestIndex = raft.getCurrentSnapshotIndex();
+    if (latestIndex >= request.index()) {
+      abortPendingSnapshots();
+
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.OK)
+                  .withPreferredChunkSize(snapshotChunkSize)
+                  .build()));
+    }
+
+    if (!request.complete() && request.nextChunkId() == null) {
+      abortPendingSnapshots();
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(
+                      Type.PROTOCOL_ERROR,
+                      "Snapshot installation is not complete but did not provide any next expected chunk")
+                  .build()));
+    }
+    return Either.right(null);
   }
 
   private CompletableFuture<InstallResponse> failIfSnapshotAlreadyExists(

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -353,7 +353,11 @@ public final class ControllableRaftContexts {
       final long term = reader.next().term();
 
       InMemorySnapshot.newPersistedSnapshot(
-          snapshotIndex, term, random.nextInt(1, 10), testSnapshotStore);
+          Integer.parseInt(memberId.id()),
+          snapshotIndex,
+          term,
+          random.nextInt(1, 10),
+          testSnapshotStore);
 
       LOG.info(
           "Snapshot taken at index {}. Current commit index is {}",

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -341,7 +341,8 @@ public final class ControllableRaftContexts {
     // Take snapshot at an index between lastSnapshotIndex and current commitIndex
     final TestSnapshotStore testSnapshotStore = snapshotStores.get(memberId);
     final var startIndex =
-        Math.max(raftContext.getLog().getFirstIndex(), testSnapshotStore.getCurrentSnapshotIndex());
+        Math.max(
+            raftContext.getLog().getFirstIndex(), testSnapshotStore.getCurrentSnapshotIndex() + 1);
     if (startIndex >= raftContext.getCommitIndex()) {
       // cannot take snapshot
       return;

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/RaftRule.java
@@ -376,7 +376,8 @@ public final class RaftRule extends ExternalResource {
     final var snapshotStore = getSnapshotStore(memberId.id());
 
     return Optional.of(
-        InMemorySnapshot.newPersistedSnapshot(index, raftContext.getTerm(), size, snapshotStore));
+        InMemorySnapshot.newPersistedSnapshot(
+            Integer.parseInt(memberId.id()), index, raftContext.getTerm(), size, snapshotStore));
   }
 
   private TestSnapshotStore getSnapshotStore(final String memberId) {

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/impl/LogCompactorTest.java
@@ -96,8 +96,8 @@ final class LogCompactorTest {
   void shouldCompactBasedOnOldestSnapshot() {
     // given
     final var store = new TestSnapshotStore(new AtomicReference<>());
-    InMemorySnapshot.newPersistedSnapshot(10L, 1, 30, store).reserve();
-    InMemorySnapshot.newPersistedSnapshot(30L, 1, 30, store);
+    InMemorySnapshot.newPersistedSnapshot(0, 10L, 1, 30, store).reserve();
+    InMemorySnapshot.newPersistedSnapshot(0, 30L, 1, 30, store);
 
     // when
     compactor.compactFromSnapshots(store);

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -57,16 +57,24 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
     term = Long.parseLong(parts[1]);
   }
 
-  InMemorySnapshot(final TestSnapshotStore testSnapshotStore, final long index, final long term) {
+  InMemorySnapshot(
+      final TestSnapshotStore testSnapshotStore,
+      final long index,
+      final long term,
+      final int nodeId) {
     this.testSnapshotStore = testSnapshotStore;
     this.index = index;
     this.term = term;
-    id = String.format("%d-%d", index, term);
+    id = String.format("%d-%d-%d", index, term, nodeId);
   }
 
   public static InMemorySnapshot newPersistedSnapshot(
-      final long index, final long term, final int size, final TestSnapshotStore snapshotStore) {
-    final var snapshot = new InMemorySnapshot(snapshotStore, index, term);
+      final int nodeId,
+      final long index,
+      final long term,
+      final int size,
+      final TestSnapshotStore snapshotStore) {
+    final var snapshot = new InMemorySnapshot(snapshotStore, index, term, nodeId);
     for (int i = 0; i < size; i++) {
       snapshot.writeChunks("chunk-" + i, ("test-" + i).getBytes());
     }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/steps/SnapshotStoreStep.java
@@ -27,6 +27,7 @@ public final class SnapshotStoreStep implements StartupStep<PartitionStartupCont
 
     final var snapshotStore =
         new FileBasedSnapshotStore(
+            context.brokerConfig().getCluster().getNodeId(),
             context.partitionMetadata().id().id(),
             context.partitionDirectory(),
             new ChecksumProviderRocksDBImpl());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -60,7 +60,7 @@ public final class AsyncSnapshottingTest {
   public void setup() throws IOException {
     final var rootDirectory = tempFolderRule.getRoot().toPath();
     final int partitionId = 1;
-    persistedSnapshotStore = new FileBasedSnapshotStore(partitionId, rootDirectory);
+    persistedSnapshotStore = new FileBasedSnapshotStore(0, partitionId, rootDirectory);
     actorSchedulerRule.submitActor(persistedSnapshotStore).join();
 
     snapshotController =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -60,7 +60,7 @@ public final class StateControllerImplTest {
   @Before
   public void setup() throws IOException {
 
-    store = new FileBasedSnapshotStore(1, tempFolderRule.newFolder("data").toPath());
+    store = new FileBasedSnapshotStore(0, 1, tempFolderRule.newFolder("data").toPath());
     actorSchedulerRule.submitActor(store).join();
 
     runtimeDirectory = tempFolderRule.getRoot().toPath().resolve("runtime");

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -44,7 +44,7 @@ final class TestState {
             .build();
     actorScheduler.start();
 
-    final var snapshotStore = new FileBasedSnapshotStore(1, tempDirectory);
+    final var snapshotStore = new FileBasedSnapshotStore(0, 1, tempDirectory);
     actorScheduler.submitActor(snapshotStore).join();
 
     generateSnapshot(snapshotStore, sizeInBytes);

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -40,12 +40,15 @@ public class PartitionRestoreService {
 
   final Path rootDirectory;
   private final RaftPartition partition;
+  private final int brokerId;
 
-  public PartitionRestoreService(final BackupStore backupStore, final RaftPartition partition) {
+  public PartitionRestoreService(
+      final BackupStore backupStore, final RaftPartition partition, final int brokerId) {
     this.backupStore = backupStore;
     partitionId = partition.id().id();
     rootDirectory = partition.dataDirectory().toPath();
     this.partition = partition;
+    this.brokerId = brokerId;
   }
 
   /**
@@ -176,7 +179,8 @@ public class PartitionRestoreService {
 
     @SuppressWarnings("resource")
     final RestorableSnapshotStore snapshotStore =
-        new FileBasedSnapshotStore(partition.id().id(), partition.dataDirectory().toPath());
+        new FileBasedSnapshotStore(
+            brokerId, partition.id().id(), partition.dataDirectory().toPath());
 
     try {
       snapshotStore.restore(

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -93,7 +93,8 @@ public class RestoreManager {
       LOG.warn("Restoring without validating backup");
       validator = BackupValidator.none();
     }
-    return new PartitionRestoreService(backupStore, partition)
+    return new PartitionRestoreService(
+            backupStore, partition, configuration.getCluster().getNodeId())
         .restore(backupId, validator)
         .thenAccept(backup -> logSuccessfulRestore(backup, partition.id().id(), backupId));
   }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -80,7 +80,7 @@ class PartitionRestoreServiceTest {
   void setUp() {
     backupStore = new TestRestorableBackupStore();
 
-    snapshotStore = new FileBasedSnapshotStore(partitionId, dataDirectory);
+    snapshotStore = new FileBasedSnapshotStore(0, partitionId, dataDirectory);
     actorScheduler.submitActor(snapshotStore, SchedulingHints.IO_BOUND);
 
     backupService =
@@ -99,7 +99,7 @@ class PartitionRestoreServiceTest {
             PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile());
-    restoreService = new PartitionRestoreService(backupStore, raftPartition);
+    restoreService = new PartitionRestoreService(backupStore, raftPartition, nodeId);
 
     journal =
         SegmentedJournal.builder()

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotId.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotId.java
@@ -16,12 +16,29 @@ import org.slf4j.LoggerFactory;
 
 public final class FileBasedSnapshotId implements SnapshotId {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedSnapshotId.class);
-  private static final int SNAPSHOT_ID_PARTS = 4;
+  private static final int SNAPSHOT_ID_PARTS = 5;
+  private static final int PREV_SNAPSHOT_ID_PARTS = 4;
 
   private final long index;
   private final long term;
   private final long processedPosition;
   private final long exporterPosition;
+  // To ensure snapshots taken by different replicas have unique Ids, we include the brokerId. For
+  // backward compatibility we make it an optional. Can be eventually make it mandatory.
+  private final Optional<Integer> brokerId;
+
+  FileBasedSnapshotId(
+      final long index,
+      final long term,
+      final long processedPosition,
+      final long exporterPosition,
+      final int brokerId) {
+    this.index = index;
+    this.term = term;
+    this.processedPosition = processedPosition;
+    this.exporterPosition = exporterPosition;
+    this.brokerId = Optional.of(brokerId);
+  }
 
   FileBasedSnapshotId(
       final long index,
@@ -32,6 +49,7 @@ public final class FileBasedSnapshotId implements SnapshotId {
     this.term = term;
     this.processedPosition = processedPosition;
     this.exporterPosition = exporterPosition;
+    brokerId = Optional.empty();
   }
 
   // TODO(npepinpe): using Either here would improve readability and observability, as validation
@@ -51,6 +69,21 @@ public final class FileBasedSnapshotId implements SnapshotId {
         final var term = Long.parseLong(parts[1]);
         final var processedPosition = Long.parseLong(parts[2]);
         final var exporterPosition = Long.parseLong(parts[3]);
+        final var brokerId = Integer.parseInt((parts[4]));
+
+        snapshotId =
+            Optional.of(
+                new FileBasedSnapshotId(
+                    index, term, processedPosition, exporterPosition, brokerId));
+      } catch (final NumberFormatException e) {
+        LOGGER.warn("Failed to parse part of snapshot id", e);
+      }
+    } else if (parts.length == PREV_SNAPSHOT_ID_PARTS) {
+      try {
+        final var index = Long.parseLong(parts[0]);
+        final var term = Long.parseLong(parts[1]);
+        final var processedPosition = Long.parseLong(parts[2]);
+        final var exporterPosition = Long.parseLong(parts[3]);
 
         snapshotId =
             Optional.of(new FileBasedSnapshotId(index, term, processedPosition, exporterPosition));
@@ -58,7 +91,7 @@ public final class FileBasedSnapshotId implements SnapshotId {
         LOGGER.warn("Failed to parse part of snapshot id", e);
       }
     } else {
-      LOGGER.warn("Expected snapshot file format to be %d-%d-%d-%d, but was {}", name);
+      LOGGER.warn("Expected snapshot file format to be %d-%d-%d-%d-%d, but was {}", name);
     }
 
     return snapshotId;
@@ -86,13 +119,22 @@ public final class FileBasedSnapshotId implements SnapshotId {
 
   @Override
   public String getSnapshotIdAsString() {
-    return String.format(
-        "%d-%d-%d-%d", getIndex(), getTerm(), getProcessedPosition(), getExportedPosition());
+    return brokerId
+        .map(
+            broker ->
+                String.format(
+                    "%d-%d-%d-%d-%d",
+                    getIndex(), getTerm(), getProcessedPosition(), getExportedPosition(), broker))
+        // For backward compatibility
+        .orElse(
+            String.format(
+                "%d-%d-%d-%d",
+                getIndex(), getTerm(), getProcessedPosition(), getExportedPosition()));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(index, term, processedPosition, exporterPosition);
+    return Objects.hash(index, term, processedPosition, exporterPosition, brokerId.hashCode());
   }
 
   @Override
@@ -107,7 +149,8 @@ public final class FileBasedSnapshotId implements SnapshotId {
     return index == that.index
         && term == that.term
         && processedPosition == that.processedPosition
-        && exporterPosition == that.exporterPosition;
+        && exporterPosition == that.exporterPosition
+        && brokerId.equals(that.brokerId);
   }
 
   @Override
@@ -121,6 +164,8 @@ public final class FileBasedSnapshotId implements SnapshotId {
         + processedPosition
         + ", exporterPosition="
         + exporterPosition
+        + ", brokerId="
+        + brokerId
         + '}';
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -64,6 +64,7 @@ public final class FileBasedSnapshotStore extends Actor
   private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedSnapshotStore.class);
   private static final String CHECKSUM_SUFFIX = ".checksum";
   private static final String TMP_CHECKSUM_SUFFIX = ".tmp";
+  private final int brokerId;
   // the root snapshotsDirectory where all snapshots should be stored
   private final Path snapshotsDirectory;
   // the root snapshotsDirectory when pending snapshots should be stored
@@ -82,12 +83,16 @@ public final class FileBasedSnapshotStore extends Actor
   private final String actorName;
   private final int partitionId;
 
-  public FileBasedSnapshotStore(final int partitionId, final Path root) {
-    this(partitionId, root, null);
+  public FileBasedSnapshotStore(final int brokerId, final int partitionId, final Path root) {
+    this(brokerId, partitionId, root, null);
   }
 
   public FileBasedSnapshotStore(
-      final int partitionId, final Path root, final ChecksumProvider checksumProvider) {
+      final int brokerId,
+      final int partitionId,
+      final Path root,
+      final ChecksumProvider checksumProvider) {
+    this.brokerId = brokerId;
     snapshotsDirectory = root.resolve(SNAPSHOTS_DIRECTORY);
     pendingDirectory = root.resolve(PENDING_DIRECTORY);
 
@@ -418,7 +423,7 @@ public final class FileBasedSnapshotStore extends Actor
       final long exportedPosition) {
 
     final var newSnapshotId =
-        new FileBasedSnapshotId(index, term, processedPosition, exportedPosition);
+        new FileBasedSnapshotId(index, term, processedPosition, exportedPosition, brokerId);
     final FileBasedSnapshot currentSnapshot = currentPersistedSnapshotRef.get();
     if (currentSnapshot != null && currentSnapshot.getSnapshotId().compareTo(newSnapshotId) == 0) {
       final String error =

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -28,7 +28,7 @@ public class PersistedSnapshotStoreTest {
     final var partitionId = 1;
     final var root = temporaryFolder.getRoot();
 
-    final var snapshotStore = new FileBasedSnapshotStore(partitionId, root.toPath());
+    final var snapshotStore = new FileBasedSnapshotStore(0, partitionId, root.toPath());
     scheduler.submitActor(snapshotStore).join();
     persistedSnapshotStore = snapshotStore;
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -188,7 +188,7 @@ public class ReceivedSnapshotTest {
         .withThrowableOfType(ExecutionException.class)
         .withCauseInstanceOf(SnapshotAlreadyExistsException.class)
         .withMessageContaining(
-            "Expected to receive snapshot with id 1-0-1-0, but was already persisted");
+            "Expected to receive snapshot with id 1-0-1-0-0, but was already persisted");
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -51,10 +51,10 @@ public class ReceivedSnapshotTest {
     final var senderDirectory = temporaryFolder.newFolder("sender").toPath();
     final var receiverDirectory = temporaryFolder.newFolder("receiver").toPath();
 
-    senderSnapshotStore = new FileBasedSnapshotStore(partitionId, senderDirectory);
+    senderSnapshotStore = new FileBasedSnapshotStore(0, partitionId, senderDirectory);
     scheduler.get().submitActor((Actor) senderSnapshotStore).join();
 
-    receiverSnapshotStore = new FileBasedSnapshotStore(partitionId, receiverDirectory);
+    receiverSnapshotStore = new FileBasedSnapshotStore(0, partitionId, receiverDirectory);
 
     scheduler.get().submitActor((Actor) receiverSnapshotStore).join();
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -48,7 +48,7 @@ public class TransientSnapshotTest {
     final int partitionId = 1;
     final File root = temporaryFolder.getRoot();
 
-    snapshotStore = new FileBasedSnapshotStore(partitionId, root.toPath());
+    snapshotStore = new FileBasedSnapshotStore(0, partitionId, root.toPath());
     scheduler.submitActor(snapshotStore).join();
   }
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -260,7 +260,7 @@ public class FileBasedReceivedSnapshotTest {
           .hasMessageContaining(
               "Expected to have checksum "
                   + 0xCAFEL
-                  + " for snapshot chunk file1 (1-0-1-0), but calculated 3806033162");
+                  + " for snapshot chunk file1 (1-0-1-0-0), but calculated 3806033162");
     }
   }
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -407,7 +407,7 @@ public class FileBasedReceivedSnapshotTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) {
-    final var store = new FileBasedSnapshotStore(PARTITION_ID, root);
+    final var store = new FileBasedSnapshotStore(0, PARTITION_ID, root);
     scheduler.submitActor(store);
 
     return store;

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -57,7 +57,7 @@ public class FileBasedSnapshotStoreTest {
     final var root = temporaryFolder.getRoot().toPath();
 
     // when
-    final var store = new FileBasedSnapshotStore(1, root);
+    final var store = new FileBasedSnapshotStore(0, 1, root);
 
     // then
     assertThat(root.resolve(FileBasedSnapshotStore.SNAPSHOTS_DIRECTORY)).exists().isDirectory();
@@ -253,7 +253,7 @@ public class FileBasedSnapshotStoreTest {
     final var testChecksumProvider = new TestChecksumProvider(badChecksums);
 
     // when
-    final var store = new FileBasedSnapshotStore(1, rootDirectory, testChecksumProvider);
+    final var store = new FileBasedSnapshotStore(0, 1, rootDirectory, testChecksumProvider);
     scheduler.submitActor(store).join();
     final var takenSnapshot = (FileBasedSnapshot) takeTransientSnapshot(1, store).persist().join();
 
@@ -379,7 +379,7 @@ public class FileBasedSnapshotStoreTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) {
-    final var store = new FileBasedSnapshotStore(1, root);
+    final var store = new FileBasedSnapshotStore(0, 1, root);
     scheduler.submitActor(store).join();
 
     return store;

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
@@ -111,7 +111,7 @@ public final class FileBasedSnapshotTest {
 
   private FileBasedSnapshot createSnapshot(final Path snapshotPath, final Path checksumPath)
       throws IOException {
-    final var metadata = new FileBasedSnapshotId(1L, 1L, 1L, 1L);
+    final var metadata = new FileBasedSnapshotId(1L, 1L, 1L, 1L, 0);
 
     FileUtil.ensureDirectoryExists(snapshotPath);
     for (final var entry : SNAPSHOT_FILE_CONTENTS.entrySet()) {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -358,7 +358,7 @@ public class FileBasedTransientSnapshotTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) throws IOException {
-    final var store = new FileBasedSnapshotStore(1, root);
+    final var store = new FileBasedSnapshotStore(0, 1, root);
     scheduler.submitActor(store);
     return store;
   }


### PR DESCRIPTION
## Description

There were two issues:

1. The follower assumes it is a duplicate request when seeing the same chunk id. This is incorrect because two different snapshots can have the same chunk id. This is fixed by also comparing the snapshotIds of received and the local pending snpashot.
     - Also refactored the long `onInstall` method.
2. The `snapshotId` was same for different snapshot. In production, it is rare to happen, but it is still possible that the leader and follower takes the snapshot for the same index and term and ends up having the same snapshotId. Even though the state in the snapshot is same, the actual contents of the files can be different. We fixed this in the production and test code by adding the brokerId to the snapshotId. This ensures that the snapshotIds are unique. This is added in a backward compatible way so that the new versions can still read the snapshots from old version.

## Related issues

closes #19862 
