### PR TITLE
[Backport stable/8.3] Fix flaky MessageStreamProcessorTest

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -129,7 +129,7 @@ public final class MessageStreamProcessorTest {
                   .addTime(
                       MessageObserver.SUBSCRIPTION_CHECK_INTERVAL.plus(
                           MessageObserver.SUBSCRIPTION_TIMEOUT));
-              verify(mockInterpartitionCommandSender, timeout(100).times(2))
+              verify(mockInterpartitionCommandSender, timeout(100).atLeast(2))
                   .sendCommand(
                       eq(0),
                       eq(ValueType.PROCESS_MESSAGE_SUBSCRIPTION),


### PR DESCRIPTION
# Description
Backport of #20286 to `stable/8.3`.

relates to #19997
original author: @remcowesterhoud