### PR TITLE
ci: add java client reminder workflow

### DIFF
--- a/.github/workflows/java-client-reminder.yaml
+++ b/.github/workflows/java-client-reminder.yaml
@@ -1,0 +1,35 @@
+name: Camunda Java Client reminder
+
+on:
+  pull_request
+
+jobs:
+  check-path-and-comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check for changes in 'clients/java'
+        id: check_changes
+        run: |
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q '^clients/java'; then
+            echo "changes=true" >> $GITHUB_ENV
+          else
+            echo "changes=false" >> $GITHUB_ENV
+          fi
+
+      - name: Add PR comment
+        uses: thollander/actions-comment-pull-request@v2
+        if: env.changes == 'true'
+        with:
+          message: |
+            :wave: :robot: :thinking: Hello! Did you make your changes in all the right places?
+
+            Is your changes in the java client a new feature ?
+              - If yes, please ensure that the changes are only in the `io.camunda.client` package
+
+            Is your changes a bug fix and need to be backported into previous stables ?
+              - If yes, please ensure that those changes are in both packages, `io.camunda.client` and `io.camunda.zeebe.client`
+


### PR DESCRIPTION
## Description

With this https://github.com/camunda/camunda/pull/20092 we introduce some structural changes to the java client:

In `io.camunda.client` there is the new Camunda Java Client with all the new features and fix that should be delivered in the next release
In `io.camunda.zeebe.client` there is the Zeebe Java Client (updated at the last stable version)
Why we took this decision ? Because we want to enable users to use the new client (and the new features) without changing all the codebase. Users can use the new functionalities (using the new `CamundaClient`) but they can still use the old `ZeebClient` without any problem.

This workflow is a reminder to ensure that people are informed

## Related issues

closes #20281 
