### PR TITLE
ci: don't cancel concurrent builds on `main` for full results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,12 @@ on:
   merge_group: {}
   workflow_dispatch: {}
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+# Exception for deploy jobs that have to wait for each other to avoid overwriting
 concurrency:
   cancel-in-progress: true
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 defaults:
   run:

--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -13,6 +13,12 @@ on:
       - '.github/workflows/operate-a11y.yml'
       - 'operate/client/**'
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -31,11 +31,11 @@ on:
       - 'parent/*'
       - 'webapps-common/**'
 
-# This will limit the workflow to 1 concurrent run per ref (branch / PR).
-# If a new commits occurs, the current run will be canceled to save costs.
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   run-build:

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -28,11 +28,11 @@ on:
       - 'pom.xml'
       - 'webapps-common/**'
 
-# This will limit the workflow to 1 concurrent run per ref (branch / PR).
-# If a new commits occurs, the current run will be canceled to save costs.
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   integration-tests:

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -28,11 +28,11 @@ on:
       - "parent/*"
       - "pom.xml"
 
-# This will limit the workflow to 1 concurrent run per ref (branch / PR).
-# If a new commits occurs, the current run will be canceled to save costs.
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   test:

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -13,6 +13,12 @@ on:
       - '.github/workflows/operate-frontend.yml'
       - 'operate/client/**'
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+
 jobs:
   linting-and-testing:
     name: Linting & Testing

--- a/.github/workflows/operate-merge-ci.yaml
+++ b/.github/workflows/operate-merge-ci.yaml
@@ -5,6 +5,11 @@ on:
   pull_request: { }
   workflow_dispatch: { }
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   run-build:

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -14,11 +14,11 @@ on:
       - '.github/workflows/operate-playwright.yml'
       - 'operate/client/**'
 
-# This will limit the workflow to 1 concurrent run per ref (branch / PR).
-# If a new commits occurs, the current run will be canceled to save costs.
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   test:

--- a/.github/workflows/renovatelint.yml
+++ b/.github/workflows/renovatelint.yml
@@ -7,6 +7,12 @@ on:
       - '**/renovate.json'
       - '**/renovate.json5'
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+
 jobs:
   renovate-config-validator:
     runs-on: ubuntu-latest

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -26,11 +26,11 @@ on:
       - "tasklist/**"
       - "tasklist.Dockerfile"
 
-# This will limit the workflow to 1 concurrent run per ref (branch / PR).
-# If a new commits occurs, the current run will be canceled to save costs.
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   check_changes:

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -25,11 +25,11 @@ on:
       - 'tasklist.Dockerfile'
       - 'webapps-common/**'
 
-# This will limit the workflow to 1 concurrent run per ref (branch / PR).
-# If a new commits occurs, the current run will be canceled to save costs.
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   integration-tests:

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -25,11 +25,11 @@ on:
       - "tasklist.Dockerfile"
       - "webapps-common/**"
 
-# This will limit the workflow to 1 concurrent run per ref (branch / PR).
-# If a new commits occurs, the current run will be canceled to save costs.
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   test:

--- a/.github/workflows/tasklist-merge-ci.yml
+++ b/.github/workflows/tasklist-merge-ci.yml
@@ -5,9 +5,11 @@ on:
   pull_request: { }
   workflow_dispatch: { }
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 jobs:
   run-build:

--- a/.github/workflows/tasklist-update_visual_snapshots.yml
+++ b/.github/workflows/tasklist-update_visual_snapshots.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [labeled, synchronize]
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+
 jobs:
   update-snapshots:
     if: github.event.pull_request.state != 'closed' && (github.event.label.name == 'update-snapshots' || contains( github.event.pull_request.labels.*.name, 'update-snapshots'))

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -37,9 +37,12 @@ on:
   workflow_dispatch: { }
   workflow_call: { }
 
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+# Exception for main branch: complete builds for every commit needed for confidenence
+# Exception for deploy jobs that have to wait for each other to avoid overwriting
 concurrency:
   cancel-in-progress: true
-  group: "${{ github.workflow }}-${{ github.ref }}"
+  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
 
 defaults:
   run:


### PR DESCRIPTION
## Description

Currently very few builds in `main` are actually completely green:

![image](https://github.com/user-attachments/assets/fd101465-642b-4041-85c6-abf01807e73a)

Looking into [CI health dashboard](https://dashboard.int.camunda.com/d/bdmo5l8puugaoc/ci-health-camunda-camunda-monorepo?orgId=1) this also comes from a large percentage of canceled builds:

![image](https://github.com/user-attachments/assets/9fca9faa-40be-45ce-8e02-77737db8ba41)

One reason for the cancelations is the [mechanism we use to save costs](https://github.com/camunda/camunda/blob/ebd6677b941cd64e8e8107bb37b9bbb7979ee882/.github/workflows/operate-ci.yml#L34-L38) by preventing concurrent builds: when a new commit comes in to a branch/PR, older builds get aborted ➡️the assumption here is that only the most recent check results are useful and relevant. While this is true for PRs it is not so true for stable branches like `main` where new changes get merged continually.

I want to adopt the solution that is also used by Web-Modeler team to prevent concurrent builds in general (to save costs) but make an exception for `main`: https://github.com/camunda/web-modeler/blob/main/.github/workflows/build-and-test.yml#L13-L19

Ultimately this allows to have more confidence in the build results on `main` ➡️failures will not be due to cancellations anymore.

## Related issues

None