### PR TITLE
feat: include exhausted limit in backpressure error message

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/ErrorResponseWriter.java
@@ -134,10 +134,15 @@ public final class ErrorResponseWriter implements BufferWriter {
                           + " but the writer is closed. Most likely, this node is not the"
                           + " leader for this partition.")
                       .formatted(partitionId));
-      case FULL ->
+      case WRITE_LIMIT_EXHAUSTED ->
           resourceExhausted(
               String.format(
-                  "Failed to write client request to partition '%d', because the writer buffer is full.",
+                  "Failed to write client request to partition '%d', because the write limit is exhausted.",
+                  partitionId));
+      case REQUEST_LIMIT_EXHAUSTED ->
+          resourceExhausted(
+              String.format(
+                  "Failed to write client request to partition '%d', because the request limit is exhausted.",
                   partitionId));
       case INVALID_ARGUMENT -> raiseInternalError("due to invalid entry.", partitionId);
     };

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestHandlerTest.java
@@ -151,7 +151,7 @@ public class CommandApiRequestHandlerTest {
     final var logWriter = mock(LogStreamWriter.class);
     when(logWriter.canWriteEvents(anyInt(), anyInt())).thenReturn(true);
     when(logWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
-        .thenReturn(Either.left(WriteFailure.FULL));
+        .thenReturn(Either.left(WriteFailure.WRITE_LIMIT_EXHAUSTED));
     handler.addPartition(0, logWriter);
     handler.onRecovered(0);
     handler.onPaused(1);
@@ -172,7 +172,7 @@ public class CommandApiRequestHandlerTest {
         .extracting(ErrorResponse::getErrorData)
         .extracting(errorData -> BufferUtil.bufferAsString(errorData))
         .isEqualTo(
-            "Failed to write client request to partition '0', because the writer buffer is full.");
+            "Failed to write client request to partition '0', because the write limit is exhausted.");
   }
 
   @Test
@@ -181,7 +181,7 @@ public class CommandApiRequestHandlerTest {
     final var logWriter = mock(LogStreamWriter.class);
     when(logWriter.canWriteEvents(anyInt(), anyInt())).thenReturn(true);
     when(logWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
-        .thenReturn(Either.left(WriteFailure.FULL));
+        .thenReturn(Either.left(WriteFailure.WRITE_LIMIT_EXHAUSTED));
     handler.addPartition(0, logWriter);
     handler.onRecovered(0);
     handler.onPaused(0);

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/transport/partitionapi/InterPartitionCommandCheckpointTest.java
@@ -157,7 +157,7 @@ final class InterPartitionCommandCheckpointTest {
   void shouldNotWriteCommandIfCheckpointCreateFailed() {
     // given
     when(logStreamWriter.tryWrite(any(WriteContext.class), any(LogAppendEntry.class)))
-        .thenReturn(Either.left(WriteFailure.FULL), Either.right(1L));
+        .thenReturn(Either.left(WriteFailure.WRITE_LIMIT_EXHAUSTED), Either.right(1L));
     receiver.setCheckpointId(5);
     sender.setCheckpointId(17);
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -71,6 +71,8 @@ final class Sequencer implements LogStreamWriter, Closeable {
 
   /** {@inheritDoc} */
   @Override
+  // False positive: https://github.com/checkstyle/checkstyle/issues/14891
+  @SuppressWarnings("checkstyle:MissingSwitchDefault")
   public Either<WriteFailure, Long> tryWrite(
       final WriteContext context,
       final List<LogAppendEntry> appendEntries,

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -13,6 +13,8 @@ import static io.camunda.zeebe.logstreams.impl.serializer.SequencedBatchSerializ
 import static io.camunda.zeebe.scheduler.clock.ActorClock.currentTimeMillis;
 
 import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl;
+import io.camunda.zeebe.logstreams.impl.flowcontrol.FlowControl.Rejection;
+import io.camunda.zeebe.logstreams.impl.flowcontrol.InFlightEntry;
 import io.camunda.zeebe.logstreams.impl.serializer.DataFrameDescriptor;
 import io.camunda.zeebe.logstreams.log.LogAppendEntry;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
@@ -86,9 +88,15 @@ final class Sequencer implements LogStreamWriter, Closeable {
         return Either.left(WriteFailure.INVALID_ARGUMENT);
       }
     }
-    final var permit = flowControl.tryAcquire(context, copyMetadata(appendEntries));
-    if (permit.isLeft()) {
-      return Either.left(WriteFailure.FULL);
+    final InFlightEntry inFlightEntry;
+    switch (flowControl.tryAcquire(context, copyMetadata(appendEntries))) {
+      case Either.Left<Rejection, InFlightEntry>(final var rejected) -> {
+        return switch (rejected) {
+          case RequestLimitExhausted -> Either.left(WriteFailure.REQUEST_LIMIT_EXHAUSTED);
+          case WriteRateLimitExhausted -> Either.left(WriteFailure.WRITE_LIMIT_EXHAUSTED);
+        };
+      }
+      case Either.Right<Rejection, InFlightEntry>(final var accepted) -> inFlightEntry = accepted;
     }
 
     final int batchSize = appendEntries.size();
@@ -101,7 +109,7 @@ final class Sequencer implements LogStreamWriter, Closeable {
       final var sequencedBatch =
           new SequencedBatch(
               currentTimeMillis(), currentPosition, sourcePosition, appendEntries, batchLength);
-      flowControl.onAppend(permit.get(), highestPosition);
+      flowControl.onAppend(inFlightEntry, highestPosition);
       logStorage.append(currentPosition, highestPosition, sequencedBatch, flowControl);
       position = currentPosition + batchSize;
       return Either.right(highestPosition);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamWriter.java
@@ -74,7 +74,8 @@ public interface LogStreamWriter {
 
   enum WriteFailure {
     CLOSED,
-    FULL,
+    WRITE_LIMIT_EXHAUSTED,
+    REQUEST_LIMIT_EXHAUSTED,
     INVALID_ARGUMENT
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -513,7 +513,7 @@ class ProcessingScheduleServiceTest {
         final List<LogAppendEntry> appendEntries,
         final long sourcePosition) {
       if (!acceptWrites.get().getAsBoolean()) {
-        return Either.left(WriteFailure.FULL);
+        return Either.left(WriteFailure.WRITE_LIMIT_EXHAUSTED);
       }
 
       entries.addAll(appendEntries);


### PR DESCRIPTION
## Description

Adds a bit more details to the error message so that it's easy to tell which of the two limits is exhausted.

## Related issues

closes #20215
