### PR TITLE
fix: enable CamundaServicesConfiguration on camunda.rest.enabled

### DIFF
--- a/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/commons/service/CamundaServicesConfiguration.java
@@ -22,8 +22,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnProperty(
-    prefix = "zeebe.broker.gateway",
-    name = "enable",
+    name = {"zeebe.broker.gateway.enable", "camunda.rest.enabled"},
     havingValue = "true",
     matchIfMissing = true)
 public class CamundaServicesConfiguration {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

In SaaS, tasklist-importer-archiver and operate-importer-archiver pods fail to start with 
`No qualifying bean of type 'io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler` 

`ActivateJobsHandler` beans, required by `CamundaServicesConfiguration`, are conditionned by `camunda.rest.enabled` set to true, see [JobHandlerConfiguration](https://github.com/camunda/camunda/blob/main/dist/src/main/java/io/camunda/commons/job/JobHandlerConfiguration.java#L29-L32)

In SaaS, we have tasklist-importer-archiver and operate-importer-archiver deployments having `camunda.rest.enabled` set to [false](https://github.com/camunda-cloud/camunda-operator/blob/e16ffaa6e60f4e5d77eda5c29c8eb0603735b713/templates/tasklist_deployment_importer_archiver.yaml#L53-L54)

In this pull request, I am aligning `CamundaServicesConfiguration` enablement with `JobHandlerConfiguration`'s (add check on `camunda.rest.enabled`)

## Related issues

closes https://github.com/camunda/camunda/issues/20283
