### PR TITLE
test: disable duplicated flaky test

### DIFF
--- a/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -230,6 +231,8 @@ public final class OAuthCredentialsCacheTest {
   }
 
   @Test
+  @Ignore(
+      "Can be enabled when not flaky anymore, see https://github.com/camunda/camunda/issues/20136")
   public void shouldBeThreadSafe() throws InterruptedException {
     // given
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);


### PR DESCRIPTION
## Description
The test was duplicated in e073344a which missed the annotation to ignore it added in 43c70161.

## Related issues

relates to #20136
