### PR TITLE
Create `MessageCorrelationProcessor` processor

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -83,7 +83,9 @@ public final class BpmnBufferedMessageStartEventBehavior {
                   messageCorrelation.subscriptionKey,
                   messageCorrelation.subscriptionRecord,
                   storedMessage.getMessageKey(),
-                  storedMessage.getMessage());
+                  storedMessage.getMessage().getNameBuffer(),
+                  storedMessage.getMessage().getCorrelationKeyBuffer(),
+                  storedMessage.getMessage().getVariablesBuffer());
             });
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
@@ -188,7 +187,9 @@ public final class EventHandle {
       final long subscriptionKey,
       final MessageStartEventSubscriptionRecord subscription,
       final long messageKey,
-      final MessageRecord message) {
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey,
+      final DirectBuffer variables) {
 
     final var newProcessInstanceKey = keyGenerator.nextKey();
     startEventSubscriptionRecord
@@ -196,10 +197,10 @@ public final class EventHandle {
         .setBpmnProcessId(subscription.getBpmnProcessIdBuffer())
         .setStartEventId(subscription.getStartEventIdBuffer())
         .setProcessInstanceKey(newProcessInstanceKey)
-        .setCorrelationKey(message.getCorrelationKeyBuffer())
+        .setCorrelationKey(correlationKey)
         .setMessageKey(messageKey)
-        .setMessageName(message.getNameBuffer())
-        .setVariables(message.getVariablesBuffer())
+        .setMessageName(messageName)
+        .setVariables(variables)
         .setTenantId(subscription.getTenantId());
 
     stateWriter.appendFollowUpEvent(
@@ -211,7 +212,7 @@ public final class EventHandle {
         subscription.getProcessDefinitionKey(),
         newProcessInstanceKey,
         startEventSubscriptionRecord.getStartEventIdBuffer(),
-        message.getVariablesBuffer(),
+        variables,
         subscription.getTenantId());
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/EventHandle.java
@@ -183,7 +183,7 @@ public final class EventHandle {
     }
   }
 
-  public void triggerMessageStartEvent(
+  public long triggerMessageStartEvent(
       final long subscriptionKey,
       final MessageStartEventSubscriptionRecord subscription,
       final long messageKey,
@@ -214,6 +214,8 @@ public final class EventHandle {
         startEventSubscriptionRecord.getStartEventIdBuffer(),
         variables,
         subscription.getTenantId());
+
+    return newProcessInstanceKey;
   }
 
   public void activateProcessInstanceForStartEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import org.agrona.DirectBuffer;
+
+public final class MessageCorrelateBehavior {
+
+  private final MessageStartEventSubscriptionState startEventSubscriptionState;
+  private final MessageState messageState;
+  private final EventHandle eventHandle;
+
+  public MessageCorrelateBehavior(
+      final MessageStartEventSubscriptionState startEventSubscriptionState,
+      final MessageState messageState,
+      final EventHandle eventHandle) {
+    this.startEventSubscriptionState = startEventSubscriptionState;
+    this.messageState = messageState;
+    this.eventHandle = eventHandle;
+  }
+
+  public Subscriptions correlateToMessageStartEvents(
+      final String tenantId,
+      final DirectBuffer messageName,
+      final DirectBuffer correlationKey,
+      final DirectBuffer variables,
+      final long messageKey) {
+    final var correlatingSubscriptions = new Subscriptions();
+
+    startEventSubscriptionState.visitSubscriptionsByMessageName(
+        tenantId,
+        messageName,
+        subscription -> {
+          final var subscriptionRecord = subscription.getRecord();
+          final var bpmnProcessIdBuffer = subscriptionRecord.getBpmnProcessIdBuffer();
+
+          // create only one instance of a process per correlation key
+          // - allow multiple instance if correlation key is empty
+          if (!correlatingSubscriptions.contains(bpmnProcessIdBuffer)
+              && (correlationKey.capacity() == 0
+                  || !messageState.existActiveProcessInstance(
+                      tenantId, bpmnProcessIdBuffer, correlationKey))) {
+
+            correlatingSubscriptions.add(subscriptionRecord);
+
+            eventHandle.triggerMessageStartEvent(
+                subscription.getKey(),
+                subscriptionRecord,
+                messageKey,
+                messageName,
+                correlationKey,
+                variables);
+          }
+        });
+
+    return correlatingSubscriptions;
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelateBehavior.java
@@ -49,15 +49,17 @@ public final class MessageCorrelateBehavior {
                   || !messageState.existActiveProcessInstance(
                       tenantId, bpmnProcessIdBuffer, correlationKey))) {
 
-            correlatingSubscriptions.add(subscriptionRecord);
+            final var processInstanceKey =
+                eventHandle.triggerMessageStartEvent(
+                    subscription.getKey(),
+                    subscriptionRecord,
+                    messageKey,
+                    messageName,
+                    correlationKey,
+                    variables);
 
-            eventHandle.triggerMessageStartEvent(
-                subscription.getKey(),
-                subscriptionRecord,
-                messageKey,
-                messageName,
-                correlationKey,
-                variables);
+            subscriptionRecord.setProcessInstanceKey(processInstanceKey);
+            correlatingSubscriptions.add(subscriptionRecord);
           }
         });
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationProcessor.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
+import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
+import io.camunda.zeebe.engine.state.immutable.MessageStartEventSubscriptionState;
+import io.camunda.zeebe.engine.state.immutable.MessageState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public final class MessageCorrelationProcessor
+    implements TypedRecordProcessor<MessageCorrelationRecord> {
+
+  SubscriptionCommandSender commandSender;
+  private final MessageCorrelateBehavior correlateBehavior;
+  private final KeyGenerator keyGenerator;
+  private final StateWriter stateWriter;
+  private final TypedResponseWriter responseWriter;
+
+  public MessageCorrelationProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final EventScopeInstanceState eventScopeInstanceState,
+      final ProcessState processState,
+      final BpmnBehaviors bpmnBehaviors,
+      final MessageStartEventSubscriptionState startEventSubscriptionState,
+      final MessageState messageState) {
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    this.keyGenerator = keyGenerator;
+    final var eventHandle =
+        new EventHandle(
+            keyGenerator,
+            eventScopeInstanceState,
+            writers,
+            processState,
+            bpmnBehaviors.eventTriggerBehavior(),
+            bpmnBehaviors.stateBehavior());
+    correlateBehavior =
+        new MessageCorrelateBehavior(startEventSubscriptionState, messageState, eventHandle);
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<MessageCorrelationRecord> command) {
+    final long messageKey = keyGenerator.nextKey();
+
+    final var messageRecord =
+        new MessageRecord()
+            .setName(command.getValue().getName())
+            .setCorrelationKey(command.getValue().getCorrelationKey())
+            .setVariables(command.getValue().getVariablesBuffer())
+            .setTenantId(command.getValue().getTenantId())
+            .setTimeToLive(-1L);
+    stateWriter.appendFollowUpEvent(messageKey, MessageIntent.PUBLISHED, messageRecord);
+
+    final var correlatingSubscriptions = new Subscriptions();
+    correlateToMessageStartEventSubscriptions(command, messageKey, correlatingSubscriptions);
+
+    if (correlatingSubscriptions.isEmpty()) {
+      stateWriter.appendFollowUpEvent(
+          messageKey, MessageCorrelationIntent.NOT_CORRELATED, command.getValue());
+    } else {
+      sendCorrelateCommand(command.getValue(), messageKey, correlatingSubscriptions);
+    }
+
+    // Message Correlate command cannot have a TTL. As a result the message expires immediately.
+    stateWriter.appendFollowUpEvent(messageKey, MessageIntent.EXPIRED, messageRecord);
+  }
+
+  private void correlateToMessageStartEventSubscriptions(
+      final TypedRecord<MessageCorrelationRecord> command,
+      final long messageKey,
+      final Subscriptions correlatingSubscriptions) {
+    final var messageCorrelationRecord = command.getValue();
+    final var correlatedSubscriptions =
+        correlateBehavior.correlateToMessageStartEvents(
+            messageCorrelationRecord.getTenantId(),
+            messageCorrelationRecord.getNameBuffer(),
+            messageCorrelationRecord.getCorrelationKeyBuffer(),
+            messageCorrelationRecord.getVariablesBuffer(),
+            messageKey);
+    correlatingSubscriptions.addAll(correlatedSubscriptions);
+
+    if (!correlatedSubscriptions.isEmpty()) {
+      final var subscription = correlatedSubscriptions.peek();
+      messageCorrelationRecord.setProcessInstanceKey(subscription.getProcessInstanceKey());
+
+      stateWriter.appendFollowUpEvent(
+          messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord);
+      responseWriter.writeEventOnCommand(
+          messageKey, MessageCorrelationIntent.CORRELATED, messageCorrelationRecord, command);
+    }
+  }
+
+  private boolean sendCorrelateCommand(
+      final MessageCorrelationRecord messageCorrelationRecord,
+      final long messageKey,
+      final Subscriptions correlatingSubscriptions) {
+    return correlatingSubscriptions.visitSubscriptions(
+        subscription ->
+            commandSender.correlateProcessMessageSubscription(
+                subscription.getProcessInstanceKey(),
+                subscription.getElementInstanceKey(),
+                subscription.getBpmnProcessId(),
+                messageCorrelationRecord.getNameBuffer(),
+                messageKey,
+                messageCorrelationRecord.getVariablesBuffer(),
+                messageCorrelationRecord.getCorrelationKeyBuffer(),
+                messageCorrelationRecord.getTenantId()));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -115,7 +115,9 @@ public final class MessageEventProcessors {
                 processState,
                 bpmnBehaviors,
                 startEventSubscriptionState,
-                messageState))
+                messageState,
+                subscriptionState,
+                subscriptionCommandSender))
         .withListener(
             new MessageObserver(
                 scheduledTaskStateFactory,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -104,6 +105,17 @@ public final class MessageEventProcessors {
             MessageSubscriptionIntent.REJECT,
             new MessageSubscriptionRejectProcessor(
                 messageState, subscriptionState, subscriptionCommandSender, writers))
+        .onCommand(
+            ValueType.MESSAGE_CORRELATION,
+            MessageCorrelationIntent.CORRELATE,
+            new MessageCorrelationProcessor(
+                writers,
+                keyGenerator,
+                eventScopeInstanceState,
+                processState,
+                bpmnBehaviors,
+                startEventSubscriptionState,
+                messageState))
         .withListener(
             new MessageObserver(
                 scheduledTaskStateFactory,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
@@ -48,6 +48,7 @@ public final class Subscriptions {
     final var newSubscription = subscriptions.add();
     newSubscription.setBpmnProcessId(cloneBuffer(subscription.getBpmnProcessIdBuffer()));
     newSubscription.isStartEventSubscription = true;
+    newSubscription.processInstanceKey = subscription.getProcessInstanceKey();
   }
 
   private void add(final Subscription subscription) {
@@ -63,7 +64,16 @@ public final class Subscriptions {
         (subscription) -> {
           add(subscription);
           return true;
-        });
+        },
+        true);
+  }
+
+  public boolean isEmpty() {
+    return subscriptions.size() <= 0;
+  }
+
+  public Subscription peek() {
+    return subscriptions.peek();
   }
 
   public void visitBpmnProcessIds(final Consumer<DirectBuffer> bpmnProcessIdConsumer) {
@@ -73,8 +83,13 @@ public final class Subscriptions {
   }
 
   public boolean visitSubscriptions(final SubscriptionVisitor subscriptionConsumer) {
+    return visitSubscriptions(subscriptionConsumer, false);
+  }
+
+  public boolean visitSubscriptions(
+      final SubscriptionVisitor subscriptionConsumer, final boolean visitStartEvents) {
     for (final Subscription subscription : subscriptions) {
-      if (!subscription.isStartEventSubscription) {
+      if (visitStartEvents || !subscription.isStartEventSubscription) {
 
         final var applied = subscriptionConsumer.apply(subscription);
         if (!applied) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/Subscriptions.java
@@ -50,6 +50,22 @@ public final class Subscriptions {
     newSubscription.isStartEventSubscription = true;
   }
 
+  private void add(final Subscription subscription) {
+    final var newSubscription = subscriptions.add();
+    newSubscription.setBpmnProcessId(subscription.getBpmnProcessId());
+    newSubscription.processInstanceKey = subscription.processInstanceKey;
+    newSubscription.elementInstanceKey = subscription.elementInstanceKey;
+    newSubscription.isStartEventSubscription = subscription.isStartEventSubscription;
+  }
+
+  public void addAll(final Subscriptions subscriptions) {
+    subscriptions.visitSubscriptions(
+        (subscription) -> {
+          add(subscription);
+          return true;
+        });
+  }
+
   public void visitBpmnProcessIds(final Consumer<DirectBuffer> bpmnProcessIdConsumer) {
     for (final Subscription subscription : subscriptions) {
       bpmnProcessIdConsumer.accept(subscription.getBpmnProcessId());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.util.List;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -93,6 +94,7 @@ public final class CorrelateMessageTest {
   }
 
   @Test
+  @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldHaveCorrectCorrelatedLifeCycleForMessageEvent() {
     // given
     final var messageName = "messageName";
@@ -150,6 +152,7 @@ public final class CorrelateMessageTest {
   }
 
   @Test
+  @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldCorrelateToMessageIntermediaryEvent() {
     // given
     final var messageName = "messageName";
@@ -169,6 +172,7 @@ public final class CorrelateMessageTest {
   }
 
   @Test
+  @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldCorrelateToMessageBoundaryEvent() {
     // given
     final var messageName = "messageName";
@@ -296,6 +300,7 @@ public final class CorrelateMessageTest {
   }
 
   @Test
+  @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldCorrelateMessageWithVariablesToIntermediaryEvent() {
     // given
     final var processId = "processId";
@@ -329,6 +334,7 @@ public final class CorrelateMessageTest {
   }
 
   @Test
+  @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldCorrelateMessageWithVariablesToBoundaryEvent() {
     // given
     final var processId = "processId";

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
@@ -34,6 +34,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 public final class CorrelateMessageTest {
+
+  public static final String CORRELATION_KEY = "correlationKey";
+  public static final String MESSAGE_NAME = "messageName";
   @Rule public final EngineRule engine = EngineRule.singlePartition();
 
   @Rule
@@ -45,8 +48,8 @@ public final class CorrelateMessageTest {
     // when
     engine
         .messageCorrelation()
-        .withCorrelationKey("correlationKey")
-        .withName("messageName")
+        .withCorrelationKey(CORRELATION_KEY)
+        .withName(MESSAGE_NAME)
         .expectNotCorrelated()
         .correlate();
 
@@ -68,8 +71,8 @@ public final class CorrelateMessageTest {
     // when
     engine
         .messageCorrelation()
-        .withCorrelationKey("correlationKey")
-        .withName("messageName")
+        .withCorrelationKey(CORRELATION_KEY)
+        .withName(MESSAGE_NAME)
         .correlate();
 
     // then
@@ -97,15 +100,13 @@ public final class CorrelateMessageTest {
   @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldHaveCorrectCorrelatedLifeCycleForMessageEvent() {
     // given
-    final var messageName = "messageName";
-    final var correlationKey = "correlationKey";
-    deployAndStartProcessWithIntermediaryMessageEvent(messageName, correlationKey);
+    deployAndStartProcessWithIntermediaryMessageEvent(MESSAGE_NAME, CORRELATION_KEY);
 
     // when
     engine
         .messageCorrelation()
-        .withName(messageName)
-        .withCorrelationKey(correlationKey)
+        .withName(MESSAGE_NAME)
+        .withCorrelationKey(CORRELATION_KEY)
         .correlate();
 
     // then
@@ -137,14 +138,13 @@ public final class CorrelateMessageTest {
   public void shouldCorrelateMessageToStartEvent() {
     // given
     deployProcessWithMessageStartEvent();
-    final var correlationKey = "correlationKey";
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withCorrelationKey(correlationKey)
-            .withName("messageName")
+            .withCorrelationKey(CORRELATION_KEY)
+            .withName(MESSAGE_NAME)
             .correlate();
 
     // then
@@ -155,16 +155,14 @@ public final class CorrelateMessageTest {
   @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldCorrelateToMessageIntermediaryEvent() {
     // given
-    final var messageName = "messageName";
-    final var correlationKey = "correlationKey";
-    deployAndStartProcessWithIntermediaryMessageEvent(messageName, correlationKey);
+    deployAndStartProcessWithIntermediaryMessageEvent(MESSAGE_NAME, CORRELATION_KEY);
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withName(messageName)
-            .withCorrelationKey(correlationKey)
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
             .correlate();
 
     // then
@@ -175,16 +173,14 @@ public final class CorrelateMessageTest {
   @Ignore("Enable in https://github.com/camunda/camunda/issues/20175")
   public void shouldCorrelateToMessageBoundaryEvent() {
     // given
-    final var messageName = "messageName";
-    final var correlationKey = "correlationKey";
-    deployAndStartProcessWithMessageBoundaryEvent(messageName, correlationKey);
+    deployAndStartProcessWithMessageBoundaryEvent(MESSAGE_NAME, CORRELATION_KEY);
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withName(messageName)
-            .withCorrelationKey(correlationKey)
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
             .correlate();
 
     // then
@@ -194,12 +190,11 @@ public final class CorrelateMessageTest {
   @Test
   public void shouldNotCorrelateMessageIfNoProcess() {
     // when
-    final var correlationKey = "correlationKey";
     final var record =
         engine
             .messageCorrelation()
-            .withName("messageName")
-            .withCorrelationKey(correlationKey)
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
             .expectNotCorrelated()
             .correlate();
 
@@ -212,15 +207,13 @@ public final class CorrelateMessageTest {
     // given
     deployProcessWithMessageStartEvent("process1");
     deployProcessWithMessageStartEvent("process2");
-    final var correlationKey = "correlationKey";
-    final var messageName = "messageName";
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withName(messageName)
-            .withCorrelationKey(correlationKey)
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
             .correlate();
 
     // then
@@ -237,18 +230,16 @@ public final class CorrelateMessageTest {
   public void
       shouldResponseWithCreatedProcessInstanceWhenCorrelatedToStartEventAndIntermediateEvent() {
     // given
-    final var correlationKey = "correlationKey";
-    final var messageName = "messageName";
     deployProcessWithMessageStartEvent("processStartEvent");
     final var intermediaryProcessKey =
-        deployAndStartProcessWithIntermediaryMessageEvent(messageName, correlationKey);
+        deployAndStartProcessWithIntermediaryMessageEvent(MESSAGE_NAME, CORRELATION_KEY);
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withName(messageName)
-            .withCorrelationKey(correlationKey)
+            .withName(MESSAGE_NAME)
+            .withCorrelationKey(CORRELATION_KEY)
             .correlate();
 
     // then
@@ -272,15 +263,14 @@ public final class CorrelateMessageTest {
     // given
     final var processId = "processId";
     deployProcessWithMessageStartEvent(processId);
-    final var correlationKey = "correlationKey";
     final var variables = asMsgPack("foo", "bar");
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withCorrelationKey(correlationKey)
-            .withName("messageName")
+            .withCorrelationKey(CORRELATION_KEY)
+            .withName(MESSAGE_NAME)
             .withVariables(variables)
             .correlate();
 
@@ -304,17 +294,15 @@ public final class CorrelateMessageTest {
   public void shouldCorrelateMessageWithVariablesToIntermediaryEvent() {
     // given
     final var processId = "processId";
-    final var messageName = "messageName";
-    final var correlationKey = "correlationKey";
     final var variables = asMsgPack("foo", "bar");
-    deployAndStartProcessWithIntermediaryMessageEvent(messageName, correlationKey);
+    deployAndStartProcessWithIntermediaryMessageEvent(MESSAGE_NAME, CORRELATION_KEY);
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withCorrelationKey(correlationKey)
-            .withName(messageName)
+            .withCorrelationKey(CORRELATION_KEY)
+            .withName(MESSAGE_NAME)
             .withVariables(variables)
             .correlate();
 
@@ -338,17 +326,15 @@ public final class CorrelateMessageTest {
   public void shouldCorrelateMessageWithVariablesToBoundaryEvent() {
     // given
     final var processId = "processId";
-    final var messageName = "messageName";
-    final var correlationKey = "correlationKey";
     final var variables = asMsgPack("foo", "bar");
-    deployAndStartProcessWithMessageBoundaryEvent(messageName, correlationKey);
+    deployAndStartProcessWithMessageBoundaryEvent(MESSAGE_NAME, CORRELATION_KEY);
 
     // when
     final var record =
         engine
             .messageCorrelation()
-            .withCorrelationKey(correlationKey)
-            .withName(messageName)
+            .withCorrelationKey(CORRELATION_KEY)
+            .withName(MESSAGE_NAME)
             .withVariables(variables)
             .correlate();
 
@@ -374,8 +360,8 @@ public final class CorrelateMessageTest {
         .hasRecordType(RecordType.EVENT)
         .hasValueType(ValueType.MESSAGE_CORRELATION);
     Assertions.assertThat(record.getValue())
-        .hasCorrelationKey("correlationKey")
-        .hasName("messageName")
+        .hasCorrelationKey(CORRELATION_KEY)
+        .hasName(MESSAGE_NAME)
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
@@ -386,8 +372,8 @@ public final class CorrelateMessageTest {
         .hasRecordType(RecordType.EVENT)
         .hasValueType(ValueType.MESSAGE_CORRELATION);
     Assertions.assertThat(record.getValue())
-        .hasCorrelationKey("correlationKey")
-        .hasName("messageName")
+        .hasCorrelationKey(CORRELATION_KEY)
+        .hasName(MESSAGE_NAME)
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
   }
 
@@ -397,7 +383,7 @@ public final class CorrelateMessageTest {
         .withXmlResource(
             Bpmn.createExecutableProcess(processId)
                 .startEvent()
-                .message("messageName")
+                .message(MESSAGE_NAME)
                 .endEvent()
                 .done())
         .deploy();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/CorrelateMessageTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static io.camunda.zeebe.test.util.MsgPackUtil.asMsgPack;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class CorrelateMessageTest {
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Test
+  public void shouldHaveCorrectNotCorrelatedLifecycleForStartEvent() {
+    // when
+    engine
+        .messageCorrelation()
+        .withCorrelationKey("correlationKey")
+        .withName("messageName")
+        .expectNotCorrelated()
+        .correlate();
+
+    // then
+    assertThat(RecordingExporter.records().limit(r -> r.getIntent().equals(MessageIntent.EXPIRED)))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            MessageCorrelationIntent.CORRELATE,
+            MessageIntent.PUBLISHED,
+            MessageCorrelationIntent.NOT_CORRELATED,
+            MessageIntent.EXPIRED);
+  }
+
+  @Test
+  public void shouldHaveCorrectCorrelatedLifecycleForStartEvent() {
+    // given
+    deployProcessWithMessageStartEvent();
+
+    // when
+    engine
+        .messageCorrelation()
+        .withCorrelationKey("correlationKey")
+        .withName("messageName")
+        .correlate();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent().equals(MessageIntent.EXPIRED))
+                .filter(
+                    r ->
+                        List.of(
+                                ValueType.MESSAGE_CORRELATION,
+                                ValueType.MESSAGE,
+                                ValueType.MESSAGE_START_EVENT_SUBSCRIPTION)
+                            .contains(r.getValueType())))
+        .extracting(Record::getIntent)
+        .containsExactly(
+            MessageStartEventSubscriptionIntent.CREATED,
+            MessageCorrelationIntent.CORRELATE,
+            MessageIntent.PUBLISHED,
+            MessageStartEventSubscriptionIntent.CORRELATED,
+            MessageCorrelationIntent.CORRELATED,
+            MessageIntent.EXPIRED);
+  }
+
+  @Test
+  public void shouldCorrelateMessageToStartEvent() {
+    // given
+    deployProcessWithMessageStartEvent();
+    final var correlationKey = "correlationKey";
+
+    // when
+    final var record =
+        engine
+            .messageCorrelation()
+            .withCorrelationKey(correlationKey)
+            .withName("messageName")
+            .correlate();
+
+    // then
+    assertMessageIsCorrelated(record);
+  }
+
+  @Test
+  public void shouldNotCorrelateMessageToStartEventIfNoProcess() {
+    // when
+    final var correlationKey = "correlationKey";
+    final var record =
+        engine
+            .messageCorrelation()
+            .withName("messageName")
+            .withCorrelationKey(correlationKey)
+            .expectNotCorrelated()
+            .correlate();
+
+    // then
+    assertMessageIsNotCorrelated(record);
+  }
+
+  @Test
+  public void shouldRespondFirstProcessInstanceKeyWhenMultipleMessageStartEvent() {
+    // given
+    deployProcessWithMessageStartEvent("process1");
+    deployProcessWithMessageStartEvent("process2");
+    final var correlationKey = "correlationKey";
+    final var messageName = "messageName";
+
+    // when
+    final var record =
+        engine
+            .messageCorrelation()
+            .withName(messageName)
+            .withCorrelationKey(correlationKey)
+            .correlate();
+
+    // then
+    assertMessageIsCorrelated(record);
+    final var processInstanceKey =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .filter(r -> r.getValue().getBpmnProcessId().equals("process1"))
+            .getFirst()
+            .getKey();
+    assertThat(record.getValue().getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  public void shouldCorrelateMessageWithVariablesToStartEvent() {
+    // given
+    final var processId = "processId";
+    deployProcessWithMessageStartEvent(processId);
+    final var correlationKey = "correlationKey";
+    final var variables = asMsgPack("foo", "bar");
+
+    // when
+    final var record =
+        engine
+            .messageCorrelation()
+            .withCorrelationKey(correlationKey)
+            .withName("messageName")
+            .withVariables(variables)
+            .correlate();
+
+    // then
+    assertMessageIsCorrelated(record);
+    final var processInstanceRecord =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withBpmnProcessId(processId)
+            .filter(r -> r.getValue().getBpmnElementType().equals(BpmnElementType.PROCESS))
+            .getFirst();
+    assertThat(
+            RecordingExporter.variableRecords(VariableIntent.CREATED)
+                .withScopeKey(processInstanceRecord.getValue().getProcessInstanceKey())
+                .getFirst())
+        .extracting(r -> r.getValue().getName(), r -> r.getValue().getValue())
+        .containsExactly("foo", "\"bar\"");
+  }
+
+  private static void assertMessageIsCorrelated(
+      final Record<MessageCorrelationRecordValue> record) {
+    Assertions.assertThat(record)
+        .hasIntent(MessageCorrelationIntent.CORRELATED)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.MESSAGE_CORRELATION);
+    Assertions.assertThat(record.getValue())
+        .hasCorrelationKey("correlationKey")
+        .hasName("messageName")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  private static void assertMessageIsNotCorrelated(
+      final Record<MessageCorrelationRecordValue> record) {
+    Assertions.assertThat(record)
+        .hasIntent(MessageCorrelationIntent.NOT_CORRELATED)
+        .hasRecordType(RecordType.EVENT)
+        .hasValueType(ValueType.MESSAGE_CORRELATION);
+    Assertions.assertThat(record.getValue())
+        .hasCorrelationKey("correlationKey")
+        .hasName("messageName")
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  }
+
+  private void deployProcessWithMessageStartEvent(final String processId) {
+    engine
+        .deployment()
+        .withXmlResource(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent()
+                .message("messageName")
+                .endEvent()
+                .done())
+        .deploy();
+  }
+
+  private void deployProcessWithMessageStartEvent() {
+    deployProcessWithMessageStartEvent("process");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
 import io.camunda.zeebe.engine.util.client.JobActivationClient;
 import io.camunda.zeebe.engine.util.client.JobClient;
+import io.camunda.zeebe.engine.util.client.MessageCorrelationClient;
 import io.camunda.zeebe.engine.util.client.ProcessInstanceClient;
 import io.camunda.zeebe.engine.util.client.PublishMessageClient;
 import io.camunda.zeebe.engine.util.client.ResourceDeletionClient;
@@ -283,6 +284,10 @@ public final class EngineRule extends ExternalResource {
 
   public PublishMessageClient message() {
     return new PublishMessageClient(environmentRule, partitionCount);
+  }
+
+  public MessageCorrelationClient messageCorrelation() {
+    return new MessageCorrelationClient(environmentRule, partitionCount);
   }
 
   public VariableClient variables() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.impl.encoding.MsgPackConverter;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
+import io.camunda.zeebe.test.util.MsgPackUtil;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import java.util.function.Function;
+import org.agrona.DirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+
+public final class MessageCorrelationClient {
+  private static final Function<Message, Record<MessageCorrelationRecordValue>>
+      SUCCESSFUL_EXPECTATION =
+          (message) ->
+              RecordingExporter.messageCorrelationRecords(MessageCorrelationIntent.CORRELATED)
+                  .withPartitionId(message.partitionId)
+                  .withCorrelationKey(message.correlationKey)
+                  .getFirst();
+
+  private static final Function<Message, Record<MessageCorrelationRecordValue>> NOT_CORRELATED =
+      (message) ->
+          RecordingExporter.messageCorrelationRecords(MessageCorrelationIntent.NOT_CORRELATED)
+              .withPartitionId(message.partitionId)
+              .withCorrelationKey(message.correlationKey)
+              .getFirst();
+  private static final int NOT_SET = -1;
+  private final MessageCorrelationRecord messageCorrelationRecord;
+  private final CommandWriter writer;
+  private final int partitionCount;
+  private Function<Message, Record<MessageCorrelationRecordValue>> expectation =
+      SUCCESSFUL_EXPECTATION;
+  private int partitionId = NOT_SET;
+
+  public MessageCorrelationClient(final CommandWriter environmentRule, final int partitionCount) {
+    writer = environmentRule;
+    this.partitionCount = partitionCount;
+    messageCorrelationRecord = new MessageCorrelationRecord();
+  }
+
+  public MessageCorrelationClient withName(final String name) {
+    messageCorrelationRecord.setName(name);
+    return this;
+  }
+
+  public MessageCorrelationClient withCorrelationKey(final String correlationKey) {
+    messageCorrelationRecord.setCorrelationKey(correlationKey);
+    return this;
+  }
+
+  public MessageCorrelationClient withVariables(final Map<String, Object> variables) {
+    return withVariables(MsgPackUtil.asMsgPack(variables));
+  }
+
+  public MessageCorrelationClient withVariables(final DirectBuffer variables) {
+    messageCorrelationRecord.setVariables(variables);
+    return this;
+  }
+
+  public MessageCorrelationClient withVariables(final String variables) {
+    messageCorrelationRecord.setVariables(
+        new UnsafeBuffer(MsgPackConverter.convertToMsgPack(variables)));
+    return this;
+  }
+
+  public MessageCorrelationClient withTenantId(final String tenantId) {
+    messageCorrelationRecord.setTenantId(tenantId);
+    return this;
+  }
+
+  public MessageCorrelationClient onPartition(final int partitionId) {
+    this.partitionId = partitionId;
+    return this;
+  }
+
+  public MessageCorrelationClient expectNotCorrelated() {
+    expectation = NOT_CORRELATED;
+    return this;
+  }
+
+  public Record<MessageCorrelationRecordValue> correlate() {
+
+    if (partitionId == NOT_SET) {
+      partitionId =
+          SubscriptionUtil.getSubscriptionPartitionId(
+              messageCorrelationRecord.getCorrelationKeyBuffer(), partitionCount);
+    }
+
+    final var position =
+        writer.writeCommandOnPartition(
+            partitionId, MessageCorrelationIntent.CORRELATE, messageCorrelationRecord);
+    return expectation.apply(
+        new Message(messageCorrelationRecord.getCorrelationKey(), position, partitionId));
+  }
+
+  private record Message(String correlationKey, long position, int partitionId) {}
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/message/MessageCorrelationRecord.java
@@ -67,6 +67,16 @@ public final class MessageCorrelationRecord extends UnifiedRecordValue
     return this;
   }
 
+  @JsonIgnore
+  public DirectBuffer getNameBuffer() {
+    return nameProp.getValue();
+  }
+
+  @JsonIgnore
+  public DirectBuffer getCorrelationKeyBuffer() {
+    return correlationKeyProp.getValue();
+  }
+
   @Override
   public Map<String, Object> getVariables() {
     return MsgPackConverter.convertToMap(variablesProp.getValue());

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -143,6 +143,8 @@ public interface Intent {
         return ProcessInstanceMigrationIntent.from(intent);
       case COMPENSATION_SUBSCRIPTION:
         return CompensationSubscriptionIntent.from(intent);
+      case MESSAGE_CORRELATION:
+        return MessageCorrelationIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageCorrelationRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/MessageCorrelationRecordStream.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
+import java.util.stream.Stream;
+
+public final class MessageCorrelationRecordStream
+    extends ExporterRecordStream<MessageCorrelationRecordValue, MessageCorrelationRecordStream> {
+
+  public MessageCorrelationRecordStream(
+      final Stream<Record<MessageCorrelationRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected MessageCorrelationRecordStream supply(
+      final Stream<Record<MessageCorrelationRecordValue>> wrappedStream) {
+    return new MessageCorrelationRecordStream(wrappedStream);
+  }
+
+  public MessageCorrelationRecordStream withName(final String name) {
+    return valueFilter(v -> name.equals(v.getName()));
+  }
+
+  public MessageCorrelationRecordStream withCorrelationKey(final String correlationKey) {
+    return valueFilter(v -> correlationKey.equals(v.getCorrelationKey()));
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
@@ -45,6 +46,7 @@ import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobBatchRecordValue;
 import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageBatchRecordValue;
+import io.camunda.zeebe.protocol.record.value.MessageCorrelationRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageStartEventSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.MessageSubscriptionRecordValue;
@@ -179,6 +181,16 @@ public final class RecordingExporter implements Exporter {
   public static MessageStartEventSubscriptionRecordStream messageStartEventSubscriptionRecords(
       final MessageStartEventSubscriptionIntent intent) {
     return messageStartEventSubscriptionRecords().withIntent(intent);
+  }
+
+  public static MessageCorrelationRecordStream messageCorrelationRecords() {
+    return new MessageCorrelationRecordStream(
+        records(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecordValue.class));
+  }
+
+  public static MessageCorrelationRecordStream messageCorrelationRecords(
+      final MessageCorrelationIntent intent) {
+    return messageCorrelationRecords().withIntent(intent);
   }
 
   public static DeploymentRecordStream deploymentRecords() {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/ReusableObjectList.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/ReusableObjectList.java
@@ -62,9 +62,7 @@ public final class ReusableObjectList<T extends Reusable> implements Iterable<T>
   }
 
   public T poll() {
-    for (int i = 0; i < elements.size(); i++) {
-      final ReusableElement element = elements.get(i);
-
+    for (final ReusableElement element : elements) {
       if (element.isSet()) {
         element.set(false);
         size -= 1;
@@ -76,9 +74,7 @@ public final class ReusableObjectList<T extends Reusable> implements Iterable<T>
   }
 
   public T peek() {
-    for (int i = 0; i < elements.size(); i++) {
-      final ReusableElement element = elements.get(i);
-
+    for (final ReusableElement element : elements) {
       if (element.isSet()) {
         return element.getElement();
       }

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/ReusableObjectList.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/collection/ReusableObjectList.java
@@ -75,6 +75,17 @@ public final class ReusableObjectList<T extends Reusable> implements Iterable<T>
     return null;
   }
 
+  public T peek() {
+    for (int i = 0; i < elements.size(); i++) {
+      final ReusableElement element = elements.get(i);
+
+      if (element.isSet()) {
+        return element.getElement();
+      }
+    }
+    return null;
+  }
+
   public int size() {
     return size;
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

This processor will handle the `MessageCorrelation.CORRELATE` command. It will write the events that are already known from the existing `Message.PUBLISH` command. What's different is that this will send a response back to the client. 

- If it finds a message start event subscription it will respond with the process instance key of the first process instance it has found.
- If it finds only a message subscription it will correlate is as usual. There is no response yet. This is part of a later issue.
- If it finds no subscriptions it will respond with a `NOT_CORRELATED` event.


Note: I worked test driven and got too excited. Some of the tests I wrote won't succeed until I've implemented some other features. I've added an ignore to those for now.

## Related issues

closes #20173
