### PR TITLE
Store message request data in state

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationProcessor.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.message;
 
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
+import io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior.MessageData;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -98,11 +99,12 @@ public final class MessageCorrelationProcessor
     final var messageCorrelationRecord = command.getValue();
     final var correlatedSubscriptions =
         correlateBehavior.correlateToMessageStartEvents(
-            messageCorrelationRecord.getTenantId(),
-            messageCorrelationRecord.getNameBuffer(),
-            messageCorrelationRecord.getCorrelationKeyBuffer(),
-            messageCorrelationRecord.getVariablesBuffer(),
-            messageKey);
+            new MessageData(
+                messageKey,
+                messageCorrelationRecord.getNameBuffer(),
+                messageCorrelationRecord.getCorrelationKeyBuffer(),
+                messageCorrelationRecord.getVariablesBuffer(),
+                messageCorrelationRecord.getTenantId()));
     correlatingSubscriptions.addAll(correlatedSubscriptions);
 
     if (!correlatedSubscriptions.isEmpty()) {
@@ -122,11 +124,12 @@ public final class MessageCorrelationProcessor
       final Subscriptions correlatingSubscriptions) {
     final var correlatedSubscriptions =
         correlateBehavior.correlateToMessageEvents(
-            messageCorrelationRecord.getTenantId(),
-            messageCorrelationRecord.getNameBuffer(),
-            messageCorrelationRecord.getCorrelationKeyBuffer(),
-            messageCorrelationRecord.getVariablesBuffer(),
-            messageKey);
+            new MessageData(
+                messageKey,
+                messageCorrelationRecord.getNameBuffer(),
+                messageCorrelationRecord.getCorrelationKeyBuffer(),
+                messageCorrelationRecord.getVariablesBuffer(),
+                messageCorrelationRecord.getTenantId()));
     correlatingSubscriptions.addAll(correlatedSubscriptions);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessagePublishProcessor.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnStateBehavior;
 import io.camunda.zeebe.engine.processing.common.EventHandle;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
+import io.camunda.zeebe.engine.processing.message.MessageCorrelateBehavior.MessageData;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
@@ -121,19 +122,21 @@ public final class MessagePublishProcessor implements TypedRecordProcessor<Messa
 
   private void correlateToSubscriptions(final long messageKey, final MessageRecord message) {
     correlateBehavior.correlateToMessageEvents(
-        message.getTenantId(),
-        message.getNameBuffer(),
-        message.getCorrelationKeyBuffer(),
-        message.getVariablesBuffer(),
-        messageKey);
+        new MessageData(
+            messageKey,
+            message.getNameBuffer(),
+            message.getCorrelationKeyBuffer(),
+            message.getVariablesBuffer(),
+            message.getTenantId()));
   }
 
   private void correlateToMessageStartEvents(final MessageRecord messageRecord) {
     correlateBehavior.correlateToMessageStartEvents(
-        messageRecord.getTenantId(),
-        messageRecord.getNameBuffer(),
-        messageRecord.getCorrelationKeyBuffer(),
-        messageRecord.getVariablesBuffer(),
-        messageKey);
+        new MessageData(
+            messageKey,
+            messageRecord.getNameBuffer(),
+            messageRecord.getCorrelationKeyBuffer(),
+            messageRecord.getVariablesBuffer(),
+            messageRecord.getTenantId()));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -166,8 +166,13 @@ public final class DbMessageSubscriptionState
               record.getElementInstanceKey(), record.getMessageName()));
     }
 
-    // update the message key and the variables
-    subscription.getRecord().setMessageKey(messageKey).setVariables(messageVariables);
+    // update the message key, variables and request data
+    subscription
+        .getRecord()
+        .setMessageKey(messageKey)
+        .setVariables(messageVariables)
+        .setRequestId(record.getRequestId())
+        .setRequestStreamId(record.getRequestStreamId());
 
     updateCorrelatingFlag(subscription, true);
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

In order to send a response to the `MessageCorrelation.CORRELATE` command we need to have access to the request data. Since we don't always send the response in the processor we need to store it in the state so we can reaccess it when we need it (similar to create PI with result).
This PR makes it so we store the request data in the message subscription. If the message correlates with multiple subscriptions, we only store the request data for one of them, as we can only send 1 response back to the client.

⚠️ This PR contains no tests. These will added as part of #20175 and #20176

## Related issues

closes #20174 
