### PR TITLE
ci: skip optimize-upgrade docker when testing

### DIFF
--- a/optimize/upgrade/pom.xml
+++ b/optimize/upgrade/pom.xml
@@ -10,6 +10,10 @@
 
   <artifactId>upgrade-optimize</artifactId>
 
+  <properties>
+    <skip.docker>${skipTests}</skip.docker>
+  </properties>
+
   <dependencies>
 
     <!-- Optimize dependencies -->


### PR DESCRIPTION
## Description

With this PR, we avoid launching the `docker compose up` command that starts the elasticseach container of the optimize-upgrade module, as this conflicts with the build environment of other teams.
