### PR TITLE
feat: Incident records provide tree path properties that locate the incident in a hierarchy of process instances

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnIncidentBehavior.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.IncidentState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -27,6 +28,7 @@ public final class BpmnIncidentBehavior {
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
   private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
   public BpmnIncidentBehavior(
       final ProcessingState processingState,
@@ -34,6 +36,7 @@ public final class BpmnIncidentBehavior {
       final StateWriter stateWriter) {
     incidentState = processingState.getIncidentState();
     elementInstanceState = processingState.getElementInstanceState();
+    processState = processingState.getProcessState();
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
   }
@@ -61,6 +64,7 @@ public final class BpmnIncidentBehavior {
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
+            .withProcessState(processState)
             .withElementInstanceKey(context.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -11,21 +11,31 @@ import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.Objects;
 
 public class ElementTreePathBuilder {
-  private final ElementInstanceState elementInstanceState;
-  private final Long elementInstanceKey;
-  private final ElementTreePathProperties properties;
+  private ElementInstanceState elementInstanceState;
+  private Long elementInstanceKey;
+  private ElementTreePathProperties properties;
 
-  public ElementTreePathBuilder(
-      final ElementInstanceState elementInstanceState, final Long elementInstanceKey) {
+  public ElementTreePathBuilder() {}
+
+  public ElementTreePathBuilder withElementInstanceState(
+      final ElementInstanceState elementInstanceState) {
     this.elementInstanceState = elementInstanceState;
-    this.elementInstanceKey = elementInstanceKey;
-    properties =
-        new ElementTreePathProperties(new LinkedList<>(), new LinkedList<>(), new LinkedList<>());
+    return this;
   }
 
-  public ElementTreePathProperties getProperties() {
+  public ElementTreePathBuilder withElementInstanceKey(final long elementInstanceKey) {
+    this.elementInstanceKey = elementInstanceKey;
+    return this;
+  }
+
+  public ElementTreePathProperties build() {
+    Objects.requireNonNull(elementInstanceState, "elementInstanceState cannot be null");
+    Objects.requireNonNull(elementInstanceKey, "elementInstanceKey cannot be null");
+    properties =
+        new ElementTreePathProperties(new LinkedList<>(), new LinkedList<>(), new LinkedList<>());
     buildElementTreePathProperties(elementInstanceKey);
     return properties;
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -41,8 +41,10 @@ public class ElementTreePathBuilder {
       parentElementInstanceKey = instance.getParentKey();
     }
     properties.elementInstancePath.addFirst(elementInstancePath);
+    final var processInstanceRecord = instance.getValue();
+    properties.processDefinitionPath.addFirst(processInstanceRecord.getProcessDefinitionKey());
 
-    final long callingElementInstanceKey = instance.getValue().getParentElementInstanceKey();
+    final long callingElementInstanceKey = processInstanceRecord.getParentElementInstanceKey();
     if (callingElementInstanceKey != -1) {
       buildElementTreePathProperties(callingElementInstanceKey);
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -12,7 +12,6 @@ import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Objects;
-import org.agrona.DirectBuffer;
 
 public class ElementTreePathBuilder {
   private ElementInstanceState elementInstanceState;
@@ -62,16 +61,16 @@ public class ElementTreePathBuilder {
     }
   }
 
-  private DirectBuffer getCallActivityId(final long callingElementInstanceKey) {
+  private String getCallActivityId(final long callingElementInstanceKey) {
     final ElementInstance callActivityElementInstance =
         elementInstanceState.getInstance(callingElementInstanceKey);
     final var callActivityInstanceRecord = callActivityElementInstance.getValue();
 
-    return callActivityInstanceRecord.getElementIdBuffer();
+    return callActivityInstanceRecord.getElementId();
   }
 
   public record ElementTreePathProperties(
       List<List<Long>> elementInstancePath,
       List<Long> processDefinitionPath,
-      List<DirectBuffer> callingElementPath) {}
+      List<String> callingElementPath) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -68,7 +68,7 @@ public class ElementTreePathBuilder {
     }
   }
 
-  private Long getCallActivityIdHash(final long callingElementInstanceKey) {
+  private String getCallActivityIdHash(final long callingElementInstanceKey) {
     final ElementInstance callActivityElementInstance =
         elementInstanceState.getInstance(callingElementInstanceKey);
     final var callActivityInstanceRecord = callActivityElementInstance.getValue();
@@ -76,11 +76,11 @@ public class ElementTreePathBuilder {
     final HashCode hashCode =
         hashFunction.hashString(
             callActivityInstanceRecord.getElementId(), Charset.defaultCharset());
-    return hashCode.asLong();
+    return hashCode.toString();
   }
 
   public record ElementTreePathProperties(
       List<List<Long>> elementInstancePath,
       List<Long> processDefinitionPath,
-      List<Long> callingElementPath) {}
+      List<String> callingElementPath) {}
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilder.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import java.util.Deque;
+import java.util.LinkedList;
+
+public class ElementTreePathBuilder {
+  private final ElementInstanceState elementInstanceState;
+  private final Long elementInstanceKey;
+  private final ElementTreePathProperties properties;
+
+  public ElementTreePathBuilder(
+      final ElementInstanceState elementInstanceState, final Long elementInstanceKey) {
+    this.elementInstanceState = elementInstanceState;
+    this.elementInstanceKey = elementInstanceKey;
+    properties =
+        new ElementTreePathProperties(new LinkedList<>(), new LinkedList<>(), new LinkedList<>());
+  }
+
+  public ElementTreePathProperties getProperties() {
+    buildElementTreePathProperties(elementInstanceKey);
+    return properties;
+  }
+
+  private void buildElementTreePathProperties(final long elementInstanceKey) {
+    final Deque<Long> elementInstancePath = new LinkedList<>();
+    elementInstancePath.add(elementInstanceKey);
+    ElementInstance instance = elementInstanceState.getInstance(elementInstanceKey);
+    long parentElementInstanceKey = instance.getParentKey();
+    while (parentElementInstanceKey != -1) {
+      instance = elementInstanceState.getInstance(parentElementInstanceKey);
+      elementInstancePath.addFirst(parentElementInstanceKey);
+      parentElementInstanceKey = instance.getParentKey();
+    }
+    properties.elementInstancePath.addFirst(elementInstancePath);
+
+    final long callingElementInstanceKey = instance.getValue().getParentElementInstanceKey();
+    if (callingElementInstanceKey != -1) {
+      buildElementTreePathProperties(callingElementInstanceKey);
+    }
+  }
+
+  public record ElementTreePathProperties(
+      Deque<Deque<Long>> elementInstancePath,
+      Deque<Long> processDefinitionPath,
+      Deque<Long> callingElementPath) {}
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
@@ -15,6 +15,7 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   private boolean propagateAllChildVariablesEnabled;
   private boolean propagateAllParentVariablesEnabled;
+  private int lexicographicIndex;
 
   public ExecutableCallActivity(final String id) {
     super(id);
@@ -41,7 +42,16 @@ public class ExecutableCallActivity extends ExecutableActivity {
     return propagateAllParentVariablesEnabled;
   }
 
-  public void setPropagateAllParentVariablesEnabled(boolean propagateAllParentVariablesEnabled) {
+  public void setPropagateAllParentVariablesEnabled(
+      final boolean propagateAllParentVariablesEnabled) {
     this.propagateAllParentVariablesEnabled = propagateAllParentVariablesEnabled;
+  }
+
+  public int getLexicographicIndex() {
+    return lexicographicIndex;
+  }
+
+  public void setLexicographicIndex(final int index) {
+    lexicographicIndex = index;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
@@ -15,6 +15,11 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   private boolean propagateAllChildVariablesEnabled;
   private boolean propagateAllParentVariablesEnabled;
+
+  /**
+   * The index of this call activity element ID in a <i>lexicographically</i> sorted list of all
+   * Call Activity IDs in all the processes in one BPMN deployment resource.
+   */
   private int lexicographicIndex;
 
   public ExecutableCallActivity(final String id) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -10,12 +10,14 @@ package io.camunda.zeebe.engine.processing.job;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.engine.metrics.JobMetrics;
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.job.JobBatchCollector.TooLargeJob;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
@@ -38,6 +40,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final JobBatchCollector jobBatchCollector;
   private final KeyGenerator keyGenerator;
   private final JobMetrics jobMetrics;
+  private final ElementInstanceState elementInstanceState;
 
   public JobBatchActivateProcessor(
       final Writers writers,
@@ -54,6 +57,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
 
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
+    elementInstanceState = state.getElementInstanceState();
   }
 
   @Override
@@ -136,6 +140,13 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
                 "The job with key '%s' can not be activated, because with %s it is larger than the configured message size (per default is 4 MB). "
                     + "Try to reduce the size by reducing the number of fetched variables or modifying the variable values.",
                 jobKey, jobSize));
+
+    final var treePathProperties =
+        new ElementTreePathBuilder()
+            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceKey(job.getElementInstanceKey())
+            .build();
+
     final var incidentEvent =
         new IncidentRecord()
             .setErrorType(ErrorType.MESSAGE_SIZE_EXCEEDED)
@@ -147,7 +158,10 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
             .setElementInstanceKey(job.getElementInstanceKey())
             .setJobKey(jobKey)
             .setTenantId(job.getTenantId())
-            .setVariableScopeKey(job.getElementInstanceKey());
+            .setVariableScopeKey(job.getElementInstanceKey())
+            .setElementInstancePath(treePathProperties.elementInstancePath())
+            .setProcessDefinitionPath(treePathProperties.processDefinitionPath())
+            .setCallingElementPath(treePathProperties.callingElementPath());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBatchActivateProcessor.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobBatchRecord;
@@ -41,6 +42,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
   private final KeyGenerator keyGenerator;
   private final JobMetrics jobMetrics;
   private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
   public JobBatchActivateProcessor(
       final Writers writers,
@@ -58,6 +60,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     this.keyGenerator = keyGenerator;
     this.jobMetrics = jobMetrics;
     elementInstanceState = state.getElementInstanceState();
+    processState = state.getProcessState();
   }
 
   @Override
@@ -144,6 +147,7 @@ public final class JobBatchActivateProcessor implements TypedRecordProcessor<Job
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
+            .withProcessState(processState)
             .withElementInstanceKey(job.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -57,6 +58,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
   private final SideEffectWriter sideEffectWriter;
   private final JobCommandPreconditionChecker preconditionChecker;
   private final ElementInstanceState elementInstanceState;
+  private final ProcessState processState;
 
   public JobFailProcessor(
       final ProcessingState state,
@@ -67,6 +69,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       final BpmnBehaviors bpmnBehaviors) {
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
+    processState = state.getProcessState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
@@ -170,6 +173,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
+            .withProcessState(processState)
             .withElementInstanceKey(value.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -14,6 +14,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -21,6 +22,7 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejection
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
+import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.JobState.State;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
@@ -54,6 +56,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
   private final BpmnJobActivationBehavior jobActivationBehavior;
   private final SideEffectWriter sideEffectWriter;
   private final JobCommandPreconditionChecker preconditionChecker;
+  private final ElementInstanceState elementInstanceState;
 
   public JobFailProcessor(
       final ProcessingState state,
@@ -63,6 +66,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
       final JobBackoffChecker jobBackoffChecker,
       final BpmnBehaviors bpmnBehaviors) {
     jobState = state.getJobState();
+    elementInstanceState = state.getElementInstanceState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     responseWriter = writers.response();
@@ -163,6 +167,12 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
             ? ErrorType.EXECUTION_LISTENER_NO_RETRIES
             : ErrorType.JOB_NO_RETRIES;
 
+    final var treePathProperties =
+        new ElementTreePathBuilder()
+            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceKey(value.getElementInstanceKey())
+            .build();
+
     incidentEvent.reset();
     incidentEvent
         .setErrorType(errorType)
@@ -174,7 +184,10 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
         .setElementInstanceKey(value.getElementInstanceKey())
         .setJobKey(key)
         .setVariableScopeKey(value.getElementInstanceKey())
-        .setTenantId(value.getTenantId());
+        .setTenantId(value.getTenantId())
+        .setElementInstancePath(treePathProperties.elementInstancePath())
+        .setProcessDefinitionPath(treePathProperties.processDefinitionPath())
+        .setCallingElementPath(treePathProperties.callingElementPath());
 
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), IncidentIntent.CREATED, incidentEvent);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.engine.state.analyzers.CatchEventAnalyzer.CatchEventTupl
 import io.camunda.zeebe.engine.state.immutable.ElementInstanceState;
 import io.camunda.zeebe.engine.state.immutable.EventScopeInstanceState;
 import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.impl.record.value.incident.IncidentRecord;
@@ -59,6 +60,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
   private final EventScopeInstanceState eventScopeInstanceState;
   private final BpmnEventPublicationBehavior eventPublicationBehavior;
   private final JobMetrics jobMetrics;
+  private final ProcessState processState;
 
   public JobThrowErrorProcessor(
       final ProcessingState state,
@@ -68,6 +70,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
     this.keyGenerator = keyGenerator;
     jobState = state.getJobState();
     elementInstanceState = state.getElementInstanceState();
+    processState = state.getProcessState();
     eventScopeInstanceState = state.getEventScopeInstanceState();
 
     defaultProcessor =
@@ -157,6 +160,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
     final var treePathProperties =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
+            .withProcessState(processState)
             .withElementInstanceKey(job.getElementInstanceKey())
             .build();
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -767,8 +767,10 @@ public final class CallActivityTest {
     final String callActivity1Id = "callParent";
     final String callActivity2Id = "callChild";
     final HashFunction hashFunction = Hashing.murmur3_128();
-    final var ca1Hash = hashFunction.hashString(callActivity1Id, Charset.defaultCharset()).asLong();
-    final var ca2Hash = hashFunction.hashString(callActivity2Id, Charset.defaultCharset()).asLong();
+    final var ca1Hash =
+        hashFunction.hashString(callActivity1Id, Charset.defaultCharset()).toString();
+    final var ca2Hash =
+        hashFunction.hashString(callActivity2Id, Charset.defaultCharset()).toString();
     ENGINE
         .deployment()
         .withXmlResource(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -22,10 +23,12 @@ import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.junit.Before;
@@ -55,18 +58,25 @@ public final class CallActivityTest {
     return builder.endEvent().done();
   }
 
+  private static BpmnModelInstance childProcess(
+      final String jobType, final Consumer<ServiceTaskBuilder> consumer) {
+    final var builder =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD)
+            .startEvent()
+            .serviceTask("child-task", t -> t.zeebeJobType(jobType));
+
+    consumer.accept(builder);
+
+    return builder.endEvent().done();
+  }
+
   @Before
   public void init() {
     jobType = helper.getJobType();
 
     final var parentProcess = parentProcess(CallActivityBuilder::done);
 
-    final var childProcess =
-        Bpmn.createExecutableProcess(PROCESS_ID_CHILD)
-            .startEvent()
-            .serviceTask("child-task", t -> t.zeebeJobType(jobType))
-            .endEvent()
-            .done();
+    final var childProcess = childProcess(jobType, ServiceTaskBuilder::done);
 
     ENGINE
         .deployment()
@@ -661,12 +671,7 @@ public final class CallActivityTest {
     final var incidentResolved =
         ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentKey).resolve();
 
-    assertThat(
-            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
-                .withProcessInstanceKey(processInstanceKey)
-                .withElementType(BpmnElementType.CALL_ACTIVITY)
-                .getFirst()
-                .getPosition())
+    assertThat(getCallActivityInstance(processInstanceKey).getPosition())
         .describedAs("Expected call activity to be ACTIVATED after incident is resolved")
         .isGreaterThan(incidentResolved.getPosition());
   }
@@ -752,6 +757,51 @@ public final class CallActivityTest {
             tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
+  @Test
+  public void shouldPropagateCallingElementPathWithIncident() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-parent.bpmn", parentProcess(c -> c.zeebeProcessId(PROCESS_ID_CHILD)))
+        .withXmlResource(
+            "wf-child.bpmn",
+            childProcess(jobType, c -> c.zeebeOutputExpression("assert(x, x != null)", "y")))
+        .deploy();
+
+    final var parentInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID_PARENT).create();
+
+    final var parentInstance = getProcessInstanceRecordValue(parentInstanceKey);
+    final var childInstance = getChildInstanceOf(parentInstanceKey);
+    final long childInstanceKey = childInstance.getProcessInstanceKey();
+    final var callActivityInstance = getCallActivityInstance(parentInstanceKey);
+
+    completeJobWith(Map.of());
+
+    // then
+    final IncidentRecordValue incident =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(childInstanceKey)
+            .getFirst()
+            .getValue();
+
+    Assertions.assertThat(incident)
+        .hasElementInstancePath(
+            List.of(parentInstanceKey, callActivityInstance.getKey()),
+            List.of(childInstanceKey, incident.getElementInstanceKey()))
+        .hasProcessDefinitionPath(
+            parentInstance.getProcessDefinitionKey(), childInstance.getProcessDefinitionKey())
+        .hasCallingElementPath("call");
+  }
+
+  private static ProcessInstanceRecordValue getProcessInstanceRecordValue(
+      final long processInstanceKey) {
+    return RecordingExporter.processInstanceRecords()
+        .withProcessInstanceKey(processInstanceKey)
+        .getFirst()
+        .getValue();
+  }
+
   private void completeJobWith(final Map<String, Object> variables) {
 
     RecordingExporter.jobRecords(JobIntent.CREATED).withType(jobType).getFirst().getValue();
@@ -774,11 +824,14 @@ public final class CallActivityTest {
   }
 
   private long getCallActivityInstanceKey(final long processInstanceKey) {
+    return getCallActivityInstance(processInstanceKey).getKey();
+  }
 
+  private static Record<ProcessInstanceRecordValue> getCallActivityInstance(
+      final long processInstanceKey) {
     return RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
         .withProcessInstanceKey(processInstanceKey)
         .withElementType(BpmnElementType.CALL_ACTIVITY)
-        .getFirst()
-        .getKey();
+        .getFirst();
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -10,6 +10,8 @@ package io.camunda.zeebe.engine.processing.bpmn.activity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import com.google.common.hash.HashFunction;
+import com.google.common.hash.Hashing;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -28,6 +30,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -763,7 +766,9 @@ public final class CallActivityTest {
     final String rootProcessId = "root";
     final String callActivity1Id = "callParent";
     final String callActivity2Id = "callChild";
-
+    final HashFunction hashFunction = Hashing.murmur3_128();
+    final var ca1Hash = hashFunction.hashString(callActivity1Id, Charset.defaultCharset()).asLong();
+    final var ca2Hash = hashFunction.hashString(callActivity2Id, Charset.defaultCharset()).asLong();
     ENGINE
         .deployment()
         .withXmlResource(
@@ -808,7 +813,7 @@ public final class CallActivityTest {
             rootInstance.getProcessDefinitionKey(),
             parentInstance.getProcessDefinitionKey(),
             childInstance.getProcessDefinitionKey())
-        .hasOnlyCallingElementPath(callActivity1Id, callActivity2Id);
+        .hasOnlyCallingElementPath(ca1Hash, ca2Hash);
   }
 
   private static ProcessInstanceRecordValue getProcessInstanceRecordValue(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -10,8 +10,6 @@ package io.camunda.zeebe.engine.processing.bpmn.activity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
@@ -30,7 +28,6 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -766,11 +763,9 @@ public final class CallActivityTest {
     final String rootProcessId = "root";
     final String callActivity1Id = "callParent";
     final String callActivity2Id = "callChild";
-    final HashFunction hashFunction = Hashing.murmur3_128();
-    final var ca1Hash =
-        hashFunction.hashString(callActivity1Id, Charset.defaultCharset()).toString();
-    final var ca2Hash =
-        hashFunction.hashString(callActivity2Id, Charset.defaultCharset()).toString();
+    // every deployment resource will have indexes starting from zero
+    final var ca1Index = 0;
+    final var ca2Index = 0;
     ENGINE
         .deployment()
         .withXmlResource(
@@ -815,7 +810,7 @@ public final class CallActivityTest {
             rootInstance.getProcessDefinitionKey(),
             parentInstance.getProcessDefinitionKey(),
             childInstance.getProcessDefinitionKey())
-        .hasOnlyCallingElementPath(ca1Hash, ca2Hash);
+        .hasOnlyCallingElementPath(ca1Index, ca2Index);
   }
 
   private static ProcessInstanceRecordValue getProcessInstanceRecordValue(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,6 +66,9 @@ public class ElementTreePathBuilderTest {
     assertThat(properties.elementInstancePath()).isNotNull();
     assertThat(properties.elementInstancePath()).hasSize(1); // no call activities
     assertThat(properties.elementInstancePath().getFirst()).containsExactly(100L, 102L);
+    assertThat(properties.processDefinitionPath()).hasSize(1);
+    assertThat(properties.processDefinitionPath())
+        .containsExactly(parentProcessInstanceRecord.getProcessDefinitionKey());
   }
 
   @Test
@@ -103,6 +107,10 @@ public class ElementTreePathBuilderTest {
     assertThat(properties.elementInstancePath()).hasSize(2);
     assertThat(properties.elementInstancePath().getFirst()).containsExactly(100L, 101L);
     assertThat(properties.elementInstancePath().getLast()).containsExactly(102L, 103L);
+    assertThat(properties.processDefinitionPath()).hasSize(2);
+    assertThat(properties.processDefinitionPath())
+        .containsExactly(
+            processARecord.getProcessDefinitionKey(), processBRecord.getProcessDefinitionKey());
   }
 
   private ProcessInstanceRecord createProcessInstanceRecord() {
@@ -112,7 +120,7 @@ public class ElementTreePathBuilderTest {
     processInstanceRecord.setProcessInstanceKey(1000L);
     processInstanceRecord.setFlowScopeKey(1001L);
     processInstanceRecord.setVersion(1);
-    processInstanceRecord.setProcessDefinitionKey(2);
+    processInstanceRecord.setProcessDefinitionKey(ThreadLocalRandom.current().nextLong(1000));
     processInstanceRecord.setBpmnElementType(BpmnElementType.START_EVENT);
 
     return processInstanceRecord;

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -81,7 +81,7 @@ public class ElementTreePathBuilderTest {
     final String callActivityId = "callActivity";
     final HashFunction hashFunction = Hashing.murmur3_128();
     final var callActivityIdHash =
-        hashFunction.hashString(callActivityId, Charset.defaultCharset()).asLong();
+        hashFunction.hashString(callActivityId, Charset.defaultCharset()).toString();
 
     final var processARecord = createProcessInstanceRecord();
     final ElementInstance processA =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -10,18 +10,24 @@ package io.camunda.zeebe.engine.processing.common;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.google.common.hash.HashFunction;
-import com.google.common.hash.Hashing;
 import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder.ElementTreePathProperties;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
+import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import java.nio.charset.Charset;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.function.Consumer;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,11 +36,13 @@ public class ElementTreePathBuilderTest {
   @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
 
   private MutableElementInstanceState elementInstanceState;
+  private MutableProcessState processState;
 
   @Before
   public void setUp() {
     final MutableProcessingState processingState = stateRule.getProcessingState();
     elementInstanceState = processingState.getElementInstanceState();
+    processState = processingState.getProcessState();
   }
 
   @Test
@@ -63,6 +71,7 @@ public class ElementTreePathBuilderTest {
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
+            .withProcessState(processState)
             .withElementInstanceKey(subProcess2.getKey());
 
     final ElementTreePathProperties properties = builder.build();
@@ -79,16 +88,20 @@ public class ElementTreePathBuilderTest {
   public void shouldIncludeProcessDefinitionAndCallingElementTreePaths() {
     // given
     final String callActivityId = "callActivity";
-    final HashFunction hashFunction = Hashing.murmur3_128();
-    final var callActivityIdHash =
-        hashFunction.hashString(callActivityId, Charset.defaultCharset()).toString();
 
     final var processARecord = createProcessInstanceRecord();
     final ElementInstance processA =
         elementInstanceState.newInstance(
             100, processARecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+    processState.putProcess(
+        processARecord.getProcessDefinitionKey(),
+        createParentProcess(
+            processARecord.getProcessDefinitionKey(),
+            "A",
+            c -> c.id(callActivityId).zeebeProcessId("B")));
 
-    final var callActivityRecord = createProcessInstanceRecord();
+    final var callActivityRecord =
+        createProcessInstanceRecord(processARecord.getProcessDefinitionKey());
     callActivityRecord.setElementId(callActivityId);
     final ElementInstance callActivityElementInstance =
         elementInstanceState.newInstance(
@@ -100,16 +113,26 @@ public class ElementTreePathBuilderTest {
     final ElementInstance processB =
         elementInstanceState.newInstance(
             102, processBRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    processState.putProcess(
+        processBRecord.getProcessDefinitionKey(),
+        createChildProcess(
+            processBRecord.getProcessDefinitionKey(), "B", ServiceTaskBuilder::done));
 
     final var subProcessCRecord = createProcessInstanceRecord();
     callActivityRecord.setElementId("subProcessC");
     final ElementInstance subProcessC =
         elementInstanceState.newInstance(
             processB, 103, subProcessCRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    processState.putProcess(
+        subProcessCRecord.getProcessDefinitionKey(),
+        createChildProcess(
+            subProcessCRecord.getProcessDefinitionKey(), "C", ServiceTaskBuilder::done));
+
     // when
     final ElementTreePathBuilder builder =
         new ElementTreePathBuilder()
             .withElementInstanceState(elementInstanceState)
+            .withProcessState(processState)
             .withElementInstanceKey(subProcessC.getKey());
 
     final ElementTreePathProperties properties = builder.build();
@@ -123,19 +146,62 @@ public class ElementTreePathBuilderTest {
         .containsExactly(
             processARecord.getProcessDefinitionKey(), processBRecord.getProcessDefinitionKey());
     assertThat(properties.callingElementPath()).hasSize(1);
-    assertThat(properties.callingElementPath().getFirst()).isEqualTo(callActivityIdHash);
+    assertThat(properties.callingElementPath().getFirst()).isEqualTo(0);
   }
 
   private ProcessInstanceRecord createProcessInstanceRecord() {
+    return createProcessInstanceRecord(ThreadLocalRandom.current().nextLong(1000));
+  }
+
+  private ProcessInstanceRecord createProcessInstanceRecord(final long processDefinitionKey) {
     final ProcessInstanceRecord processInstanceRecord = new ProcessInstanceRecord();
     processInstanceRecord.setElementId("startEvent");
     processInstanceRecord.setBpmnProcessId(wrapString("process1"));
     processInstanceRecord.setProcessInstanceKey(1000L);
     processInstanceRecord.setFlowScopeKey(1001L);
     processInstanceRecord.setVersion(1);
-    processInstanceRecord.setProcessDefinitionKey(ThreadLocalRandom.current().nextLong(1000));
+    processInstanceRecord.setProcessDefinitionKey(processDefinitionKey);
     processInstanceRecord.setBpmnElementType(BpmnElementType.START_EVENT);
 
     return processInstanceRecord;
+  }
+
+  private static ProcessRecord createParentProcess(
+      final long processKey, final String processId, final Consumer<CallActivityBuilder> consumer) {
+    final var builder = Bpmn.createExecutableProcess(processId).startEvent().callActivity();
+
+    consumer.accept(builder);
+    final var modelInstance = builder.endEvent().done();
+    return createProcessRecord(processKey, processId, modelInstance);
+  }
+
+  private static ProcessRecord createChildProcess(
+      final long processKey, final String processId, final Consumer<ServiceTaskBuilder> consumer) {
+    final var builder = Bpmn.createExecutableProcess(processId).startEvent().serviceTask();
+
+    consumer.accept(builder);
+    final var modelInstance = builder.endEvent().done();
+    return createProcessRecord(processKey, processId, modelInstance);
+  }
+
+  private static ProcessRecord createProcessRecord(
+      final long processKey, final String processId, final BpmnModelInstance modelInstance) {
+
+    final ProcessRecord processRecord = new ProcessRecord();
+    final String resourceName = "process.bpmn";
+    final var resource = wrapString(Bpmn.convertToString(modelInstance));
+    final var checksum = wrapString("checksum" + TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    processRecord
+        .setResourceName(wrapString(resourceName))
+        .setResource(resource)
+        .setBpmnProcessId(BufferUtil.wrapString(processId))
+        .setVersion(1)
+        .setKey(processKey)
+        .setResourceName(resourceName)
+        .setChecksum(checksum)
+        .setTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+
+    return processRecord;
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.common;
+
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.processing.common.ElementTreePathBuilder.ElementTreePathProperties;
+import io.camunda.zeebe.engine.state.instance.ElementInstance;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateRule;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ElementTreePathBuilderTest {
+  @Rule public final ProcessingStateRule stateRule = new ProcessingStateRule();
+
+  private MutableElementInstanceState elementInstanceState;
+  private MutableProcessingState processingState;
+
+  @Before
+  public void setUp() {
+    processingState = stateRule.getProcessingState();
+    elementInstanceState = processingState.getElementInstanceState();
+  }
+
+  @Test
+  public void shouldBuildElementInstanceTreePath() {
+    // given
+    final var parentProcessInstanceRecord = createProcessInstanceRecord();
+    final ElementInstance parentInstance =
+        elementInstanceState.newInstance(
+            100, parentProcessInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    final var subProcessInstanceRecord = createProcessInstanceRecord();
+    subProcessInstanceRecord.setElementId("subProcess");
+    elementInstanceState.newInstance(
+        parentInstance, 101, subProcessInstanceRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+    final var subProcess2InstanceRecord = createProcessInstanceRecord();
+    subProcess2InstanceRecord.setElementId("subProcess2");
+    final ElementInstance subProcess2 =
+        elementInstanceState.newInstance(
+            parentInstance,
+            102,
+            subProcess2InstanceRecord,
+            ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+    // when
+    final ElementTreePathBuilder builder =
+        new ElementTreePathBuilder(elementInstanceState, subProcess2.getKey());
+
+    final ElementTreePathProperties properties = builder.getProperties();
+
+    assertThat(properties.elementInstancePath()).isNotNull();
+    assertThat(properties.elementInstancePath()).hasSize(1); // no call activities
+    assertThat(properties.elementInstancePath().getFirst()).containsExactly(100L, 102L);
+  }
+
+  @Test
+  public void shouldIncludeCallingProcessTreePath() {
+    // given
+    final var processARecord = createProcessInstanceRecord();
+    final ElementInstance processA =
+        elementInstanceState.newInstance(
+            100, processARecord, ProcessInstanceIntent.ELEMENT_ACTIVATED);
+
+    final var callActivityRecord = createProcessInstanceRecord();
+    callActivityRecord.setElementId("callActivity");
+    final ElementInstance callActivityElementInstance =
+        elementInstanceState.newInstance(
+            processA, 101, callActivityRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+    final var processBRecord = createProcessInstanceRecord();
+    processBRecord.setElementId("processB");
+    processBRecord.setParentElementInstanceKey(callActivityElementInstance.getKey());
+    final ElementInstance processB =
+        elementInstanceState.newInstance(
+            102, processBRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+
+    final var subProcessCRecord = createProcessInstanceRecord();
+    callActivityRecord.setElementId("subProcessC");
+    final ElementInstance subProcessC =
+        elementInstanceState.newInstance(
+            processB, 103, subProcessCRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
+    // when
+    final ElementTreePathBuilder builder =
+        new ElementTreePathBuilder(elementInstanceState, subProcessC.getKey());
+
+    final ElementTreePathProperties properties = builder.getProperties();
+
+    assertThat(properties.elementInstancePath()).isNotNull();
+    assertThat(properties.elementInstancePath()).hasSize(2);
+    assertThat(properties.elementInstancePath().getFirst()).containsExactly(100L, 101L);
+    assertThat(properties.elementInstancePath().getLast()).containsExactly(102L, 103L);
+  }
+
+  private ProcessInstanceRecord createProcessInstanceRecord() {
+    final ProcessInstanceRecord processInstanceRecord = new ProcessInstanceRecord();
+    processInstanceRecord.setElementId("startEvent");
+    processInstanceRecord.setBpmnProcessId(wrapString("process1"));
+    processInstanceRecord.setProcessInstanceKey(1000L);
+    processInstanceRecord.setFlowScopeKey(1001L);
+    processInstanceRecord.setVersion(1);
+    processInstanceRecord.setProcessDefinitionKey(2);
+    processInstanceRecord.setBpmnElementType(BpmnElementType.START_EVENT);
+
+    return processInstanceRecord;
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -59,9 +59,11 @@ public class ElementTreePathBuilderTest {
 
     // when
     final ElementTreePathBuilder builder =
-        new ElementTreePathBuilder(elementInstanceState, subProcess2.getKey());
+        new ElementTreePathBuilder()
+            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceKey(subProcess2.getKey());
 
-    final ElementTreePathProperties properties = builder.getProperties();
+    final ElementTreePathProperties properties = builder.build();
 
     assertThat(properties.elementInstancePath()).isNotNull();
     assertThat(properties.elementInstancePath()).hasSize(1); // no call activities
@@ -99,9 +101,11 @@ public class ElementTreePathBuilderTest {
             processB, 103, subProcessCRecord, ProcessInstanceIntent.ELEMENT_ACTIVATING);
     // when
     final ElementTreePathBuilder builder =
-        new ElementTreePathBuilder(elementInstanceState, subProcessC.getKey());
+        new ElementTreePathBuilder()
+            .withElementInstanceState(elementInstanceState)
+            .withElementInstanceKey(subProcessC.getKey());
 
-    final ElementTreePathProperties properties = builder.getProperties();
+    final ElementTreePathProperties properties = builder.build();
 
     assertThat(properties.elementInstancePath()).isNotNull();
     assertThat(properties.elementInstancePath()).hasSize(2);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Before;
 import org.junit.Rule;
@@ -74,7 +75,7 @@ public class ElementTreePathBuilderTest {
   }
 
   @Test
-  public void shouldIncludeCallingProcessTreePath() {
+  public void shouldIncludeProcessDefinitionAndCallingElementTreePaths() {
     // given
     final var processARecord = createProcessInstanceRecord();
     final ElementInstance processA =
@@ -115,6 +116,9 @@ public class ElementTreePathBuilderTest {
     assertThat(properties.processDefinitionPath())
         .containsExactly(
             processARecord.getProcessDefinitionKey(), processBRecord.getProcessDefinitionKey());
+    assertThat(properties.callingElementPath()).hasSize(1);
+    assertThat(properties.callingElementPath().getFirst())
+        .isEqualTo(BufferUtil.wrapString("callActivity"));
   }
 
   private ProcessInstanceRecord createProcessInstanceRecord() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ElementTreePathBuilderTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.util.concurrent.ThreadLocalRandom;
 import org.junit.Before;
 import org.junit.Rule;
@@ -117,8 +116,7 @@ public class ElementTreePathBuilderTest {
         .containsExactly(
             processARecord.getProcessDefinitionKey(), processBRecord.getProcessDefinitionKey());
     assertThat(properties.callingElementPath()).hasSize(1);
-    assertThat(properties.callingElementPath().getFirst())
-        .isEqualTo(BufferUtil.wrapString("callActivity"));
+    assertThat(properties.callingElementPath().getFirst()).isEqualTo("callActivity");
   }
 
   private ProcessInstanceRecord createProcessInstanceRecord() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.test.util.Strings;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.List;
 import java.util.function.Function;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -107,6 +108,8 @@ public final class CallActivityIncidentTest {
         getCallActivityInstance(processInstanceKey);
 
     assertIncidentCreated(incident, elementInstance)
+        .hasElementInstancePath(List.of(List.of(processInstanceKey, elementInstance.getKey())))
+        .hasProcessDefinitionKey(incident.getValue().getProcessDefinitionKey())
         .hasErrorType(ErrorType.CALLED_ELEMENT_ERROR)
         .hasErrorMessage(
             "Expected process with BPMN process id '"
@@ -189,6 +192,8 @@ public final class CallActivityIncidentTest {
         getCallActivityInstance(processInstanceKey);
 
     assertIncidentCreated(incident, elementInstance, tenantId)
+        .hasElementInstancePath(List.of(List.of(processInstanceKey, elementInstance.getKey())))
+        .hasProcessDefinitionKey(incident.getValue().getProcessDefinitionKey())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
         .hasErrorMessage(
             """

--- a/zeebe/engine/src/test/resources/processes/callActivity.bpmn
+++ b/zeebe/engine/src/test/resources/processes/callActivity.bpmn
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.24.0">
+  <bpmn:collaboration id="call-activity">
+    <bpmn:participant id="Participant_04mrpvv" processRef="root-process" />
+    <bpmn:participant id="Participant_0totse7" processRef="parent-process" />
+    <bpmn:participant id="Participant_0pre113" processRef="child-process" />
+  </bpmn:collaboration>
+  <bpmn:process id="root-process" name="" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_13zbler">
+      <bpmn:outgoing>SequenceFlow_12yjisf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0f5vr8g">
+      <bpmn:incoming>SequenceFlow_05tsq21</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="call-parent" name="call parent">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="parent-process" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_12yjisf</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_05tsq21</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_12yjisf" sourceRef="StartEvent_13zbler" targetRef="call-parent" />
+    <bpmn:sequenceFlow id="SequenceFlow_05tsq21" sourceRef="call-parent" targetRef="EndEvent_0f5vr8g" />
+  </bpmn:process>
+  <bpmn:process id="parent-process" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1rgk9pd">
+      <bpmn:outgoing>SequenceFlow_07qovpb</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_1ptwlnh">
+      <bpmn:incoming>SequenceFlow_13flveu</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="call-child" name="call child">
+      <bpmn:extensionElements>
+        <zeebe:calledElement processId="child-process" propagateAllChildVariables="false" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_07qovpb</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_13flveu</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="SequenceFlow_07qovpb" sourceRef="StartEvent_1rgk9pd" targetRef="call-child" />
+    <bpmn:sequenceFlow id="SequenceFlow_13flveu" sourceRef="call-child" targetRef="EndEvent_1ptwlnh" />
+  </bpmn:process>
+  <bpmn:process id="child-process" isExecutable="true">
+    <bpmn:startEvent id="Event_1qw17zo">
+      <bpmn:outgoing>Flow_0uvc3ya</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_1awfapd">
+      <bpmn:incoming>Flow_08jisnk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:serviceTask id="Activity_0igcts0" name="test task">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="job-shouldPropagateCorrectIndexesInCallingElementPathWhenMultipleProcessesInSameFile" />
+        <zeebe:ioMapping>
+          <zeebe:output source="=assert(x, x != null)" target="y" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0uvc3ya</bpmn:incoming>
+      <bpmn:outgoing>Flow_08jisnk</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0uvc3ya" sourceRef="Event_1qw17zo" targetRef="Activity_0igcts0" />
+    <bpmn:sequenceFlow id="Flow_08jisnk" sourceRef="Activity_0igcts0" targetRef="Event_1awfapd" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="call-activity">
+      <bpmndi:BPMNShape id="Participant_04mrpvv_di" bpmnElement="Participant_04mrpvv" isHorizontal="true">
+        <dc:Bounds x="158" y="114" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_13zbler_di" bpmnElement="StartEvent_13zbler">
+        <dc:Bounds x="240" y="208" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="358" y="247" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0f5vr8g_di" bpmnElement="EndEvent_0f5vr8g">
+        <dc:Bounds x="523" y="208" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="641" y="247" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0pvsxy1_di" bpmnElement="call-parent">
+        <dc:Bounds x="345" y="186" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_12yjisf_di" bpmnElement="SequenceFlow_12yjisf">
+        <di:waypoint x="276" y="226" />
+        <di:waypoint x="345" y="226" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="410.5" y="204.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_05tsq21_di" bpmnElement="SequenceFlow_05tsq21">
+        <di:waypoint x="445" y="226" />
+        <di:waypoint x="523" y="226" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="584" y="204.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Participant_0totse7_di" bpmnElement="Participant_0totse7" isHorizontal="true">
+        <dc:Bounds x="158" y="455" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="StartEvent_1rgk9pd_di" bpmnElement="StartEvent_1rgk9pd">
+        <dc:Bounds x="237" y="575" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="355" y="614" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1ptwlnh_di" bpmnElement="EndEvent_1ptwlnh">
+        <dc:Bounds x="529" y="575" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="647" y="614" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0h2gvgg_di" bpmnElement="call-child">
+        <dc:Bounds x="349" y="553" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_07qovpb_di" bpmnElement="SequenceFlow_07qovpb">
+        <di:waypoint x="273" y="593" />
+        <di:waypoint x="349" y="593" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="411" y="571.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_13flveu_di" bpmnElement="SequenceFlow_13flveu">
+        <di:waypoint x="449" y="593" />
+        <di:waypoint x="529" y="593" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="589" y="571.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="BPMNShape_05dqrhl" bpmnElement="Participant_0pre113" isHorizontal="true">
+        <dc:Bounds x="158" y="770" width="600" height="250" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_03k4alf" bpmnElement="Event_1qw17zo">
+        <dc:Bounds x="237" y="890" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="355" y="614" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_04nq2hv" bpmnElement="Event_1awfapd">
+        <dc:Bounds x="529" y="890" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="647" y="614" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="BPMNShape_137trfh" bpmnElement="Activity_0igcts0">
+        <dc:Bounds x="349" y="868" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="BPMNEdge_00mta0y" bpmnElement="Flow_0uvc3ya">
+        <di:waypoint x="273" y="908" />
+        <di:waypoint x="349" y="908" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="411" y="571.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="BPMNEdge_0g2fzek" bpmnElement="Flow_08jisnk">
+        <di:waypoint x="449" y="908" />
+        <di:waypoint x="529" y="908" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="589" y="571.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -48,6 +48,15 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "elementInstancePath": {
+              "enabled": false
+            },
+            "processDefinitionPath": {
+              "enabled": false
+            },
+            "callingElementPath": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-incident-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-incident-template.json
@@ -48,6 +48,15 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "elementInstancePath": {
+              "enabled": false
+            },
+            "processDefinitionPath": {
+              "enabled": false
+            },
+            "callingElementPath": {
+              "enabled": false
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -199,6 +199,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
   public List<List<Long>> getElementInstancePath() {
     final var elementInstancePath = new ArrayList<List<Long>>();
     elementInstancePathProp.forEach(
@@ -220,6 +221,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
   public List<Long> getProcessDefinitionPath() {
     final var processDefinitionPath = new ArrayList<Long>();
     processDefinitionPathProp.forEach(e -> processDefinitionPath.add(e.getValue()));
@@ -232,6 +234,7 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
+  @Override
   public List<String> getCallingElementPath() {
     final var callingElementPath = new ArrayList<String>();
     callingElementPathProp.forEach(

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -13,8 +13,8 @@ import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
+import io.camunda.zeebe.msgpack.value.IntegerValue;
 import io.camunda.zeebe.msgpack.value.LongValue;
-import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -43,8 +43,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new ArrayProperty<>("elementInstancePath", () -> new ArrayValue<>(LongValue::new));
   private final ArrayProperty<LongValue> processDefinitionPathProp =
       new ArrayProperty<>("processDefinitionPath", LongValue::new);
-  private final ArrayProperty<StringValue> callingElementPathProp =
-      new ArrayProperty<>("callingElementPath", StringValue::new);
+  private final ArrayProperty<IntegerValue> callingElementPathProp =
+      new ArrayProperty<>("callingElementPath", IntegerValue::new);
 
   public IncidentRecord() {
     super(13);
@@ -200,16 +200,15 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   }
 
   @Override
-  public List<String> getCallingElementPath() {
-    final var callingElementPath = new ArrayList<String>();
-    callingElementPathProp.forEach(
-        e -> callingElementPath.add(BufferUtil.bufferAsString(e.getValue())));
+  public List<Integer> getCallingElementPath() {
+    final var callingElementPath = new ArrayList<Integer>();
+    callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));
     return callingElementPath;
   }
 
-  public IncidentRecord setCallingElementPath(final List<String> callingElementPath) {
+  public IncidentRecord setCallingElementPath(final List<Integer> callingElementPath) {
     callingElementPathProp.reset();
-    callingElementPath.forEach(e -> callingElementPathProp.add().wrap(BufferUtil.wrapString(e)));
+    callingElementPath.forEach(e -> callingElementPathProp.add().setValue(e));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -42,8 +43,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new ArrayProperty<>("elementInstancePath", () -> new ArrayValue<>(LongValue::new));
   private final ArrayProperty<LongValue> processDefinitionPathProp =
       new ArrayProperty<>("processDefinitionPath", LongValue::new);
-  private final ArrayProperty<LongValue> callingElementPathProp =
-      new ArrayProperty<>("callingElementPath", LongValue::new);
+  private final ArrayProperty<StringValue> callingElementPathProp =
+      new ArrayProperty<>("callingElementPath", StringValue::new);
 
   public IncidentRecord() {
     super(13);
@@ -199,15 +200,16 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   }
 
   @Override
-  public List<Long> getCallingElementPath() {
-    final var callingElementPath = new ArrayList<Long>();
-    callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));
+  public List<String> getCallingElementPath() {
+    final var callingElementPath = new ArrayList<String>();
+    callingElementPathProp.forEach(
+        e -> callingElementPath.add(BufferUtil.bufferAsString(e.getValue())));
     return callingElementPath;
   }
 
-  public IncidentRecord setCallingElementPath(final List<Long> callingElementPath) {
+  public IncidentRecord setCallingElementPath(final List<String> callingElementPath) {
     callingElementPathProp.reset();
-    callingElementPath.forEach(e -> callingElementPathProp.add().setValue(e));
+    callingElementPath.forEach(e -> callingElementPathProp.add().wrap(BufferUtil.wrapString(e)));
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -8,14 +8,20 @@
 package io.camunda.zeebe.protocol.impl.record.value.incident;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
+import io.camunda.zeebe.msgpack.value.ArrayValue;
+import io.camunda.zeebe.msgpack.value.LongValue;
+import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.ArrayList;
+import java.util.List;
 import org.agrona.DirectBuffer;
 
 public final class IncidentRecord extends UnifiedRecordValue implements IncidentRecordValue {
@@ -33,9 +39,15 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   private final LongProperty variableScopeKeyProp = new LongProperty("variableScopeKey", -1L);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final ArrayProperty<ArrayValue<LongValue>> elementInstancePathProp =
+      new ArrayProperty<>("elementInstancePath", () -> new ArrayValue<>(LongValue::new));
+  private final ArrayProperty<LongValue> processDefinitionPathProp =
+      new ArrayProperty<>("processDefinitionPath", LongValue::new);
+  private final ArrayProperty<StringValue> callingElementPathProp =
+      new ArrayProperty<>("callingElementPath", StringValue::new);
 
   public IncidentRecord() {
-    super(10);
+    super(13);
     declareProperty(errorTypeProp)
         .declareProperty(errorMessageProp)
         .declareProperty(bpmnProcessIdProp)
@@ -45,7 +57,10 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
         .declareProperty(elementInstanceKeyProp)
         .declareProperty(jobKeyProp)
         .declareProperty(variableScopeKeyProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(elementInstancePathProp)
+        .declareProperty(processDefinitionPathProp)
+        .declareProperty(callingElementPathProp);
   }
 
   public void wrap(final IncidentRecord record) {
@@ -59,6 +74,9 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     jobKeyProp.setValue(record.getJobKey());
     variableScopeKeyProp.setValue(record.getVariableScopeKey());
     tenantIdProp.setValue(record.getTenantId());
+    setElementInstancePath(record.getElementInstancePath());
+    setProcessDefinitionPath(record.getProcessDefinitionPath());
+    setCallingElementPath(record.getCallingElementPath());
   }
 
   @JsonIgnore
@@ -178,6 +196,51 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
 
   public IncidentRecord setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
+    return this;
+  }
+
+  public List<List<Long>> getElementInstancePath() {
+    final var elementInstancePath = new ArrayList<List<Long>>();
+    elementInstancePathProp.forEach(
+        pe -> {
+          final var pathEntry = new ArrayList<Long>();
+          pe.forEach(e -> pathEntry.add(e.getValue()));
+          elementInstancePath.add(pathEntry);
+        });
+    return elementInstancePath;
+  }
+
+  public IncidentRecord setElementInstancePath(final List<List<Long>> elementInstancePath) {
+    elementInstancePathProp.reset();
+    elementInstancePath.forEach(
+        pathEntry -> {
+          final var entry = elementInstancePathProp.add();
+          pathEntry.forEach(element -> entry.add().setValue(element));
+        });
+    return this;
+  }
+
+  public List<Long> getProcessDefinitionPath() {
+    final var processDefinitionPath = new ArrayList<Long>();
+    processDefinitionPathProp.forEach(e -> processDefinitionPath.add(e.getValue()));
+    return processDefinitionPath;
+  }
+
+  public IncidentRecord setProcessDefinitionPath(final List<Long> processDefinitionPath) {
+    processDefinitionPathProp.reset();
+    processDefinitionPath.forEach(e -> processDefinitionPathProp.add().setValue(e));
+    return this;
+  }
+
+  public List<DirectBuffer> getCallingElementPath() {
+    final var callingElementPath = new ArrayList<DirectBuffer>();
+    callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));
+    return callingElementPath;
+  }
+
+  public IncidentRecord setCallingElementPath(final List<DirectBuffer> callingElementPath) {
+    callingElementPathProp.reset();
+    callingElementPath.forEach(e -> callingElementPathProp.add().wrap(e));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -14,7 +14,6 @@ import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ArrayValue;
 import io.camunda.zeebe.msgpack.value.LongValue;
-import io.camunda.zeebe.msgpack.value.StringValue;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
@@ -43,8 +42,8 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
       new ArrayProperty<>("elementInstancePath", () -> new ArrayValue<>(LongValue::new));
   private final ArrayProperty<LongValue> processDefinitionPathProp =
       new ArrayProperty<>("processDefinitionPath", LongValue::new);
-  private final ArrayProperty<StringValue> callingElementPathProp =
-      new ArrayProperty<>("callingElementPath", StringValue::new);
+  private final ArrayProperty<LongValue> callingElementPathProp =
+      new ArrayProperty<>("callingElementPath", LongValue::new);
 
   public IncidentRecord() {
     super(13);
@@ -235,16 +234,16 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   }
 
   @Override
-  public List<String> getCallingElementPath() {
-    final var callingElementPath = new ArrayList<String>();
+  public List<Long> getCallingElementPath() {
+    final var callingElementPath = new ArrayList<Long>();
     callingElementPathProp.forEach(
-        e -> callingElementPath.add(BufferUtil.bufferAsString(e.getValue())));
+        e -> callingElementPath.add(e.getValue()));
     return callingElementPath;
   }
 
-  public IncidentRecord setCallingElementPath(final List<String> callingElementPath) {
+  public IncidentRecord setCallingElementPath(final List<Long> callingElementPath) {
     callingElementPathProp.reset();
-    callingElementPath.forEach(e -> callingElementPathProp.add().wrap(BufferUtil.wrapString(e)));
+    callingElementPath.forEach(e -> callingElementPathProp.add().setValue(e));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -163,41 +163,6 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
-  public IncidentRecord setJobKey(final long jobKey) {
-    jobKeyProp.setValue(jobKey);
-    return this;
-  }
-
-  public IncidentRecord setProcessInstanceKey(final long processInstanceKey) {
-    processInstanceKeyProp.setValue(processInstanceKey);
-    return this;
-  }
-
-  public IncidentRecord setErrorMessage(final DirectBuffer errorMessage) {
-    errorMessageProp.setValue(errorMessage);
-    return this;
-  }
-
-  public IncidentRecord setErrorMessage(final String errorMessage) {
-    errorMessageProp.setValue(errorMessage);
-    return this;
-  }
-
-  public IncidentRecord setErrorType(final ErrorType errorType) {
-    errorTypeProp.setValue(errorType);
-    return this;
-  }
-
-  @Override
-  public String getTenantId() {
-    return BufferUtil.bufferAsString(tenantIdProp.getValue());
-  }
-
-  public IncidentRecord setTenantId(final String tenantId) {
-    tenantIdProp.setValue(tenantId);
-    return this;
-  }
-
   @Override
   public List<List<Long>> getElementInstancePath() {
     final var elementInstancePath = new ArrayList<List<Long>>();
@@ -236,14 +201,48 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
   @Override
   public List<Long> getCallingElementPath() {
     final var callingElementPath = new ArrayList<Long>();
-    callingElementPathProp.forEach(
-        e -> callingElementPath.add(e.getValue()));
+    callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));
     return callingElementPath;
   }
 
   public IncidentRecord setCallingElementPath(final List<Long> callingElementPath) {
     callingElementPathProp.reset();
     callingElementPath.forEach(e -> callingElementPathProp.add().setValue(e));
+    return this;
+  }
+
+  public IncidentRecord setJobKey(final long jobKey) {
+    jobKeyProp.setValue(jobKey);
+    return this;
+  }
+
+  public IncidentRecord setProcessInstanceKey(final long processInstanceKey) {
+    processInstanceKeyProp.setValue(processInstanceKey);
+    return this;
+  }
+
+  public IncidentRecord setErrorMessage(final DirectBuffer errorMessage) {
+    errorMessageProp.setValue(errorMessage);
+    return this;
+  }
+
+  public IncidentRecord setErrorMessage(final String errorMessage) {
+    errorMessageProp.setValue(errorMessage);
+    return this;
+  }
+
+  public IncidentRecord setErrorType(final ErrorType errorType) {
+    errorTypeProp.setValue(errorType);
+    return this;
+  }
+
+  @Override
+  public String getTenantId() {
+    return BufferUtil.bufferAsString(tenantIdProp.getValue());
+  }
+
+  public IncidentRecord setTenantId(final String tenantId) {
+    tenantIdProp.setValue(tenantId);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/incident/IncidentRecord.java
@@ -232,15 +232,16 @@ public final class IncidentRecord extends UnifiedRecordValue implements Incident
     return this;
   }
 
-  public List<DirectBuffer> getCallingElementPath() {
-    final var callingElementPath = new ArrayList<DirectBuffer>();
-    callingElementPathProp.forEach(e -> callingElementPath.add(e.getValue()));
+  public List<String> getCallingElementPath() {
+    final var callingElementPath = new ArrayList<String>();
+    callingElementPathProp.forEach(
+        e -> callingElementPath.add(BufferUtil.bufferAsString(e.getValue())));
     return callingElementPath;
   }
 
-  public IncidentRecord setCallingElementPath(final List<DirectBuffer> callingElementPath) {
+  public IncidentRecord setCallingElementPath(final List<String> callingElementPath) {
     callingElementPathProp.reset();
-    callingElementPath.forEach(e -> callingElementPathProp.add().wrap(e));
+    callingElementPath.forEach(e -> callingElementPathProp.add().wrap(BufferUtil.wrapString(e)));
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -518,8 +518,8 @@ final class JsonSerializableToJsonTest {
               final ErrorType errorType = ErrorType.IO_MAPPING_ERROR;
               final long jobKey = 123;
               final var elementInstancePath = List.of(List.of(101L, 102L), List.of(103L, 104L));
-              final List<Long> processDefinitionPath = List.of(101L, 102L);
-              final List<Long> callingElementPath = List.of(12345L, 67890L);
+              final var processDefinitionPath = List.of(101L, 102L);
+              final var callingElementPath = List.of("callX", "callY");
               return new IncidentRecord()
                   .setElementInstanceKey(elementInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
@@ -548,7 +548,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "elementInstancePath":[[101, 102], [103, 104]],
           "processDefinitionPath": [101, 102],
-          "callingElementPath": [12345, 67890]
+          "callingElementPath": ["callX", "callY"]
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -519,7 +519,7 @@ final class JsonSerializableToJsonTest {
               final long jobKey = 123;
               final var elementInstancePath = List.of(List.of(101L, 102L), List.of(103L, 104L));
               final List<Long> processDefinitionPath = List.of(101L, 102L);
-              final List<String> callingElementPath = List.of("CallX", "CallY");
+              final List<Long> callingElementPath = List.of(12345L, 67890L);
               return new IncidentRecord()
                   .setElementInstanceKey(elementInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
@@ -548,7 +548,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "elementInstancePath":[[101, 102], [103, 104]],
           "processDefinitionPath": [101, 102],
-          "callingElementPath": ["CallX", "CallY"]
+          "callingElementPath": [12345, 67890]
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -519,7 +519,7 @@ final class JsonSerializableToJsonTest {
               final long jobKey = 123;
               final var elementInstancePath = List.of(List.of(101L, 102L), List.of(103L, 104L));
               final var processDefinitionPath = List.of(101L, 102L);
-              final var callingElementPath = List.of("callX", "callY");
+              final var callingElementPath = List.of(12345, 67890);
               return new IncidentRecord()
                   .setElementInstanceKey(elementInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
@@ -548,7 +548,7 @@ final class JsonSerializableToJsonTest {
           "tenantId": "<default>",
           "elementInstancePath":[[101, 102], [103, 104]],
           "processDefinitionPath": [101, 102],
-          "callingElementPath": ["callX", "callY"]
+          "callingElementPath": [12345, 67890]
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -517,7 +517,9 @@ final class JsonSerializableToJsonTest {
               final String errorMessage = "error";
               final ErrorType errorType = ErrorType.IO_MAPPING_ERROR;
               final long jobKey = 123;
-
+              final var elementInstancePath = List.of(List.of(101L, 102L), List.of(103L, 104L));
+              final List<Long> processDefinitionPath = List.of(101L, 102L);
+              final List<String> callingElementPath = List.of("CallX", "CallY");
               return new IncidentRecord()
                   .setElementInstanceKey(elementInstanceKey)
                   .setProcessDefinitionKey(processDefinitionKey)
@@ -527,7 +529,10 @@ final class JsonSerializableToJsonTest {
                   .setErrorMessage(errorMessage)
                   .setErrorType(errorType)
                   .setJobKey(jobKey)
-                  .setVariableScopeKey(elementInstanceKey);
+                  .setVariableScopeKey(elementInstanceKey)
+                  .setElementInstancePath(elementInstancePath)
+                  .setProcessDefinitionPath(processDefinitionPath)
+                  .setCallingElementPath(callingElementPath);
             },
         """
         {
@@ -540,7 +545,10 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": 34,
           "jobKey": 123,
           "variableScopeKey": 34,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "elementInstancePath":[[101, 102], [103, 104]],
+          "processDefinitionPath": [101, 102],
+          "callingElementPath": ["CallX", "CallY"]
         }
         """
       },
@@ -561,7 +569,10 @@ final class JsonSerializableToJsonTest {
           "elementInstanceKey": -1,
           "jobKey": -1,
           "variableScopeKey": -1,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "elementInstancePath":[],
+          "processDefinitionPath":[],
+          "callingElementPath":[]
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -103,5 +103,5 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
    * @return tree path information about call activities in the hierarchy of the incident. Each
    *     entry is a reference to the call activity in BPMN model containing an incident.
    */
-  List<Long> getCallingElementPath();
+  List<String> getCallingElementPath();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.protocol.record.value;
 import io.camunda.zeebe.protocol.record.ImmutableProtocol;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import java.util.List;
 import org.immutables.value.Value;
 
 /**
@@ -83,4 +84,24 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
    *     -1</code> if the incident record is part of a {@link IncidentIntent#RESOLVE} command.
    */
   long getVariableScopeKey();
+
+  /**
+   * @return tree path information about all element instances in the call hierarchy leading to an
+   *     incident. It contains an entry per process instance in the hierarchy of the incident, each
+   *     contains all the instance keys of all the elements in the call hierarchy within this
+   *     process instance
+   */
+  List<List<Long>> getElementInstancePath();
+
+  /**
+   * @return tree path information for all process definitions in the hierarchy of the incident.
+   *     Each entry is a process definition key for the corresponding process instance
+   */
+  List<Long> getProcessDefinitionPath();
+
+  /**
+   * @return tree path information about call activities in the hierarchy of the incident. Each
+   *     entry is a reference to the call activity in BPMN model containing an incident.
+   */
+  List<String> getCallingElementPath();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -103,5 +103,5 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
    * @return tree path information about call activities in the hierarchy of the incident. Each
    *     entry is a reference to the call activity in BPMN model containing an incident.
    */
-  List<String> getCallingElementPath();
+  List<Long> getCallingElementPath();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/IncidentRecordValue.java
@@ -103,5 +103,5 @@ public interface IncidentRecordValue extends RecordValue, ProcessInstanceRelated
    * @return tree path information about call activities in the hierarchy of the incident. Each
    *     entry is a reference to the call activity in BPMN model containing an incident.
    */
-  List<String> getCallingElementPath();
+  List<Integer> getCallingElementPath();
 }


### PR DESCRIPTION
## Description
For the https://github.com/camunda/product-hub/issues/2128, we need to provide the so-called tree path. It is a concept to assign entities their location in a tree of process instances and BPMN scopes, so that we can query for it and find all entities within a particular subtree.
With this feature, we want to provide the tree path for incident records, because that is where Operate currently needs the functionality. In the future and as the feature set evolves, we may roll it out to more records.

For this implementation, I've created an `ElementTreePathBuilder` that uses the `elementInstanceKey` and `elementInstanceState` to build the tree-path properties.

The changes provide 3 new properties to the `IncidentRecord`:
1. `elementInstancePath`: A list of lists, each list is contains the `elementInstanceKey`s  for all the elements contained within one process definition in the path to an incident.
2. `processDefinitionPath`: A list of `processDefinitionKey`s for each process in the path for an incident
3. `callingElementPath`: A list of encoded `ElementId`s for each `CallActivity` element in the path for an incident. ~~Since ElementIds are just a limited number of strings unique locally to the deployed model
we could use a hashing function to hash these Ids in the callingElementTreePath. Operate can use the same hashing function to hash all elementIds in a model and build a reverse `Map<Hash, ElementId>`, and use this map to look up the elementId string using the hash. I decided to use `murmur3_128` because it is a fast hashing function with low chance of collision. And I choose an implementation from `google guava`~~ 
The Element Ids are encoded by lexicographically sorting all calling activity elements in one deployment resource, and using the index of each call activity Id in this sorted list as the respective encoded value.

## Related issues

closes #16915
