### PR TITLE
ci: fix release dry-run CI

### DIFF
--- a/.ci/docker/test/camunda-docker-labels.golden.json
+++ b/.ci/docker/test/camunda-docker-labels.golden.json
@@ -7,7 +7,7 @@
   "io.openshift.wants": "elasticsearch",
   "org.opencontainers.image.authors": "community@camunda.com",
   "org.opencontainers.image.base.digest": $DIGEST,
-  "org.opencontainers.image.base.name": "docker.io/library/ubuntu:jammy",
+  "org.opencontainers.image.base.name": $BASE_IMAGE,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Camunda platform: the universal process orchestrator",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/about-self-managed/",

--- a/.ci/docker/test/operate-docker-labels.golden.json
+++ b/.ci/docker/test/operate-docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch",
   "io.openshift.tags": "bpmn,operate,camunda",
   "org.opencontainers.image.authors": "operate@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.19.1",
+  "org.opencontainers.image.base.name": "docker.io/library/$BASE_IMAGE",
   "org.opencontainers.image.base.digest": $DIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Tool for process observability and troubleshooting processes running in Camunda Platform 8",

--- a/.ci/docker/test/operate-docker-labels.golden.json
+++ b/.ci/docker/test/operate-docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch",
   "io.openshift.tags": "bpmn,operate,camunda",
   "org.opencontainers.image.authors": "operate@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/$BASE_IMAGE",
+  "org.opencontainers.image.base.name": $BASE_IMAGE,
   "org.opencontainers.image.base.digest": $DIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Tool for process observability and troubleshooting processes running in Camunda Platform 8",

--- a/.ci/docker/test/tasklist-docker-labels.golden.json
+++ b/.ci/docker/test/tasklist-docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch",
   "io.openshift.tags": "bpmn,tasklist,camunda",
   "org.opencontainers.image.authors": "hto@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/alpine:3.19.1",
+  "org.opencontainers.image.base.name": "docker.io/library/$BASE_IMAGE",
   "org.opencontainers.image.base.digest": $DIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Tasklist is a ready-to-use application to rapidly implement business processes alongside user tasks in Zeebe",

--- a/.ci/docker/test/tasklist-docker-labels.golden.json
+++ b/.ci/docker/test/tasklist-docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.wants": "zeebe,elasticsearch",
   "io.openshift.tags": "bpmn,tasklist,camunda",
   "org.opencontainers.image.authors": "hto@camunda.com",
-  "org.opencontainers.image.base.name": "docker.io/library/$BASE_IMAGE",
+  "org.opencontainers.image.base.name": $BASE_IMAGE,
   "org.opencontainers.image.base.digest": $DIGEST,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Tasklist is a ready-to-use application to rapidly implement business processes alongside user tasks in Zeebe",

--- a/.ci/docker/test/verify.sh
+++ b/.ci/docker/test/verify.sh
@@ -119,7 +119,7 @@ expectedLabels=$(
     --arg REVISION "${REVISION}" \
     --arg DATE "${DATE}" \
     --arg DIGEST "${DIGEST}" \
-    --arg BASE_IMAGE "${BASE_IMAGE}" \
+    --arg BASE_IMAGE "docker.io/library/${BASE_IMAGE}" \
     "$(cat "${labelsGoldenFile}")"
 )
 

--- a/.ci/docker/test/verify.sh
+++ b/.ci/docker/test/verify.sh
@@ -90,6 +90,16 @@ else
     exit 1
 fi
 
+BASE_IMAGE_REGEX='ARG BASE_IMAGE="([^"]+)"'
+DOCKERFILE=$(<"${BASH_SOURCE%/*}/../../../${DOCKERFILENAME}")
+if [[ $DOCKERFILE =~ $BASE_IMAGE_REGEX ]]; then
+    BASE_IMAGE="${BASH_REMATCH[1]}"
+    echo "Base image found: $BASE_IMAGE"
+else
+    echo >&2 "Base image cannot be found in the Dockerfile (with name $DOCKERFILENAME)"
+    exit 1
+fi
+
 # Extract the actual labels from the info - make sure to sort keys so we always have the same
 # ordering for maps to compare things properly
 actualLabels=$(echo "${imageInfo}" | jq --sort-keys '.[0].Config.Labels')
@@ -109,6 +119,7 @@ expectedLabels=$(
     --arg REVISION "${REVISION}" \
     --arg DATE "${DATE}" \
     --arg DIGEST "${DIGEST}" \
+    --arg BASE_IMAGE "${BASE_IMAGE}" \
     "$(cat "${labelsGoldenFile}")"
 )
 

--- a/.ci/docker/test/verify.sh
+++ b/.ci/docker/test/verify.sh
@@ -91,7 +91,6 @@ else
 fi
 
 BASE_IMAGE_REGEX='ARG BASE_IMAGE="([^"]+)"'
-DOCKERFILE=$(<"${BASH_SOURCE%/*}/../../../${DOCKERFILENAME}")
 if [[ $DOCKERFILE =~ $BASE_IMAGE_REGEX ]]; then
     BASE_IMAGE="${BASH_REMATCH[1]}"
     echo "Base image found: $BASE_IMAGE"

--- a/.ci/docker/test/zeebe-docker-labels.golden.json
+++ b/.ci/docker/test/zeebe-docker-labels.golden.json
@@ -6,7 +6,7 @@
   "io.openshift.tags": "bpmn,orchestration,workflow",
   "org.opencontainers.image.authors": "zeebe@camunda.com",
   "org.opencontainers.image.base.digest": $DIGEST,
-  "org.opencontainers.image.base.name": "docker.io/library/ubuntu:jammy",
+  "org.opencontainers.image.base.name": $BASE_IMAGE,
   "org.opencontainers.image.created": $DATE,
   "org.opencontainers.image.description": "Workflow engine for microservice orchestration",
   "org.opencontainers.image.documentation": "https://docs.camunda.io/docs/self-managed/zeebe-deployment/",

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -1,13 +1,19 @@
 name: Camunda Platform Release Dry Run from main
 on:
-  workflow_dispatch: { }
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Specifies the branch, for which the Release Dry Run should be executed'
+        default: 'main'
+        required: false
+        type: string
   schedule:
     # Runs at 01:00 every week day; see this link for more: https://crontab.guru/#0_1_*_*_1-5
     - cron: '0 1 * * 1-5'
 
 jobs:
   dry-run-release:
-    name: "${{ matrix.version }} from main"
+    name: "${{ matrix.version }} from ${{ inputs.branch || 'main' }}"
     uses: ./.github/workflows/camunda-platform-release.yml
     secrets: inherit
     strategy:
@@ -20,7 +26,7 @@ jobs:
           - version: 0.8.2-alpha1
             latest: false
     with:
-      releaseBranch: main
+      releaseBranch: ${{ inputs.branch || 'main' }}
       releaseVersion: ${{ matrix.version }}
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}
@@ -29,7 +35,7 @@ jobs:
     name: Send slack notification
     runs-on: ubuntu-latest
     needs: [ dry-run-release ]
-    if: ${{ always() }}
+    if: ${{ github.event_name == 'schedule' }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -26,7 +26,7 @@ jobs:
           - version: 0.8.2-alpha1
             latest: false
     with:
-      releaseBranch: 'docker_golden_file'
+      releaseBranch: ${{ inputs.branch || 'main' }}
       releaseVersion: ${{ matrix.version }}
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}

--- a/.github/workflows/camunda-platform-release-main-dry-run.yml
+++ b/.github/workflows/camunda-platform-release-main-dry-run.yml
@@ -26,7 +26,7 @@ jobs:
           - version: 0.8.2-alpha1
             latest: false
     with:
-      releaseBranch: ${{ inputs.branch || 'main' }}
+      releaseBranch: 'docker_golden_file'
       releaseVersion: ${{ matrix.version }}
       nextDevelopmentVersion: 0.0.0-SNAPSHOT
       isLatest: ${{ matrix.latest }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->
release dry-run CI after the upgrade of alpine version in dockerfiles
- in this pull request, I update the docker verification script:
  - added BASE_IMAGE placeholder in the golden file 
  - extract the base image from the dockerfile

I also updated the CI so that it can be manually run on workflow_dispatch from any other branch and not only `main`
Slack notification is skipped in case the CI is triggered with workflow_dispatch to avoid the noise in the channel

release dry-run on this branch: https://github.com/camunda/camunda/actions/runs/10075985777

## Related issues

closes #
