### PR TITLE
fix: instrument all on:push workflows to send CI health metrics

### DIFF
--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -46,3 +46,12 @@ jobs:
           name: Playwright report
           path: operate/client/playwright-report/
           retention-days: 30
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-build-observe-reusable.yml
+++ b/.github/workflows/operate-ci-build-observe-reusable.yml
@@ -71,3 +71,13 @@ jobs:
       - name: Build Maven
         run: |
           ${{ inputs.command }}
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -73,7 +73,6 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
-            secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/operate/ci/github-actions REGISTRY_HUB_DOCKER_COM_PSW;
             secret/data/products/operate/ci/github-actions OPERATE_CI_ALERT_WEBHOOK_URL;
@@ -145,8 +144,12 @@ jobs:
 
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics
-      - uses: camunda/infra-global-github-actions/submit-build-status@main
-        if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
         with:
-          build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
-          gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-ci-test-reusable.yml
+++ b/.github/workflows/operate-ci-test-reusable.yml
@@ -115,3 +115,13 @@ jobs:
               "github_run_url": "https://github.com/camunda/camunda/actions/runs/${{ github.run_id }}",
               "branch": "${{ github.head_ref || github.ref_name }}"
             }
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -105,3 +105,13 @@ jobs:
         uses: ./.github/actions/collect-operate-test-artifacts
         with:
           name: "docker tests"
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -131,3 +131,13 @@ jobs:
           name: Playwright report
           path: operate/client/playwright-report/
           retention-days: 30
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -35,3 +35,13 @@ jobs:
         name: ESLint
       - run: yarn test:ci
         name: Unit & Integration tests
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -50,3 +50,13 @@ jobs:
           name: Playwright report
           path: operate/client/playwright-report/
           retention-days: 30
+
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -73,7 +73,6 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
-            secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
             secret/data/products/tasklist/ci/tasklist REGISTRY_HUB_DOCKER_COM_USR;
             secret/data/products/tasklist/ci/tasklist REGISTRY_HUB_DOCKER_COM_PSW;
 
@@ -148,8 +147,12 @@ jobs:
 
       #########################################################################
       # Collect information about build status for central statistics with CI Analytics
-      - uses: camunda/infra-global-github-actions/submit-build-status@main
-        if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
         with:
-          build_status: "${{ contains(steps.*.outcome, 'failure') && 'failure' || 'success' }}"
-          gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -21,6 +21,15 @@ jobs:
         name: Install dependencies
       - run: yarn ts-check
         name: Type checks
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   fe-eslint:
     name: ESLint
@@ -39,6 +48,15 @@ jobs:
         name: Install dependencies
       - run: yarn eslint
         name: ESLint
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   fe-stylelint:
     name: Stylelint
@@ -57,6 +75,15 @@ jobs:
         name: Install dependencies
       - run: yarn stylelint
         name: Stylelint
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   fe-tests:
     name: Tests
@@ -75,6 +102,15 @@ jobs:
         name: Install dependencies
       - run: yarn test:ci
         name: Unit & Integration tests
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   fe-visual-regression-tests:
     name: Visual regression tests
@@ -108,6 +144,15 @@ jobs:
           name: visual-regression-report
           path: tasklist/client/playwright-report/
           retention-days: 30
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
 
   fe-a11y-tests:
     name: a11y tests
@@ -141,3 +186,12 @@ jobs:
           name: a11y-report
           path: tasklist/client/playwright-report/
           retention-days: 30
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-ci-test-reusable.yml
+++ b/.github/workflows/tasklist-ci-test-reusable.yml
@@ -103,3 +103,14 @@ jobs:
           name: jacoco-report-${{ steps.sanitize.outputs.branch_name }}-${{ matrix.database }}
           path: ${{ github.workspace }}/test-coverage/target/site/jacoco-aggregate/
           retention-days: 2
+
+      # Send metrics about CI health
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -109,3 +109,12 @@ jobs:
         uses: ./.github/actions/collect-tasklist-test-artifacts
         with:
           name: "docker tests"
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -133,3 +133,12 @@ jobs:
           name: Playwright report
           path: tasklist/client/playwright-report/
           retention-days: 30
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}


### PR DESCRIPTION
## Description

This PR makes all GHA workflows running `on: push` to `main` or other persistent branches integrate with [CI health metrics collection](https://github.com/camunda/camunda/wiki/CI-&-Automation#ci-health-metrics). This works towards the goal of https://github.com/camunda/camunda/issues/18210

The following BigQuery query can be used to check the availability of metrics for this specific PR:

```
SELECT *
FROM `ci-30-162810.prod_ci_analytics.build_status_v2`
WHERE ci_url="https://github.com/camunda/camunda" AND build_ref="refs/pull/20284/merge"
ORDER BY report_time DESC
LIMIT 100
```

Given those results it is working so far:

![image](https://github.com/user-attachments/assets/b1e2d3f5-8696-4ebb-8ff8-b34086fcc146)

## Related issues

Related to #18210 
