### PR TITLE
Upgrade to rocksdb 9.4.0

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -80,7 +80,7 @@
     <version.protobuf>3.25.3</version.protobuf>
     <version.protobuf-common>2.41.0</version.protobuf-common>
     <version.micrometer>1.13.2</version.micrometer>
-    <version.rocksdbjni>8.11.4</version.rocksdbjni>
+    <version.rocksdbjni>9.4.0</version.rocksdbjni>
     <version.sbe>1.31.1</version.sbe>
     <version.scala>2.13.14</version.scala>
     <version.slf4j>2.0.13</version.slf4j>

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/transaction/ZeebeTransaction.java
@@ -49,7 +49,6 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
       final int keyOffset = 0;
       final int valueOffset = 0;
       RocksDbInternal.putWithHandle.invokeExact(
-          transaction,
           nativeHandle,
           key,
           keyOffset,
@@ -74,13 +73,7 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
       final int keyOffset = 0;
       return (byte[])
           RocksDbInternal.getWithHandle.invokeExact(
-              transaction,
-              nativeHandle,
-              readOptionsHandle,
-              key,
-              keyOffset,
-              keyLength,
-              columnFamilyHandle);
+              nativeHandle, readOptionsHandle, key, keyOffset, keyLength, columnFamilyHandle);
     } catch (final Throwable e) {
       LangUtil.rethrowUnchecked(e);
       return null; // unreachable
@@ -91,7 +84,7 @@ public class ZeebeTransaction implements ZeebeDbTransaction, AutoCloseable {
       throws Exception {
     try {
       RocksDbInternal.removeWithHandle.invokeExact(
-          transaction, nativeHandle, key, keyLength, columnFamilyHandle, false);
+          nativeHandle, key, keyLength, columnFamilyHandle, false);
     } catch (final Throwable e) {
       LangUtil.rethrowUnchecked(e);
     }


### PR DESCRIPTION
## Description

Upgrading rocksDB to 9.4.0 and fix all broken APIs as a result of the private reflected methods being changed from non-static to static. 

## Related issues

closes #19981 
