### PR TITLE
Add logging to setup commands

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -304,9 +304,13 @@ func (s *integrationTestSuite) TestCommonCommands() {
 	for _, test := range tests {
 		passed := s.T().Run(test.name, func(t *testing.T) {
 			for _, cmd := range test.setupCmds {
-				if cmdOut, err := s.runCommand(cmd, false); err != nil {
+				fmt.Printf("Executing setup cmd '%s'\n", cmd)
+				cmdOut, err := s.runCommand(cmd, false)
+				if err != nil {
 					t.Fatalf("failed while executing set up command '%s' (%v). Output: \n%s",
 						strings.Join(cmd, " "), err, cmdOut)
+				} else {
+					fmt.Printf("Setup cmd execution success. Result:\n'%s'", cmdOut)
 				}
 
 				// to mitigate race conditions between setup commands,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

I've added some logging to the setup commands to make it easier to debug failing tests. Example:

```
=== RUN   TestZbctlWithInsecureGateway/TestCommonCommands/update_job_timeout
Executing setup cmd '[--insecure deploy resource testdata/job_model.bpmn]'
Setup cmd execution success. Result:
'{
  "key":  "2251799813685365",
  "deployments":  [
    {
      "process":  {
        "bpmnProcessId":  "jobProcess",
        "version":  2,
        "processDefinitionKey":  "2251799813685277",
        "resourceName":  "testdata/job_model.bpmn",
        "tenantId":  "<default>"
      }
    }
  ],
  "tenantId":  "<default>"
}
'Executing setup cmd '[--insecure create instance jobProcess]'
Setup cmd execution success. Result:
'{
  "processDefinitionKey":  "2251799813685277",
  "bpmnProcessId":  "jobProcess",
  "version":  2,
  "processInstanceKey":  "2251799813685366",
  "tenantId":  "<default>"
}
'Executing setup cmd '[--insecure activate jobs jobType --maxJobsToActivate 1]'
Setup cmd execution success. Result:
'{
  "jobs":  [
    {
      "key":  "2251799813685371",
      "type":  "jobType",
      "processInstanceKey":  "2251799813685366",
      "bpmnProcessId":  "jobProcess",
      "processDefinitionVersion":  2,
      "processDefinitionKey":  "2251799813685277",
      "elementId":  "ServiceTask_0drxnet",
      "elementInstanceKey":  "2251799813685370",
      "customHeaders":  "{}",
      "worker":  "zbctl",
      "retries":  3,
      "deadline":  "1721638257981",
      "variables":  "{}",
      "tenantId":  "<default>"
    }
  ]
}
```

## Related issues

closes #15699 

I know it doesn't solve the flakiness, but I cannot reproduce it locally. By closing it I know it'll get reopened when/if we encounter it again and I'll at least have some more context with this logging.
