### PR TITLE
Add new camunda client properties

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/ClientProperties.java
+++ b/clients/java/src/main/java/io/camunda/client/ClientProperties.java
@@ -28,135 +28,135 @@ public final class ClientProperties {
    * @see CamundaClientBuilder#applyEnvironmentVariableOverrides(boolean)
    */
   public static final String APPLY_ENVIRONMENT_VARIABLES_OVERRIDES =
-      "zeebe.client.applyEnvironmentVariableOverrides";
+      "client.zeebe.applyEnvironmentVariableOverrides";
 
   /**
    * @deprecated since 8.5 for removal with 8.8, replaced by {@link ClientProperties#GRPC_ADDRESS}
    * @see CamundaClientBuilder#gatewayAddress(String)
    */
-  @Deprecated public static final String GATEWAY_ADDRESS = "zeebe.client.gateway.address";
+  @Deprecated public static final String GATEWAY_ADDRESS = "client.zeebe.gateway.address";
 
   /**
    * @deprecated since 8.5 for removal with 8.8, where toggling between both will not be possible
    * @see CamundaClientBuilder#preferRestOverGrpc(boolean)
    */
   @Deprecated
-  public static final String PREFER_REST_OVER_GRPC = "zeebe.client.gateway.preferRestOverGrpc";
+  public static final String PREFER_REST_OVER_GRPC = "client.zeebe.gateway.preferRestOverGrpc";
 
   /**
    * @see CamundaClientBuilder#restAddress(URI)
    */
-  public static final String REST_ADDRESS = "zeebe.client.gateway.rest.address";
+  public static final String REST_ADDRESS = "client.zeebe.gateway.rest.address";
 
   /**
    * @see CamundaClientBuilder#grpcAddress(URI)
    */
-  public static final String GRPC_ADDRESS = "zeebe.client.gateway.grpc.address";
+  public static final String GRPC_ADDRESS = "client.zeebe.gateway.grpc.address";
 
   /**
    * @see CamundaClientBuilder#defaultTenantId(String)
    */
-  public static final String DEFAULT_TENANT_ID = "zeebe.client.tenantId";
+  public static final String DEFAULT_TENANT_ID = "client.zeebe.tenantId";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerTenantIds(List)
    */
-  public static final String DEFAULT_JOB_WORKER_TENANT_IDS = "zeebe.client.worker.tenantIds";
+  public static final String DEFAULT_JOB_WORKER_TENANT_IDS = "client.zeebe.worker.tenantIds";
 
   /**
    * @see CamundaClientBuilder#numJobWorkerExecutionThreads(int)
    */
-  public static final String JOB_WORKER_EXECUTION_THREADS = "zeebe.client.worker.threads";
+  public static final String JOB_WORKER_EXECUTION_THREADS = "client.zeebe.worker.threads";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerMaxJobsActive(int)
    */
-  public static final String JOB_WORKER_MAX_JOBS_ACTIVE = "zeebe.client.worker.maxJobsActive";
+  public static final String JOB_WORKER_MAX_JOBS_ACTIVE = "client.zeebe.worker.maxJobsActive";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerName(String)
    */
-  public static final String DEFAULT_JOB_WORKER_NAME = "zeebe.client.worker.name";
+  public static final String DEFAULT_JOB_WORKER_NAME = "client.zeebe.worker.name";
 
   /**
    * @see CamundaClientBuilder#defaultJobTimeout(Duration)
    */
-  public static final String DEFAULT_JOB_TIMEOUT = "zeebe.client.job.timeout";
+  public static final String DEFAULT_JOB_TIMEOUT = "client.zeebe.job.timeout";
 
   /**
    * @see CamundaClientBuilder#defaultJobPollInterval(Duration)
    */
-  public static final String DEFAULT_JOB_POLL_INTERVAL = "zeebe.client.job.pollinterval";
+  public static final String DEFAULT_JOB_POLL_INTERVAL = "client.zeebe.job.pollinterval";
 
   /**
    * @see CamundaClientBuilder#defaultMessageTimeToLive(Duration)
    */
-  public static final String DEFAULT_MESSAGE_TIME_TO_LIVE = "zeebe.client.message.timeToLive";
+  public static final String DEFAULT_MESSAGE_TIME_TO_LIVE = "client.zeebe.message.timeToLive";
 
   /**
    * @see CamundaClientBuilder#defaultRequestTimeout(Duration)
    */
-  public static final String DEFAULT_REQUEST_TIMEOUT = "zeebe.client.requestTimeout";
+  public static final String DEFAULT_REQUEST_TIMEOUT = "client.zeebe.requestTimeout";
 
   /**
    * @see CamundaClientBuilder#usePlaintext()
    */
-  public static final String USE_PLAINTEXT_CONNECTION = "zeebe.client.security.plaintext";
+  public static final String USE_PLAINTEXT_CONNECTION = "client.zeebe.security.plaintext";
 
   /**
    * @see CamundaClientBuilder#caCertificatePath(String)
    */
-  public static final String CA_CERTIFICATE_PATH = "zeebe.client.security.certpath";
+  public static final String CA_CERTIFICATE_PATH = "client.zeebe.security.certpath";
 
   /**
    * @see CamundaClientBuilder#keepAlive(Duration)
    */
-  public static final String KEEP_ALIVE = "zeebe.client.keepalive";
+  public static final String KEEP_ALIVE = "client.zeebe.keepalive";
 
   /**
    * @see CamundaClientBuilder#overrideAuthority(String)
    */
-  public static final String OVERRIDE_AUTHORITY = "zeebe.client.overrideauthority";
+  public static final String OVERRIDE_AUTHORITY = "client.zeebe.overrideauthority";
 
   /**
    * @see CamundaClientBuilder#maxMessageSize(int) (String)
    */
-  public static final String MAX_MESSAGE_SIZE = "zeebe.client.maxMessageSize";
+  public static final String MAX_MESSAGE_SIZE = "client.zeebe.maxMessageSize";
 
   /**
    * @see CamundaClientBuilder#maxMetadataSize(int)
    */
-  public static final String MAX_METADATA_SIZE = "zeebe.client.maxMetadataSize";
+  public static final String MAX_METADATA_SIZE = "client.zeebe.maxMetadataSize";
 
   /**
    * @see CamundaClientCloudBuilderStep1#withClusterId(String)
    */
-  public static final String CLOUD_CLUSTER_ID = "zeebe.client.cloud.clusterId";
+  public static final String CLOUD_CLUSTER_ID = "client.zeebe.cloud.clusterId";
 
   /**
    * @see CamundaClientCloudBuilderStep2#withClientId(String)
    */
-  public static final String CLOUD_CLIENT_ID = "zeebe.client.cloud.clientId";
+  public static final String CLOUD_CLIENT_ID = "client.zeebe.cloud.clientId";
 
   /**
    * @see CamundaClientCloudBuilderStep3#withClientSecret( String)
    */
-  public static final String CLOUD_CLIENT_SECRET = "zeebe.client.cloud.secret";
+  public static final String CLOUD_CLIENT_SECRET = "client.zeebe.cloud.secret";
 
   /**
    * @see CamundaClientCloudBuilderStep4#withRegion(String)
    */
-  public static final String CLOUD_REGION = "zeebe.client.cloud.region";
+  public static final String CLOUD_REGION = "client.zeebe.cloud.region";
 
   /**
    * @see CamundaClientBuilder#defaultJobWorkerStreamEnabled(boolean)
    */
-  public static final String STREAM_ENABLED = "zeebe.client.worker.stream.enabled";
+  public static final String STREAM_ENABLED = "client.zeebe.worker.stream.enabled";
 
   /**
    * @see CamundaClientBuilder#useDefaultRetryPolicy(boolean)
    */
-  public static final String USE_DEFAULT_RETRY_POLICY = "zeebe.client.useDefaultRetryPolicy";
+  public static final String USE_DEFAULT_RETRY_POLICY = "client.zeebe.useDefaultRetryPolicy";
 
   private ClientProperties() {}
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/BuilderUtils.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/BuilderUtils.java
@@ -15,6 +15,9 @@
  */
 package io.camunda.client.impl;
 
+import java.util.Properties;
+import java.util.function.Consumer;
+
 final class BuilderUtils {
 
   private BuilderUtils() {}
@@ -22,5 +25,27 @@ final class BuilderUtils {
   static void appendProperty(
       final StringBuilder sb, final String propertyName, final Object value) {
     sb.append(propertyName).append(": ").append(value).append("\n");
+  }
+
+  static void applyIfNotNull(
+      final Properties properties,
+      final String propertyName,
+      final String legacyPropertyName,
+      final Consumer<String> action) {
+    final String value = getOrLegacy(properties, propertyName, legacyPropertyName);
+    if (value != null) {
+      action.accept(value);
+    }
+  }
+
+  static String getOrLegacy(
+      final Properties properties, final String propertyName, final String legacyPropertyName) {
+    if (properties.containsKey(propertyName)) {
+      return properties.getProperty(propertyName);
+    }
+    if (properties.containsKey(legacyPropertyName)) {
+      return properties.getProperty(legacyPropertyName);
+    }
+    return null;
   }
 }

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientBuilderImpl.java
@@ -15,31 +15,43 @@
  */
 package io.camunda.client.impl;
 
+import static io.camunda.client.ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES;
 import static io.camunda.client.ClientProperties.CA_CERTIFICATE_PATH;
+import static io.camunda.client.ClientProperties.DEFAULT_JOB_POLL_INTERVAL;
+import static io.camunda.client.ClientProperties.DEFAULT_JOB_TIMEOUT;
+import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_NAME;
+import static io.camunda.client.ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS;
 import static io.camunda.client.ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE;
 import static io.camunda.client.ClientProperties.DEFAULT_REQUEST_TIMEOUT;
+import static io.camunda.client.ClientProperties.DEFAULT_TENANT_ID;
+import static io.camunda.client.ClientProperties.GATEWAY_ADDRESS;
+import static io.camunda.client.ClientProperties.GRPC_ADDRESS;
+import static io.camunda.client.ClientProperties.JOB_WORKER_EXECUTION_THREADS;
+import static io.camunda.client.ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE;
 import static io.camunda.client.ClientProperties.KEEP_ALIVE;
 import static io.camunda.client.ClientProperties.MAX_MESSAGE_SIZE;
 import static io.camunda.client.ClientProperties.MAX_METADATA_SIZE;
 import static io.camunda.client.ClientProperties.OVERRIDE_AUTHORITY;
 import static io.camunda.client.ClientProperties.PREFER_REST_OVER_GRPC;
+import static io.camunda.client.ClientProperties.REST_ADDRESS;
 import static io.camunda.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.client.ClientProperties.USE_DEFAULT_RETRY_POLICY;
 import static io.camunda.client.ClientProperties.USE_PLAINTEXT_CONNECTION;
 import static io.camunda.client.impl.BuilderUtils.appendProperty;
+import static io.camunda.client.impl.BuilderUtils.applyIfNotNull;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_KB;
 import static io.camunda.client.impl.util.DataSizeUtil.ONE_MB;
 
 import io.camunda.client.CamundaClient;
 import io.camunda.client.CamundaClientBuilder;
 import io.camunda.client.CamundaClientConfiguration;
-import io.camunda.client.ClientProperties;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.api.command.CommandWithTenantStep;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
 import io.camunda.client.impl.util.DataSizeUtil;
 import io.camunda.client.impl.util.Environment;
+import io.camunda.zeebe.client.ClientProperties;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -70,7 +82,7 @@ public final class CamundaClientBuilderImpl
   public static final String DEFAULT_TENANT_ID_VAR = "ZEEBE_DEFAULT_TENANT_ID";
   public static final String DEFAULT_JOB_WORKER_TENANT_IDS_VAR =
       "ZEEBE_DEFAULT_JOB_WORKER_TENANT_IDS";
-  public static final String DEFAULT_JOB_WORKER_NAME = "default";
+  public static final String DEFAULT_JOB_WORKER_NAME_VAR = "default";
   public static final String USE_DEFAULT_RETRY_POLICY_VAR = "ZEEBE_CLIENT_USE_DEFAULT_RETRY_POLICY";
   private static final String TENANT_ID_LIST_SEPARATOR = ",";
   private static final boolean DEFAULT_PREFER_REST_OVER_GRPC = false;
@@ -87,7 +99,7 @@ public final class CamundaClientBuilderImpl
       Collections.singletonList(CommandWithTenantStep.DEFAULT_TENANT_IDENTIFIER);
   private int jobWorkerMaxJobsActive = 32;
   private int numJobWorkerExecutionThreads = 1;
-  private String defaultJobWorkerName = DEFAULT_JOB_WORKER_NAME;
+  private String defaultJobWorkerName = DEFAULT_JOB_WORKER_NAME_VAR;
   private Duration defaultJobTimeout = Duration.ofMinutes(5);
   private Duration defaultJobPollInterval = Duration.ofMillis(100);
   private Duration defaultMessageTimeToLive = Duration.ofHours(1);
@@ -238,99 +250,143 @@ public final class CamundaClientBuilderImpl
 
   @Override
   public CamundaClientBuilder withProperties(final Properties properties) {
-    if (properties.containsKey(ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES)) {
-      applyEnvironmentVariableOverrides(
-          Boolean.parseBoolean(
-              properties.getProperty(ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES)));
-    }
-    if (properties.containsKey(ClientProperties.GRPC_ADDRESS)) {
-      final URI grpcAddr = getURIFromString(properties.getProperty(ClientProperties.GRPC_ADDRESS));
-      grpcAddress(grpcAddr);
-    }
-    if (properties.containsKey(ClientProperties.REST_ADDRESS)) {
-      final URI restAddr = getURIFromString(properties.getProperty(ClientProperties.REST_ADDRESS));
-      restAddress(restAddr);
-    }
-    if (properties.containsKey(ClientProperties.GATEWAY_ADDRESS)) {
-      gatewayAddress(properties.getProperty(ClientProperties.GATEWAY_ADDRESS));
-    }
-    if (properties.containsKey(PREFER_REST_OVER_GRPC)) {
-      preferRestOverGrpc(Boolean.parseBoolean(properties.getProperty(PREFER_REST_OVER_GRPC)));
-    }
-    if (properties.containsKey(ClientProperties.DEFAULT_TENANT_ID)) {
-      defaultTenantId(properties.getProperty(ClientProperties.DEFAULT_TENANT_ID));
-    }
-    if (properties.containsKey(ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS)) {
-      final String tenantIdsList =
-          properties.getProperty(ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS);
-      final List<String> tenantIds = Arrays.asList(tenantIdsList.split(TENANT_ID_LIST_SEPARATOR));
-      defaultJobWorkerTenantIds(tenantIds);
-    }
+    applyIfNotNull(
+        properties,
+        APPLY_ENVIRONMENT_VARIABLES_OVERRIDES,
+        ClientProperties.APPLY_ENVIRONMENT_VARIABLES_OVERRIDES,
+        value -> applyEnvironmentVariableOverrides(Boolean.parseBoolean(value)));
 
-    if (properties.containsKey(ClientProperties.JOB_WORKER_EXECUTION_THREADS)) {
-      numJobWorkerExecutionThreads(
-          Integer.parseInt(properties.getProperty(ClientProperties.JOB_WORKER_EXECUTION_THREADS)));
-    }
-    if (properties.containsKey(ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE)) {
-      defaultJobWorkerMaxJobsActive(
-          Integer.parseInt(properties.getProperty(ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE)));
-    }
-    if (properties.containsKey(ClientProperties.DEFAULT_JOB_WORKER_NAME)) {
-      defaultJobWorkerName(properties.getProperty(ClientProperties.DEFAULT_JOB_WORKER_NAME));
-    }
-    if (properties.containsKey(ClientProperties.DEFAULT_JOB_TIMEOUT)) {
-      defaultJobTimeout(
-          Duration.ofMillis(
-              Integer.parseInt(properties.getProperty(ClientProperties.DEFAULT_JOB_TIMEOUT))));
-    }
-    if (properties.containsKey(ClientProperties.DEFAULT_JOB_POLL_INTERVAL)) {
-      defaultJobPollInterval(
-          Duration.ofMillis(
-              Integer.parseInt(
-                  properties.getProperty(ClientProperties.DEFAULT_JOB_POLL_INTERVAL))));
-    }
-    if (properties.containsKey(DEFAULT_MESSAGE_TIME_TO_LIVE)) {
-      defaultMessageTimeToLive(
-          Duration.ofMillis(Long.parseLong(properties.getProperty(DEFAULT_MESSAGE_TIME_TO_LIVE))));
-    }
-    if (properties.containsKey(DEFAULT_REQUEST_TIMEOUT)) {
-      defaultRequestTimeout(
-          Duration.ofMillis(Long.parseLong(properties.getProperty(DEFAULT_REQUEST_TIMEOUT))));
-    }
-    if (properties.containsKey(USE_PLAINTEXT_CONNECTION)) {
-      /**
-       * The following condition is phrased in this particular way in order to be backwards
-       * compatible with older versions of the software. In older versions the content of the
-       * property was not interpreted. It was assumed to be true, whenever it was set. Because of
-       * that, code examples in this code base set the flag to an empty string. By phrasing the
-       * condition this way, the old code will still work with this new implementation. Only if
-       * somebody deliberately sets the flag to false, the behavior will change
-       */
-      if (!"false".equalsIgnoreCase(properties.getProperty(USE_PLAINTEXT_CONNECTION))) {
-        usePlaintext();
-      }
-    }
-    if (properties.containsKey(CA_CERTIFICATE_PATH)) {
-      caCertificatePath(properties.getProperty(CA_CERTIFICATE_PATH));
-    }
-    if (properties.containsKey(KEEP_ALIVE)) {
-      keepAlive(properties.getProperty(KEEP_ALIVE));
-    }
-    if (properties.containsKey(OVERRIDE_AUTHORITY)) {
-      overrideAuthority(properties.getProperty(OVERRIDE_AUTHORITY));
-    }
-    if (properties.containsKey(MAX_MESSAGE_SIZE)) {
-      maxMessageSize(DataSizeUtil.parse(properties.getProperty(MAX_MESSAGE_SIZE)));
-    }
-    if (properties.containsKey(MAX_METADATA_SIZE)) {
-      maxMetadataSize(DataSizeUtil.parse(properties.getProperty(MAX_METADATA_SIZE)));
-    }
-    if (properties.containsKey(STREAM_ENABLED)) {
-      defaultJobWorkerStreamEnabled(Boolean.parseBoolean(properties.getProperty(STREAM_ENABLED)));
-    }
-    if (properties.containsKey(USE_DEFAULT_RETRY_POLICY)) {
-      useDefaultRetryPolicy(Boolean.parseBoolean(properties.getProperty(USE_DEFAULT_RETRY_POLICY)));
-    }
+    applyIfNotNull(
+        properties,
+        GRPC_ADDRESS,
+        ClientProperties.GRPC_ADDRESS,
+        value -> grpcAddress(getURIFromString(value)));
+
+    applyIfNotNull(
+        properties,
+        REST_ADDRESS,
+        ClientProperties.REST_ADDRESS,
+        value -> restAddress(getURIFromString(value)));
+
+    applyIfNotNull(
+        properties, GATEWAY_ADDRESS, ClientProperties.GATEWAY_ADDRESS, this::gatewayAddress);
+
+    applyIfNotNull(
+        properties,
+        PREFER_REST_OVER_GRPC,
+        ClientProperties.PREFER_REST_OVER_GRPC,
+        value -> preferRestOverGrpc(Boolean.parseBoolean(value)));
+
+    applyIfNotNull(
+        properties, DEFAULT_TENANT_ID, ClientProperties.DEFAULT_TENANT_ID, this::defaultTenantId);
+
+    applyIfNotNull(
+        properties,
+        DEFAULT_JOB_WORKER_TENANT_IDS,
+        ClientProperties.DEFAULT_JOB_WORKER_TENANT_IDS,
+        value -> {
+          final List<String> tenantIds = Arrays.asList(value.split(TENANT_ID_LIST_SEPARATOR));
+          defaultJobWorkerTenantIds(tenantIds);
+        });
+
+    applyIfNotNull(
+        properties,
+        JOB_WORKER_EXECUTION_THREADS,
+        ClientProperties.JOB_WORKER_EXECUTION_THREADS,
+        value -> numJobWorkerExecutionThreads(Integer.parseInt(value)));
+
+    applyIfNotNull(
+        properties,
+        JOB_WORKER_MAX_JOBS_ACTIVE,
+        ClientProperties.JOB_WORKER_MAX_JOBS_ACTIVE,
+        value -> defaultJobWorkerMaxJobsActive(Integer.parseInt(value)));
+
+    applyIfNotNull(
+        properties,
+        DEFAULT_JOB_WORKER_NAME,
+        ClientProperties.DEFAULT_JOB_WORKER_NAME,
+        this::defaultJobWorkerName);
+
+    applyIfNotNull(
+        properties,
+        DEFAULT_JOB_TIMEOUT,
+        ClientProperties.DEFAULT_JOB_TIMEOUT,
+        value -> defaultJobTimeout(Duration.ofMillis(Long.parseLong(value))));
+
+    applyIfNotNull(
+        properties,
+        DEFAULT_JOB_POLL_INTERVAL,
+        ClientProperties.DEFAULT_JOB_POLL_INTERVAL,
+        value -> defaultJobPollInterval(Duration.ofMillis(Long.parseLong(value))));
+
+    applyIfNotNull(
+        properties,
+        DEFAULT_MESSAGE_TIME_TO_LIVE,
+        ClientProperties.DEFAULT_MESSAGE_TIME_TO_LIVE,
+        value -> defaultMessageTimeToLive(Duration.ofMillis(Long.parseLong(value))));
+
+    applyIfNotNull(
+        properties,
+        DEFAULT_REQUEST_TIMEOUT,
+        ClientProperties.DEFAULT_REQUEST_TIMEOUT,
+        value -> defaultRequestTimeout(Duration.ofSeconds(Long.parseLong(value))));
+
+    applyIfNotNull(
+        properties,
+        USE_PLAINTEXT_CONNECTION,
+        ClientProperties.USE_PLAINTEXT_CONNECTION,
+        value -> {
+          /**
+           * The following condition is phrased in this particular way in order to be backwards
+           * compatible with older versions of the software. In older versions the content of the
+           * property was not interpreted. It was assumed to be true, whenever it was set. Because
+           * of that, code examples in this code base set the flag to an empty string. By phrasing
+           * the condition this way, the old code will still work with this new implementation. Only
+           * if somebody deliberately sets the flag to false, the behavior will change
+           */
+          if (!"false".equalsIgnoreCase(value)) {
+            usePlaintext();
+          }
+        });
+
+    applyIfNotNull(
+        properties,
+        CA_CERTIFICATE_PATH,
+        ClientProperties.CA_CERTIFICATE_PATH,
+        this::caCertificatePath);
+
+    applyIfNotNull(properties, KEEP_ALIVE, ClientProperties.KEEP_ALIVE, this::keepAlive);
+
+    applyIfNotNull(
+        properties,
+        OVERRIDE_AUTHORITY,
+        ClientProperties.OVERRIDE_AUTHORITY,
+        this::overrideAuthority);
+
+    applyIfNotNull(
+        properties,
+        MAX_MESSAGE_SIZE,
+        ClientProperties.MAX_MESSAGE_SIZE,
+        value -> maxMessageSize(DataSizeUtil.parse(value)));
+
+    applyIfNotNull(
+        properties,
+        MAX_METADATA_SIZE,
+        ClientProperties.MAX_METADATA_SIZE,
+        value -> maxMetadataSize(DataSizeUtil.parse(value)));
+
+    applyIfNotNull(
+        properties,
+        STREAM_ENABLED,
+        ClientProperties.STREAM_ENABLED,
+        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)));
+
+    applyIfNotNull(
+        properties,
+        USE_DEFAULT_RETRY_POLICY,
+        ClientProperties.USE_DEFAULT_RETRY_POLICY,
+        value -> useDefaultRetryPolicy(Boolean.parseBoolean(value)));
+
     return this;
   }
 

--- a/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/CamundaClientCloudBuilderImpl.java
@@ -15,7 +15,13 @@
  */
 package io.camunda.client.impl;
 
+import static io.camunda.client.ClientProperties.CLOUD_CLIENT_ID;
+import static io.camunda.client.ClientProperties.CLOUD_CLIENT_SECRET;
+import static io.camunda.client.ClientProperties.CLOUD_CLUSTER_ID;
+import static io.camunda.client.ClientProperties.CLOUD_REGION;
+import static io.camunda.client.ClientProperties.STREAM_ENABLED;
 import static io.camunda.client.impl.BuilderUtils.appendProperty;
+import static io.camunda.client.impl.BuilderUtils.applyIfNotNull;
 import static io.camunda.client.impl.command.ArgumentUtil.ensureNotNull;
 
 import io.camunda.client.CamundaClient;
@@ -24,11 +30,11 @@ import io.camunda.client.CamundaClientCloudBuilderStep1;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3;
 import io.camunda.client.CamundaClientCloudBuilderStep1.CamundaClientCloudBuilderStep2.CamundaClientCloudBuilderStep3.CamundaClientCloudBuilderStep4;
-import io.camunda.client.ClientProperties;
 import io.camunda.client.CredentialsProvider;
 import io.camunda.client.api.ExperimentalApi;
 import io.camunda.client.api.JsonMapper;
 import io.camunda.client.impl.oauth.OAuthCredentialsProviderBuilder;
+import io.camunda.zeebe.client.ClientProperties;
 import io.grpc.ClientInterceptor;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -83,22 +89,23 @@ public class CamundaClientCloudBuilderImpl
 
   @Override
   public CamundaClientBuilder withProperties(final Properties properties) {
-    if (properties.containsKey(ClientProperties.CLOUD_CLUSTER_ID)) {
-      withClusterId(properties.getProperty(ClientProperties.CLOUD_CLUSTER_ID));
-    }
-    if (properties.containsKey(ClientProperties.CLOUD_CLIENT_ID)) {
-      withClientId(properties.getProperty(ClientProperties.CLOUD_CLIENT_ID));
-    }
-    if (properties.containsKey(ClientProperties.CLOUD_CLIENT_SECRET)) {
-      withClientSecret(properties.getProperty(ClientProperties.CLOUD_CLIENT_SECRET));
-    }
-    if (properties.containsKey(ClientProperties.CLOUD_REGION)) {
-      withRegion(properties.getProperty(ClientProperties.CLOUD_REGION));
-    }
-    if (properties.containsKey(ClientProperties.STREAM_ENABLED)) {
-      defaultJobWorkerStreamEnabled(
-          Boolean.parseBoolean(properties.getProperty(ClientProperties.STREAM_ENABLED)));
-    }
+    applyIfNotNull(
+        properties, CLOUD_CLUSTER_ID, ClientProperties.CLOUD_CLUSTER_ID, this::withClusterId);
+
+    applyIfNotNull(
+        properties, CLOUD_CLIENT_ID, ClientProperties.CLOUD_CLIENT_ID, this::withClientId);
+
+    applyIfNotNull(
+        properties, CLOUD_CLIENT_SECRET, ClientProperties.CLOUD_CLIENT_SECRET, this::withClientId);
+
+    applyIfNotNull(properties, CLOUD_REGION, ClientProperties.CLOUD_REGION, this::withRegion);
+
+    applyIfNotNull(
+        properties,
+        STREAM_ENABLED,
+        ClientProperties.STREAM_ENABLED,
+        value -> defaultJobWorkerStreamEnabled(Boolean.parseBoolean(value)));
+
     innerBuilder.withProperties(properties);
 
     // todo(#14106): allow default tenant id setting for cloud client

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsRestTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsRestTest.java
@@ -419,7 +419,7 @@ public final class ActivateJobsRestTest extends ClientRestTest {
 
     // then
     final JobActivationRequest request = gatewayService.getLastRequest(JobActivationRequest.class);
-    assertThat(request.getWorker()).isEqualTo(CamundaClientBuilderImpl.DEFAULT_JOB_WORKER_NAME);
+    assertThat(request.getWorker()).isEqualTo(CamundaClientBuilderImpl.DEFAULT_JOB_WORKER_NAME_VAR);
   }
 
   private static final class VariablesPojo {

--- a/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
+++ b/clients/java/src/test/java/io/camunda/client/job/ActivateJobsTest.java
@@ -408,7 +408,7 @@ public final class ActivateJobsTest extends ClientTest {
 
     // then
     final ActivateJobsRequest request = gatewayService.getLastRequest();
-    assertThat(request.getWorker()).isEqualTo(CamundaClientBuilderImpl.DEFAULT_JOB_WORKER_NAME);
+    assertThat(request.getWorker()).isEqualTo(CamundaClientBuilderImpl.DEFAULT_JOB_WORKER_NAME_VAR);
   }
 
   @Test

--- a/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/spring-boot-starter-camunda-sdk/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -15,9 +15,9 @@
  */
 package io.camunda.zeebe.spring.client.properties;
 
-import io.camunda.client.ClientProperties;
-import io.camunda.client.impl.CamundaClientBuilderImpl;
-import io.camunda.client.impl.util.Environment;
+import io.camunda.zeebe.client.ClientProperties;
+import io.camunda.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.camunda.zeebe.client.impl.util.Environment;
 import io.camunda.zeebe.spring.client.annotation.value.ZeebeWorkerValue;
 import jakarta.annotation.PostConstruct;
 import java.net.URI;
@@ -39,8 +39,8 @@ import org.springframework.boot.context.properties.NestedConfigurationProperty;
 @Deprecated
 public class ZeebeClientConfigurationProperties {
   // Used to read default config values
-  public static final CamundaClientBuilderImpl DEFAULT =
-      (CamundaClientBuilderImpl) new CamundaClientBuilderImpl().withProperties(new Properties());
+  public static final ZeebeClientBuilderImpl DEFAULT =
+      (ZeebeClientBuilderImpl) new ZeebeClientBuilderImpl().withProperties(new Properties());
   public static final String CONNECTION_MODE_CLOUD = "CLOUD";
   public static final String CONNECTION_MODE_ADDRESS = "ADDRESS";
   private static final Logger LOGGER =

--- a/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
+++ b/spring-boot-starter-camunda-sdk/src/test/java/io/camunda/zeebe/spring/client/properties/JavaClientPropertiesTest.java
@@ -55,10 +55,12 @@ public class JavaClientPropertiesTest {
     assertThat(properties.getGatewayAddress()).isEqualTo("localhost12345");
   }
 
+  @Test
   public void hasGrpcAddress() {
     assertThat(properties.getGrpcAddress().toString()).isEqualTo("https://localhost:1234");
   }
 
+  @Test
   public void hasRestAddress() {
     assertThat(properties.getRestAddress().toString()).isEqualTo("https://localhost:8080");
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

With the new Camunda Client also properties should be renamed. Older properties `zeebe.client....` are refactored into more general ones `client.zeebe....` in this way other component can add their own properties (eg `client.operate....)`

We should ensure also that users can still use the old properties configuration, but with less priority the the new ones.
If the same property is set in the new format and old format, the new format has more priority, example:

```
client.zeebe.tenantId=default
zeebe.client.tenantId=randomId

client.getTenantId == "default"  ==> true
client.getTenantId == "randomId" ==> false
```

## Related issues

closes #19487 
