### PR TITLE
fix: Tasklist index prefixes are not correctly setup on OpenSearch

### DIFF
--- a/tasklist/common/pom.xml
+++ b/tasklist/common/pom.xml
@@ -275,6 +275,12 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/tasklist/common/src/main/java/io/camunda/tasklist/util/SpringContextHolder.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/util/SpringContextHolder.java
@@ -28,6 +28,17 @@ public class SpringContextHolder implements ApplicationContextAware {
     return context.getBean(beanClass);
   }
 
+  /**
+   * Retrieves the property value associated with the given key from Spring's application context
+   * environment.
+   *
+   * @param key The key whose associated value is to be retrieved.
+   * @return The value associated with the specified key, or null if the key is not found.
+   */
+  public static String getProperty(String key) {
+    return context.getEnvironment().getProperty(key);
+  }
+
   @Override
   public void setApplicationContext(ApplicationContext context) throws BeansException {
     // store ApplicationContext reference to access required beans later on

--- a/tasklist/common/src/main/java/io/camunda/tasklist/util/TasklistPropertiesUtil.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/util/TasklistPropertiesUtil.java
@@ -9,17 +9,25 @@ package io.camunda.tasklist.util;
 
 public final class TasklistPropertiesUtil {
 
-  private static final String DATABASE_PROPERTY_NAME = "camunda.tasklist.database";
+  public static final String DATABASE_PROPERTY_NAME = "camunda.tasklist.database";
+  private static volatile Boolean isOpenSearchDatabaseCache = null;
 
   private TasklistPropertiesUtil() {
     /*utility class*/
   }
 
-  public static String getTasklistDatabase() {
-    return System.getProperty(DATABASE_PROPERTY_NAME, System.getenv(DATABASE_PROPERTY_NAME));
+  public static boolean isOpenSearchDatabase() {
+    if (isOpenSearchDatabaseCache == null) {
+      synchronized (TasklistPropertiesUtil.class) {
+        if (isOpenSearchDatabaseCache == null) {
+          isOpenSearchDatabaseCache = "opensearch".equalsIgnoreCase(getTasklistDatabase());
+        }
+      }
+    }
+    return Boolean.TRUE.equals(isOpenSearchDatabaseCache);
   }
 
-  public static boolean isOpenSearchDatabase() {
-    return "opensearch".equalsIgnoreCase(TasklistPropertiesUtil.getTasklistDatabase());
+  private static String getTasklistDatabase() {
+    return SpringContextHolder.getProperty(DATABASE_PROPERTY_NAME);
   }
 }

--- a/tasklist/common/src/test/java/io/camunda/tasklist/util/TasklistPropertiesUtilTest.java
+++ b/tasklist/common/src/test/java/io/camunda/tasklist/util/TasklistPropertiesUtilTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.tasklist.util;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.Field;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = SpringContextHolder.class)
+public class TasklistPropertiesUtilTest {
+
+  @AfterEach
+  public void clearCache() throws Exception {
+    final Field field = TasklistPropertiesUtil.class.getDeclaredField("isOpenSearchDatabaseCache");
+    field.setAccessible(true);
+    field.set(null, null);
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.tasklist.database=opensearch"})
+  class OpenSearchDatabaseTests {
+
+    @Test
+    public void testIsOpenSearchDatabaseWhenTrue() {
+      assertTrue(TasklistPropertiesUtil.isOpenSearchDatabase());
+    }
+  }
+
+  @Nested
+  @TestPropertySource(properties = {"camunda.tasklist.database=elasticsearch"})
+  class ElasticSearchDatabaseTests {
+
+    @Test
+    public void testIsOpenSearchDatabaseWhenFalse() {
+      assertFalse(TasklistPropertiesUtil.isOpenSearchDatabase());
+    }
+  }
+}

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/TaskStoreElasticSearchTest.java
@@ -25,6 +25,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.queries.TaskQuery;
 import io.camunda.tasklist.schema.templates.TaskTemplate;
 import io.camunda.tasklist.tenant.TenantAwareElasticsearchClient;
+import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.views.TaskSearchView;
 import java.io.IOException;
 import java.util.List;
@@ -38,12 +39,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -57,11 +60,15 @@ class TaskStoreElasticSearchTest {
 
   @Spy private ObjectMapper objectMapper = CommonUtils.OBJECT_MAPPER;
 
+  @Spy private SpringContextHolder springContextHolder;
+
   @InjectMocks private TaskStoreElasticSearch instance;
 
   @BeforeEach
   public void setUp() {
     ReflectionTestUtils.setField(taskTemplate, "tasklistProperties", new TasklistProperties());
+    springContextHolder.setApplicationContext(
+        mock(ApplicationContext.class, Answers.RETURNS_DEEP_STUBS));
   }
 
   @ParameterizedTest

--- a/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearchTest.java
+++ b/tasklist/els-schema/src/test/java/io/camunda/tasklist/store/elasticsearch/VariableStoreElasticSearchTest.java
@@ -22,6 +22,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.schema.indices.FlowNodeInstanceIndex;
 import io.camunda.tasklist.schema.indices.VariableIndex;
 import io.camunda.tasklist.schema.templates.TaskVariableTemplate;
+import io.camunda.tasklist.util.SpringContextHolder;
 import java.util.List;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -33,12 +34,14 @@ import org.elasticsearch.search.SearchHits;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Answers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,6 +54,7 @@ class VariableStoreElasticSearchTest {
   @Spy private TaskVariableTemplate taskVariableTemplate = new TaskVariableTemplate();
   @Spy private TasklistProperties tasklistProperties = new TasklistProperties();
   @Spy private ObjectMapper objectMapper = CommonUtils.OBJECT_MAPPER;
+  @Spy private SpringContextHolder springContextHolder;
   @InjectMocks private VariableStoreElasticSearch instance;
 
   @BeforeEach
@@ -58,6 +62,8 @@ class VariableStoreElasticSearchTest {
     ReflectionTestUtils.setField(taskVariableTemplate, "tasklistProperties", tasklistProperties);
     ReflectionTestUtils.setField(variableIndex, "tasklistProperties", tasklistProperties);
     ReflectionTestUtils.setField(flowNodeInstanceIndex, "tasklistProperties", tasklistProperties);
+    springContextHolder.setApplicationContext(
+        mock(ApplicationContext.class, Answers.RETURNS_DEEP_STUBS));
   }
 
   @Test

--- a/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
+++ b/tasklist/qa/backup-restore-tests/src/test/java/io/camunda/tasklist/qa/backup/BackupRestoreTest.java
@@ -15,6 +15,7 @@ import io.camunda.tasklist.exceptions.TasklistRuntimeException;
 import io.camunda.tasklist.qa.backup.generator.BackupRestoreDataGenerator;
 import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
 import io.camunda.tasklist.qa.util.TestContainerUtil;
+import io.camunda.tasklist.util.SpringContextHolder;
 import io.camunda.tasklist.util.TasklistPropertiesUtil;
 import io.camunda.tasklist.webapp.management.dto.TakeBackupResponseDto;
 import io.camunda.zeebe.client.ZeebeClient;
@@ -41,7 +42,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.GenericContainer;
@@ -291,5 +294,7 @@ public class BackupRestoreTest {
       "io.camunda.tasklist.qa.backup",
       "io.camunda.tasklist.webapp.graphql.entity",
       "io.camunda.tasklist.qa.util.rest"
-    })
+    },
+    includeFilters =
+        @Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SpringContextHolder.class))
 class TestConfig {}

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/StartupIT.java
@@ -13,6 +13,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd;
 import io.camunda.tasklist.qa.util.ContainerVersionsUtil;
 import io.camunda.tasklist.qa.util.TestContainerUtil;
 import io.camunda.tasklist.qa.util.TestContext;
+import io.camunda.tasklist.util.SpringContextHolder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -23,12 +24,14 @@ import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 
 @ExtendWith(SpringExtension.class)
 @EnabledIfSystemProperty(named = "spring.profiles.active", matches = "docker-test")
+@ContextConfiguration(classes = SpringContextHolder.class)
 public class StartupIT {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StartupIT.class);

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/SessionlessTasklistZeebeIntegrationTest.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/SessionlessTasklistZeebeIntegrationTest.java
@@ -40,7 +40,6 @@ import org.springframework.core.annotation.Order;
 import org.springframework.test.util.ReflectionTestUtils;
 
 public abstract class SessionlessTasklistZeebeIntegrationTest extends TasklistIntegrationTest {
-  public static final Boolean IS_ELASTIC = !TasklistPropertiesUtil.isOpenSearchDatabase();
 
   @Autowired public BeanFactory beanFactory;
 

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestApplication.java
@@ -43,7 +43,7 @@ public class TestApplication {
   @Bean(name = "dataGenerator")
   @ConditionalOnMissingBean
   public DataGenerator stubDataGenerator() {
-    return TasklistZeebeIntegrationTest.IS_ELASTIC
+    return TestUtil.isElasticSearch()
         ? new DevDataGeneratorElasticSearch()
         : new DevDataGeneratorOpenSearch();
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestUtil.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/TestUtil.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.tasklist.util;
 
+import static io.camunda.tasklist.util.TasklistPropertiesUtil.DATABASE_PROPERTY_NAME;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
@@ -82,10 +84,10 @@ public abstract class TestUtil {
   }
 
   public static boolean isElasticSearch() {
-    return !TasklistPropertiesUtil.isOpenSearchDatabase();
+    return !isOpenSearch();
   }
 
   public static boolean isOpenSearch() {
-    return TasklistPropertiesUtil.isOpenSearchDatabase();
+    return "opensearch".equalsIgnoreCase(System.getProperty(DATABASE_PROPERTY_NAME));
   }
 }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/apps/modules/ModulesTestApplication.java
@@ -12,8 +12,8 @@ import io.camunda.tasklist.archiver.security.ArchiverSecurityModuleConfiguration
 import io.camunda.tasklist.data.DataGenerator;
 import io.camunda.tasklist.data.es.DevDataGeneratorElasticSearch;
 import io.camunda.tasklist.data.os.DevDataGeneratorOpenSearch;
-import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
 import io.camunda.tasklist.util.TestApplication;
+import io.camunda.tasklist.util.TestUtil;
 import io.camunda.tasklist.webapp.management.WebappManagementModuleConfiguration;
 import io.camunda.tasklist.webapp.security.WebappSecurityModuleConfiguration;
 import io.camunda.tasklist.zeebeimport.security.ImporterSecurityModuleConfiguration;
@@ -69,7 +69,7 @@ public class ModulesTestApplication {
   @Bean(name = "dataGenerator")
   @ConditionalOnMissingBean
   public DataGenerator stubDataGenerator() {
-    return TasklistZeebeIntegrationTest.IS_ELASTIC
+    return TestUtil.isElasticSearch()
         ? new DevDataGeneratorElasticSearch()
         : new DevDataGeneratorOpenSearch();
   }

--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportWithMissedDataIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/zeebeimport/ZeebeImportWithMissedDataIT.java
@@ -13,6 +13,7 @@ import io.camunda.tasklist.property.TasklistProperties;
 import io.camunda.tasklist.queries.TaskQuery;
 import io.camunda.tasklist.store.TaskStore;
 import io.camunda.tasklist.util.TasklistZeebeIntegrationTest;
+import io.camunda.tasklist.util.TestUtil;
 import io.camunda.tasklist.util.ZeebeTestUtil;
 import io.camunda.tasklist.views.TaskSearchView;
 import io.camunda.zeebe.protocol.Protocol;
@@ -38,7 +39,7 @@ public class ZeebeImportWithMissedDataIT extends TasklistZeebeIntegrationTest {
   @DynamicPropertySource
   protected static void registerProperties(final DynamicPropertyRegistry registry) {
     // make batch size smaller
-    if (IS_ELASTIC) {
+    if (TestUtil.isElasticSearch()) {
       registry.add(
           TasklistProperties.PREFIX + ".zeebeElasticsearch.batchSize", () -> IMPORTER_BATCH_SIZE);
     } else {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->
Fixes the following issue reported with helm deployement when setting different index prefix in Opensearch

- to get the prefix to be used for indices, Tasklist uses [TasklistOpenSearchProperties](https://github.com/camunda/camunda/blob/main/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistOpenSearchProperties.java) or [TasklistElasticSearchProperties](https://github.com/camunda/camunda/blob/main/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java), depending if Opensearch database is used or not
- Tasklist [reads](https://github.com/camunda/camunda/blob/5d2d5eeb723ac946547b5b8e8548cdeba48c1250/tasklist/common/src/main/java/io/camunda/tasklist/util/TasklistPropertiesUtil.java#L19) `camunda.tasklist.database` system property or system env parameter to know if opensearch being used
- in the helm charts, `camunda.tasklist.database` is defined inside application.yml key in a configMap. Which is read a spring property and not system property.
- `getTasklistDatabase()` returns null, and Tasklist defaults [TasklistElasticSearchProperties](https://github.com/camunda/camunda/blob/main/tasklist/common/src/main/java/io/camunda/tasklist/property/TasklistElasticsearchProperties.java), in which the index prefix is the default one (tasklist) and not the one defined in `CAMUNDA_TASKLIST_OPENSEARCH_INDEXPREFIX`
- The indices are created with tasklist prefix

In this pull request:
- read `camunda.tasklist.database` as spring property
- cache `isOpensearchDatabase`, as it is static, to avoid multiple calls to `applicationContext.getEnvironment().getProperty()`
## Related issues

closes #19905 

This needs to be backported to 8.5 and 8.4 (Opensearch was officially supported since 8.4)
