### PR TITLE
Fix OauthCredentialsCache concurrency issues

### DIFF
--- a/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/camunda/client/impl/oauth/OAuthCredentialsCache.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
@@ -46,8 +47,17 @@ public final class OAuthCredentialsCache {
       new TypeReference<Map<String, OAuthCachedCredentials>>() {};
   private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
 
-  private final AtomicReference<Map<String, OAuthCachedCredentials>> audiences;
+  /**
+   * This lock is used to make access to the cache file thread-safe. It allows multiple threads to
+   * read at once, as long as no threads are writing. Only one thread is allowed to write at a time.
+   */
+  private static final ReentrantReadWriteLock READ_WRITE_LOCK = new ReentrantReadWriteLock();
+
+  private static final ReentrantReadWriteLock.ReadLock READ_LOCK = READ_WRITE_LOCK.readLock();
+  private static final ReentrantReadWriteLock.WriteLock WRITE_LOCK = READ_WRITE_LOCK.writeLock();
+
   private final File cacheFile;
+  private final AtomicReference<Map<String, OAuthCachedCredentials>> audiences;
 
   public OAuthCredentialsCache(final File cacheFile) {
     this.cacheFile = cacheFile;
@@ -55,12 +65,17 @@ public final class OAuthCredentialsCache {
   }
 
   public OAuthCredentialsCache readCache() throws IOException {
-    if (!cacheFile.exists() || cacheFile.length() == 0) {
-      return this;
-    }
+    READ_LOCK.lock();
+    try {
+      if (!cacheFile.exists() || cacheFile.length() == 0) {
+        return this;
+      }
 
-    final Map<String, OAuthCachedCredentials> cache = MAPPER.readValue(cacheFile, TYPE_REFERENCE);
-    audiences.set(cache);
+      final Map<String, OAuthCachedCredentials> cache = MAPPER.readValue(cacheFile, TYPE_REFERENCE);
+      audiences.set(cache);
+    } finally {
+      READ_LOCK.unlock();
+    }
 
     return this;
   }
@@ -73,8 +88,13 @@ public final class OAuthCredentialsCache {
       cache.put(audience.getKey(), Collections.singletonMap(KEY_AUTH, audience.getValue()));
     }
 
-    ensureCacheFileExists();
-    MAPPER.writer().writeValue(cacheFile, cache);
+    WRITE_LOCK.lock();
+    try {
+      ensureCacheFileExists();
+      MAPPER.writer().writeValue(cacheFile, cache);
+    } finally {
+      WRITE_LOCK.unlock();
+    }
   }
 
   public Optional<CamundaClientCredentials> get(final String endpoint) {

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCache.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import net.jcip.annotations.ThreadSafe;
 
 @ThreadSafe
@@ -46,6 +47,15 @@ public final class OAuthCredentialsCache {
       new TypeReference<Map<String, OAuthCachedCredentials>>() {};
   private static final ObjectMapper MAPPER = new ObjectMapper(new YAMLFactory());
 
+  /**
+   * This lock is used to make access to the cache file thread-safe. It allows multiple threads to
+   * read at once, as long as no threads are writing. Only one thread is allowed to write at a time.
+   */
+  private static final ReentrantReadWriteLock READ_WRITE_LOCK = new ReentrantReadWriteLock();
+
+  private static final ReentrantReadWriteLock.ReadLock READ_LOCK = READ_WRITE_LOCK.readLock();
+  private static final ReentrantReadWriteLock.WriteLock WRITE_LOCK = READ_WRITE_LOCK.writeLock();
+
   private final File cacheFile;
   private final AtomicReference<Map<String, OAuthCachedCredentials>> audiences;
 
@@ -55,12 +65,17 @@ public final class OAuthCredentialsCache {
   }
 
   public OAuthCredentialsCache readCache() throws IOException {
-    if (!cacheFile.exists() || cacheFile.length() == 0) {
-      return this;
-    }
+    READ_LOCK.lock();
+    try {
+      if (!cacheFile.exists() || cacheFile.length() == 0) {
+        return this;
+      }
 
-    final Map<String, OAuthCachedCredentials> cache = MAPPER.readValue(cacheFile, TYPE_REFERENCE);
-    audiences.set(cache);
+      final Map<String, OAuthCachedCredentials> cache = MAPPER.readValue(cacheFile, TYPE_REFERENCE);
+      audiences.set(cache);
+    } finally {
+      READ_LOCK.unlock();
+    }
 
     return this;
   }
@@ -73,8 +88,13 @@ public final class OAuthCredentialsCache {
       cache.put(audience.getKey(), Collections.singletonMap(KEY_AUTH, audience.getValue()));
     }
 
-    ensureCacheFileExists();
-    MAPPER.writer().writeValue(cacheFile, cache);
+    WRITE_LOCK.lock();
+    try {
+      ensureCacheFileExists();
+      MAPPER.writer().writeValue(cacheFile, cache);
+    } finally {
+      WRITE_LOCK.unlock();
+    }
   }
 
   public Optional<ZeebeClientCredentials> get(final String endpoint) {

--- a/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -231,8 +230,6 @@ public final class OAuthCredentialsCacheTest {
   }
 
   @Test
-  @Ignore(
-      "Can be enabled when not flaky anymore, see https://github.com/camunda/camunda/issues/20136")
   public void shouldBeThreadSafe() throws InterruptedException {
     // given
     final OAuthCredentialsCache cache = new OAuthCredentialsCache(cacheFile);

--- a/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/impl/oauth/OAuthCredentialsCacheTest.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -229,8 +228,6 @@ public final class OAuthCredentialsCacheTest {
     assertThat(copy.size()).isEqualTo(2);
   }
 
-  @Ignore(
-      "Can be enabled when not flaky anymore, see https://github.com/camunda/camunda/issues/20136")
   @Test
   public void shouldBeThreadSafe() throws InterruptedException {
     // given


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

We were reading and writing to the cache file simultaneously. As a result this wasn't thread safe. By adding a read
write lock we can ensure that we are only reading when there's no other thread writing. And we will only start writing
when there's no other threads reading. Due to the nature of the ReentrantReadWriteLock multiple threads are allowed to read simultaneously.

## Related issues

closes #20136
