### PR TITLE
fix: report flaky tests via build status to CI health

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,8 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -271,6 +273,8 @@ jobs:
         with:
           job_name: "integration-tests/${{ matrix.group }}"
           build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -157,10 +157,13 @@ jobs:
         uses: ./.github/actions/observe-build-status
         with:
           job_name: "integration-tests/${{ matrix.group }}"
-          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   unit-tests:
     name: Unit tests
     runs-on: [ self-hosted, linux, amd64, "16" ]
@@ -212,10 +215,13 @@ jobs:
         continue-on-error: true
         uses: ./.github/actions/observe-build-status
         with:
-          build_status: ${{ contains(steps.*.conclusion, 'failure') && 'failure' || 'success' }}
+          build_status: ${{ job.status }}
+          user_reason: ${{ (steps.analyze-test-run.outputs.flakyTests != '') && 'flaky-tests' || '' }}
+          user_description: ${{ steps.analyze-test-run.outputs.flakyTests }}
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   smoke-tests:
     name: "[Smoke] ${{ matrix.os }} with ${{ matrix.arch }}"
     timeout-minutes: 20


### PR DESCRIPTION
## Description

Report flaky tests from Unified CI & Zeebe CI [via build status](https://github.com/camunda/infra-global-github-actions/tree/main/submit-build-status) for CI health observability following the conventions for `build_status` and `user_reason`. This works towards the goal of #18210 and implicitly addresses some tasks from #18856  as well for the Zeebe CI.

The list of flaky tests is best-effort just for information until https://github.com/camunda/team-infrastructure/issues/608 gets implemented.

The data is ingested successfully (at the example of this PR and [this failed run](https://github.com/camunda/camunda/actions/runs/9990809809/job/27612279255)) and looks like this which can be later used for visualizations:

![image](https://github.com/user-attachments/assets/7f2a1a61-6dc2-4368-b038-7754cc1d481a)

## Related issues

Related to #18210 and to #18856
