### PR TITLE
Don't remove commands from cache when skipped

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/MockProcessingResult.java
@@ -47,6 +47,11 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
     return records().isEmpty();
   }
 
+  @Override
+  public boolean isSkipped() {
+    return false;
+  }
+
   record Event(
       Intent intent,
       RecordType type,
@@ -108,5 +113,8 @@ record MockProcessingResult(List<Event> records) implements ProcessingResult {
     public boolean canWriteEventOfLength(final int eventLength) {
       return false;
     }
+
+    @Override
+    public void setSkipped(final boolean skipped) {}
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -123,8 +123,14 @@ public class Engine implements RecordProcessor {
       final boolean noBanCheckNeeded =
           !(record.getIntent() instanceof ProcessInstanceRelatedIntent)
               || record.getIntent() instanceof ProcessInstanceCreationIntent;
-      if (noBanCheckNeeded || !processingState.getBannedInstanceState().isBanned(typedCommand)) {
+      final boolean isBanned = processingState.getBannedInstanceState().isBanned(typedCommand);
+      if (noBanCheckNeeded || !isBanned) {
         currentProcessor.processRecord(record);
+      }
+
+      if (isBanned) {
+        // we skip processing the banned instance
+        processingResultBuilder.setSkipped(true);
       }
     }
     return processingResultBuilder.build();

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/FakeProcessingResultBuilder.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/stream/FakeProcessingResultBuilder.java
@@ -100,4 +100,7 @@ public class FakeProcessingResultBuilder<V extends UnifiedRecordValue>
   public boolean canWriteEventOfLength(final int eventLength) {
     return true;
   }
+
+  @Override
+  public void setSkipped(final boolean skipped) {}
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/TimerTriggerBannedInstanceIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/processing/TimerTriggerBannedInstanceIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.processing;
+
+import io.camunda.client.CamundaClient;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.qa.util.actuator.BanningActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources;
+import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
+import io.camunda.zeebe.test.util.junit.RegressionTest;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.util.Map;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+
+@AutoCloseResources
+@ZeebeIntegration
+final class TimerTriggerBannedInstanceIT {
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  @AutoCloseResource private CamundaClient client;
+
+  @BeforeEach
+  void beforeEach() {
+    client = zeebe.newClientBuilder().build();
+  }
+
+  /**
+   * Given a process with a timer event that triggers some time in the future, when the instance is
+   * banned before the timer is triggered, we should not produce many Timer TRIGGER commands for
+   * that timer.
+   *
+   * <p>This was a problem previously because every time the DueDateChecker ran, it finds the timer
+   * instance of the banned instance. Since, we remove the timer record from the command cache after
+   * writing the record to the log, we write banned instance's timer record to the command log again
+   * and again.
+   */
+  @RegressionTest("https://github.com/camunda/camunda/issues/14213")
+  public void shouldTriggerTimerEventOnlyOnceWhenInstanceIsBanned() {
+    // given
+    final var processId = "process1";
+    client
+        .newDeployResourceCommand()
+        .addProcessModel(
+            Bpmn.createExecutableProcess(processId)
+                .startEvent("start")
+                .intermediateCatchEvent("timer", b -> b.timerWithDurationExpression("duration"))
+                .endEvent("end")
+                .done(),
+            "process1.bpmn")
+        .send()
+        .join();
+
+    final long processInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variables(Map.of("duration", "PT2S"))
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    RecordingExporter.timerRecords()
+        .withIntents(TimerIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    final BanningActuator actuator = BanningActuator.of(zeebe);
+    actuator.ban(processInstanceKey);
+
+    // create a timer instance with a longer due date, so that banned instance's timer is also
+    // triggered
+    final long firstTriggeredProcessInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variable("duration", "PT3S")
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+        .withProcessInstanceKey(firstTriggeredProcessInstanceKey)
+        .await();
+
+    final long shorterDueDateProcessInstanceKey =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId(processId)
+            .latestVersion()
+            .variable("duration", "PT1S")
+            .send()
+            .join()
+            .getProcessInstanceKey();
+
+    RecordingExporter.timerRecords(TimerIntent.TRIGGERED)
+        .withProcessInstanceKey(shorterDueDateProcessInstanceKey)
+        .await();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.timerRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .limit(t -> t.getIntent() == TimerIntent.TRIGGERED)
+                .filter(t -> t.getIntent() == TimerIntent.TRIGGER)
+                .onlyCommands())
+        .describedAs("We only expect a single TRIGGER command for the banned instance")
+        .hasSize(1);
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EmptyProcessingResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/EmptyProcessingResult.java
@@ -39,4 +39,9 @@ public final class EmptyProcessingResult implements ProcessingResult {
   public boolean isEmpty() {
     return true;
   }
+
+  @Override
+  public boolean isSkipped() {
+    return false;
+  }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResult.java
@@ -49,4 +49,6 @@ public interface ProcessingResult {
    *     false otherwise.
    */
   boolean isEmpty();
+
+  boolean isSkipped();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ProcessingResultBuilder.java
@@ -87,4 +87,6 @@ public interface ProcessingResultBuilder {
   ProcessingResult build();
 
   boolean canWriteEventOfLength(int eventLength);
+
+  void setSkipped(boolean skipped);
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedProcessingResultBuilder.java
@@ -41,6 +41,7 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
   private final RecordBatch mutableRecordBatch;
   private ProcessingResponseImpl processingResponse;
   private final long operationReference;
+  private boolean skipped = false;
 
   BufferedProcessingResultBuilder(final RecordBatchSizePredicate predicate) {
     this(predicate, operationReferenceNullValue());
@@ -121,12 +122,17 @@ final class BufferedProcessingResultBuilder implements ProcessingResultBuilder {
 
   @Override
   public ProcessingResult build() {
-    return new BufferedResult(mutableRecordBatch, processingResponse, postCommitTasks);
+    return new BufferedResult(mutableRecordBatch, processingResponse, postCommitTasks, skipped);
   }
 
   @Override
   public boolean canWriteEventOfLength(final int eventLength) {
     return mutableRecordBatch.canAppendRecordOfLength(eventLength);
+  }
+
+  @Override
+  public void setSkipped(final boolean skipped) {
+    this.skipped = skipped;
   }
 
   record ProcessingResponseImpl(RecordBatchEntry responseValue, long requestId, int requestStreamId)

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/BufferedResult.java
@@ -26,14 +26,17 @@ final class BufferedResult implements ProcessingResult, TaskResult {
   private final List<PostCommitTask> postCommitTasks;
   private final ImmutableRecordBatch immutableRecordBatch;
   private final ProcessingResponseImpl processingResponse;
+  private final boolean skipped;
 
   BufferedResult(
       final ImmutableRecordBatch immutableRecordBatch,
       final ProcessingResponseImpl processingResponse,
-      final List<PostCommitTask> postCommitTasks) {
+      final List<PostCommitTask> postCommitTasks,
+      final boolean skipped) {
     this.postCommitTasks = new ArrayList<>(postCommitTasks);
     this.processingResponse = processingResponse;
     this.immutableRecordBatch = immutableRecordBatch;
+    this.skipped = skipped;
   }
 
   @Override
@@ -66,5 +69,10 @@ final class BufferedResult implements ProcessingResult, TaskResult {
     return getProcessingResponse().isEmpty()
         && getRecordBatch().isEmpty()
         && postCommitTasks.isEmpty();
+  }
+
+  @Override
+  public boolean isSkipped() {
+    return skipped;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingStateMachine.java
@@ -664,7 +664,9 @@ public final class ProcessingStateMachine {
                   updateState();
                 });
           } else {
-            scheduledCommandCache.remove(metadata.getIntent(), currentRecord.getKey());
+            if (!currentProcessingResult.isSkipped()) {
+              scheduledCommandCache.remove(metadata.getIntent(), currentRecord.getKey());
+            }
             executeSideEffects();
           }
         });


### PR DESCRIPTION
## Description

A boolean field is introduced to `ProcessingResult` and `ProcessingResultBuilder` to allow updating the
field. This field will be set to `true` when a command is skipped (e.g. banned instance's
commands). When a `ProcessingResult` is marked as `skipped`, we do not remove the command from the
command cache to prevent appending it to the log over and over again.

## Related issues

closes #14213 
