### PR TITLE
fix: fix constant in recordsAreFetchedWithSequenceOrPosition

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/util/ZeebeBpmnModels.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/util/ZeebeBpmnModels.java
@@ -18,7 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ZeebeBpmnModels {
 
-  public static final String START_EVENT = "start";
+  public static final String START_EVENT = "startEvent";
   public static final String SERVICE_TASK = "service_task";
   public static final String SEND_TASK = "send_task";
   public static final String USER_TASK = "user_task";


### PR DESCRIPTION
## Description

Target workflow:
* Optimize CI / Integration Tests (latest, ccsm-test) (pull_request)

An integration test is using a wrong constant to test the result. The test is `recordsAreFetchedWithSequenceOrPosition`.