### PR TITLE
refactor: reduce `ActorJob` size

### DIFF
--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -117,18 +117,26 @@ public final class ActorJob {
 
   @Override
   public String toString() {
-    String toString = "";
-
-    if (runnable != null) {
-      toString += runnable.getClass().getName();
-    }
+    final StringBuilder sb = new StringBuilder("ActorJob{");
+    sb.append("schedulingState=").append(schedulingState);
+    sb.append(", task=").append(task);
     if (callable != null) {
-      toString += callable.getClass().getName();
+      sb.append(", callable=").append(callable);
     }
-
-    toString += " " + schedulingState;
-
-    return toString;
+    if (runnable != null) {
+      sb.append(", runnable=").append(runnable);
+    }
+    if (resultFuture != null) {
+      sb.append(", resultFuture=").append(resultFuture);
+    }
+    if (subscription != null) {
+      sb.append(", subscription=").append(subscription);
+    }
+    if (scheduledAt != -1) {
+      sb.append(", scheduledAt=").append(scheduledAt);
+    }
+    sb.append('}');
+    return sb.toString();
   }
 
   public boolean isTriggeredBySubscription() {

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -24,7 +24,6 @@ public final class ActorJob {
   TaskSchedulingState schedulingState;
   Actor actor;
   ActorTask task;
-  ActorThread actorThread;
   private Callable<?> callable;
   private Runnable runnable;
   private Object invocationResult;
@@ -41,7 +40,6 @@ public final class ActorJob {
 
   @Async.Execute
   void execute(final ActorThread runner) {
-    actorThread = runner;
     observeSchedulingLatency(runner.getActorMetrics());
     try {
       invoke();
@@ -55,8 +53,6 @@ public final class ActorJob {
       FATAL_ERROR_HANDLER.handleError(e);
       task.onFailure(e);
     } finally {
-      actorThread = null;
-
       // in any case, success or exception, decide if the job should be resubmitted
       if (isTriggeredBySubscription() || runnable == null) {
         schedulingState = TaskSchedulingState.TERMINATED;
@@ -116,7 +112,6 @@ public final class ActorJob {
     actor = null;
 
     task = null;
-    actorThread = null;
 
     callable = null;
     runnable = null;

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/ActorJob.java
@@ -22,7 +22,6 @@ public final class ActorJob {
   private static final FatalErrorHandler FATAL_ERROR_HANDLER = FatalErrorHandler.withLogger(LOG);
 
   TaskSchedulingState schedulingState;
-  Actor actor;
   ActorTask task;
   private Callable<?> callable;
   private Runnable runnable;
@@ -33,7 +32,6 @@ public final class ActorJob {
 
   public void onJobAddedToTask(final ActorTask task) {
     scheduledAt = System.nanoTime();
-    actor = task.actor;
     this.task = task;
     schedulingState = TaskSchedulingState.QUEUED;
   }
@@ -109,8 +107,6 @@ public final class ActorJob {
     schedulingState = TaskSchedulingState.NOT_SCHEDULED;
     scheduledAt = -1;
 
-    actor = null;
-
     task = null;
 
     callable = null;
@@ -155,7 +151,7 @@ public final class ActorJob {
   }
 
   public Actor getActor() {
-    return actor;
+    return task.actor;
   }
 
   public void setResultFuture(final ActorFuture resultFuture) {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/LifecycleRecordingActor.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/lifecycle/LifecycleRecordingActor.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.scheduler.lifecycle;
 
 import static org.assertj.core.util.Lists.newArrayList;
-import static org.mockito.Mockito.mock;
 
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorControl;
@@ -27,6 +26,7 @@ class LifecycleRecordingActor extends Actor {
           ActorLifecyclePhase.CLOSE_REQUESTED,
           ActorLifecyclePhase.CLOSING,
           ActorLifecyclePhase.CLOSED);
+  private static final BiConsumer<Void, Throwable> NOOP_CONSUMER = (ok, err) -> {};
 
   public final List<ActorLifecyclePhase> phases = new ArrayList<>();
 
@@ -61,26 +61,27 @@ class LifecycleRecordingActor extends Actor {
   }
 
   protected void blockPhase() {
-    blockPhase(new CompletableActorFuture<>(), mock(BiConsumer.class));
+    blockPhase(new CompletableActorFuture<>(), NOOP_CONSUMER);
   }
 
   protected void blockPhase(final ActorFuture<Void> future) {
-    blockPhase(future, mock(BiConsumer.class));
+    blockPhase(future, NOOP_CONSUMER);
   }
 
   @SuppressWarnings("unchecked")
-  protected void blockPhase(final ActorFuture<Void> future, final BiConsumer consumer) {
+  protected void blockPhase(
+      final ActorFuture<Void> future, final BiConsumer<Void, Throwable> consumer) {
     actor.runOnCompletionBlockingCurrentPhase(future, consumer);
   }
 
   @SuppressWarnings("unchecked")
   protected void runOnCompletion() {
-    actor.runOnCompletion(new CompletableActorFuture<>(), mock(BiConsumer.class));
+    actor.runOnCompletion(new CompletableActorFuture<>(), NOOP_CONSUMER);
   }
 
   @SuppressWarnings("unchecked")
   protected void runOnCompletion(final ActorFuture<Void> future) {
-    actor.runOnCompletion(future, mock(BiConsumer.class));
+    actor.runOnCompletion(future, NOOP_CONSUMER);
   }
 
   public ActorControl control() {


### PR DESCRIPTION
## Description
Reduces the size of `ActorJob` by removing unnecessary fields.

Before:
```
io.camunda.zeebe.scheduler.ActorJob object internals:
OFF  SZ                  TYPE DESCRIPTION                 VALUE
  0   8                       (object header: mark)       N/A
  8   4                       (object header: class)      N/A
 12   4   TaskSchedulingState ActorJob.schedulingState    N/A
 16   8                  long ActorJob.scheduledAt        N/A
 24   4                 Actor ActorJob.actor              N/A
 28   4             ActorTask ActorJob.task               N/A
 32   4           ActorThread ActorJob.actorThread        N/A
 36   4           Callable<?> ActorJob.callable           N/A
 40   4              Runnable ActorJob.runnable           N/A
 44   4                Object ActorJob.invocationResult   N/A
 48   4           ActorFuture ActorJob.resultFuture       N/A
 52   4     ActorSubscription ActorJob.subscription       N/A
Instance size: 56 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

After:
```
io.camunda.zeebe.scheduler.ActorJob object internals:
OFF  SZ                  TYPE DESCRIPTION                VALUE
  0   8                       (object header: mark)      N/A
  8   4                       (object header: class)     N/A
 12   4   TaskSchedulingState ActorJob.schedulingState   N/A
 16   8                  long ActorJob.scheduledAt       N/A
 24   4             ActorTask ActorJob.task              N/A
 28   4           Callable<?> ActorJob.callable          N/A
 32   4              Runnable ActorJob.runnable          N/A
 36   4           ActorFuture ActorJob.resultFuture      N/A
 40   4     ActorSubscription ActorJob.subscription      N/A
 44   4                       (object alignment gap)     
Instance size: 48 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```
