### PR TITLE
fix: #20199 persist tenantId on variable record store

### DIFF
--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/VariableZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/es/VariableZeebeRecordProcessorElasticSearch.java
@@ -63,6 +63,7 @@ public class VariableZeebeRecordProcessorElasticSearch {
     entity.setScopeFlowNodeId(String.valueOf(recordValue.getScopeKey()));
     entity.setProcessInstanceId(String.valueOf(recordValue.getProcessInstanceKey()));
     entity.setName(recordValue.getName());
+    entity.setTenantId(recordValue.getTenantId());
     if (recordValue.getValue().length()
         > tasklistProperties.getImporter().getVariableSizeThreshold()) {
       // store preview

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/VariableZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/processors/os/VariableZeebeRecordProcessorOpenSearch.java
@@ -57,6 +57,7 @@ public class VariableZeebeRecordProcessorOpenSearch {
     entity.setScopeFlowNodeId(String.valueOf(recordValue.getScopeKey()));
     entity.setProcessInstanceId(String.valueOf(recordValue.getProcessInstanceKey()));
     entity.setName(recordValue.getName());
+    entity.setTenantId(recordValue.getTenantId());
     if (recordValue.getValue().length()
         > tasklistProperties.getImporter().getVariableSizeThreshold()) {
       // store preview

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/VariableZeebeRecordProcessorElasticSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/es/VariableZeebeRecordProcessorElasticSearch.java
@@ -63,6 +63,7 @@ public class VariableZeebeRecordProcessorElasticSearch {
     entity.setScopeFlowNodeId(String.valueOf(recordValue.getScopeKey()));
     entity.setProcessInstanceId(String.valueOf(recordValue.getProcessInstanceKey()));
     entity.setName(recordValue.getName());
+    entity.setTenantId(recordValue.getTenantId());
     if (recordValue.getValue().length()
         > tasklistProperties.getImporter().getVariableSizeThreshold()) {
       // store preview

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/VariableZeebeRecordProcessorOpenSearch.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/processors/os/VariableZeebeRecordProcessorOpenSearch.java
@@ -57,6 +57,7 @@ public class VariableZeebeRecordProcessorOpenSearch {
     entity.setScopeFlowNodeId(String.valueOf(recordValue.getScopeKey()));
     entity.setProcessInstanceId(String.valueOf(recordValue.getProcessInstanceKey()));
     entity.setName(recordValue.getName());
+    entity.setTenantId(recordValue.getTenantId());
     if (recordValue.getValue().length()
         > tasklistProperties.getImporter().getVariableSizeThreshold()) {
       // store preview


### PR DESCRIPTION
## Description
Include tenantId field from Zeebe record to process variable index store.

## Related issues
Ref: https://github.com/camunda/tasklist/issues/4989

Closes #20199 

