### PR TITLE
[Backport stable/8.5] ci: add java client reminder workflow

### DIFF
--- a/.github/workflows/java-client-reminder.yaml
+++ b/.github/workflows/java-client-reminder.yaml
@@ -1,0 +1,35 @@
+name: Camunda Java Client reminder
+
+on:
+  pull_request
+
+jobs:
+  check-path-and-comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Check for changes in 'clients/java'
+        id: check_changes
+        run: |
+          if git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | grep -q '^clients/java'; then
+            echo "changes=true" >> $GITHUB_ENV
+          else
+            echo "changes=false" >> $GITHUB_ENV
+          fi
+
+      - name: Add PR comment
+        uses: thollander/actions-comment-pull-request@v2
+        if: env.changes == 'true'
+        with:
+          message: |
+            :wave: :robot: :thinking: Hello! Did you make your changes in all the right places?
+
+            Is your changes in the java client a new feature ?
+              - If yes, please ensure that the changes are only in the `io.camunda.client` package
+
+            Is your changes a bug fix and need to be backported into previous stables ?
+              - If yes, please ensure that those changes are in both packages, `io.camunda.client` and `io.camunda.zeebe.client`
+


### PR DESCRIPTION
# Description
Backport of #20285 to `stable/8.5`.

relates to #20281
original author: @nicpuppa