### PR TITLE
fix: ensure controlled actor scheduler is closed after tests

### DIFF
--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.scheduler.testing;
 
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.ActorScheduler.ActorSchedulerBuilder;
@@ -20,6 +22,8 @@ import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
 import org.agrona.concurrent.IdleStrategy;
 import org.junit.rules.ExternalResource;
 
@@ -50,7 +54,11 @@ public final class ControlledActorSchedulerRule extends ExternalResource {
 
   @Override
   protected void after() {
-    actorScheduler.stop();
+    try {
+      actorScheduler.stop().get(5000, MILLISECONDS);
+    } catch (final InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public ActorFuture<Void> submitActor(final Actor actor) {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorThread.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorThread.java
@@ -12,13 +12,12 @@ import io.camunda.zeebe.scheduler.ActorThreadGroup;
 import io.camunda.zeebe.scheduler.ActorTimerQueue;
 import io.camunda.zeebe.scheduler.TaskScheduler;
 import io.camunda.zeebe.scheduler.clock.ActorClock;
-import java.util.concurrent.BrokenBarrierException;
-import java.util.concurrent.CyclicBarrier;
-import org.agrona.LangUtil;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Phaser;
 import org.agrona.concurrent.IdleStrategy;
 
 public final class ControlledActorThread extends ActorThread {
-  private final CyclicBarrier barrier = new CyclicBarrier(2);
+  private final Phaser phaser = new Phaser(2);
 
   public ControlledActorThread(
       final String name,
@@ -32,17 +31,18 @@ public final class ControlledActorThread extends ActorThread {
     this.idleStrategy = new ControlledIdleStrategy(idleStrategy);
   }
 
-  public void resumeTasks() {
-    try {
-      barrier.await(); // work at least 1 full cycle until the runner becomes idle after having been
-    } catch (final InterruptedException | BrokenBarrierException e) {
-      LangUtil.rethrowUnchecked(e);
-    }
+  @Override
+  public CompletableFuture<Void> close() {
+    phaser.arriveAndDeregister();
+    return super.close();
   }
 
-  // ControlledActorThread#resumeTasks must be called before this method
+  public void resumeTasks() {
+    phaser.arriveAndAwaitAdvance();
+  }
+
   public void waitUntilDone() {
-    while (barrier.getNumberWaiting() < 1) {
+    while (phaser.getArrivedParties() < 1) {
       // spin until thread is idle again
       Thread.yield();
     }
@@ -62,12 +62,7 @@ public final class ControlledActorThread extends ActorThread {
     @Override
     protected void onIdle() {
       super.onIdle();
-
-      try {
-        barrier.await();
-      } catch (final InterruptedException | BrokenBarrierException e) {
-        LangUtil.rethrowUnchecked(e);
-      }
+      phaser.arriveAndAwaitAdvance();
     }
   }
 }


### PR DESCRIPTION
## Description

Previously, most tests using the `ControlledActorScheduler` failed to close threads and leaked resources. This is fixed now, when a `ControlledActorThread` is closed, it unblocks the idling, ensuring that the thread can wrap up and complete the closing future.

While I don't have a good explanation _why_, I think this might close #13493 and #18590 because both were caused my mocking/concurrency issues and use the `ControlledActorScheduler`.

## Related issues

closes #13493
closes #18590
