### PR TITLE
Create new version of every resource in multi-resource deployment if at least one has changed

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -137,7 +137,7 @@ var tests = []testCase{
 	{
 		name:       "evaluate decision with decision key",
 		setupCmds:  [][]string{strings.Fields("--insecure deploy resource testdata/drg-force-user.dmn")},
-		cmd:        strings.Fields("--insecure evaluate decision 2251799813685271 --variables {\"lightsaberColor\":\"blue\"}"),
+		cmd:        strings.Fields("--insecure evaluate decision 2251799813685272 --variables {\"lightsaberColor\":\"blue\"}"),
 		goldenFile: "testdata/evaluate_decision.golden",
 		jsonOutput: true,
 	},
@@ -217,7 +217,7 @@ var tests = []testCase{
 		setupCmds: [][]string{
 			strings.Fields("--insecure deploy resource testdata/model.bpmn"),
 		},
-		cmd:        strings.Fields("--insecure delete resource 2251799813685257"),
+		cmd:        strings.Fields("--insecure delete resource 2251799813685258"),
 		goldenFile: "testdata/delete_resource.golden",
 	},
 	{
@@ -236,7 +236,7 @@ var tests = []testCase{
 			strings.Fields("--insecure create instance jobProcess"),
 			strings.Fields("--insecure activate jobs jobType --maxJobsToActivate 1"),
 		},
-		cmd:        strings.Fields("--insecure update timeout 2251799813685371 --timeout 10000"),
+		cmd:        strings.Fields("--insecure update timeout 2251799813685372 --timeout 10000"),
 		goldenFile: "testdata/update_job_timeout.golden",
 	},
 }

--- a/clients/go/cmd/zbctl/testdata/delete_resource.golden
+++ b/clients/go/cmd/zbctl/testdata/delete_resource.golden
@@ -1,1 +1,1 @@
-Deleted resource with key '2251799813685257'
+Deleted resource with key '2251799813685258'

--- a/clients/go/cmd/zbctl/testdata/evaluate_decision.golden
+++ b/clients/go/cmd/zbctl/testdata/evaluate_decision.golden
@@ -1,5 +1,5 @@
 {
-  "decisionKey": "2251799813685271",
+  "decisionKey": "2251799813685272",
   "decisionId": "jedi_or_sith",
   "decisionName": "Jedi or Sith",
   "decisionVersion": 2,
@@ -8,7 +8,7 @@
   "decisionOutput": "\"Jedi\"",
   "evaluatedDecisions": [
       {
-      	"decisionKey": "2251799813685271",
+      	"decisionKey": "2251799813685272",
       	"decisionId": "jedi_or_sith",
       	"decisionName": "Jedi or Sith",
       	"decisionVersion": 2,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentResourceTransformer.java
@@ -15,13 +15,27 @@ import io.camunda.zeebe.util.Either;
 interface DeploymentResourceTransformer {
 
   /**
-   * Transform the given resource. As a result, the transformer should add the deployed resource to
-   * the deployment record and write an event for the resource (e.g. a process record).
+   * Step 1 of transforming the given resource: The transformer should add the deployed resource's
+   * metadata to the deployment record, but not write any event records yet.
    *
    * @param resource the resource to transform
    * @param deployment the deployment to add the deployed resource to
    * @return either {@link Either.Right} if the resource is transformed successfully, or {@link
    *     Either.Left} if the transformation failed
    */
-  Either<Failure, Void> transformResource(DeploymentResource resource, DeploymentRecord deployment);
+  Either<Failure, Void> createMetadata(
+      final DeploymentResource resource, final DeploymentRecord deployment);
+
+  /**
+   * Step 2 of transforming the given resource: The transformer should update the previously created
+   * metadata (if necessary) and eventually write the actual event record(s) (e.g. "process
+   * created").
+   *
+   * @param resource the resource to transform
+   * @param deployment the deployment record containing the metadata created in {@link
+   *     DeploymentResourceTransformer#createMetadata(DeploymentResource, DeploymentRecord)}
+   * @return either {@link Either.Right} if the resource is transformed successfully, or {@link
+   *     Either.Left} if the transformation failed
+   */
+  Either<Failure, Void> writeRecords(DeploymentResource resource, DeploymentRecord deployment);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DmnResourceTransformer.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.engine.processing.deployment.transform;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
-import static java.util.function.Predicate.not;
 
 import io.camunda.zeebe.dmn.DecisionEngine;
 import io.camunda.zeebe.dmn.DecisionEngineFactory;
@@ -20,7 +19,6 @@ import io.camunda.zeebe.engine.state.deployment.DeployedDrg;
 import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.immutable.DecisionState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsMetadataRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRequirementsRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentResource;
@@ -64,7 +62,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
   }
 
   @Override
-  public Either<Failure, Void> transformResource(
+  public Either<Failure, Void> createMetadata(
       final DeploymentResource resource, final DeploymentRecord deployment) {
 
     final var dmnResource = new ByteArrayInputStream(resource.getResource());
@@ -74,8 +72,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
       return checkForDuplicateIds(resource, parsedDrg, deployment)
           .map(
               noDuplicates -> {
-                final var drgKey = appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
-                writeRecords(deployment, resource, drgKey);
+                appendMetadataToDeploymentEvent(resource, parsedDrg, deployment);
                 return null;
               });
 
@@ -84,6 +81,74 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
           String.format("'%s': %s", resource.getResourceName(), parsedDrg.getFailureMessage());
       return Either.left(new Failure(failure));
     }
+  }
+
+  @Override
+  public Either<Failure, Void> writeRecords(
+      final DeploymentResource resource, final DeploymentRecord deployment) {
+    if (deployment.hasDuplicatesOnly()) {
+      return Either.right(null);
+    }
+    final var checksum = checksumGenerator.apply(resource.getResource());
+    deployment.decisionRequirementsMetadata().stream()
+        .filter(drg -> checksum.equals(drg.getChecksumBuffer()))
+        .findFirst()
+        .ifPresent(
+            drg -> {
+              var drgKey = drg.getDecisionRequirementsKey();
+              if (drg.isDuplicate()) {
+                // create new version as the deployment contains at least one other non-duplicate
+                // resource and all resources in a deployment should be versioned together
+                drgKey = keyGenerator.nextKey();
+                drg.setDecisionRequirementsKey(drgKey)
+                    .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion() + 1)
+                    .setDuplicate(false);
+              }
+              stateWriter.appendFollowUpEvent(
+                  drgKey,
+                  DecisionRequirementsIntent.CREATED,
+                  new DecisionRequirementsRecord()
+                      .setDecisionRequirementsKey(drgKey)
+                      .setDecisionRequirementsId(drg.getDecisionRequirementsId())
+                      .setDecisionRequirementsName(drg.getDecisionRequirementsName())
+                      .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
+                      .setNamespace(drg.getNamespace())
+                      .setResourceName(drg.getResourceName())
+                      .setChecksum(drg.getChecksumBuffer())
+                      .setResource(resource.getResourceBuffer())
+                      .setTenantId(drg.getTenantId()));
+
+              deployment.decisionsMetadata().stream()
+                  .filter(
+                      decision ->
+                          decision
+                              .getDecisionRequirementsId()
+                              .equals(drg.getDecisionRequirementsId()))
+                  .forEach(
+                      decision -> {
+                        var decisionKey = decision.getDecisionKey();
+                        if (decision.isDuplicate()) {
+                          decisionKey = keyGenerator.nextKey();
+                          decision
+                              .setDecisionKey(decisionKey)
+                              .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
+                              .setVersion(decision.getVersion() + 1)
+                              .setDuplicate(false);
+                        }
+                        stateWriter.appendFollowUpEvent(
+                            decisionKey,
+                            DecisionIntent.CREATED,
+                            new DecisionRecord()
+                                .setDecisionKey(decisionKey)
+                                .setDecisionId(decision.getDecisionId())
+                                .setDecisionName(decision.getDecisionName())
+                                .setVersion(decision.getVersion())
+                                .setDecisionRequirementsId(decision.getDecisionRequirementsId())
+                                .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
+                                .setTenantId(decision.getTenantId()));
+                      });
+            });
+    return Either.right(null);
   }
 
   private Either<Failure, ?> checkForDuplicateIds(
@@ -155,7 +220,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
         .orElse("<?>");
   }
 
-  private long appendMetadataToDeploymentEvent(
+  private void appendMetadataToDeploymentEvent(
       final DeploymentResource resource,
       final ParsedDecisionRequirementsGraph parsedDrg,
       final DeploymentRecord deploymentEvent) {
@@ -187,7 +252,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                 drgRecord
                     .setDecisionRequirementsKey(latestDrg.getDecisionRequirementsKey())
                     .setDecisionRequirementsVersion(latestVersion)
-                    .markAsDuplicate();
+                    .setDuplicate(true);
               } else {
                 drgRecord
                     .setDecisionRequirementsKey(newDecisionRequirementsKey.getAsLong())
@@ -226,7 +291,7 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                           decisionRecord
                               .setDecisionKey(latestDecision.getDecisionKey())
                               .setVersion(latestVersion)
-                              .markAsDuplicate();
+                              .setDuplicate(true);
                         } else {
                           decisionRecord
                               .setDecisionKey(newDecisionKey.getAsLong())
@@ -238,8 +303,6 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                               .setDecisionKey(newDecisionKey.getAsLong())
                               .setVersion(INITIAL_VERSION));
             });
-
-    return drgRecord.getDecisionRequirementsKey();
   }
 
   private boolean hasSameResourceNameAs(final DeploymentResource resource, final DeployedDrg drg) {
@@ -262,48 +325,5 @@ public final class DmnResourceTransformer implements DeploymentResourceTransform
                     .map(PersistedDecision::getDecisionRequirementsKey)
                     .orElse(UNKNOWN_DECISION_REQUIREMENTS_KEY))
         .allMatch(drgKey -> drgKey == drg.getDecisionRequirementsKey());
-  }
-
-  private void writeRecords(
-      final DeploymentRecord deployment,
-      final DeploymentResource resource,
-      final long decisionRequirementsKey) {
-
-    deployment.decisionRequirementsMetadata().stream()
-        .filter(drg -> drg.getDecisionRequirementsKey() == decisionRequirementsKey)
-        .filter(not(DecisionRequirementsMetadataRecord::isDuplicate))
-        .findFirst()
-        .ifPresent(
-            drg ->
-                stateWriter.appendFollowUpEvent(
-                    drg.getDecisionRequirementsKey(),
-                    DecisionRequirementsIntent.CREATED,
-                    new DecisionRequirementsRecord()
-                        .setDecisionRequirementsKey(drg.getDecisionRequirementsKey())
-                        .setDecisionRequirementsId(drg.getDecisionRequirementsId())
-                        .setDecisionRequirementsName(drg.getDecisionRequirementsName())
-                        .setDecisionRequirementsVersion(drg.getDecisionRequirementsVersion())
-                        .setNamespace(drg.getNamespace())
-                        .setResourceName(drg.getResourceName())
-                        .setChecksum(drg.getChecksumBuffer())
-                        .setResource(resource.getResourceBuffer())
-                        .setTenantId(drg.getTenantId())));
-
-    deployment.decisionsMetadata().stream()
-        .filter(decision -> decision.getDecisionRequirementsKey() == decisionRequirementsKey)
-        .filter(not(DecisionRecord::isDuplicate))
-        .forEach(
-            decision ->
-                stateWriter.appendFollowUpEvent(
-                    decision.getDecisionKey(),
-                    DecisionIntent.CREATED,
-                    new DecisionRecord()
-                        .setDecisionKey(decision.getDecisionKey())
-                        .setDecisionId(decision.getDecisionId())
-                        .setDecisionName(decision.getDecisionName())
-                        .setVersion(decision.getVersion())
-                        .setDecisionRequirementsId(decision.getDecisionRequirementsId())
-                        .setDecisionRequirementsKey(decision.getDecisionRequirementsKey())
-                        .setTenantId(decision.getTenantId())));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/FormResourceTransformer.java
@@ -30,9 +30,6 @@ import org.agrona.DirectBuffer;
 public final class FormResourceTransformer implements DeploymentResourceTransformer {
 
   private static final int INITIAL_VERSION = 1;
-
-  private static final Either<Failure, Object> NO_DUPLICATES = Either.right(null);
-
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
 
   private final KeyGenerator keyGenerator;
@@ -52,9 +49,8 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
   }
 
   @Override
-  public Either<Failure, Void> transformResource(
+  public Either<Failure, Void> createMetadata(
       final DeploymentResource resource, final DeploymentRecord deployment) {
-
     return parseFormId(resource)
         .flatMap(
             formId ->
@@ -64,10 +60,36 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
                           final FormMetadataRecord formRecord = deployment.formMetadata().add();
                           appendMetadataToFormRecord(
                               formRecord, formId, resource, deployment.getTenantId());
-                          writeFormRecord(formRecord, resource);
-
                           return null;
                         }));
+  }
+
+  @Override
+  public Either<Failure, Void> writeRecords(
+      final DeploymentResource resource, final DeploymentRecord deployment) {
+    if (deployment.hasDuplicatesOnly()) {
+      return Either.right(null);
+    }
+    final var checksum = checksumGenerator.apply(resource.getResource());
+    deployment.formMetadata().stream()
+        .filter(metadata -> checksum.equals(metadata.getChecksumBuffer()))
+        .findFirst()
+        .ifPresent(
+            metadata -> {
+              var key = metadata.getFormKey();
+              if (metadata.isDuplicate()) {
+                // create new version as the deployment contains at least one other non-duplicate
+                // resource and all resources in a deployment should be versioned together
+                key = keyGenerator.nextKey();
+                metadata
+                    .setFormKey(key)
+                    .setVersion(
+                        formState.getNextFormVersion(metadata.getFormId(), metadata.getTenantId()))
+                    .setDuplicate(false);
+              }
+              writeFormRecord(metadata, resource);
+            });
+    return Either.right(null);
   }
 
   private Either<Failure, String> parseFormId(final DeploymentResource resource) {
@@ -131,7 +153,7 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
                 formRecord
                     .setFormKey(latestForm.getFormKey())
                     .setVersion(latestVersion)
-                    .markAsDuplicate();
+                    .setDuplicate(true);
               } else {
                 formRecord
                     .setFormKey(newFormKey.getAsLong())
@@ -143,12 +165,10 @@ public final class FormResourceTransformer implements DeploymentResourceTransfor
 
   private void writeFormRecord(
       final FormMetadataRecord formRecord, final DeploymentResource resource) {
-    if (!formRecord.isDuplicate()) {
-      stateWriter.appendFollowUpEvent(
-          formRecord.getFormKey(),
-          FormIntent.CREATED,
-          new FormRecord().wrap(formRecord, resource.getResource()));
-    }
+    stateWriter.appendFollowUpEvent(
+        formRecord.getFormKey(),
+        FormIntent.CREATED,
+        new FormRecord().wrap(formRecord, resource.getResource()));
   }
 
   private Either<Failure, String> validateFormId(final String formId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/MultiResourceDeploymentTest.java
@@ -1,0 +1,342 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.deployment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
+import io.camunda.zeebe.protocol.record.intent.DecisionRequirementsIntent;
+import io.camunda.zeebe.protocol.record.intent.FormIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.DecisionRequirementsMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
+import io.camunda.zeebe.protocol.record.value.deployment.ProcessMetadataValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.function.Consumer;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Enclosed.class)
+public class MultiResourceDeploymentTest {
+
+  private static final BpmnModelInstance PROCESS_V1 =
+      Bpmn.createExecutableProcess("process1").startEvent("v1").endEvent().done();
+  private static final String FORM_V1 = "/form/test-form-1.form";
+  private static final String FORM_V2 = "/form/test-form-1_v2.form";
+  private static final String DMN_V1 = "/dmn/decision-table.dmn";
+  private static final String DMN_V2 = "/dmn/decision-table_v2.dmn";
+
+  @RunWith(Parameterized.class)
+  public static class DeploymentWithChangesTest {
+
+    @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+    @Parameter(0)
+    public String testName;
+
+    @Parameter(1)
+    public BpmnModelInstance bpmn1;
+
+    @Parameter(2)
+    public BpmnModelInstance bpmn2;
+
+    @Parameter(3)
+    public String dmn1;
+
+    @Parameter(4)
+    public String dmn2;
+
+    @Parameter(5)
+    public String form1;
+
+    @Parameter(6)
+    public String form2;
+
+    @Parameters(name = "{0}")
+    public static Object[][] parameters() {
+      return new Object[][] {
+        new Object[] {
+          "BPMN has changed",
+          PROCESS_V1,
+          Bpmn.createExecutableProcess("process1").startEvent("v2").endEvent().done(),
+          DMN_V1,
+          DMN_V1,
+          FORM_V1,
+          FORM_V1
+        },
+        new Object[] {"DMN has changed", PROCESS_V1, PROCESS_V1, DMN_V1, DMN_V2, FORM_V1, FORM_V1},
+        new Object[] {"Form has changed", PROCESS_V1, PROCESS_V1, DMN_V1, DMN_V1, FORM_V1, FORM_V2}
+      };
+    }
+
+    @Test
+    public void shouldCreateNewVersionsOfAllResourcesIfAtLeastOneResourceHasChanged() {
+      // given
+      final var firstDeployment =
+          engine
+              .deployment()
+              .withXmlResource(bpmn1)
+              .withXmlClasspathResource(dmn1)
+              .withJsonClasspathResource(form1)
+              .deploy()
+              .getValue();
+      final var processV1 = firstDeployment.getProcessesMetadata().getFirst();
+      final var drgV1 = firstDeployment.getDecisionRequirementsMetadata().getFirst();
+      final var decisionV1 = firstDeployment.getDecisionsMetadata().getFirst();
+      final var formV1 = firstDeployment.getFormMetadata().getFirst();
+
+      // when
+      final var secondDeployment =
+          engine
+              .deployment()
+              .withXmlResource(bpmn2)
+              .withXmlClasspathResource(dmn2)
+              .withJsonClasspathResource(form2)
+              .deploy()
+              .getValue();
+
+      // then
+      final var processesMetadata = secondDeployment.getProcessesMetadata();
+      assertThat(processesMetadata).hasSize(1);
+      final var processV2 = processesMetadata.getFirst();
+      assertThat(processV2).satisfies(expectedProcessMetadata(processV1.getProcessDefinitionKey()));
+
+      final var decisionRequirementsMetadata = secondDeployment.getDecisionRequirementsMetadata();
+      assertThat(decisionRequirementsMetadata).hasSize(1);
+      final var drgV2 = decisionRequirementsMetadata.getFirst();
+      assertThat(drgV2)
+          .satisfies(expectedDecisionRequirementsMetadata(drgV1.getDecisionRequirementsKey()));
+
+      final var decisionsMetadata = secondDeployment.getDecisionsMetadata();
+      assertThat(decisionsMetadata).hasSize(1);
+      final var decisionV2 = decisionsMetadata.getFirst();
+      assertThat(decisionV2)
+          .satisfies(
+              expectedDecisionMetadata(
+                  drgV2.getDecisionRequirementsKey(), decisionV1.getDecisionKey()));
+
+      final var formMetadata = secondDeployment.getFormMetadata();
+      assertThat(formMetadata).hasSize(1);
+      final var formV2 = formMetadata.getFirst();
+      assertThat(formV2).satisfies(expectedFormMetadata(formV1.getFormKey()));
+
+      assertNewProcessCreatedRecord(processV2.getProcessDefinitionKey());
+      assertNewDecisionRequirementsCreatedRecord(drgV2.getDecisionRequirementsKey());
+      assertNewDecisionCreatedRecord(
+          decisionV2.getDecisionKey(), drgV2.getDecisionRequirementsKey());
+      assertNewFormCreatedRecord(formV2.getFormKey());
+    }
+
+    private static Consumer<ProcessMetadataValue> expectedProcessMetadata(
+        final long previousProcessDefinitionKey) {
+      return process ->
+          Assertions.assertThat(process)
+              .hasVersion(2)
+              .isNotDuplicate()
+              .extracting(
+                  ProcessMetadataValue::getProcessDefinitionKey, InstanceOfAssertFactories.LONG)
+              .isGreaterThan(previousProcessDefinitionKey);
+    }
+
+    private static Consumer<DecisionRequirementsMetadataValue> expectedDecisionRequirementsMetadata(
+        final long previousDecisionRequirementsKey) {
+      return drg ->
+          Assertions.assertThat(drg)
+              .hasDecisionRequirementsVersion(2)
+              .isNotDuplicate()
+              .extracting(
+                  DecisionRequirementsMetadataValue::getDecisionRequirementsKey,
+                  InstanceOfAssertFactories.LONG)
+              .isGreaterThan(previousDecisionRequirementsKey);
+    }
+
+    private static Consumer<DecisionRecordValue> expectedDecisionMetadata(
+        final long expectedDecisionRequirementsKey, final long previousDecisionKey) {
+      return decision ->
+          Assertions.assertThat(decision)
+              .hasVersion(2)
+              .hasDecisionRequirementsKey(expectedDecisionRequirementsKey)
+              .isNotDuplicate()
+              .extracting(DecisionRecordValue::getDecisionKey, InstanceOfAssertFactories.LONG)
+              .isGreaterThan(previousDecisionKey);
+    }
+
+    private static Consumer<FormMetadataValue> expectedFormMetadata(final long previousFormKey) {
+      return form ->
+          Assertions.assertThat(form)
+              .hasVersion(2)
+              .isNotDuplicate()
+              .extracting(FormMetadataValue::getFormKey, InstanceOfAssertFactories.LONG)
+              .isGreaterThan(previousFormKey);
+    }
+
+    private static void assertNewProcessCreatedRecord(final long expectedProcessDefinitionKey) {
+      assertThat(
+              RecordingExporter.processRecords()
+                  .withIntent(ProcessIntent.CREATED)
+                  .limit(2)
+                  .getLast())
+          .satisfies(
+              record -> {
+                assertThat(record.getKey()).isEqualTo(expectedProcessDefinitionKey);
+                assertThat(record.getValue().getProcessDefinitionKey())
+                    .isEqualTo(expectedProcessDefinitionKey);
+                assertThat(record.getValue().getVersion()).isEqualTo(2);
+              });
+    }
+
+    private static void assertNewDecisionRequirementsCreatedRecord(
+        final long expectedDecisionRequirementsKey) {
+      assertThat(
+              RecordingExporter.decisionRequirementsRecords()
+                  .withIntent(DecisionRequirementsIntent.CREATED)
+                  .limit(2)
+                  .getLast())
+          .satisfies(
+              record -> {
+                assertThat(record.getKey()).isEqualTo(expectedDecisionRequirementsKey);
+                assertThat(record.getValue().getDecisionRequirementsKey())
+                    .isEqualTo(expectedDecisionRequirementsKey);
+                assertThat(record.getValue().getDecisionRequirementsVersion()).isEqualTo(2);
+              });
+    }
+
+    private static void assertNewDecisionCreatedRecord(
+        final long expectedDecisionKey, final long expectedDecisionRequirementsKey) {
+      assertThat(
+              RecordingExporter.decisionRecords()
+                  .withIntent(DecisionIntent.CREATED)
+                  .limit(2)
+                  .getLast())
+          .satisfies(
+              record -> {
+                assertThat(record.getKey()).isEqualTo(expectedDecisionKey);
+                assertThat(record.getValue().getDecisionKey()).isEqualTo(expectedDecisionKey);
+                assertThat(record.getValue().getDecisionRequirementsKey())
+                    .isEqualTo(expectedDecisionRequirementsKey);
+                assertThat(record.getValue().getVersion()).isEqualTo(2);
+              });
+    }
+
+    private static void assertNewFormCreatedRecord(final long expectedFormKey) {
+      assertThat(RecordingExporter.formRecords().withIntent(FormIntent.CREATED).limit(2).getLast())
+          .satisfies(
+              record -> {
+                assertThat(record.getKey()).isEqualTo(expectedFormKey);
+                assertThat(record.getValue().getFormKey()).isEqualTo(expectedFormKey);
+                assertThat(record.getValue().getVersion()).isEqualTo(2);
+              });
+    }
+  }
+
+  public static class DeploymentWithNoChangesTest {
+
+    @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+    @Test
+    public void shouldNotCreateNewVersionsIfNoResourceHasChanged() {
+      // given
+      final var firstDeploymentRecord =
+          engine
+              .deployment()
+              .withXmlResource(PROCESS_V1)
+              .withXmlClasspathResource(DMN_V1)
+              .withJsonClasspathResource(FORM_V1)
+              .deploy();
+      final var firstDeployment = firstDeploymentRecord.getValue();
+      final var processV1 = firstDeployment.getProcessesMetadata().getFirst();
+      final var drgV1 = firstDeployment.getDecisionRequirementsMetadata().getFirst();
+      final var decisionV1 = firstDeployment.getDecisionsMetadata().getFirst();
+      final var formV1 = firstDeployment.getFormMetadata().getFirst();
+      final long recordsCountBefore =
+          RecordingExporter.records()
+              .onlyEvents()
+              .limit(record -> record.getPosition() >= firstDeploymentRecord.getPosition())
+              .count();
+      assertThat(recordsCountBefore)
+          .describedAs("Should have created event records for 4 resources and 1 deployment")
+          .isEqualTo(5);
+
+      // when
+      final var secondDeploymentRecord =
+          engine
+              .deployment()
+              // deploy the exact same resources again
+              .withXmlResource(PROCESS_V1)
+              .withXmlClasspathResource(DMN_V1)
+              .withJsonClasspathResource(FORM_V1)
+              .deploy();
+
+      // then
+      final var secondDeployment = secondDeploymentRecord.getValue();
+      assertThat(secondDeployment.getProcessesMetadata())
+          .singleElement()
+          .satisfies(
+              metadata ->
+                  Assertions.assertThat(metadata)
+                      .hasVersion(1)
+                      .isDuplicate()
+                      .extracting(
+                          ProcessMetadataValue::getProcessDefinitionKey,
+                          InstanceOfAssertFactories.LONG)
+                      .isEqualTo(processV1.getProcessDefinitionKey()));
+      assertThat(secondDeployment.getDecisionRequirementsMetadata())
+          .singleElement()
+          .satisfies(
+              metadata ->
+                  Assertions.assertThat(metadata)
+                      .hasDecisionRequirementsVersion(1)
+                      .isDuplicate()
+                      .extracting(
+                          DecisionRequirementsMetadataValue::getDecisionRequirementsKey,
+                          InstanceOfAssertFactories.LONG)
+                      .isEqualTo(drgV1.getDecisionRequirementsKey()));
+      assertThat(secondDeployment.getDecisionsMetadata())
+          .singleElement()
+          .satisfies(
+              metadata ->
+                  Assertions.assertThat(metadata)
+                      .hasVersion(1)
+                      .isDuplicate()
+                      .extracting(
+                          DecisionRecordValue::getDecisionKey,
+                          DecisionRecordValue::getDecisionRequirementsKey)
+                      .containsExactly(
+                          decisionV1.getDecisionKey(), drgV1.getDecisionRequirementsKey()));
+      assertThat(secondDeployment.getFormMetadata())
+          .singleElement()
+          .satisfies(
+              metadata ->
+                  Assertions.assertThat(metadata)
+                      .hasVersion(1)
+                      .isDuplicate()
+                      .extracting(FormMetadataValue::getFormKey)
+                      .isEqualTo(formV1.getFormKey()));
+
+      final long recordsCountAfter =
+          RecordingExporter.records()
+              .onlyEvents()
+              .limit(record -> record.getPosition() >= secondDeploymentRecord.getPosition())
+              .count();
+      assertThat(recordsCountAfter - recordsCountBefore)
+          .describedAs("Should have created only one extra deployment record")
+          .isEqualTo(1);
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
@@ -425,7 +425,7 @@ public final class ProcessDeploymentTest {
   }
 
   @Test
-  public void shouldFilterWithOneDifferentAndOneEqual() {
+  public void shouldNotFilterWithOneDifferentAndOneEqual() {
     // given
     final Record<DeploymentRecordValue> original =
         ENGINE
@@ -447,7 +447,7 @@ public final class ProcessDeploymentTest {
     final var repeatedProcesses = repeated.getValue().getProcessesMetadata();
     assertThat(repeatedProcesses.size()).isEqualTo(originalProcesses.size()).isEqualTo(2);
 
-    assertSameResource(
+    assertDifferentResources(
         findProcess(originalProcesses, processId), findProcess(repeatedProcesses, processId));
     assertDifferentResources(
         findProcess(originalProcesses, processId2), findProcess(repeatedProcesses, processId2));

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRecord.java
@@ -82,6 +82,11 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
     return isDuplicateProp.getValue();
   }
 
+  public DecisionRecord setDuplicate(final boolean duplicate) {
+    isDuplicateProp.setValue(duplicate);
+    return this;
+  }
+
   public DecisionRecord setDecisionRequirementsKey(final long decisionRequirementsKey) {
     decisionRequirementsKeyProp.setValue(decisionRequirementsKey);
     return this;
@@ -109,11 +114,6 @@ public final class DecisionRecord extends UnifiedRecordValue implements Decision
 
   public DecisionRecord setDecisionId(final String decisionId) {
     decisionIdProp.setValue(decisionId);
-    return this;
-  }
-
-  public DecisionRecord markAsDuplicate() {
-    isDuplicateProp.setValue(true);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DecisionRequirementsMetadataRecord.java
@@ -95,6 +95,11 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
     return isDuplicateProp.getValue();
   }
 
+  public DecisionRequirementsMetadataRecord setDuplicate(final boolean duplicate) {
+    isDuplicateProp.setValue(duplicate);
+    return this;
+  }
+
   public DecisionRequirementsMetadataRecord setChecksum(final DirectBuffer checksum) {
     checksumProp.setValue(checksum);
     return this;
@@ -131,11 +136,6 @@ public class DecisionRequirementsMetadataRecord extends UnifiedRecordValue
   public DecisionRequirementsMetadataRecord setDecisionRequirementsId(
       final String decisionRequirementsId) {
     decisionRequirementsIdProp.setValue(decisionRequirementsId);
-    return this;
-  }
-
-  public DecisionRequirementsMetadataRecord markAsDuplicate() {
-    isDuplicateProp.setValue(true);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -178,4 +178,11 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
         .map(io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource::getResourceName)
         .anyMatch(x -> x.endsWith(".form"));
   }
+
+  public boolean hasDuplicatesOnly() {
+    return processesMetadata().stream().allMatch(ProcessMetadata::isDuplicate)
+        && decisionRequirementsMetadata().stream()
+            .allMatch(DecisionRequirementsMetadataValue::isDuplicate)
+        && formMetadata().stream().allMatch(FormMetadataValue::isDuplicate);
+  }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormMetadataRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/FormMetadataRecord.java
@@ -98,8 +98,8 @@ public class FormMetadataRecord extends UnifiedRecordValue implements FormMetada
     return isDuplicateProp.getValue();
   }
 
-  public FormMetadataRecord markAsDuplicate() {
-    isDuplicateProp.setValue(true);
+  public FormMetadataRecord setDuplicate(final boolean isDuplicate) {
+    isDuplicateProp.setValue(isDuplicate);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -86,6 +86,11 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
     return isDuplicateProp.getValue();
   }
 
+  public ProcessMetadata setDuplicate(final boolean isDuplicate) {
+    isDuplicateProp.setValue(isDuplicate);
+    return this;
+  }
+
   public ProcessMetadata setResourceName(final String resourceName) {
     resourceNameProp.setValue(resourceName);
     return this;
@@ -151,11 +156,6 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   public ProcessMetadata setBpmnProcessId(
       final DirectBuffer bpmnProcessId, final int offset, final int length) {
     bpmnProcessIdProp.setValue(bpmnProcessId, offset, length);
-    return this;
-  }
-
-  public ProcessMetadata markAsDuplicate() {
-    isDuplicateProp.setValue(true);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -309,7 +309,7 @@ final class JsonSerializableToJsonTest {
                   .setResourceName(wrapString(resourceName))
                   .setVersion(processVersion)
                   .setChecksum(checksum)
-                  .markAsDuplicate();
+                  .setDuplicate(true);
               record
                   .decisionRequirementsMetadata()
                   .add()
@@ -320,7 +320,7 @@ final class JsonSerializableToJsonTest {
                   .setNamespace("namespace")
                   .setResourceName("resource-name")
                   .setChecksum(checksum)
-                  .markAsDuplicate();
+                  .setDuplicate(true);
               record
                   .decisionsMetadata()
                   .add()
@@ -330,7 +330,7 @@ final class JsonSerializableToJsonTest {
                   .setDecisionKey(2L)
                   .setDecisionRequirementsKey(1L)
                   .setDecisionRequirementsId("drg-id")
-                  .markAsDuplicate();
+                  .setDuplicate(true);
               record
                   .formMetadata()
                   .add()
@@ -339,7 +339,7 @@ final class JsonSerializableToJsonTest {
                   .setFormKey(1L)
                   .setResourceName("form1.form")
                   .setChecksum(checksum)
-                  .markAsDuplicate();
+                  .setDuplicate(true);
               return record;
             },
         """


### PR DESCRIPTION
## Description
Changes the deployment logic if multiple resources are deployed together:
If at least one of them has changed (compared to the latest already deployed version), a new version of _every_ resource
contained in the deployment will be created (even if this particular resource has not changed).

The change is done to properly support the new "deployment" binding type:
If a process contains a resource link with "deployment" binding, each instance of a particular version of this process
should call the same version of the target resource (to ensure a deterministic behavior that is easy to understand).

## Related issues
closes #19859