### PR TITLE
fix: "adress" typo

### DIFF
--- a/dist/src/main/config/application.yaml
+++ b/dist/src/main/config/application.yaml
@@ -134,7 +134,7 @@ camunda:
     # Zeebe instance
     zeebe:
       # Gateway address
-      gatewayAdress: localhost:26500
+      gatewayAddress: localhost:26500
     # ELS instance to export Zeebe data to
     zeebeElasticsearch:
       # Cluster name

--- a/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/zeebe/ZeebeConnector.java
@@ -33,10 +33,10 @@ public class ZeebeConnector {
   }
 
   public ZeebeClient newZeebeClient(final ZeebeProperties zeebeProperties) {
-    final var gatewayAdress = getGatewayAddress(zeebeProperties);
+    final var gatewayAddress = getGatewayAddress(zeebeProperties);
     final ZeebeClientBuilder builder =
         ZeebeClient.newClientBuilder()
-            .gatewayAddress(gatewayAdress)
+            .gatewayAddress(gatewayAddress)
             .defaultJobWorkerMaxJobsActive(JOB_WORKER_MAX_JOBS_ACTIVE);
     if (zeebeProperties.isSecure()) {
       builder.caCertificatePath(zeebeProperties.getCertificatePath());

--- a/tasklist/docker-compose.yml
+++ b/tasklist/docker-compose.yml
@@ -218,7 +218,7 @@ services:
     environment:
       - camunda.tasklist.elasticsearch.url=http://elasticsearch:9200
       - camunda.tasklist.zeebeElasticsearch.url=http://elasticsearch:9200
-      - camunda.tasklist.zeebe.gatewayAdress=zeebe:26500
+      - camunda.tasklist.zeebe.gatewayAddress=zeebe:26500
       - spring.profiles.active=dev,dev-data,sso-auth
       - camunda.tasklist.auth0.backendDomain=camunda-dev.eu.auth0.com
       - camunda.tasklist.auth0.claimName=https://camunda.com/orgs


### PR DESCRIPTION
## Description

While working on running Camunda as a plain Java app and adding the steps to the docs, I encounter a typo in multiple files - `adress` instead of `address`. I don't think this is intentional. This PR addresses the typo via find & replace.

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

No related issue.
