### PR TITLE
[Backport stable/8.3] Add logging to setup commands

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -241,9 +241,13 @@ func (s *integrationTestSuite) TestCommonCommands() {
 	for _, test := range tests {
 		passed := s.T().Run(test.name, func(t *testing.T) {
 			for _, cmd := range test.setupCmds {
-				if cmdOut, err := s.runCommand(cmd, false); err != nil {
+				fmt.Printf("Executing setup cmd '%s'\n", cmd)
+				cmdOut, err := s.runCommand(cmd, false)
+				if err != nil {
 					t.Fatalf("failed while executing set up command '%s' (%v). Output: \n%s",
 						strings.Join(cmd, " "), err, cmdOut)
+				} else {
+					fmt.Printf("Setup cmd execution success. Result:\n'%s'", cmdOut)
 				}
 
 				// to mitigate race conditions between setup commands,


### PR DESCRIPTION
# Description
Backport of #20389 to `stable/8.3`.

relates to #15699
original author: @remcowesterhoud