### PR TITLE
docs: reference REST endpoint guide from dev handbook

### DIFF
--- a/zeebe/docs/developer_handbook.md
+++ b/zeebe/docs/developer_handbook.md
@@ -195,3 +195,6 @@ docker run --platform=linux/arm64 camunda/zeebe:SNAPSHOT
 
 or using the equivalent [platform property of docker-compose](https://docs.docker.com/compose/compose-file/#platform).
 
+## How to create a new REST endpoint
+
+Follow the [REST endpoint guide](../../docs/rest-controller.md). It will walk you through the required steps to consider.


### PR DESCRIPTION
## Description

Adds a reference to the REST endpoint guide to the developer handbook for better discoverability.

## Related issues

related to #20444 
