### PR TITLE
refactor: refactor SearchQuerySort mapper

### DIFF
--- a/service/src/main/java/io/camunda/service/search/sort/ProcessInstanceSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/ProcessInstanceSort.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.service.search.sort;
 
-import io.camunda.search.clients.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
 import java.util.function.Function;
@@ -40,14 +39,6 @@ public final record ProcessInstanceSort(List<FieldSorting> orderings) implements
     public Builder endDate() {
       currentOrdering = new FieldSorting("endDate", null);
       return this;
-    }
-
-    public Builder asc() {
-      return addOrdering(SortOrder.ASC);
-    }
-
-    public Builder desc() {
-      return addOrdering(SortOrder.DESC);
     }
 
     @Override

--- a/service/src/main/java/io/camunda/service/search/sort/SortOption.java
+++ b/service/src/main/java/io/camunda/service/search/sort/SortOption.java
@@ -33,6 +33,14 @@ public interface SortOption {
 
       return self();
     }
+
+    public T asc() {
+      return addOrdering(SortOrder.ASC);
+    }
+
+    public T desc() {
+      return addOrdering(SortOrder.DESC);
+    }
   }
 
   public final record FieldSorting(String field, SortOrder order) {}

--- a/service/src/main/java/io/camunda/service/search/sort/UserTaskSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/UserTaskSort.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.service.search.sort;
 
-import io.camunda.search.clients.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
 import java.util.function.Function;
@@ -34,14 +33,6 @@ public final record UserTaskSort(List<FieldSorting> orderings) implements SortOp
     public Builder completionDate() {
       currentOrdering = new FieldSorting("completionTime", null);
       return this;
-    }
-
-    public Builder asc() {
-      return addOrdering(SortOrder.ASC);
-    }
-
-    public Builder desc() {
-      return addOrdering(SortOrder.DESC);
     }
 
     @Override

--- a/service/src/main/java/io/camunda/service/search/sort/VariableSort.java
+++ b/service/src/main/java/io/camunda/service/search/sort/VariableSort.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.service.search.sort;
 
-import io.camunda.search.clients.sort.SortOrder;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
 import java.util.function.Function;
@@ -29,14 +28,6 @@ public final record VariableSort(List<FieldSorting> orderings) implements SortOp
     public Builder value() {
       currentOrdering = new FieldSorting("value", null);
       return this;
-    }
-
-    public Builder asc() {
-      return addOrdering(SortOrder.ASC);
-    }
-
-    public Builder desc() {
-      return addOrdering(SortOrder.DESC);
     }
 
     @Override

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1482,9 +1482,9 @@ components:
           type: string
         order:
           type: string
+          default: asc
       required:
         - field
-        - order
     SearchQueryResponse:
       type: object
       properties:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1482,6 +1482,9 @@ components:
           type: string
         order:
           type: string
+      required:
+        - field
+        - order
     SearchQueryResponse:
       type: object
       properties:

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceControllerTest.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.query.SearchQueryResult;
+import io.camunda.service.search.query.SearchQueryResult.Builder;
+import io.camunda.service.search.sort.ProcessInstanceSort;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(ProcessInstanceController.class)
+public class ProcessInstanceControllerTest extends RestControllerTest {
+
+  static final String EXPECTED_SEARCH_RESPONSE =
+      """
+      {
+          "items": [
+              {
+                  "tenantId": "t",
+                  "key": 0,
+                  "processVersion": 1,
+                  "bpmnProcessId": "b",
+                  "parentKey": 2,
+                  "parentFlowNodeInstanceKey": 3,
+                  "startDate": "s",
+                  "endDate": "e"
+              }
+          ],
+          "page": {
+              "totalItems": 1,
+              "firstSortValues": [],
+              "lastSortValues": [
+                  "v"
+              ]
+          }
+      }""";
+
+  static final SearchQueryResult<ProcessInstanceEntity> SEARCH_QUERY_RESULT =
+      new Builder<ProcessInstanceEntity>()
+          .total(1L)
+          .items(List.of(new ProcessInstanceEntity("t", 0L, 1, "b", 2L, 3L, "s", "e")))
+          .sortValues(new Object[] {"v"})
+          .build();
+
+  static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/process-instances/search";
+
+  @MockBean ProcessInstanceServices processInstanceServices;
+
+  @BeforeEach
+  void setupServices() {
+    when(processInstanceServices.withAuthentication(any(Function.class)))
+        .thenReturn(processInstanceServices);
+  }
+
+  @Test
+  void shouldSearchProcessInstancesWithEmptyQuery() {
+    // given
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    final String request = "{}";
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(processInstanceServices).search(new ProcessInstanceQuery.Builder().build());
+  }
+
+  @Test
+  void shouldSearchProcessInstancesWithSorting() {
+    // given
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+        .thenReturn(SEARCH_QUERY_RESULT);
+    final var request =
+        """
+        {
+            "sort": [
+                {
+                    "field": "processInstanceKey",
+                    "order": "desc"
+                },
+                {
+                    "field": "startDate",
+                    "order": "asc"
+                },
+                {
+                    "field": "endDate"
+                }
+            ]
+        }""";
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_SEARCH_RESPONSE);
+
+    verify(processInstanceServices)
+        .search(
+            new ProcessInstanceQuery.Builder()
+                .sort(
+                    new ProcessInstanceSort.Builder()
+                        .processInstanceKey()
+                        .desc()
+                        .startDate()
+                        .asc()
+                        .endDate()
+                        .asc()
+                        .build())
+                .build());
+  }
+
+  @Test
+  void shouldInvalidateProcessInstancesSearchQueryWithBadSortOrder() {
+    // given
+    final var request =
+        """
+        {
+            "sort": [
+                {
+                    "field": "processInstanceKey",
+                    "order": "dsc"
+                }
+            ]
+        }""";
+    final var expectedResponse =
+        String.format(
+            """
+        {
+          "type": "about:blank",
+          "title": "Bad Request",
+          "status": 400,
+          "detail": "Unknown sortOrder: dsc",
+          "instance": "%s"
+        }""",
+            PROCESS_INSTANCES_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse);
+
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
+  }
+
+  @Test
+  void shouldInvalidateProcessInstancesSearchQueryWithBadSortField() {
+    // given
+    final var request =
+        """
+        {
+            "sort": [
+                {
+                    "field": "tenantId",
+                    "order": "asc"
+                }
+            ]
+        }""";
+    final var expectedResponse =
+        String.format(
+            """
+        {
+          "type": "about:blank",
+          "title": "Bad Request",
+          "status": 400,
+          "detail": "Unknown sortBy: tenantId",
+          "instance": "%s"
+        }""",
+            PROCESS_INSTANCES_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse);
+
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
+  }
+
+  @Test
+  void shouldInvalidateProcessInstancesSearchQueryWithMissingSortField() {
+    // given
+    final var request =
+        """
+        {
+            "sort": [
+                {
+                    "order": "asc"
+                }
+            ]
+        }""";
+    final var expectedResponse =
+        String.format(
+            """
+        {
+          "type": "about:blank",
+          "title": "Bad Request",
+          "status": 400,
+          "detail": "Sort field must not be null",
+          "instance": "%s"
+        }""",
+            PROCESS_INSTANCES_SEARCH_URL);
+    // when / then
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
+        .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedResponse);
+
+    verify(processInstanceServices, never()).search(any(ProcessInstanceQuery.class));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->
Make `SearchQueryRequestMapper.toSearchQuerySort` generic to support object types other than ProcessInstance.
If we need to handle a new object type `MyObject` that supports search and sorting.
1. We need just to define `applyMyObjectSortField` that maps the supported sort fields (later, the unsupported sorted fields can be returned in a `ProblemDetail`):
```java
  private static void applyMyObjectSortField(
      final String field, final MyObjectSort.Builder builder) {
    switch (field) {
      case "foo" -> builder.foo();
      case "bar" -> builder.bar();
      default -> throw new IllegalArgumentException("Unknown sortBy: " + field);
    }
  }
```
2. Then, the `sorting` object can be obtained:
```java
    final var sorting =
        toSearchQuerySort(
                request.getSort(),
                SortOptionBuilders::myObject,
                SearchQueryRequestMapper::applyMyObjectSortField)
            .get();
```

In this pull request, I also made `field` and `order` fields mandatory under `SearchQuerySortRequest` in the rest-api.yaml. I need to check if this can be validated out-of-the-box without the need to manual nullity checks.

## Related issues

closes #
