### PR TITLE
Use file based snapshots in raft randomized tests

### DIFF
--- a/zeebe/atomix/cluster/pom.xml
+++ b/zeebe/atomix/cluster/pom.xml
@@ -144,6 +144,21 @@
     </dependency>
 
     <!-- test dependencies -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-snapshots</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>net.jodah</groupId>

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -30,8 +30,6 @@ import io.atomix.raft.partition.RaftElectionConfig;
 import io.atomix.raft.partition.RaftPartitionConfig;
 import io.atomix.raft.protocol.ControllableRaftServerProtocol;
 import io.atomix.raft.roles.LeaderRole;
-import io.atomix.raft.snapshot.InMemorySnapshot;
-import io.atomix.raft.snapshot.TestSnapshotStore;
 import io.atomix.raft.storage.RaftStorage;
 import io.atomix.raft.storage.log.IndexedRaftLogEntry;
 import io.atomix.raft.storage.log.RaftLog;
@@ -39,6 +37,8 @@ import io.atomix.raft.storage.log.RaftLogReader;
 import io.atomix.raft.zeebe.EntryValidator.NoopEntryValidator;
 import io.atomix.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.camunda.zeebe.journal.JournalException;
+import io.camunda.zeebe.scheduler.testing.TestConcurrencyControl;
+import io.camunda.zeebe.snapshots.testing.TestFileBasedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.collection.Tuple;
 import java.io.File;
@@ -62,7 +62,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.jmock.lib.concurrent.DeterministicScheduler;
@@ -88,7 +87,7 @@ public final class ControllableRaftContexts {
 
   private final int nodeCount;
   private final Map<MemberId, RaftContext> raftServers = new HashMap<>();
-  private final Map<MemberId, TestSnapshotStore> snapshotStores = new HashMap<>();
+  private final Map<MemberId, TestFileBasedSnapshotStore> snapshotStores = new HashMap<>();
   private Duration electionTimeout;
   private Duration heartbeatTimeout;
   private int nextEntry = 0;
@@ -171,7 +170,11 @@ public final class ControllableRaftContexts {
 
   private RaftContext createRaftContextForMember(final Random random, final int nodeId) {
     final var memberId = MemberId.from(String.valueOf(nodeId));
-    final var snapshotStore = new TestSnapshotStore(new AtomicReference<>());
+    final var snapshotStore =
+        new TestFileBasedSnapshotStore(
+            nodeId,
+            getMemberDirectory(directory, memberId.toString()).toPath().resolve("snapshots"),
+            new TestConcurrencyControl());
     snapshotStores.put(memberId, snapshotStore);
     final RaftContext raftContext =
         createRaftContext(
@@ -339,7 +342,7 @@ public final class ControllableRaftContexts {
   public void snapshotAndCompact(final MemberId memberId) {
     final RaftContext raftContext = raftServers.get(memberId);
     // Take snapshot at an index between lastSnapshotIndex and current commitIndex
-    final TestSnapshotStore testSnapshotStore = snapshotStores.get(memberId);
+    final TestFileBasedSnapshotStore testSnapshotStore = snapshotStores.get(memberId);
     final var startIndex =
         Math.max(
             raftContext.getLog().getFirstIndex(), testSnapshotStore.getCurrentSnapshotIndex() + 1);
@@ -352,12 +355,7 @@ public final class ControllableRaftContexts {
       reader.seek(snapshotIndex);
       final long term = reader.next().term();
 
-      InMemorySnapshot.newPersistedSnapshot(
-          Integer.parseInt(memberId.id()),
-          snapshotIndex,
-          term,
-          random.nextInt(1, 10),
-          testSnapshotStore);
+      testSnapshotStore.newSnapshot(snapshotIndex, term, random.nextInt(1, 10), random);
 
       LOG.info(
           "Snapshot taken at index {}. Current commit index is {}",
@@ -371,14 +369,9 @@ public final class ControllableRaftContexts {
   public void restart(final MemberId memberId) {
     raftServers.get(memberId).close();
     deterministicExecutors.remove(memberId).close();
-    final var newContext =
-        createRaftContext(
-            memberId,
-            random,
-            createStorage(memberId, cfg -> cfg.withSnapshotStore(snapshotStores.get(memberId))));
+    snapshotStores.get(memberId).close();
+    final var newContext = createRaftContextForMember(random, Integer.parseInt(memberId.id()));
     newContext.getCluster().bootstrap(raftServers.keySet());
-
-    raftServers.put(memberId, newContext);
   }
 
   // This is a different from other operations, as it restarts the node and force operations on

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/ControllableRaftContexts.java
@@ -128,6 +128,8 @@ public final class ControllableRaftContexts {
   }
 
   public void shutdown() throws IOException {
+    snapshotStores.forEach((m, store) -> store.close());
+    snapshotStores.clear();
     raftServers.forEach((m, c) -> c.close());
     raftServers.clear();
     serverProtocols.clear();

--- a/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
+++ b/zeebe/restore/src/main/java/io/camunda/zeebe/restore/PartitionRestoreService.java
@@ -18,7 +18,7 @@ import io.camunda.zeebe.backup.common.BackupIdentifierWildcardImpl;
 import io.camunda.zeebe.journal.JournalMetaStore.InMemory;
 import io.camunda.zeebe.journal.JournalReader;
 import io.camunda.zeebe.journal.file.SegmentedJournal;
-import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.RestorableSnapshotStore;
 import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStore;
 import io.camunda.zeebe.util.FileUtil;
@@ -43,13 +43,13 @@ public class PartitionRestoreService {
   final Path rootDirectory;
   private final RaftPartition partition;
   private final int brokerId;
-  private final ChecksumProvider checksumProvider;
+  private final CRC32CChecksumProvider checksumProvider;
 
   public PartitionRestoreService(
       final BackupStore backupStore,
       final RaftPartition partition,
       final int brokerId,
-      final ChecksumProvider checksumProvider) {
+      final CRC32CChecksumProvider checksumProvider) {
     this.backupStore = backupStore;
     partitionId = partition.id().id();
     rootDirectory = partition.dataDirectory().toPath();

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/Actor.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.scheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.util.Loggers;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -123,6 +124,12 @@ public abstract class Actor implements AutoCloseable, AsyncClosable, Concurrency
   public <T> void runOnCompletion(
       final ActorFuture<T> future, final BiConsumer<T, Throwable> callback) {
     actor.runOnCompletion(future, callback);
+  }
+
+  @Override
+  public <T> void runOnCompletion(
+      final Collection<ActorFuture<T>> actorFutures, final Consumer<Throwable> callback) {
+    actor.runOnCompletion(actorFutures, callback);
   }
 
   @Override

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorControl.java
@@ -295,6 +295,7 @@ public class ActorControl implements ConcurrencyControl {
    * @param callback The throwable is <code>null</code> when all futures are completed successfully.
    *     Otherwise, it holds the exception of the last completed future.
    */
+  @Override
   public <T> void runOnCompletion(
       final Collection<ActorFuture<T>> futures, final Consumer<Throwable> callback) {
     if (!futures.isEmpty()) {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ConcurrencyControl.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.scheduler;
 
+import io.camunda.zeebe.scheduler.ActorTask.ActorLifecyclePhase;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import org.jetbrains.annotations.NotNull;
 
 /**
@@ -29,6 +32,20 @@ public interface ConcurrencyControl extends Executor {
    * @param <T> result type of the future
    */
   <T> void runOnCompletion(final ActorFuture<T> future, final BiConsumer<T, Throwable> callback);
+
+  /**
+   * Invoke the callback when the given futures are completed (successfully or exceptionally). This
+   * call does not block the actor.
+   *
+   * <p>The callback is executed while the actor is in the following actor lifecycle phases: {@link
+   * ActorLifecyclePhase#STARTED}
+   *
+   * @param futures the futures to wait on
+   * @param callback The throwable is <code>null</code> when all futures are completed successfully.
+   *     Otherwise, it holds the exception of the last completed future.
+   */
+  <T> void runOnCompletion(
+      final Collection<ActorFuture<T>> futures, final Consumer<Throwable> callback);
 
   /**
    * Schedules an action to be invoked (must be called from an actor thread)

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/TestConcurrencyControl.java
@@ -51,6 +51,11 @@ public class TestConcurrencyControl implements ConcurrencyControl {
   @Override
   public <T> void runOnCompletion(
       final Collection<ActorFuture<T>> actorFutures, final Consumer<Throwable> callback) {
+    if (actorFutures.isEmpty()) {
+      callback.accept(null);
+      return;
+    }
+
     final var error = new AtomicReference<Throwable>();
     final var futuresCompleted = new AtomicInteger(actorFutures.size());
     final var finalFuture = new TestActorFuture<>();

--- a/zeebe/snapshot/pom.xml
+++ b/zeebe/snapshot/pom.xml
@@ -94,4 +94,20 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/CRC32CChecksumProvider.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/CRC32CChecksumProvider.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.snapshots;
 import java.nio.file.Path;
 import java.util.Map;
 
-public interface ChecksumProvider {
+public interface CRC32CChecksumProvider {
 
   /**
    * @param snapshotPath path of snapshot to get live file checksums

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
-import io.camunda.zeebe.scheduler.ActorControl;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -39,7 +39,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   private final Consumer<FileBasedSnapshot> onSnapshotDeleted;
 
   private final Set<FileBasedSnapshotReservation> reservations = new HashSet<>();
-  private final ActorControl actor;
+  private final ConcurrencyControl actor;
 
   private boolean deleted = false;
 
@@ -50,7 +50,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
       final FileBasedSnapshotId snapshotId,
       final SnapshotMetadata metadata,
       final Consumer<FileBasedSnapshot> onSnapshotDeleted,
-      final ActorControl actor) {
+      final ConcurrencyControl actor) {
     this.directory = directory;
     this.checksumFile = checksumFile;
     this.checksum = checksum;

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.snapshots.impl;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
@@ -36,7 +36,7 @@ public final class FileBasedSnapshotStore extends Actor
       final int brokerId,
       final int partitionId,
       final Path root,
-      final ChecksumProvider checksumProvider) {
+      final CRC32CChecksumProvider checksumProvider) {
     actorName = buildActorName("SnapshotStore", partitionId);
     this.partitionId = partitionId;
     snapshotStore =

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStore.java
@@ -7,106 +7,40 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
-import static io.camunda.zeebe.util.FileUtil.deleteFolder;
-import static io.camunda.zeebe.util.FileUtil.ensureDirectoryExists;
-
 import io.camunda.zeebe.scheduler.Actor;
-import io.camunda.zeebe.scheduler.ActorThread;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ChecksumProvider;
 import io.camunda.zeebe.snapshots.ConstructableSnapshotStore;
-import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
-import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
 import io.camunda.zeebe.snapshots.RestorableSnapshotStore;
 import io.camunda.zeebe.snapshots.SnapshotException;
-import io.camunda.zeebe.snapshots.SnapshotException.CorruptedSnapshotException;
-import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
-import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.TransientSnapshot;
 import io.camunda.zeebe.util.Either;
-import io.camunda.zeebe.util.FileUtil;
 import java.io.IOException;
-import java.io.UncheckedIOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
-import java.util.ConcurrentModificationException;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class FileBasedSnapshotStore extends Actor
     implements ConstructableSnapshotStore, ReceivableSnapshotStore, RestorableSnapshotStore {
-  public static final String SNAPSHOTS_DIRECTORY = "snapshots";
-  public static final String PENDING_DIRECTORY = "pending";
 
-  static final int VERSION = 1;
-
-  // When sorted with other files in the snapshot, the metadata file must be ordered at the end.
-  // This is required for backward compatibility of checksum calculation. Otherwise, the older
-  // versions, which are not aware of the metadata will calculate the checksum using a different
-  // order of files. The  ordering requirement is fulfilled because the name "zeebe.metadata" is
-  // lexicographically greater than all other snapshot files. We can change the name in later
-  // versions, because the new checksum calculation already order the metadata file explicitly
-  // instead of using the implicit sort order.
-  static final String METADATA_FILE_NAME = "zeebe.metadata";
-  // first is the metadata and the second the received snapshot count
-  private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedSnapshotStore.class);
-  private static final String CHECKSUM_SUFFIX = ".checksum";
-  private static final String TMP_CHECKSUM_SUFFIX = ".tmp";
-  private final int brokerId;
-  // the root snapshotsDirectory where all snapshots should be stored
-  private final Path snapshotsDirectory;
-  // the root snapshotsDirectory when pending snapshots should be stored
-  private final Path pendingDirectory;
-  // keeps track of all snapshot modification listeners
-  private final Set<PersistedSnapshotListener> listeners;
-  private final SnapshotMetrics snapshotMetrics;
-  // Use AtomicReference so that getting latest snapshot doesn't have to go through the actor
-  private final AtomicReference<FileBasedSnapshot> currentPersistedSnapshotRef =
-      new AtomicReference<>();
-  // used to write concurrently received snapshots in different pending directories
-  private final AtomicLong receivingSnapshotStartCount;
-  private final Set<PersistableSnapshot> pendingSnapshots = new HashSet<>();
-  private final Set<FileBasedSnapshot> availableSnapshots = new HashSet<>();
-  private final ChecksumProvider checksumProvider;
   private final String actorName;
   private final int partitionId;
+  private final FileBasedSnapshotStoreImpl snapshotStore;
 
   public FileBasedSnapshotStore(
       final int brokerId,
       final int partitionId,
       final Path root,
       final ChecksumProvider checksumProvider) {
-    this.brokerId = brokerId;
-    snapshotsDirectory = root.resolve(SNAPSHOTS_DIRECTORY);
-    pendingDirectory = root.resolve(PENDING_DIRECTORY);
-
-    try {
-      FileUtil.ensureDirectoryExists(snapshotsDirectory);
-      FileUtil.ensureDirectoryExists(pendingDirectory);
-    } catch (final IOException e) {
-      throw new UncheckedIOException("Failed to create snapshot directories", e);
-    }
-
-    snapshotMetrics = new SnapshotMetrics(String.valueOf(partitionId));
-    receivingSnapshotStartCount = new AtomicLong();
-
-    listeners = new CopyOnWriteArraySet<>();
     actorName = buildActorName("SnapshotStore", partitionId);
     this.partitionId = partitionId;
-    this.checksumProvider = Objects.requireNonNull(checksumProvider);
+    snapshotStore =
+        new FileBasedSnapshotStoreImpl(brokerId, partitionId, root, checksumProvider, this);
   }
 
   @Override
@@ -123,293 +57,68 @@ public final class FileBasedSnapshotStore extends Actor
 
   @Override
   protected void onActorStarting() {
-    final FileBasedSnapshot latestSnapshot = loadLatestSnapshot(snapshotsDirectory);
-    currentPersistedSnapshotRef.set(latestSnapshot);
-    if (latestSnapshot != null) {
-      availableSnapshots.add(latestSnapshot);
-    }
-    purgePendingSnapshotsDirectory();
+    snapshotStore.start();
   }
 
   @Override
   protected void onActorClosing() {
-    listeners.clear();
-  }
-
-  private FileBasedSnapshot loadLatestSnapshot(final Path snapshotDirectory) {
-    FileBasedSnapshot latestPersistedSnapshot = null;
-    try (final var stream = Files.newDirectoryStream(snapshotDirectory, Files::isDirectory)) {
-      for (final var path : stream) {
-        final var snapshot = collectSnapshot(path);
-        if (snapshot != null) {
-          if ((latestPersistedSnapshot == null)
-              || snapshot.getSnapshotId().compareTo(latestPersistedSnapshot.getSnapshotId()) >= 0) {
-            latestPersistedSnapshot = snapshot;
-          }
-        }
-      }
-      // Cleanup of the snapshot directory. Older or corrupted snapshots are deleted
-      if (latestPersistedSnapshot != null) {
-        cleanupSnapshotDirectory(snapshotDirectory, latestPersistedSnapshot);
-      }
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
-    return latestPersistedSnapshot;
-  }
-
-  private void cleanupSnapshotDirectory(
-      final Path snapshotDirectory, final FileBasedSnapshot latestPersistedSnapshot)
-      throws IOException {
-    final var latestChecksumFile = latestPersistedSnapshot.getChecksumPath();
-    final var latestDirectory = latestPersistedSnapshot.getDirectory();
-    try (final var paths =
-        Files.newDirectoryStream(
-            snapshotDirectory, p -> !p.equals(latestDirectory) && !p.equals(latestChecksumFile))) {
-      LOGGER.debug("Deleting snapshots other than {}", latestPersistedSnapshot.getId());
-      paths.forEach(
-          p -> {
-            try {
-              LOGGER.debug("Deleting {}", p);
-              FileUtil.deleteFolderIfExists(p);
-            } catch (final IOException e) {
-              LOGGER.warn("Unable to delete {}", p, e);
-            }
-          });
-    }
-  }
-
-  // TODO(npepinpe): using Either here would improve readability and observability, as validation
-  //  can have better error messages, and the return type better expresses what we attempt to do,
-  //  i.e. either it failed (with an error) or it succeeded
-  private FileBasedSnapshot collectSnapshot(final Path path) throws IOException {
-    final var optionalMeta = FileBasedSnapshotId.ofPath(path);
-    if (optionalMeta.isEmpty()) {
-      return null;
-    }
-
-    final var snapshotId = optionalMeta.get();
-    final var checksumPath = buildSnapshotsChecksumPath(snapshotId);
-
-    if (!Files.exists(checksumPath)) {
-      // checksum was not completely/successfully written, we can safely delete it and proceed
-      LOGGER.debug(
-          "Snapshot {} does not have a checksum file, which most likely indicates a partial write"
-              + " (e.g. crash during move), and will be deleted",
-          path);
-      try {
-        deleteFolder(path);
-      } catch (final Exception e) {
-        // it's fine to ignore failures to delete here, as it would constitute mostly noise
-        LOGGER.debug("Failed to delete partial snapshot {}", path, e);
-      }
-
-      return null;
-    }
-
-    try {
-      final var expectedChecksum = SnapshotChecksum.read(checksumPath);
-      final var actualChecksum =
-          SnapshotChecksum.calculateWithProvidedChecksums(path, checksumProvider);
-      if (!actualChecksum.sameChecksums(expectedChecksum)) {
-        LOGGER.warn(
-            "Expected snapshot {} to have checksums {}, but the actual checksums are {}; the snapshot is most likely corrupted. The startup will fail if there is no other valid snapshot and the log has been compacted.",
-            path,
-            expectedChecksum.getChecksums(),
-            actualChecksum.getChecksums());
-        return null;
-      }
-
-      final var metadata = collectMetadata(path, snapshotId);
-      return new FileBasedSnapshot(
-          path,
-          checksumPath,
-          actualChecksum.getCombinedValue(),
-          snapshotId,
-          metadata,
-          this::onSnapshotDeleted,
-          actor);
-    } catch (final Exception e) {
-      LOGGER.warn("Could not load snapshot in {}", path, e);
-      return null;
-    }
-  }
-
-  private FileBasedSnapshotMetadata collectMetadata(
-      final Path path, final FileBasedSnapshotId snapshotId) throws IOException {
-    final var metadataPath = path.resolve(METADATA_FILE_NAME);
-    if (metadataPath.toFile().exists()) {
-      final var encodedMetadata = Files.readAllBytes(metadataPath);
-      return FileBasedSnapshotMetadata.decode(encodedMetadata);
-    } else {
-      // backward compatibility mode
-      return new FileBasedSnapshotMetadata(
-          VERSION,
-          snapshotId.getProcessedPosition(),
-          snapshotId.getExportedPosition(),
-          Long.MAX_VALUE);
-    }
-  }
-
-  private void purgePendingSnapshotsDirectory() {
-    try (final var files = Files.list(pendingDirectory)) {
-      files.filter(Files::isDirectory).forEach(this::purgePendingSnapshot);
-    } catch (final IOException e) {
-      LOGGER.error(
-          "Failed to purge pending snapshots, which may result in unnecessary disk usage and should be monitored",
-          e);
-    }
+    snapshotStore.close();
   }
 
   @Override
   public boolean hasSnapshotId(final String id) {
-    final var optLatestSnapshot = getLatestSnapshot();
-
-    if (optLatestSnapshot.isPresent()) {
-      final var snapshot = optLatestSnapshot.get();
-      return snapshot.getPath().getFileName().toString().equals(id);
-    }
-    return false;
+    return snapshotStore.hasSnapshotId(id);
   }
 
   @Override
   public Optional<PersistedSnapshot> getLatestSnapshot() {
-    return Optional.ofNullable(currentPersistedSnapshotRef.get());
+    return snapshotStore.getLatestSnapshot();
   }
 
   @Override
   public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
-    // return a new set so that caller cannot modify availableSnapshot
-    return actor.call(() -> Collections.unmodifiableSet(availableSnapshots));
+    return snapshotStore.getAvailableSnapshots();
   }
 
   @Override
   public ActorFuture<Long> getCompactionBound() {
-    return actor.call(
-        () ->
-            availableSnapshots.stream()
-                .map(PersistedSnapshot::getCompactionBound)
-                .min(Long::compareTo)
-                .orElse(0L));
+    return snapshotStore.getCompactionBound();
   }
 
   @Override
   public ActorFuture<Void> purgePendingSnapshots() {
     final CompletableActorFuture<Void> abortFuture = new CompletableActorFuture<>();
-    actor.run(
-        () -> {
-          final var abortedAll = pendingSnapshots.stream().map(PersistableSnapshot::abort).toList();
-          actor.runOnCompletion(
-              abortedAll,
-              error -> {
-                if (error == null) {
-                  abortFuture.complete(null);
-                } else {
-                  abortFuture.completeExceptionally(error);
-                }
-              });
-        });
-    return abortFuture;
+    return snapshotStore.purgePendingSnapshots();
   }
 
   @Override
   public ActorFuture<Boolean> addSnapshotListener(final PersistedSnapshotListener listener) {
-    return actor.call(() -> listeners.add(listener));
+    return snapshotStore.addSnapshotListener(listener);
   }
 
   @Override
   public ActorFuture<Boolean> removeSnapshotListener(final PersistedSnapshotListener listener) {
-    return actor.call(() -> listeners.remove(listener));
+    return snapshotStore.removeSnapshotListener(listener);
   }
 
   @Override
   public long getCurrentSnapshotIndex() {
-    return getLatestSnapshot().map(PersistedSnapshot::getIndex).orElse(0L);
+    return snapshotStore.getCurrentSnapshotIndex();
   }
 
   @Override
   public ActorFuture<Void> delete() {
-    return actor.call(
-        () -> {
-          currentPersistedSnapshotRef.set(null);
-
-          try {
-            LOGGER.debug("DELETE FOLDER {}", snapshotsDirectory);
-            deleteFolder(snapshotsDirectory);
-          } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-          }
-
-          try {
-            LOGGER.debug("DELETE FOLDER {}", pendingDirectory);
-            deleteFolder(pendingDirectory);
-          } catch (final IOException e) {
-            throw new UncheckedIOException(e);
-          }
-        });
+    return snapshotStore.delete();
   }
 
   @Override
   public Path getPath() {
-    return snapshotsDirectory;
+    return snapshotStore.getPath();
   }
 
   @Override
   public ActorFuture<FileBasedReceivedSnapshot> newReceivedSnapshot(final String snapshotId) {
-    final var newSnapshotFuture = new CompletableActorFuture<FileBasedReceivedSnapshot>();
-    final var optSnapshotId = FileBasedSnapshotId.ofFileName(snapshotId);
-    final var parsedSnapshotId =
-        optSnapshotId.orElseThrow(
-            () ->
-                new IllegalArgumentException(
-                    "Expected snapshot id in a format like 'index-term-processedPosition-exportedPosition', got '"
-                        + snapshotId
-                        + "'."));
-
-    actor.run(
-        () -> {
-          final var directory = buildSnapshotDirectory(parsedSnapshotId);
-          try {
-            checkAndCleanupExistingDirectory(snapshotId, parsedSnapshotId, directory);
-            createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
-          } catch (final Exception e) {
-            newSnapshotFuture.completeExceptionally(e);
-          }
-        });
-    return newSnapshotFuture;
-  }
-
-  private void createReceivedSnapshot(
-      final FileBasedSnapshotId parsedSnapshotId,
-      final Path directory,
-      final CompletableActorFuture<FileBasedReceivedSnapshot> newSnapshotFuture) {
-    final var newPendingSnapshot =
-        new FileBasedReceivedSnapshot(parsedSnapshotId, directory, this, actor);
-    addPendingSnapshot(newPendingSnapshot);
-    newSnapshotFuture.complete(newPendingSnapshot);
-  }
-
-  private void checkAndCleanupExistingDirectory(
-      final String snapshotId, final FileBasedSnapshotId parsedSnapshotId, final Path directory) {
-    if (directory.toFile().exists()) {
-      if (!buildSnapshotsChecksumPath(parsedSnapshotId).toFile().exists()) {
-        try {
-          // old pending/incomplete received snapshots which we can delete
-          FileUtil.deleteFolderIfExists(directory);
-        } catch (final IOException e) {
-          throw new IllegalStateException(
-              "Expected to delete pending received snapshot, but failed.", e);
-        }
-      } else {
-        // this should not happen
-        // this means we persisted a snapshot - marked as valid
-        // and now received the same snapshot via replication
-        throw new SnapshotAlreadyExistsException(
-            String.format(
-                "Expected to receive snapshot with id %s, but was already persisted. This shouldn't happen.",
-                snapshotId));
-      }
-    }
+    return snapshotStore.newReceivedSnapshot(snapshotId);
   }
 
   @Override
@@ -418,323 +127,25 @@ public final class FileBasedSnapshotStore extends Actor
       final long term,
       final long processedPosition,
       final long exportedPosition) {
-
-    final var newSnapshotId =
-        new FileBasedSnapshotId(index, term, processedPosition, exportedPosition, brokerId);
-    final FileBasedSnapshot currentSnapshot = currentPersistedSnapshotRef.get();
-    if (currentSnapshot != null && currentSnapshot.getSnapshotId().compareTo(newSnapshotId) == 0) {
-      final String error =
-          String.format(
-              "Previous snapshot was taken for the same processed position %d and exported position %d.",
-              processedPosition, exportedPosition);
-      return Either.left(new SnapshotAlreadyExistsException(error));
-    }
-    // transient snapshots are directly written to our snapshot dir
-    // with the sfv checksum file they are marked as valid
-    final var directory = buildSnapshotDirectory(newSnapshotId);
-    final var newPendingSnapshot =
-        new FileBasedTransientSnapshot(newSnapshotId, directory, this, actor, checksumProvider);
-    addPendingSnapshot(newPendingSnapshot);
-    return Either.right(newPendingSnapshot);
-  }
-
-  private void addPendingSnapshot(final PersistableSnapshot pendingSnapshot) {
-    final Runnable action = () -> pendingSnapshots.add(pendingSnapshot);
-
-    if (!isCurrentActor()) {
-      actor.submit(action);
-    } else {
-      action.run();
-    }
-  }
-
-  void removePendingSnapshot(final PersistableSnapshot pendingSnapshot) {
-    pendingSnapshots.remove(pendingSnapshot);
-  }
-
-  private boolean isCurrentActor() {
-    final var currentActorThread = ActorThread.current();
-
-    if (currentActorThread != null) {
-      final var task = currentActorThread.getCurrentTask();
-      if (task != null) {
-        return task.getActor() == this;
-      }
-    }
-
-    return false;
-  }
-
-  private void observeSnapshotSize(final FileBasedSnapshot persistedSnapshot) {
-    try (final var contents = Files.newDirectoryStream(persistedSnapshot.getPath())) {
-      var totalSize = 0L;
-      var totalCount = 0L;
-      for (final var path : contents) {
-        if (Files.isRegularFile(path)) {
-          final var size = Files.size(path);
-          snapshotMetrics.observeSnapshotFileSize(size);
-          totalSize += size;
-          totalCount++;
-        }
-      }
-
-      snapshotMetrics.observeSnapshotSize(totalSize);
-      snapshotMetrics.observeSnapshotChunkCount(totalCount);
-    } catch (final IOException e) {
-      LOGGER.warn("Failed to observe size for snapshot {}", persistedSnapshot, e);
-    }
-  }
-
-  private void purgePendingSnapshots(final SnapshotId cutoffSnapshot) {
-    LOGGER.trace(
-        "Search for orphaned snapshots below oldest valid snapshot with index {} in {}",
-        cutoffSnapshot.getSnapshotIdAsString(),
-        pendingDirectory);
-
-    pendingSnapshots.stream()
-        .filter(pendingSnapshot -> pendingSnapshot.snapshotId().compareTo(cutoffSnapshot) < 0)
-        .forEach(PersistableSnapshot::abort);
-
-    // If there are orphaned directories if a previous abort failed, delete them explicitly
-    try (final var pendingSnapshotsDirectories = Files.newDirectoryStream(pendingDirectory)) {
-      for (final var pendingSnapshot : pendingSnapshotsDirectories) {
-        purgePendingSnapshot(cutoffSnapshot, pendingSnapshot);
-      }
-    } catch (final IOException e) {
-      LOGGER.warn(
-          "Failed to delete orphaned snapshots, could not list pending directory {}",
-          pendingDirectory,
-          e);
-    }
-  }
-
-  private void purgePendingSnapshot(final SnapshotId cutoffIndex, final Path pendingSnapshot) {
-    final var optionalMetadata = FileBasedSnapshotId.ofPath(pendingSnapshot);
-    if (optionalMetadata.isPresent() && optionalMetadata.get().compareTo(cutoffIndex) < 0) {
-      try {
-        deleteFolder(pendingSnapshot);
-        LOGGER.debug("Deleted orphaned snapshot {}", pendingSnapshot);
-      } catch (final IOException e) {
-        LOGGER.warn(
-            "Failed to delete orphaned snapshot {}, risk using unnecessary disk space",
-            pendingSnapshot,
-            e);
-      }
-    }
-  }
-
-  private boolean isCurrentSnapshotNewer(final FileBasedSnapshotId snapshotId) {
-    final var persistedSnapshot = currentPersistedSnapshotRef.get();
-    return (persistedSnapshot != null
-        && persistedSnapshot.getSnapshotId().compareTo(snapshotId) >= 0);
-  }
-
-  FileBasedSnapshot persistNewSnapshot(
-      final FileBasedSnapshotId snapshotId,
-      final ImmutableChecksumsSFV immutableChecksumsSFV,
-      final FileBasedSnapshotMetadata metadata) {
-    final var currentPersistedSnapshot = currentPersistedSnapshotRef.get();
-
-    if (isCurrentSnapshotNewer(snapshotId)) {
-      final var currentPersistedSnapshotId = currentPersistedSnapshot.getSnapshotId();
-
-      LOGGER.debug(
-          "Snapshot is older than the latest snapshot {}. Snapshot {} won't be committed.",
-          currentPersistedSnapshotId,
-          snapshotId);
-
-      purgePendingSnapshots(currentPersistedSnapshotId);
-      return currentPersistedSnapshot;
-    }
-
-    try (final var ignored = snapshotMetrics.startPersistTimer()) {
-      // it's important to persist the checksum file only after the move is finished, since we use
-      // it as a marker file to guarantee the move was complete and not partial
-      final var destination = buildSnapshotDirectory(snapshotId);
-      final var checksumPath = buildSnapshotsChecksumPath(snapshotId);
-      final var tmpChecksumPath =
-          checksumPath.resolveSibling(checksumPath.getFileName().toString() + TMP_CHECKSUM_SUFFIX);
-      try {
-        SnapshotChecksum.persist(tmpChecksumPath, immutableChecksumsSFV);
-        FileUtil.moveDurably(tmpChecksumPath, checksumPath);
-      } catch (final IOException e) {
-        rollbackPartialSnapshot(destination);
-        throw new UncheckedIOException(e);
-      }
-
-      final var newPersistedSnapshot =
-          new FileBasedSnapshot(
-              destination,
-              checksumPath,
-              immutableChecksumsSFV.getCombinedValue(),
-              snapshotId,
-              metadata,
-              this::onSnapshotDeleted,
-              actor);
-      final var failed =
-          !currentPersistedSnapshotRef.compareAndSet(
-              currentPersistedSnapshot, newPersistedSnapshot);
-      if (failed) {
-        // we moved already the snapshot but we expected that this will be cleaned up by the next
-        // successful snapshot
-        final var errorMessage =
-            "Expected that last snapshot is '%s', which should be replace with '%s', but last snapshot was '%s'.";
-        throw new ConcurrentModificationException(
-            String.format(
-                errorMessage,
-                currentPersistedSnapshot,
-                newPersistedSnapshot.getSnapshotId(),
-                currentPersistedSnapshotRef.get()));
-      }
-
-      availableSnapshots.add(newPersistedSnapshot);
-
-      LOGGER.info("Committed new snapshot {}", newPersistedSnapshot.getId());
-
-      snapshotMetrics.incrementSnapshotCount();
-      observeSnapshotSize(newPersistedSnapshot);
-
-      deleteOlderSnapshots(newPersistedSnapshot);
-
-      listeners.forEach(listener -> listener.onNewSnapshot(newPersistedSnapshot));
-
-      return newPersistedSnapshot;
-    }
-  }
-
-  private void deleteOlderSnapshots(final FileBasedSnapshot newPersistedSnapshot) {
-    LOGGER.trace(
-        "Purging snapshots older than {}",
-        newPersistedSnapshot.getSnapshotId().getSnapshotIdAsString());
-    final var snapshotsToDelete =
-        availableSnapshots.stream()
-            .filter(s -> !s.getId().equals(newPersistedSnapshot.getId()))
-            .filter(s -> !s.isReserved())
-            .toList();
-    snapshotsToDelete.forEach(
-        previousSnapshot -> {
-          LOGGER.debug("Deleting previous snapshot {}", previousSnapshot.getId());
-          previousSnapshot.delete();
-        });
-    purgePendingSnapshots(newPersistedSnapshot.getSnapshotId());
-  }
-
-  private void rollbackPartialSnapshot(final Path destination) {
-    try {
-      FileUtil.deleteFolderIfExists(destination);
-    } catch (final IOException ioException) {
-      LOGGER.debug(
-          "Pending snapshot {} could not be deleted on rollback, but will be safely ignored as a "
-              + "partial snapshot",
-          destination,
-          ioException);
-    }
-  }
-
-  private void purgePendingSnapshot(final Path pendingSnapshot) {
-    try {
-      deleteFolder(pendingSnapshot);
-      LOGGER.debug("Deleted not completed (orphaned) snapshot {}", pendingSnapshot);
-    } catch (final IOException e) {
-      LOGGER.warn("Failed to delete not completed (orphaned) snapshot {}", pendingSnapshot, e);
-    }
-  }
-
-  private Path buildSnapshotDirectory(final FileBasedSnapshotId snapshotId) {
-    return snapshotsDirectory.resolve(snapshotId.getSnapshotIdAsString());
-  }
-
-  private Path buildSnapshotsChecksumPath(final FileBasedSnapshotId snapshotId) {
-    return snapshotsDirectory.resolve(snapshotId.getSnapshotIdAsString() + CHECKSUM_SUFFIX);
-  }
-
-  private boolean isChecksumFile(final String name) {
-    return name.endsWith(CHECKSUM_SUFFIX);
-  }
-
-  SnapshotMetrics getSnapshotMetrics() {
-    return snapshotMetrics;
-  }
-
-  void onSnapshotDeleted(final FileBasedSnapshot snapshot) {
-    availableSnapshots.remove(snapshot);
-  }
-
-  @Override
-  public String toString() {
-    return "FileBasedSnapshotStore{"
-        + "snapshotsDirectory="
-        + snapshotsDirectory
-        + ", pendingDirectory="
-        + pendingDirectory
-        + ", listeners="
-        + listeners
-        + ", currentPersistedSnapshotRef="
-        + currentPersistedSnapshotRef
-        + ", receivingSnapshotStartCount="
-        + receivingSnapshotStartCount
-        + ", pendingSnapshots="
-        + pendingSnapshots
-        + ", availableSnapshots="
-        + availableSnapshots
-        + ", actorName='"
-        + actorName
-        + '\''
-        + ", partitionId="
-        + partitionId
-        + "}";
+    return snapshotStore.newTransientSnapshot(index, term, processedPosition, exportedPosition);
   }
 
   @Override
   public void restore(final String snapshotId, final Map<String, Path> snapshotFiles)
       throws IOException {
-    final var parsedSnapshotId =
-        FileBasedSnapshotId.ofFileName(snapshotId)
-            .orElseThrow(
-                () ->
-                    new IllegalArgumentException(
-                        "Failed to parse snapshot id %s".formatted(snapshotId)));
-    final var checksumPath = buildSnapshotsChecksumPath(parsedSnapshotId);
-    final var snapshotPath = buildSnapshotDirectory(parsedSnapshotId);
-    ensureDirectoryExists(snapshotPath);
-
-    LOGGER.info("Moving snapshot {} to {}", snapshotId, snapshotPath);
-
-    final var snapshotFileNames = snapshotFiles.keySet();
-    snapshotFileNames.stream()
-        .filter(name -> !isChecksumFile(name))
-        .forEach(name -> copyNamedFileToDirectory(name, snapshotFiles.get(name), snapshotPath));
-
-    final var checksumFile =
-        snapshotFileNames.stream()
-            .filter(this::isChecksumFile)
-            .findFirst()
-            .map(snapshotFiles::get)
-            .orElseThrow();
-
-    Files.copy(checksumFile, checksumPath);
-
-    // Flush directory of this snapshot as well as root snapshot directory
-    FileUtil.flushDirectory(snapshotPath);
-    FileUtil.flushDirectory(snapshotsDirectory);
-
-    LOGGER.info("Moved snapshot {} to {}", snapshotId, snapshotPath);
-
-    // verify snapshot is not corrupted
-    final var snapshot = collectSnapshot(snapshotPath);
-    if (snapshot == null) {
-      throw new CorruptedSnapshotException(
-          "Failed to open restored snapshot in %s".formatted(snapshotPath));
-    }
+    snapshotStore.restore(snapshotId, snapshotFiles);
   }
 
-  private void copyNamedFileToDirectory(
-      final String name, final Path source, final Path targetDirectory) {
-    final var targetFilePath = targetDirectory.resolve(name);
-    try {
-      Files.move(source, targetFilePath);
-    } catch (final IOException e) {
-      throw new UncheckedIOException(e);
-    }
+  @Override
+  public String toString() {
+    return "FileBasedSnapshotStore{"
+        + "actorName='"
+        + actorName
+        + '\''
+        + ", partitionId="
+        + partitionId
+        + ", snapshotStore="
+        + snapshotStore
+        + '}';
   }
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -1,0 +1,685 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.impl;
+
+import static io.camunda.zeebe.util.FileUtil.deleteFolder;
+import static io.camunda.zeebe.util.FileUtil.ensureDirectoryExists;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
+import io.camunda.zeebe.snapshots.PersistableSnapshot;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
+import io.camunda.zeebe.snapshots.SnapshotException;
+import io.camunda.zeebe.snapshots.SnapshotException.CorruptedSnapshotException;
+import io.camunda.zeebe.snapshots.SnapshotException.SnapshotAlreadyExistsException;
+import io.camunda.zeebe.snapshots.SnapshotId;
+import io.camunda.zeebe.snapshots.TransientSnapshot;
+import io.camunda.zeebe.util.Either;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.ConcurrentModificationException;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class FileBasedSnapshotStoreImpl {
+  public static final String SNAPSHOTS_DIRECTORY = "snapshots";
+  public static final String PENDING_DIRECTORY = "pending";
+
+  static final int VERSION = 1;
+
+  // When sorted with other files in the snapshot, the metadata file must be ordered at the end.
+  // This is required for backward compatibility of checksum calculation. Otherwise, the older
+  // versions, which are not aware of the metadata will calculate the checksum using a different
+  // order of files. The  ordering requirement is fulfilled because the name "zeebe.metadata" is
+  // lexicographically greater than all other snapshot files. We can change the name in later
+  // versions, because the new checksum calculation already order the metadata file explicitly
+  // instead of using the implicit sort order.
+  static final String METADATA_FILE_NAME = "zeebe.metadata";
+  // first is the metadata and the second the received snapshot count
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileBasedSnapshotStoreImpl.class);
+  private static final String CHECKSUM_SUFFIX = ".checksum";
+  private static final String TMP_CHECKSUM_SUFFIX = ".tmp";
+  private final int brokerId;
+  // the root snapshotsDirectory where all snapshots should be stored
+  private final Path snapshotsDirectory;
+  // the root snapshotsDirectory when pending snapshots should be stored
+  private final Path pendingDirectory;
+  // keeps track of all snapshot modification listeners
+  private final Set<PersistedSnapshotListener> listeners;
+  private final SnapshotMetrics snapshotMetrics;
+  // Use AtomicReference so that getting latest snapshot doesn't have to go through the actor
+  private final AtomicReference<FileBasedSnapshot> currentPersistedSnapshotRef =
+      new AtomicReference<>();
+  // used to write concurrently received snapshots in different pending directories
+  private final AtomicLong receivingSnapshotStartCount;
+  private final Set<PersistableSnapshot> pendingSnapshots = new HashSet<>();
+  private final Set<FileBasedSnapshot> availableSnapshots = new HashSet<>();
+  private final ChecksumProvider checksumProvider;
+  private final ConcurrencyControl actor;
+
+  public FileBasedSnapshotStoreImpl(
+      final int brokerId,
+      final int partitionId,
+      final Path root,
+      final ChecksumProvider checksumProvider,
+      final ConcurrencyControl actor) {
+    this.brokerId = brokerId;
+    snapshotsDirectory = root.resolve(SNAPSHOTS_DIRECTORY);
+    pendingDirectory = root.resolve(PENDING_DIRECTORY);
+    this.actor = actor;
+
+    try {
+      FileUtil.ensureDirectoryExists(snapshotsDirectory);
+      FileUtil.ensureDirectoryExists(pendingDirectory);
+    } catch (final IOException e) {
+      throw new UncheckedIOException("Failed to create snapshot directories", e);
+    }
+
+    snapshotMetrics = new SnapshotMetrics(String.valueOf(partitionId));
+    receivingSnapshotStartCount = new AtomicLong();
+
+    listeners = new CopyOnWriteArraySet<>();
+    this.checksumProvider = Objects.requireNonNull(checksumProvider);
+  }
+
+  public void start() {
+    final FileBasedSnapshot latestSnapshot = loadLatestSnapshot(snapshotsDirectory);
+    currentPersistedSnapshotRef.set(latestSnapshot);
+    if (latestSnapshot != null) {
+      availableSnapshots.add(latestSnapshot);
+    }
+    purgePendingSnapshotsDirectory();
+  }
+
+  public void close() {
+    listeners.clear();
+  }
+
+  private FileBasedSnapshot loadLatestSnapshot(final Path snapshotDirectory) {
+    FileBasedSnapshot latestPersistedSnapshot = null;
+    try (final var stream = Files.newDirectoryStream(snapshotDirectory, Files::isDirectory)) {
+      for (final var path : stream) {
+        final var snapshot = collectSnapshot(path);
+        if (snapshot != null) {
+          if ((latestPersistedSnapshot == null)
+              || snapshot.getSnapshotId().compareTo(latestPersistedSnapshot.getSnapshotId()) >= 0) {
+            latestPersistedSnapshot = snapshot;
+          }
+        }
+      }
+      // Cleanup of the snapshot directory. Older or corrupted snapshots are deleted
+      if (latestPersistedSnapshot != null) {
+        cleanupSnapshotDirectory(snapshotDirectory, latestPersistedSnapshot);
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return latestPersistedSnapshot;
+  }
+
+  private void cleanupSnapshotDirectory(
+      final Path snapshotDirectory, final FileBasedSnapshot latestPersistedSnapshot)
+      throws IOException {
+    final var latestChecksumFile = latestPersistedSnapshot.getChecksumPath();
+    final var latestDirectory = latestPersistedSnapshot.getDirectory();
+    try (final var paths =
+        Files.newDirectoryStream(
+            snapshotDirectory, p -> !p.equals(latestDirectory) && !p.equals(latestChecksumFile))) {
+      LOGGER.debug("Deleting snapshots other than {}", latestPersistedSnapshot.getId());
+      paths.forEach(
+          p -> {
+            try {
+              LOGGER.debug("Deleting {}", p);
+              FileUtil.deleteFolderIfExists(p);
+            } catch (final IOException e) {
+              LOGGER.warn("Unable to delete {}", p, e);
+            }
+          });
+    }
+  }
+
+  // TODO(npepinpe): using Either here would improve readability and observability, as validation
+  //  can have better error messages, and the return type better expresses what we attempt to do,
+  //  i.e. either it failed (with an error) or it succeeded
+  private FileBasedSnapshot collectSnapshot(final Path path) throws IOException {
+    final var optionalMeta = FileBasedSnapshotId.ofPath(path);
+    if (optionalMeta.isEmpty()) {
+      return null;
+    }
+
+    final var snapshotId = optionalMeta.get();
+    final var checksumPath = buildSnapshotsChecksumPath(snapshotId);
+
+    if (!Files.exists(checksumPath)) {
+      // checksum was not completely/successfully written, we can safely delete it and proceed
+      LOGGER.debug(
+          "Snapshot {} does not have a checksum file, which most likely indicates a partial write"
+              + " (e.g. crash during move), and will be deleted",
+          path);
+      try {
+        deleteFolder(path);
+      } catch (final Exception e) {
+        // it's fine to ignore failures to delete here, as it would constitute mostly noise
+        LOGGER.debug("Failed to delete partial snapshot {}", path, e);
+      }
+
+      return null;
+    }
+
+    try {
+      final var expectedChecksum = SnapshotChecksum.read(checksumPath);
+      final var actualChecksum =
+          SnapshotChecksum.calculateWithProvidedChecksums(path, checksumProvider);
+      if (!actualChecksum.sameChecksums(expectedChecksum)) {
+        LOGGER.warn(
+            "Expected snapshot {} to have checksums {}, but the actual checksums are {}; the snapshot is most likely corrupted. The startup will fail if there is no other valid snapshot and the log has been compacted.",
+            path,
+            expectedChecksum.getChecksums(),
+            actualChecksum.getChecksums());
+        return null;
+      }
+
+      final var metadata = collectMetadata(path, snapshotId);
+      return new FileBasedSnapshot(
+          path,
+          checksumPath,
+          actualChecksum.getCombinedValue(),
+          snapshotId,
+          metadata,
+          this::onSnapshotDeleted,
+          actor);
+    } catch (final Exception e) {
+      LOGGER.warn("Could not load snapshot in {}", path, e);
+      return null;
+    }
+  }
+
+  private FileBasedSnapshotMetadata collectMetadata(
+      final Path path, final FileBasedSnapshotId snapshotId) throws IOException {
+    final var metadataPath = path.resolve(METADATA_FILE_NAME);
+    if (metadataPath.toFile().exists()) {
+      final var encodedMetadata = Files.readAllBytes(metadataPath);
+      return FileBasedSnapshotMetadata.decode(encodedMetadata);
+    } else {
+      // backward compatibility mode
+      return new FileBasedSnapshotMetadata(
+          VERSION,
+          snapshotId.getProcessedPosition(),
+          snapshotId.getExportedPosition(),
+          Long.MAX_VALUE);
+    }
+  }
+
+  private void purgePendingSnapshotsDirectory() {
+    try (final var files = Files.list(pendingDirectory)) {
+      files.filter(Files::isDirectory).forEach(this::purgePendingSnapshot);
+    } catch (final IOException e) {
+      LOGGER.error(
+          "Failed to purge pending snapshots, which may result in unnecessary disk usage and should be monitored",
+          e);
+    }
+  }
+
+  public boolean hasSnapshotId(final String id) {
+    final var optLatestSnapshot = getLatestSnapshot();
+
+    if (optLatestSnapshot.isPresent()) {
+      final var snapshot = optLatestSnapshot.get();
+      return snapshot.getPath().getFileName().toString().equals(id);
+    }
+    return false;
+  }
+
+  public Optional<PersistedSnapshot> getLatestSnapshot() {
+    return Optional.ofNullable(currentPersistedSnapshotRef.get());
+  }
+
+  public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
+    // return a new set so that caller cannot modify availableSnapshot
+    return actor.call(() -> Collections.unmodifiableSet(availableSnapshots));
+  }
+
+  public ActorFuture<Long> getCompactionBound() {
+    return actor.call(
+        () ->
+            availableSnapshots.stream()
+                .map(PersistedSnapshot::getCompactionBound)
+                .min(Long::compareTo)
+                .orElse(0L));
+  }
+
+  public ActorFuture<Void> purgePendingSnapshots() {
+    final CompletableActorFuture<Void> abortFuture = new CompletableActorFuture<>();
+    actor.run(
+        () -> {
+          final var abortedAll = pendingSnapshots.stream().map(PersistableSnapshot::abort).toList();
+          actor.runOnCompletion(
+              abortedAll,
+              error -> {
+                if (error == null) {
+                  abortFuture.complete(null);
+                } else {
+                  abortFuture.completeExceptionally(error);
+                }
+              });
+        });
+    return abortFuture;
+  }
+
+  public ActorFuture<Boolean> addSnapshotListener(final PersistedSnapshotListener listener) {
+    return actor.call(() -> listeners.add(listener));
+  }
+
+  public ActorFuture<Boolean> removeSnapshotListener(final PersistedSnapshotListener listener) {
+    return actor.call(() -> listeners.remove(listener));
+  }
+
+  public long getCurrentSnapshotIndex() {
+    return getLatestSnapshot().map(PersistedSnapshot::getIndex).orElse(0L);
+  }
+
+  public ActorFuture<Void> delete() {
+    return actor.call(
+        () -> {
+          currentPersistedSnapshotRef.set(null);
+
+          try {
+            LOGGER.debug("DELETE FOLDER {}", snapshotsDirectory);
+            deleteFolder(snapshotsDirectory);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+
+          try {
+            LOGGER.debug("DELETE FOLDER {}", pendingDirectory);
+            deleteFolder(pendingDirectory);
+          } catch (final IOException e) {
+            throw new UncheckedIOException(e);
+          }
+          return null;
+        });
+  }
+
+  public Path getPath() {
+    return snapshotsDirectory;
+  }
+
+  public ActorFuture<FileBasedReceivedSnapshot> newReceivedSnapshot(final String snapshotId) {
+    final var newSnapshotFuture = new CompletableActorFuture<FileBasedReceivedSnapshot>();
+    final var optSnapshotId = FileBasedSnapshotId.ofFileName(snapshotId);
+    final var parsedSnapshotId =
+        optSnapshotId.orElseThrow(
+            () ->
+                new IllegalArgumentException(
+                    "Expected snapshot id in a format like 'index-term-processedPosition-exportedPosition', got '"
+                        + snapshotId
+                        + "'."));
+
+    actor.run(
+        () -> {
+          final var directory = buildSnapshotDirectory(parsedSnapshotId);
+          try {
+            checkAndCleanupExistingDirectory(snapshotId, parsedSnapshotId, directory);
+            createReceivedSnapshot(parsedSnapshotId, directory, newSnapshotFuture);
+          } catch (final Exception e) {
+            newSnapshotFuture.completeExceptionally(e);
+          }
+        });
+    return newSnapshotFuture;
+  }
+
+  private void createReceivedSnapshot(
+      final FileBasedSnapshotId parsedSnapshotId,
+      final Path directory,
+      final CompletableActorFuture<FileBasedReceivedSnapshot> newSnapshotFuture) {
+    final var newPendingSnapshot =
+        new FileBasedReceivedSnapshot(parsedSnapshotId, directory, this, actor);
+    addPendingSnapshot(newPendingSnapshot);
+    newSnapshotFuture.complete(newPendingSnapshot);
+  }
+
+  private void checkAndCleanupExistingDirectory(
+      final String snapshotId, final FileBasedSnapshotId parsedSnapshotId, final Path directory) {
+    if (directory.toFile().exists()) {
+      if (!buildSnapshotsChecksumPath(parsedSnapshotId).toFile().exists()) {
+        try {
+          // old pending/incomplete received snapshots which we can delete
+          FileUtil.deleteFolderIfExists(directory);
+        } catch (final IOException e) {
+          throw new IllegalStateException(
+              "Expected to delete pending received snapshot, but failed.", e);
+        }
+      } else {
+        // this should not happen
+        // this means we persisted a snapshot - marked as valid
+        // and now received the same snapshot via replication
+        throw new SnapshotAlreadyExistsException(
+            String.format(
+                "Expected to receive snapshot with id %s, but was already persisted. This shouldn't happen.",
+                snapshotId));
+      }
+    }
+  }
+
+  public Either<SnapshotException, TransientSnapshot> newTransientSnapshot(
+      final long index,
+      final long term,
+      final long processedPosition,
+      final long exportedPosition) {
+
+    final var newSnapshotId =
+        new FileBasedSnapshotId(index, term, processedPosition, exportedPosition, brokerId);
+    final FileBasedSnapshot currentSnapshot = currentPersistedSnapshotRef.get();
+    if (currentSnapshot != null && currentSnapshot.getSnapshotId().compareTo(newSnapshotId) == 0) {
+      final String error =
+          String.format(
+              "Previous snapshot was taken for the same processed position %d and exported position %d.",
+              processedPosition, exportedPosition);
+      return Either.left(new SnapshotAlreadyExistsException(error));
+    }
+    // transient snapshots are directly written to our snapshot dir
+    // with the sfv checksum file they are marked as valid
+    final var directory = buildSnapshotDirectory(newSnapshotId);
+    final var newPendingSnapshot =
+        new FileBasedTransientSnapshot(newSnapshotId, directory, this, actor, checksumProvider);
+    addPendingSnapshot(newPendingSnapshot);
+    return Either.right(newPendingSnapshot);
+  }
+
+  private void addPendingSnapshot(final PersistableSnapshot pendingSnapshot) {
+    final Runnable action = () -> pendingSnapshots.add(pendingSnapshot);
+    actor.run(action);
+  }
+
+  void removePendingSnapshot(final PersistableSnapshot pendingSnapshot) {
+    pendingSnapshots.remove(pendingSnapshot);
+  }
+
+  private void observeSnapshotSize(final FileBasedSnapshot persistedSnapshot) {
+    try (final var contents = Files.newDirectoryStream(persistedSnapshot.getPath())) {
+      var totalSize = 0L;
+      var totalCount = 0L;
+      for (final var path : contents) {
+        if (Files.isRegularFile(path)) {
+          final var size = Files.size(path);
+          snapshotMetrics.observeSnapshotFileSize(size);
+          totalSize += size;
+          totalCount++;
+        }
+      }
+
+      snapshotMetrics.observeSnapshotSize(totalSize);
+      snapshotMetrics.observeSnapshotChunkCount(totalCount);
+    } catch (final IOException e) {
+      LOGGER.warn("Failed to observe size for snapshot {}", persistedSnapshot, e);
+    }
+  }
+
+  private void purgePendingSnapshots(final SnapshotId cutoffSnapshot) {
+    LOGGER.trace(
+        "Search for orphaned snapshots below oldest valid snapshot with index {} in {}",
+        cutoffSnapshot.getSnapshotIdAsString(),
+        pendingDirectory);
+
+    pendingSnapshots.stream()
+        .filter(pendingSnapshot -> pendingSnapshot.snapshotId().compareTo(cutoffSnapshot) < 0)
+        .forEach(PersistableSnapshot::abort);
+
+    // If there are orphaned directories if a previous abort failed, delete them explicitly
+    try (final var pendingSnapshotsDirectories = Files.newDirectoryStream(pendingDirectory)) {
+      for (final var pendingSnapshot : pendingSnapshotsDirectories) {
+        purgePendingSnapshot(cutoffSnapshot, pendingSnapshot);
+      }
+    } catch (final IOException e) {
+      LOGGER.warn(
+          "Failed to delete orphaned snapshots, could not list pending directory {}",
+          pendingDirectory,
+          e);
+    }
+  }
+
+  private void purgePendingSnapshot(final SnapshotId cutoffIndex, final Path pendingSnapshot) {
+    final var optionalMetadata = FileBasedSnapshotId.ofPath(pendingSnapshot);
+    if (optionalMetadata.isPresent() && optionalMetadata.get().compareTo(cutoffIndex) < 0) {
+      try {
+        deleteFolder(pendingSnapshot);
+        LOGGER.debug("Deleted orphaned snapshot {}", pendingSnapshot);
+      } catch (final IOException e) {
+        LOGGER.warn(
+            "Failed to delete orphaned snapshot {}, risk using unnecessary disk space",
+            pendingSnapshot,
+            e);
+      }
+    }
+  }
+
+  private boolean isCurrentSnapshotNewer(final FileBasedSnapshotId snapshotId) {
+    final var persistedSnapshot = currentPersistedSnapshotRef.get();
+    return (persistedSnapshot != null
+        && persistedSnapshot.getSnapshotId().compareTo(snapshotId) >= 0);
+  }
+
+  FileBasedSnapshot persistNewSnapshot(
+      final FileBasedSnapshotId snapshotId,
+      final ImmutableChecksumsSFV immutableChecksumsSFV,
+      final FileBasedSnapshotMetadata metadata) {
+    final var currentPersistedSnapshot = currentPersistedSnapshotRef.get();
+
+    if (isCurrentSnapshotNewer(snapshotId)) {
+      final var currentPersistedSnapshotId = currentPersistedSnapshot.getSnapshotId();
+
+      LOGGER.debug(
+          "Snapshot is older than the latest snapshot {}. Snapshot {} won't be committed.",
+          currentPersistedSnapshotId,
+          snapshotId);
+
+      purgePendingSnapshots(currentPersistedSnapshotId);
+      return currentPersistedSnapshot;
+    }
+
+    try (final var ignored = snapshotMetrics.startPersistTimer()) {
+      // it's important to persist the checksum file only after the move is finished, since we use
+      // it as a marker file to guarantee the move was complete and not partial
+      final var destination = buildSnapshotDirectory(snapshotId);
+      final var checksumPath = buildSnapshotsChecksumPath(snapshotId);
+      final var tmpChecksumPath =
+          checksumPath.resolveSibling(checksumPath.getFileName().toString() + TMP_CHECKSUM_SUFFIX);
+      try {
+        SnapshotChecksum.persist(tmpChecksumPath, immutableChecksumsSFV);
+        FileUtil.moveDurably(tmpChecksumPath, checksumPath);
+      } catch (final IOException e) {
+        rollbackPartialSnapshot(destination);
+        throw new UncheckedIOException(e);
+      }
+
+      final var newPersistedSnapshot =
+          new FileBasedSnapshot(
+              destination,
+              checksumPath,
+              immutableChecksumsSFV.getCombinedValue(),
+              snapshotId,
+              metadata,
+              this::onSnapshotDeleted,
+              actor);
+      final var failed =
+          !currentPersistedSnapshotRef.compareAndSet(
+              currentPersistedSnapshot, newPersistedSnapshot);
+      if (failed) {
+        // we moved already the snapshot but we expected that this will be cleaned up by the next
+        // successful snapshot
+        final var errorMessage =
+            "Expected that last snapshot is '%s', which should be replace with '%s', but last snapshot was '%s'.";
+        throw new ConcurrentModificationException(
+            String.format(
+                errorMessage,
+                currentPersistedSnapshot,
+                newPersistedSnapshot.getSnapshotId(),
+                currentPersistedSnapshotRef.get()));
+      }
+
+      availableSnapshots.add(newPersistedSnapshot);
+
+      LOGGER.info("Committed new snapshot {}", newPersistedSnapshot.getId());
+
+      snapshotMetrics.incrementSnapshotCount();
+      observeSnapshotSize(newPersistedSnapshot);
+
+      deleteOlderSnapshots(newPersistedSnapshot);
+
+      listeners.forEach(listener -> listener.onNewSnapshot(newPersistedSnapshot));
+
+      return newPersistedSnapshot;
+    }
+  }
+
+  private void deleteOlderSnapshots(final FileBasedSnapshot newPersistedSnapshot) {
+    LOGGER.trace(
+        "Purging snapshots older than {}",
+        newPersistedSnapshot.getSnapshotId().getSnapshotIdAsString());
+    final var snapshotsToDelete =
+        availableSnapshots.stream()
+            .filter(s -> !s.getId().equals(newPersistedSnapshot.getId()))
+            .filter(s -> !s.isReserved())
+            .toList();
+    snapshotsToDelete.forEach(
+        previousSnapshot -> {
+          LOGGER.debug("Deleting previous snapshot {}", previousSnapshot.getId());
+          previousSnapshot.delete();
+        });
+    purgePendingSnapshots(newPersistedSnapshot.getSnapshotId());
+  }
+
+  private void rollbackPartialSnapshot(final Path destination) {
+    try {
+      FileUtil.deleteFolderIfExists(destination);
+    } catch (final IOException ioException) {
+      LOGGER.debug(
+          "Pending snapshot {} could not be deleted on rollback, but will be safely ignored as a "
+              + "partial snapshot",
+          destination,
+          ioException);
+    }
+  }
+
+  private void purgePendingSnapshot(final Path pendingSnapshot) {
+    try {
+      deleteFolder(pendingSnapshot);
+      LOGGER.debug("Deleted not completed (orphaned) snapshot {}", pendingSnapshot);
+    } catch (final IOException e) {
+      LOGGER.warn("Failed to delete not completed (orphaned) snapshot {}", pendingSnapshot, e);
+    }
+  }
+
+  private Path buildSnapshotDirectory(final FileBasedSnapshotId snapshotId) {
+    return snapshotsDirectory.resolve(snapshotId.getSnapshotIdAsString());
+  }
+
+  private Path buildSnapshotsChecksumPath(final FileBasedSnapshotId snapshotId) {
+    return snapshotsDirectory.resolve(snapshotId.getSnapshotIdAsString() + CHECKSUM_SUFFIX);
+  }
+
+  private boolean isChecksumFile(final String name) {
+    return name.endsWith(CHECKSUM_SUFFIX);
+  }
+
+  SnapshotMetrics getSnapshotMetrics() {
+    return snapshotMetrics;
+  }
+
+  void onSnapshotDeleted(final FileBasedSnapshot snapshot) {
+    availableSnapshots.remove(snapshot);
+  }
+
+  @Override
+  public String toString() {
+    return "FileBasedSnapshotStore{"
+        + "snapshotsDirectory="
+        + snapshotsDirectory
+        + ", pendingDirectory="
+        + pendingDirectory
+        + ", listeners="
+        + listeners
+        + ", currentPersistedSnapshotRef="
+        + currentPersistedSnapshotRef
+        + ", receivingSnapshotStartCount="
+        + receivingSnapshotStartCount
+        + ", pendingSnapshots="
+        + pendingSnapshots
+        + ", availableSnapshots="
+        + availableSnapshots
+        + "}";
+  }
+
+  public void restore(final String snapshotId, final Map<String, Path> snapshotFiles)
+      throws IOException {
+    final var parsedSnapshotId =
+        FileBasedSnapshotId.ofFileName(snapshotId)
+            .orElseThrow(
+                () ->
+                    new IllegalArgumentException(
+                        "Failed to parse snapshot id %s".formatted(snapshotId)));
+    final var checksumPath = buildSnapshotsChecksumPath(parsedSnapshotId);
+    final var snapshotPath = buildSnapshotDirectory(parsedSnapshotId);
+    ensureDirectoryExists(snapshotPath);
+
+    LOGGER.info("Moving snapshot {} to {}", snapshotId, snapshotPath);
+
+    final var snapshotFileNames = snapshotFiles.keySet();
+    snapshotFileNames.stream()
+        .filter(name -> !isChecksumFile(name))
+        .forEach(name -> copyNamedFileToDirectory(name, snapshotFiles.get(name), snapshotPath));
+
+    final var checksumFile =
+        snapshotFileNames.stream()
+            .filter(this::isChecksumFile)
+            .findFirst()
+            .map(snapshotFiles::get)
+            .orElseThrow();
+
+    Files.copy(checksumFile, checksumPath);
+
+    // Flush directory of this snapshot as well as root snapshot directory
+    FileUtil.flushDirectory(snapshotPath);
+    FileUtil.flushDirectory(snapshotsDirectory);
+
+    LOGGER.info("Moved snapshot {} to {}", snapshotId, snapshotPath);
+
+    // verify snapshot is not corrupted
+    final var snapshot = collectSnapshot(snapshotPath);
+    if (snapshot == null) {
+      throw new CorruptedSnapshotException(
+          "Failed to open restored snapshot in %s".formatted(snapshotPath));
+    }
+  }
+
+  private void copyNamedFileToDirectory(
+      final String name, final Path source, final Path targetDirectory) {
+    final var targetFilePath = targetDirectory.resolve(name);
+    try {
+      Files.move(source, targetFilePath);
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -13,7 +13,7 @@ import static io.camunda.zeebe.util.FileUtil.ensureDirectoryExists;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
@@ -75,14 +75,14 @@ public final class FileBasedSnapshotStoreImpl {
   private final AtomicLong receivingSnapshotStartCount;
   private final Set<PersistableSnapshot> pendingSnapshots = new HashSet<>();
   private final Set<FileBasedSnapshot> availableSnapshots = new HashSet<>();
-  private final ChecksumProvider checksumProvider;
+  private final CRC32CChecksumProvider checksumProvider;
   private final ConcurrencyControl actor;
 
   public FileBasedSnapshotStoreImpl(
       final int brokerId,
       final int partitionId,
       final Path root,
-      final ChecksumProvider checksumProvider,
+      final CRC32CChecksumProvider checksumProvider,
       final ConcurrencyControl actor) {
     this.brokerId = brokerId;
     snapshotsDirectory = root.resolve(SNAPSHOTS_DIRECTORY);

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshot.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.snapshots.impl;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
@@ -41,7 +41,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
   private boolean isValid = false;
   private PersistedSnapshot snapshot;
   private MutableChecksumsSFV checksum;
-  private final ChecksumProvider checksumProvider;
+  private final CRC32CChecksumProvider checksumProvider;
   private long lastFollowupEventPosition = Long.MAX_VALUE;
 
   FileBasedTransientSnapshot(
@@ -49,7 +49,7 @@ public final class FileBasedTransientSnapshot implements TransientSnapshot {
       final Path directory,
       final FileBasedSnapshotStoreImpl snapshotStore,
       final ConcurrencyControl actor,
-      final ChecksumProvider checksumProvider) {
+      final CRC32CChecksumProvider checksumProvider) {
     this.snapshotId = snapshotId;
     this.snapshotStore = snapshotStore;
     this.directory = directory;

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
-import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import java.io.IOException;
@@ -47,12 +47,12 @@ final class SnapshotChecksum {
   }
 
   public static MutableChecksumsSFV calculateWithProvidedChecksums(
-      final Path snapshotDirectory, final ChecksumProvider provider) throws IOException {
+      final Path snapshotDirectory, final CRC32CChecksumProvider provider) throws IOException {
     return createChecksumForSnapshot(snapshotDirectory, provider);
   }
 
   private static MutableChecksumsSFV createChecksumForSnapshot(
-      final Path snapshotDirectory, final ChecksumProvider provider) throws IOException {
+      final Path snapshotDirectory, final CRC32CChecksumProvider provider) throws IOException {
 
     try (final var fileStream =
         Files.list(snapshotDirectory).filter(SnapshotChecksum::isNotMetadataFile).sorted()) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
@@ -64,7 +64,8 @@ final class SnapshotChecksum {
       // Hence when we recalculate the checksum, we must follow the same order. Otherwise base on
       // the file name, the sorted file list will have a differnt order and thus result in a
       // different checksum.
-      final var metadataFile = snapshotDirectory.resolve(FileBasedSnapshotStore.METADATA_FILE_NAME);
+      final var metadataFile =
+          snapshotDirectory.resolve(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME);
       if (metadataFile.toFile().exists()) {
         sfvChecksum.updateFromFile(metadataFile);
       }
@@ -73,7 +74,7 @@ final class SnapshotChecksum {
   }
 
   private static boolean isNotMetadataFile(final Path file) {
-    return !file.getFileName().toString().equals(FileBasedSnapshotStore.METADATA_FILE_NAME);
+    return !file.getFileName().toString().equals(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME);
   }
 
   public static void persist(final Path checksumPath, final ImmutableChecksumsSFV checksum)

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TestChecksumProvider.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/TestChecksumProvider.java
@@ -10,7 +10,7 @@ package io.camunda.zeebe.snapshots;
 import java.nio.file.Path;
 import java.util.Map;
 
-public class TestChecksumProvider implements ChecksumProvider {
+public class TestChecksumProvider implements CRC32CChecksumProvider {
   private final Map<String, Long> snapshotChecksums;
 
   public TestChecksumProvider(final Map<String, Long> snapshotChecksums) {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshotTest.java
@@ -333,7 +333,9 @@ public class FileBasedReceivedSnapshotTest {
         .describedAs("Metadata file is persisted in snapshot path")
         .isDirectoryContaining(
             name ->
-                name.getFileName().toString().equals(FileBasedSnapshotStore.METADATA_FILE_NAME));
+                name.getFileName()
+                    .toString()
+                    .equals(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME));
   }
 
   @Test

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -64,8 +64,8 @@ public class FileBasedSnapshotStoreTest {
     final var store = new FileBasedSnapshotStore(0, 1, root, snapshotPath -> Map.of());
 
     // then
-    assertThat(root.resolve(FileBasedSnapshotStore.SNAPSHOTS_DIRECTORY)).exists().isDirectory();
-    assertThat(root.resolve(FileBasedSnapshotStore.PENDING_DIRECTORY)).exists().isDirectory();
+    assertThat(root.resolve(FileBasedSnapshotStoreImpl.SNAPSHOTS_DIRECTORY)).exists().isDirectory();
+    assertThat(root.resolve(FileBasedSnapshotStoreImpl.PENDING_DIRECTORY)).exists().isDirectory();
     assertThat(store.getLatestSnapshot()).isEmpty();
   }
 

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -321,7 +321,7 @@ public class FileBasedTransientSnapshotTest {
             SnapshotMetadata::exportedPosition,
             SnapshotMetadata::lastFollowupEventPosition,
             SnapshotMetadata::version)
-        .containsExactly(3L, 4L, 100L, FileBasedSnapshotStore.VERSION);
+        .containsExactly(3L, 4L, 100L, FileBasedSnapshotStoreImpl.VERSION);
   }
 
   @Test
@@ -339,7 +339,9 @@ public class FileBasedTransientSnapshotTest {
         .describedAs("Metadata file is persisted in snapshot path")
         .isDirectoryContaining(
             path ->
-                path.getFileName().toString().equals(FileBasedSnapshotStore.METADATA_FILE_NAME));
+                path.getFileName()
+                    .toString()
+                    .equals(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME));
   }
 
   private boolean writeSnapshot(final Path path) {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -243,10 +243,10 @@ public final class SnapshotChecksumTest {
     final var checksumCalculatedInSteps = SnapshotChecksum.calculate(folder);
 
     // when
-    createChunk(folder, FileBasedSnapshotStore.METADATA_FILE_NAME);
+    createChunk(folder, FileBasedSnapshotStoreImpl.METADATA_FILE_NAME);
     // This is how checksum is calculated when persisting a transient snapshot
     checksumCalculatedInSteps.updateFromFile(
-        folder.resolve(FileBasedSnapshotStore.METADATA_FILE_NAME));
+        folder.resolve(FileBasedSnapshotStoreImpl.METADATA_FILE_NAME));
 
     // This is how checksum is calculated when verifying
     final ImmutableChecksumsSFV checksumCalculatedAtOnce = SnapshotChecksum.calculate(folder);

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
@@ -11,7 +11,7 @@ import static java.nio.file.StandardOpenOption.CREATE_NEW;
 
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
 import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
@@ -132,7 +132,7 @@ public class TestFileBasedSnapshotStore implements ReceivableSnapshotStore {
     return true;
   }
 
-  private static final class TestChecksumProvider implements ChecksumProvider {
+  private static final class TestChecksumProvider implements CRC32CChecksumProvider {
 
     @Override
     public Map<String, Long> getSnapshotChecksums(final Path snapshotPath) {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/testing/TestFileBasedSnapshotStore.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.snapshots.testing;
+
+import static java.nio.file.StandardOpenOption.CREATE_NEW;
+
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.PersistedSnapshot;
+import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
+import io.camunda.zeebe.snapshots.ReceivableSnapshotStore;
+import io.camunda.zeebe.snapshots.impl.FileBasedReceivedSnapshot;
+import io.camunda.zeebe.snapshots.impl.FileBasedSnapshotStoreImpl;
+import io.camunda.zeebe.util.FileUtil;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.zip.CRC32C;
+
+public class TestFileBasedSnapshotStore implements ReceivableSnapshotStore {
+
+  private final FileBasedSnapshotStoreImpl snapshotStore;
+
+  public TestFileBasedSnapshotStore(
+      final int nodeId, final Path root, final ConcurrencyControl concurrencyControl) {
+    snapshotStore =
+        new FileBasedSnapshotStoreImpl(
+            nodeId, 1, root, new TestChecksumProvider(), concurrencyControl);
+    snapshotStore.start();
+  }
+
+  @Override
+  public boolean hasSnapshotId(final String id) {
+    return snapshotStore.hasSnapshotId(id);
+  }
+
+  @Override
+  public Optional<PersistedSnapshot> getLatestSnapshot() {
+    return snapshotStore.getLatestSnapshot();
+  }
+
+  @Override
+  public ActorFuture<Set<PersistedSnapshot>> getAvailableSnapshots() {
+    return snapshotStore.getAvailableSnapshots();
+  }
+
+  @Override
+  public ActorFuture<Long> getCompactionBound() {
+    return snapshotStore.getCompactionBound();
+  }
+
+  @Override
+  public ActorFuture<Void> purgePendingSnapshots() {
+    return snapshotStore.purgePendingSnapshots();
+  }
+
+  @Override
+  public ActorFuture<Boolean> addSnapshotListener(final PersistedSnapshotListener listener) {
+    return snapshotStore.addSnapshotListener(listener);
+  }
+
+  @Override
+  public ActorFuture<Boolean> removeSnapshotListener(final PersistedSnapshotListener listener) {
+    return snapshotStore.removeSnapshotListener(listener);
+  }
+
+  @Override
+  public long getCurrentSnapshotIndex() {
+    return snapshotStore.getCurrentSnapshotIndex();
+  }
+
+  @Override
+  public ActorFuture<Void> delete() {
+    return snapshotStore.delete();
+  }
+
+  @Override
+  public Path getPath() {
+    return snapshotStore.getPath();
+  }
+
+  @Override
+  public ActorFuture<FileBasedReceivedSnapshot> newReceivedSnapshot(final String snapshotId) {
+    return snapshotStore.newReceivedSnapshot(snapshotId);
+  }
+
+  @Override
+  public void close() {
+    snapshotStore.close();
+  }
+
+  public void newSnapshot(final long index, final long term, final int size, final Random random) {
+    final var chunks =
+        IntStream.range(0, size)
+            .boxed()
+            .map(i -> "chunk-" + i)
+            .collect(Collectors.toMap(k -> k, v -> String.valueOf(random.nextLong())));
+    final var transientSnapshot =
+        snapshotStore.newTransientSnapshot(index, term, index, index).get();
+    transientSnapshot.take(p -> writeSnapshot(p, chunks)).join();
+    transientSnapshot.persist().join();
+  }
+
+  private boolean writeSnapshot(final Path path, final Map<String, String> chunks) {
+    try {
+      FileUtil.ensureDirectoryExists(path);
+
+      for (final var entry : chunks.entrySet()) {
+        final var fileName = path.resolve(entry.getKey());
+        final var fileContent = entry.getValue().getBytes(StandardCharsets.UTF_8);
+        Files.write(fileName, fileContent, CREATE_NEW, StandardOpenOption.WRITE);
+      }
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return true;
+  }
+
+  private static final class TestChecksumProvider implements ChecksumProvider {
+
+    @Override
+    public Map<String, Long> getSnapshotChecksums(final Path snapshotPath) {
+      final HashMap<String, Long> checksums = new HashMap<>();
+      try (final var files =
+          Files.newDirectoryStream(
+              snapshotPath, p -> p.getFileName().toString().startsWith("chunk"))) {
+        files.forEach(
+            file -> {
+              try {
+                final var fileContentChecksum = new CRC32C();
+                fileContentChecksum.update(Files.readAllBytes(file));
+                checksums.put(file.getFileName().toString(), fileContentChecksum.getValue());
+              } catch (final IOException e) {
+                throw new UncheckedIOException(e);
+              }
+            });
+      } catch (final IOException e) {
+        throw new UncheckedIOException(e);
+      }
+
+      return checksums;
+    }
+  }
+}

--- a/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ChecksumProviderRocksDBImpl.java
+++ b/zeebe/zb-db/src/main/java/io/camunda/zeebe/db/impl/rocksdb/ChecksumProviderRocksDBImpl.java
@@ -7,7 +7,7 @@
  */
 package io.camunda.zeebe.db.impl.rocksdb;
 
-import io.camunda.zeebe.snapshots.ChecksumProvider;
+import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Path;
@@ -17,7 +17,7 @@ import org.rocksdb.LiveFileMetaData;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
 
-public class ChecksumProviderRocksDBImpl implements ChecksumProvider {
+public class ChecksumProviderRocksDBImpl implements CRC32CChecksumProvider {
 
   @Override
   public Map<String, Long> getSnapshotChecksums(final Path snapshotPath) {


### PR DESCRIPTION
## Description

To cover more cases, we now use the actual snapshot store in RaftRandomizedTests instead of the in-memory ones. With this change, it was able to reproduce the bug #19984 

- Split FileBasedSnapshotStoreImpl to remove direct dependency to actors. It can now accept a ConcurrencyControl which can be used by the tests
- Added a TestFileBasedSnapshotStore which uses the TestConcurrencyControl instead of the actor.
- Use the new test store in raft randomized tests
- Added a new test `livenessTestsWithSnapshotsAndSingleRestart` which can reproduce the bug. It should have been also reproduced by the existing `livenessTestsWithSnapshotsAndRestarts`, but I couldn't. My assumption is that it was not likely to generate the sequence that reproduce it.

The usage of in-memory snapshot is only replace in RaftRandomizedTests. The other raft tests still uses the in-memory ones. 