### PR TITLE
Test for snapshot corruption when restoring from backup.

### DIFF
--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/AsyncSnapshottingTest.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -60,7 +61,8 @@ public final class AsyncSnapshottingTest {
   public void setup() throws IOException {
     final var rootDirectory = tempFolderRule.getRoot().toPath();
     final int partitionId = 1;
-    persistedSnapshotStore = new FileBasedSnapshotStore(0, partitionId, rootDirectory);
+    persistedSnapshotStore =
+        new FileBasedSnapshotStore(0, partitionId, rootDirectory, snapshotPath -> Map.of());
     actorSchedulerRule.submitActor(persistedSnapshotStore).join();
 
     snapshotController =

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/StateControllerImplTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import org.agrona.collections.MutableLong;
@@ -60,7 +61,9 @@ public final class StateControllerImplTest {
   @Before
   public void setup() throws IOException {
 
-    store = new FileBasedSnapshotStore(0, 1, tempFolderRule.newFolder("data").toPath());
+    store =
+        new FileBasedSnapshotStore(
+            0, 1, tempFolderRule.newFolder("data").toPath(), snapshotPath -> Map.of());
     actorSchedulerRule.submitActor(store).join();
 
     runtimeDirectory = tempFolderRule.getRoot().toPath().resolve("runtime");

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/perf/TestState.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import org.agrona.CloseHelper;
 import org.agrona.concurrent.UnsafeBuffer;
@@ -44,7 +45,8 @@ final class TestState {
             .build();
     actorScheduler.start();
 
-    final var snapshotStore = new FileBasedSnapshotStore(0, 1, tempDirectory);
+    final var snapshotStore =
+        new FileBasedSnapshotStore(0, 1, tempDirectory, snapshotPath -> Map.of());
     actorScheduler.submitActor(snapshotStore).join();
 
     generateSnapshot(snapshotStore, sizeInBytes);

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.management.backups.BackupInfo;
 import io.camunda.zeebe.management.backups.StateCode;
 import io.camunda.zeebe.management.backups.TakeBackupResponse;
 import io.camunda.zeebe.qa.util.actuator.BackupActuator;
+import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.restore.BackupNotFoundException;
@@ -56,6 +57,9 @@ public interface RestoreAcceptance {
       try (final var client = zeebe.newClientBuilder().build()) {
         client.newPublishMessageCommand().messageName("name").correlationKey("key").send().join();
       }
+
+      final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
+      partitions.takeSnapshot();
 
       assertThat(actuator.take(backupId)).isInstanceOf(TakeBackupResponse.class);
       Awaitility.await("until a backup exists with the given ID")

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/backup/RestoreAcceptance.java
@@ -20,7 +20,9 @@ import io.camunda.zeebe.qa.util.actuator.PartitionsActuator;
 import io.camunda.zeebe.qa.util.cluster.TestRestoreApp;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.restore.BackupNotFoundException;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotId;
 import java.time.Duration;
+import java.util.Optional;
 import java.util.concurrent.CompletionException;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
@@ -60,6 +62,14 @@ public interface RestoreAcceptance {
 
       final PartitionsActuator partitions = PartitionsActuator.of(zeebe);
       partitions.takeSnapshot();
+
+      Awaitility.await("Snapshot is taken")
+          .atMost(Duration.ofSeconds(60))
+          .until(
+              () ->
+                  Optional.ofNullable(partitions.query().get(1).snapshotId())
+                      .flatMap(FileBasedSnapshotId::ofFileName),
+              Optional::isPresent);
 
       assertThat(actuator.take(backupId)).isInstanceOf(TakeBackupResponse.class);
       Awaitility.await("until a backup exists with the given ID")

--- a/zeebe/restore/pom.xml
+++ b/zeebe/restore/pom.xml
@@ -35,6 +35,11 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
+      <artifactId>zeebe-db</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
       <artifactId>zeebe-snapshots</artifactId>
     </dependency>
 

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -15,10 +15,10 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
-import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
+import io.camunda.zeebe.snapshots.ChecksumProvider;
 import io.camunda.zeebe.snapshots.RestorableSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
@@ -27,6 +27,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.DirectoryNotEmptyException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
@@ -42,14 +43,19 @@ public class PartitionRestoreService {
   final Path rootDirectory;
   private final RaftPartition partition;
   private final int brokerId;
+  private final ChecksumProvider checksumProvider;
 
   public PartitionRestoreService(
-      final BackupStore backupStore, final RaftPartition partition, final int brokerId) {
+      final BackupStore backupStore,
+      final RaftPartition partition,
+      final int brokerId,
+      final ChecksumProvider checksumProvider) {
     this.backupStore = backupStore;
     partitionId = partition.id().id();
     rootDirectory = partition.dataDirectory().toPath();
     this.partition = partition;
     this.brokerId = brokerId;
+    this.checksumProvider = Objects.requireNonNull(checksumProvider);
   }
 
   /**
@@ -181,10 +187,7 @@ public class PartitionRestoreService {
     @SuppressWarnings("resource")
     final RestorableSnapshotStore snapshotStore =
         new FileBasedSnapshotStore(
-            brokerId,
-            partition.id().id(),
-            partition.dataDirectory().toPath(),
-            new ChecksumProviderRocksDBImpl());
+            brokerId, partition.id().id(), partition.dataDirectory().toPath(), checksumProvider);
 
     try {
       snapshotStore.restore(

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.backup.api.BackupStatus;
 import io.camunda.zeebe.backup.api.BackupStatusCode;
 import io.camunda.zeebe.backup.api.BackupStore;
 import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
+import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
@@ -180,7 +181,10 @@ public class PartitionRestoreService {
     @SuppressWarnings("resource")
     final RestorableSnapshotStore snapshotStore =
         new FileBasedSnapshotStore(
-            brokerId, partition.id().id(), partition.dataDirectory().toPath());
+            brokerId,
+            partition.id().id(),
+            partition.dataDirectory().toPath(),
+            new ChecksumProviderRocksDBImpl());
 
     try {
       snapshotStore.restore(

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/RestoreManager.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.broker.partitioning.startup.RaftPartitionFactory;
 import io.camunda.zeebe.broker.partitioning.topology.PartitionDistribution;
 import io.camunda.zeebe.broker.partitioning.topology.StaticConfigurationGenerator;
 import io.camunda.zeebe.broker.system.configuration.BrokerCfg;
+import io.camunda.zeebe.db.impl.rocksdb.ChecksumProviderRocksDBImpl;
 import io.camunda.zeebe.restore.PartitionRestoreService.BackupValidator;
 import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
@@ -94,7 +95,10 @@ public class RestoreManager {
       validator = BackupValidator.none();
     }
     return new PartitionRestoreService(
-            backupStore, partition, configuration.getCluster().getNodeId())
+            backupStore,
+            partition,
+            configuration.getCluster().getNodeId(),
+            new ChecksumProviderRocksDBImpl())
         .restore(backupId, validator)
         .thenAccept(backup -> logSuccessfulRestore(backup, partition.id().id(), backupId));
   }

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -100,7 +100,8 @@ class PartitionRestoreServiceTest {
             PartitionId.from("raft", partitionId), Set.of(), Map.of(), 1, new MemberId("1"));
     final var raftPartition =
         new RaftPartition(partitionMetadata, null, dataDirectoryToRestore.toFile());
-    restoreService = new PartitionRestoreService(backupStore, raftPartition, nodeId);
+    restoreService =
+        new PartitionRestoreService(backupStore, raftPartition, nodeId, snapshotPath -> Map.of());
 
     journal =
         SegmentedJournal.builder()

--- a/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
+++ b/zeebe/restore/src/test/java/io/camunda/zeebe/restore/PartitionRestoreServiceTest.java
@@ -80,7 +80,8 @@ class PartitionRestoreServiceTest {
   void setUp() {
     backupStore = new TestRestorableBackupStore();
 
-    snapshotStore = new FileBasedSnapshotStore(0, partitionId, dataDirectory);
+    snapshotStore =
+        new FileBasedSnapshotStore(0, partitionId, dataDirectory, snapshotPath -> Map.of());
     actorScheduler.submitActor(snapshotStore, SchedulingHints.IO_BOUND);
 
     backupService =

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -83,10 +83,6 @@ public final class FileBasedSnapshotStore extends Actor
   private final String actorName;
   private final int partitionId;
 
-  public FileBasedSnapshotStore(final int brokerId, final int partitionId, final Path root) {
-    this(brokerId, partitionId, root, null);
-  }
-
   public FileBasedSnapshotStore(
       final int brokerId,
       final int partitionId,

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.ConcurrentModificationException;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -105,7 +106,7 @@ public final class FileBasedSnapshotStore extends Actor
     listeners = new CopyOnWriteArraySet<>();
     actorName = buildActorName("SnapshotStore", partitionId);
     this.partitionId = partitionId;
-    this.checksumProvider = checksumProvider;
+    this.checksumProvider = Objects.requireNonNull(checksumProvider);
   }
 
   @Override

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
@@ -18,7 +18,6 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Collections;
 import java.util.Map;
 
 final class SnapshotChecksum {
@@ -44,7 +43,7 @@ final class SnapshotChecksum {
   }
 
   public static MutableChecksumsSFV calculate(final Path snapshotDirectory) throws IOException {
-    return createChecksumForSnapshot(snapshotDirectory, null);
+    return createChecksumForSnapshot(snapshotDirectory, snapshotPath -> Map.of());
   }
 
   public static MutableChecksumsSFV calculateWithProvidedChecksums(
@@ -58,10 +57,7 @@ final class SnapshotChecksum {
     try (final var fileStream =
         Files.list(snapshotDirectory).filter(SnapshotChecksum::isNotMetadataFile).sorted()) {
       final SfvChecksumImpl sfvChecksum = new SfvChecksumImpl();
-      final Map<String, Long> fullFileChecksums =
-          provider == null
-              ? Collections.emptyMap()
-              : provider.getSnapshotChecksums(snapshotDirectory);
+      final Map<String, Long> fullFileChecksums = provider.getSnapshotChecksums(snapshotDirectory);
       fileStream.forEachOrdered(path -> updateChecksum(sfvChecksum, fullFileChecksums, path));
 
       // While persisting transient snapshot, the checksum of metadata file is added at the end.

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/PersistedSnapshotStoreTest.java
@@ -11,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
+import java.util.Map;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -28,7 +29,8 @@ public class PersistedSnapshotStoreTest {
     final var partitionId = 1;
     final var root = temporaryFolder.getRoot();
 
-    final var snapshotStore = new FileBasedSnapshotStore(0, partitionId, root.toPath());
+    final var snapshotStore =
+        new FileBasedSnapshotStore(0, partitionId, root.toPath(), snapshotPath -> Map.of());
     scheduler.submitActor(snapshotStore).join();
     persistedSnapshotStore = snapshotStore;
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/ReceivedSnapshotTest.java
@@ -51,10 +51,12 @@ public class ReceivedSnapshotTest {
     final var senderDirectory = temporaryFolder.newFolder("sender").toPath();
     final var receiverDirectory = temporaryFolder.newFolder("receiver").toPath();
 
-    senderSnapshotStore = new FileBasedSnapshotStore(0, partitionId, senderDirectory);
+    senderSnapshotStore =
+        new FileBasedSnapshotStore(0, partitionId, senderDirectory, snapshotPath -> Map.of());
     scheduler.get().submitActor((Actor) senderSnapshotStore).join();
 
-    receiverSnapshotStore = new FileBasedSnapshotStore(0, partitionId, receiverDirectory);
+    receiverSnapshotStore =
+        new FileBasedSnapshotStore(0, partitionId, receiverDirectory, snapshotPath -> Map.of());
 
     scheduler.get().submitActor((Actor) receiverSnapshotStore).join();
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TransientSnapshotTest.java
@@ -48,7 +48,8 @@ public class TransientSnapshotTest {
     final int partitionId = 1;
     final File root = temporaryFolder.getRoot();
 
-    snapshotStore = new FileBasedSnapshotStore(0, partitionId, root.toPath());
+    snapshotStore =
+        new FileBasedSnapshotStore(0, partitionId, root.toPath(), snapshotPath -> Map.of());
     scheduler.submitActor(snapshotStore).join();
   }
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -407,7 +407,7 @@ public class FileBasedReceivedSnapshotTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) {
-    final var store = new FileBasedSnapshotStore(0, PARTITION_ID, root);
+    final var store = new FileBasedSnapshotStore(0, PARTITION_ID, root, snapshotPath -> Map.of());
     scheduler.submitActor(store);
 
     return store;

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -57,7 +57,7 @@ public class FileBasedSnapshotStoreTest {
     final var root = temporaryFolder.getRoot().toPath();
 
     // when
-    final var store = new FileBasedSnapshotStore(0, 1, root);
+    final var store = new FileBasedSnapshotStore(0, 1, root, snapshotPath -> Map.of());
 
     // then
     assertThat(root.resolve(FileBasedSnapshotStore.SNAPSHOTS_DIRECTORY)).exists().isDirectory();
@@ -379,7 +379,7 @@ public class FileBasedSnapshotStoreTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) {
-    final var store = new FileBasedSnapshotStore(0, 1, root);
+    final var store = new FileBasedSnapshotStore(0, 1, root, snapshotPath -> Map.of());
     scheduler.submitActor(store).join();
 
     return store;

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -358,7 +358,7 @@ public class FileBasedTransientSnapshotTest {
   }
 
   private FileBasedSnapshotStore createStore(final Path root) throws IOException {
-    final var store = new FileBasedSnapshotStore(0, 1, root);
+    final var store = new FileBasedSnapshotStore(0, 1, root, snapshotPath -> Map.of());
     scheduler.submitActor(store);
     return store;
   }


### PR DESCRIPTION
## Description

When restoring from a backup the snapshot should not be corrupted. To this end a file checksum verification is performed. 

The snapshot store for restoring did not have a checksum provider while all internal backups are taken with a RocksDB checksum provider causing a combined checksum mismatch.  #19988 fixes this however customers that do not have this patch fix will encounter this issue when trying to restore from any snapshots that are created with the help of RocksDB full file checksums.

This PR removes the ability to create a `FileBasedSnapshotStore` without specifying a checksum provider as all stores should aim not to fully read all files when possible for checksums.

`RestoreAcceptance.java` now also restores from snapshots which will then catch the particular case described in paragraph 2. To match the state of the code base to users encountering problems and make the tests fail:
1. `FileBasedSnapshotStore:213` change this line to compare combined values. `if (expectedChecksum.getCombinedValue() != actualChecksum.getCombinedValue()`
2. `PartitionRestoreService:182` Change this snapshot store to just a noop checksum provider `new FileBasedSnapshotStore(
            brokerId,
            partition.id().id(),
            partition.dataDirectory().toPath(),
            snapshotPath -> Map.of());` so it will calculate the checksum by fully reading all files.


## Related issues

closes #19984 
