### PR TITLE
[Backport stable/8.5] Detect duplicate InstallRequests correctly

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -115,7 +115,31 @@ public class PassiveRole extends InactiveRole {
     logRequest(request);
     updateTermAndLeader(request.currentTerm(), request.leader());
 
-    log.debug("Received snapshot {} chunk from {}", request.index(), request.leader());
+    final var snapshotChunk = new SnapshotChunkImpl();
+    final var snapshotChunkBuffer = new UnsafeBuffer(request.data());
+    if (!snapshotChunk.tryWrap(snapshotChunkBuffer)) {
+      abortPendingSnapshots();
+      return CompletableFuture.completedFuture(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(RaftResponse.Status.ERROR)
+                  .withError(RaftError.Type.APPLICATION_ERROR, "Failed to parse request data")
+                  .build()));
+    }
+
+    log.debug(
+        "Received snapshot chunk {} of snapshot {} from {}",
+        snapshotChunk.getChunkName(),
+        snapshotChunk.getSnapshotId(),
+        request.leader());
+
+    if (pendingSnapshot != null
+        && !pendingSnapshot
+            .snapshotId()
+            .getSnapshotIdAsString()
+            .equals(snapshotChunk.getSnapshotId())) {
+      abortPendingSnapshots();
+    }
 
     // If the request is for a lesser term, reject the request.
     if (request.currentTerm() < raft.getTerm()) {
@@ -167,18 +191,6 @@ public class PassiveRole extends InactiveRole {
                   .withError(
                       RaftError.Type.PROTOCOL_ERROR,
                       "Snapshot installation is not complete but did not provide any next expected chunk")
-                  .build()));
-    }
-
-    final var snapshotChunk = new SnapshotChunkImpl();
-    final var snapshotChunkBuffer = new UnsafeBuffer(request.data());
-    if (!snapshotChunk.tryWrap(snapshotChunkBuffer)) {
-      abortPendingSnapshots();
-      return CompletableFuture.completedFuture(
-          logResponse(
-              InstallResponse.builder()
-                  .withStatus(RaftResponse.Status.ERROR)
-                  .withError(RaftError.Type.APPLICATION_ERROR, "Failed to parse request data")
                   .build()));
     }
 

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/roles/PassiveRole.java
@@ -52,6 +52,11 @@ import io.camunda.zeebe.journal.JournalException.InvalidIndex;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
+<<<<<<< HEAD
+=======
+import io.camunda.zeebe.snapshots.impl.SnapshotChunkId;
+import io.camunda.zeebe.util.Either;
+>>>>>>> 9570f757 (refactor: extract verification of InstallRequest)
 import io.camunda.zeebe.util.logging.ThrottledLogger;
 import java.nio.ByteBuffer;
 import java.time.Duration;
@@ -133,6 +138,12 @@ public class PassiveRole extends InactiveRole {
         snapshotChunk.getSnapshotId(),
         request.leader());
 
+    // If a snapshot is currently being received and the snapshot versions don't match, simply
+    // close the existing snapshot. This is a naive implementation that assumes that the leader
+    // will be responsible in sending the correct snapshot to this server. Leaders must dictate
+    // where snapshots must be sent since entries can still legitimately exist prior to the
+    // snapshot, and so snapshots aren't simply sent at the beginning of the follower's log, but
+    // rather the leader dictates when a snapshot needs to be sent.
     if (pendingSnapshot != null
         && !pendingSnapshot
             .snapshotId()
@@ -141,6 +152,7 @@ public class PassiveRole extends InactiveRole {
       abortPendingSnapshots();
     }
 
+<<<<<<< HEAD
     // If the request is for a lesser term, reject the request.
     if (request.currentTerm() < raft.getTerm()) {
       return CompletableFuture.completedFuture(
@@ -193,6 +205,16 @@ public class PassiveRole extends InactiveRole {
                       "Snapshot installation is not complete but did not provide any next expected chunk")
                   .build()));
     }
+=======
+    // Validate the request and return if the request should not be processed further.
+    final var preProcessed = preProcessInstallRequest(request);
+    if (preProcessed.isLeft()) {
+      // The request is either rejected or skip processing with a success response
+      return CompletableFuture.completedFuture(preProcessed.getLeft());
+    }
+
+    // Process the request
+>>>>>>> 9570f757 (refactor: extract verification of InstallRequest)
 
     // If there is no pending snapshot, create a new snapshot.
     if (pendingSnapshot == null) {
@@ -444,6 +466,89 @@ public class PassiveRole extends InactiveRole {
                 .withError(
                     RaftError.Type.ILLEGAL_MEMBER_STATE, "Cannot request vote from RESERVE member")
                 .build()));
+  }
+
+  // validates install request and returns a response if the request should not be processed
+  // further.
+  private Either<InstallResponse, Void> preProcessInstallRequest(final InstallRequest request) {
+    if (Objects.equals(request.chunkId(), previouslyReceivedSnapshotChunkId)) {
+      // Duplicate request for the same chunk that was previously processed
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.OK)
+                  .withPreferredChunkSize(snapshotChunkSize)
+                  .build()));
+    }
+
+    // if null assume it is first chunk of file
+    if (nextPendingSnapshotChunkId != null
+        && !nextPendingSnapshotChunkId.equals(request.chunkId())) {
+      final var errMsg =
+          "Expected chunkId of ["
+              + new SnapshotChunkId(nextPendingSnapshotChunkId)
+              + "] got ["
+              + new SnapshotChunkId(request.chunkId())
+              + "].";
+      abortPendingSnapshots();
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(Type.ILLEGAL_MEMBER_STATE, errMsg)
+                  .build()));
+    }
+
+    // If the request is for a lesser term, reject the request.
+    if (request.currentTerm() < raft.getTerm()) {
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(
+                      Type.ILLEGAL_MEMBER_STATE,
+                      "Request term is less than the local term " + request.currentTerm())
+                  .build()));
+    }
+
+    // If the index has already been applied, we have enough state to populate the state machine up
+    // to this index.
+    // Skip the snapshot and response successfully.
+    if (raft.getCommitIndex() > request.index()) {
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.OK)
+                  .withPreferredChunkSize(snapshotChunkSize)
+                  .build()));
+    }
+
+    // If the snapshot already exists locally, do not overwrite it with a replicated snapshot.
+    // Simply reply to the request successfully.
+    final var latestIndex = raft.getCurrentSnapshotIndex();
+    if (latestIndex >= request.index()) {
+      abortPendingSnapshots();
+
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.OK)
+                  .withPreferredChunkSize(snapshotChunkSize)
+                  .build()));
+    }
+
+    if (!request.complete() && request.nextChunkId() == null) {
+      abortPendingSnapshots();
+      return Either.left(
+          logResponse(
+              InstallResponse.builder()
+                  .withStatus(Status.ERROR)
+                  .withError(
+                      Type.PROTOCOL_ERROR,
+                      "Snapshot installation is not complete but did not provide any next expected chunk")
+                  .build()));
+    }
+    return Either.right(null);
   }
 
   private CompletableFuture<InstallResponse> failIfSnapshotAlreadyExists(


### PR DESCRIPTION
# Description
Backport of #20214 to `stable/8.5`.

relates to #19862
original author: @deepthidevaki