### PR TITLE
ci: add PR checklist as reminder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,13 @@
 ## Description
 
 <!-- Describe the goal and purpose of this PR. -->
-<!-- -->
-<!-- For structural or foundational CI changes request review from @cmur2 -->
+
+## Checklist
+
+<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
+- [ ] for CI changes:
+  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
+  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
 
 ## Related issues
 


### PR DESCRIPTION
## Description

Make sure I get involved for structural/foundational changes and that people get reminded of the [requirements for the Unified CI](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria) (also apply to changes after inclusion, esp timeouts).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->

- [ ] for CI changes:
    - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
    - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
