### PR TITLE
fix: flaky shouldReportUnhealthyIfTransitionStepIsStuck()

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/ZeebePartitionTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -396,7 +397,7 @@ public class ZeebePartitionTest {
         .thenReturn(CompletableActorFuture.completed(null));
     when(transitionStep.transitionTo(any(), anyLong(), any()))
         .thenReturn(CompletableActorFuture.completed(null));
-    when(ctx.getCurrentRole()).thenReturn(Role.FOLLOWER);
+    doReturn(Role.FOLLOWER).when(ctx).getCurrentRole();
     partition.onNewRole(Role.FOLLOWER, 0);
     schedulerRule.workUntilDone();
 


### PR DESCRIPTION
## Description

As referenced in the original issue https://github.com/camunda/camunda/issues/18590#issuecomment-2124786370, the problem seems to stem possible from some reace condition on `ctx.getCurrentRole()` mock. 

On the tests that fail, this returns a null value.

To address the issue we can use the Mockito method `doReturn()` that actually does not make any call to the original method and just replaces the method with the mocked value. This could fix this race condition.

More on [doReturn()](https://javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/Mockito.html#doReturn(java.lang.Object)) vs [when()](https://javadoc.io/static/org.mockito/mockito-core/5.12.0/org/mockito/Mockito.html#when(T))

closes https://github.com/camunda/camunda/issues/18590
