### PR TITLE
test: disable TaskIT.shouldUpdateUserTask

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/TaskIT.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/graphql/TaskIT.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -1163,6 +1164,8 @@ public class TaskIT extends TasklistZeebeIntegrationTest {
     }
 
     @Test
+    @Disabled(
+        "This test fails with the legacy ZeebeClient, to be re-enabled after the use of the new CamundaClient")
     public void shouldUpdateUserTask() {
       final String taskId = tester.createZeebeUserTask(BPMN_PROCESS_ID, ELEMENT_ID, 1).getTaskId();
       final List<String> candidateGroups = new ArrayList<>();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->
This test fails with the legacy ZeebeClient, to be re-enabled after the use of the new CamundaClient
https://github.com/camunda/camunda/pull/20346
## Related issues

closes #
