### PR TITLE
feat: store deployment key for deployed processes

### DIFF
--- a/clients/go/cmd/zbctl/main_test.go
+++ b/clients/go/cmd/zbctl/main_test.go
@@ -123,7 +123,7 @@ var tests = []testCase{
 	{
 		name:       "create instance with process key",
 		setupCmds:  [][]string{strings.Fields("--insecure deploy testdata/model.bpmn")},
-		cmd:        strings.Fields("--insecure create instance 2251799813685249"),
+		cmd:        strings.Fields("--insecure create instance 2251799813685250"),
 		goldenFile: "testdata/create_instance.golden",
 		jsonOutput: true,
 	},
@@ -137,7 +137,7 @@ var tests = []testCase{
 	{
 		name:       "evaluate decision with decision key",
 		setupCmds:  [][]string{strings.Fields("--insecure deploy resource testdata/drg-force-user.dmn")},
-		cmd:        strings.Fields("--insecure evaluate decision 2251799813685272 --variables {\"lightsaberColor\":\"blue\"}"),
+		cmd:        strings.Fields("--insecure evaluate decision 2251799813685273 --variables {\"lightsaberColor\":\"blue\"}"),
 		goldenFile: "testdata/evaluate_decision.golden",
 		jsonOutput: true,
 	},
@@ -217,7 +217,7 @@ var tests = []testCase{
 		setupCmds: [][]string{
 			strings.Fields("--insecure deploy resource testdata/model.bpmn"),
 		},
-		cmd:        strings.Fields("--insecure delete resource 2251799813685258"),
+		cmd:        strings.Fields("--insecure delete resource 2251799813685259"),
 		goldenFile: "testdata/delete_resource.golden",
 	},
 	{

--- a/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/value/deployment/DeployedProcessImpl.java
+++ b/tasklist/importer-850/src/main/java/io/camunda/tasklist/zeebeimport/v850/record/value/deployment/DeployedProcessImpl.java
@@ -21,6 +21,7 @@ public class DeployedProcessImpl implements Process {
   private byte[] resource;
   private boolean isDuplicate;
   private String tenantId;
+  private long deploymentKey;
 
   public DeployedProcessImpl() {}
 
@@ -50,34 +51,21 @@ public class DeployedProcessImpl implements Process {
   }
 
   @Override
-  public byte[] getResource() {
-    return resource;
-  }
-
-  @Override
   public boolean isDuplicate() {
     return isDuplicate;
   }
 
   @Override
-  public String getTenantId() {
-    return tenantId;
+  public long getDeploymentKey() {
+    return deploymentKey;
   }
 
-  public void setResourceName(String resourceName) {
-    this.resourceName = resourceName;
+  public void setDeploymentKey(final long deploymentKey) {
+    this.deploymentKey = deploymentKey;
   }
 
-  public void setProcessDefinitionKey(long processDefinitionKey) {
-    this.processDefinitionKey = processDefinitionKey;
-  }
-
-  public void setVersion(int version) {
-    this.version = version;
-  }
-
-  public void setBpmnProcessId(String bpmnProcessId) {
-    this.bpmnProcessId = bpmnProcessId;
+  public void setDuplicate(final boolean duplicate) {
+    isDuplicate = duplicate;
   }
 
   public DeployedProcessImpl setChecksum(final byte[] checksum) {
@@ -85,22 +73,60 @@ public class DeployedProcessImpl implements Process {
     return this;
   }
 
+  public void setResourceName(final String resourceName) {
+    this.resourceName = resourceName;
+  }
+
+  public void setProcessDefinitionKey(final long processDefinitionKey) {
+    this.processDefinitionKey = processDefinitionKey;
+  }
+
+  public void setVersion(final int version) {
+    this.version = version;
+  }
+
+  public void setBpmnProcessId(final String bpmnProcessId) {
+    this.bpmnProcessId = bpmnProcessId;
+  }
+
+  @Override
+  public byte[] getResource() {
+    return resource;
+  }
+
   public DeployedProcessImpl setResource(final byte[] resource) {
     this.resource = resource;
     return this;
   }
 
-  public void setDuplicate(final boolean duplicate) {
-    isDuplicate = duplicate;
+  @Override
+  public String getTenantId() {
+    return tenantId;
   }
 
-  public void setTenantId(String tenantId) {
+  public void setTenantId(final String tenantId) {
     this.tenantId = tenantId;
   }
 
   @Override
   public String toJson() {
     throw new UnsupportedOperationException("toJson operation is not supported");
+  }
+
+  @Override
+  public int hashCode() {
+    int result =
+        Objects.hash(
+            bpmnProcessId,
+            resourceName,
+            processDefinitionKey,
+            version,
+            isDuplicate,
+            tenantId,
+            deploymentKey);
+    result = 31 * result + Arrays.hashCode(checksum);
+    result = 31 * result + Arrays.hashCode(resource);
+    return result;
   }
 
   @Override
@@ -115,21 +141,12 @@ public class DeployedProcessImpl implements Process {
     return processDefinitionKey == that.processDefinitionKey
         && version == that.version
         && isDuplicate == that.isDuplicate
+        && deploymentKey == that.deploymentKey
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(resourceName, that.resourceName)
         && Objects.equals(tenantId, that.tenantId)
         && Arrays.equals(checksum, that.checksum)
         && Arrays.equals(resource, that.resource);
-  }
-
-  @Override
-  public int hashCode() {
-    int result =
-        Objects.hash(
-            bpmnProcessId, resourceName, processDefinitionKey, version, isDuplicate, tenantId);
-    result = 31 * result + Arrays.hashCode(checksum);
-    result = 31 * result + Arrays.hashCode(resource);
-    return result;
   }
 
   @Override
@@ -153,6 +170,8 @@ public class DeployedProcessImpl implements Process {
         + isDuplicate
         + ", tenantId="
         + tenantId
+        + ", deploymentKey="
+        + deploymentKey
         + '}';
   }
 }

--- a/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/deployment/DeployedProcessImpl.java
+++ b/tasklist/importer-860/src/main/java/io/camunda/tasklist/zeebeimport/v860/record/value/deployment/DeployedProcessImpl.java
@@ -21,6 +21,7 @@ public class DeployedProcessImpl implements Process {
   private byte[] resource;
   private boolean isDuplicate;
   private String tenantId;
+  private long deploymentKey;
 
   public DeployedProcessImpl() {}
 
@@ -52,6 +53,15 @@ public class DeployedProcessImpl implements Process {
   @Override
   public boolean isDuplicate() {
     return isDuplicate;
+  }
+
+  @Override
+  public long getDeploymentKey() {
+    return deploymentKey;
+  }
+
+  public void setDeploymentKey(final long deploymentKey) {
+    this.deploymentKey = deploymentKey;
   }
 
   public void setDuplicate(final boolean duplicate) {
@@ -107,7 +117,13 @@ public class DeployedProcessImpl implements Process {
   public int hashCode() {
     int result =
         Objects.hash(
-            bpmnProcessId, resourceName, processDefinitionKey, version, isDuplicate, tenantId);
+            bpmnProcessId,
+            resourceName,
+            processDefinitionKey,
+            version,
+            isDuplicate,
+            tenantId,
+            deploymentKey);
     result = 31 * result + Arrays.hashCode(checksum);
     result = 31 * result + Arrays.hashCode(resource);
     return result;
@@ -125,6 +141,7 @@ public class DeployedProcessImpl implements Process {
     return processDefinitionKey == that.processDefinitionKey
         && version == that.version
         && isDuplicate == that.isDuplicate
+        && deploymentKey == that.deploymentKey
         && Objects.equals(bpmnProcessId, that.bpmnProcessId)
         && Objects.equals(resourceName, that.resourceName)
         && Objects.equals(tenantId, that.tenantId)
@@ -153,6 +170,8 @@ public class DeployedProcessImpl implements Process {
         + isDuplicate
         + ", tenantId="
         + tenantId
+        + ", deploymentKey="
+        + deploymentKey
         + '}';
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -149,6 +149,9 @@ public final class DeploymentCreateProcessor
 
   private void transformAndDistributeDeployment(final TypedRecord<DeploymentRecord> command) {
     final DeploymentRecord deploymentEvent = command.getValue();
+    final long key = keyGenerator.nextKey();
+    deploymentEvent.setKey(key);
+
     // Note: transforming a resource will also write the CREATE events for said resource
     final Either<Failure, Void> result = deploymentTransformer.transform(deploymentEvent);
 
@@ -163,7 +166,6 @@ public final class DeploymentCreateProcessor
       throw new TimerCreationFailedException(reason);
     }
 
-    final long key = keyGenerator.nextKey();
     final var recordWithoutResource = createDeploymentWithoutResources(deploymentEvent);
     responseWriter.writeEventOnCommand(
         key, DeploymentIntent.CREATED, recordWithoutResource, command);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -150,7 +150,7 @@ public final class DeploymentCreateProcessor
   private void transformAndDistributeDeployment(final TypedRecord<DeploymentRecord> command) {
     final DeploymentRecord deploymentEvent = command.getValue();
     final long key = keyGenerator.nextKey();
-    deploymentEvent.setKey(key);
+    deploymentEvent.setDeploymentKey(key);
 
     // Note: transforming a resource will also write the CREATE events for said resource
     final Either<Failure, Void> result = deploymentTransformer.transform(deploymentEvent);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -197,7 +197,8 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
           .setBpmnProcessId(BufferUtil.wrapString(bpmnProcessId))
           .setChecksum(resourceDigest)
           .setResourceName(deploymentResource.getResourceNameBuffer())
-          .setTenantId(tenantId);
+          .setTenantId(tenantId)
+          .setDeploymentKey(deploymentEvent.getKey());
 
       final var isDuplicate =
           isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -198,7 +198,7 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
           .setChecksum(resourceDigest)
           .setResourceName(deploymentResource.getResourceNameBuffer())
           .setTenantId(tenantId)
-          .setDeploymentKey(deploymentEvent.getKey());
+          .setDeploymentKey(deploymentEvent.getDeploymentKey());
 
       final var isDuplicate =
           isDuplicateOfLatest(deploymentResource, resourceDigest, lastProcess, lastDigest);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionDeleteProcessor.java
@@ -214,7 +214,8 @@ public class ResourceDeletionDeleteProcessor
             .setVersion(process.getVersion())
             .setKey(process.getKey())
             .setResourceName(process.getResourceName())
-            .setTenantId(process.getTenantId());
+            .setTenantId(process.getTenantId())
+            .setDeploymentKey(process.getDeploymentKey());
     stateWriter.appendFollowUpEvent(keyGenerator.nextKey(), ProcessIntent.DELETING, processRecord);
 
     final String processId = processRecord.getBpmnProcessId();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -108,7 +108,8 @@ public final class EventAppliers implements EventApplier {
   }
 
   private void registerProcessAppliers(final MutableProcessingState state) {
-    register(ProcessIntent.CREATED, new ProcessCreatedApplier(state));
+    register(ProcessIntent.CREATED, 1, new ProcessCreatedV1Applier(state));
+    register(ProcessIntent.CREATED, 2, new ProcessCreatedV2Applier(state));
     register(ProcessIntent.DELETING, new ProcessDeletingApplier(state));
     register(ProcessIntent.DELETED, new ProcessDeletedApplier(state));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedV1Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedV1Applier.java
@@ -13,11 +13,11 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 
-public class ProcessCreatedApplier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
+public class ProcessCreatedV1Applier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
 
   private final MutableProcessState processState;
 
-  public ProcessCreatedApplier(final MutableProcessingState state) {
+  public ProcessCreatedV1Applier(final MutableProcessingState state) {
     processState = state.getProcessState();
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedV2Applier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessCreatedV2Applier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
+
+public class ProcessCreatedV2Applier implements TypedEventApplier<ProcessIntent, ProcessRecord> {
+
+  private final MutableProcessState processState;
+
+  public ProcessCreatedV2Applier(final MutableProcessingState state) {
+    processState = state.getProcessState();
+  }
+
+  @Override
+  public void applyState(final long processDefinitionKey, final ProcessRecord value) {
+    processState.putProcess(processDefinitionKey, value);
+    processState.storeProcessDefinitionKeyByProcessIdAndDeploymentKey(value);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -83,6 +83,11 @@ public final class DbProcessState implements MutableProcessState {
   private final DbLong deploymentKey;
   private final DbTenantAwareKey<DbCompositeKey<DbString, DbLong>>
       tenantAwareProcessIdAndDeploymentKey;
+
+  /**
+   * <b>Note</b>: Will only be filled with entries deployed from 8.6 onwards; previously deployed
+   * processes will not have an entry in this column family.
+   */
   private final ColumnFamily<
           DbTenantAwareKey<DbCompositeKey<DbString, DbLong>>,
           DbForeignKey<DbTenantAwareKey<DbLong>>>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DeployedProcess.java
@@ -52,6 +52,10 @@ public final class DeployedProcess {
     return persistedProcess.getTenantId();
   }
 
+  public long getDeploymentKey() {
+    return persistedProcess.getDeploymentKey();
+  }
+
   @Override
   public String toString() {
     return "DeployedProcess{"

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/PersistedProcess.java
@@ -30,16 +30,18 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
       new EnumProperty<>("state", PersistedProcessState.class, PersistedProcessState.ACTIVE);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1L);
 
   public PersistedProcess() {
-    super(7);
+    super(8);
     declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(bpmnProcessIdProp)
         .declareProperty(resourceNameProp)
         .declareProperty(resourceProp)
         .declareProperty(stateProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(deploymentKeyProp);
   }
 
   public void wrap(final ProcessRecord processRecord, final long processDefinitionKey) {
@@ -50,6 +52,7 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
     versionProp.setValue(processRecord.getVersion());
     keyProp.setValue(processDefinitionKey);
     tenantIdProp.setValue(processRecord.getTenantId());
+    deploymentKeyProp.setValue(processRecord.getDeploymentKey());
   }
 
   public int getVersion() {
@@ -88,6 +91,10 @@ public final class PersistedProcess extends UnpackedObject implements DbValue {
   public PersistedProcess setTenantId(final String tenantId) {
     tenantIdProp.setValue(tenantId);
     return this;
+  }
+
+  public long getDeploymentKey() {
+    return deploymentKeyProp.getValue();
   }
 
   public enum PersistedProcessState {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessState.java
@@ -19,6 +19,9 @@ public interface ProcessState {
   DeployedProcess getProcessByProcessIdAndVersion(
       DirectBuffer processId, int version, final String tenantId);
 
+  DeployedProcess getProcessByProcessIdAndDeploymentKey(
+      DirectBuffer processId, long deploymentKey, final String tenantId);
+
   DeployedProcess getProcessByKeyAndTenant(long key, String tenantId);
 
   DirectBuffer getLatestVersionDigest(DirectBuffer processId, final String tenantId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessState.java
@@ -20,6 +20,8 @@ public interface MutableProcessState extends ProcessState {
 
   void putProcess(long key, ProcessRecord value);
 
+  void storeProcessDefinitionKeyByProcessIdAndDeploymentKey(final ProcessRecord processRecord);
+
   /**
    * Updates the state of a process. This method updates both the ColumnFamily and the in memory
    * cache.
@@ -30,7 +32,7 @@ public interface MutableProcessState extends ProcessState {
   void updateProcessState(final ProcessRecord processRecord, final PersistedProcessState state);
 
   /**
-   * Deletes a process fromm the state and cache
+   * Deletes a process from the state and cache
    *
    * @param processRecord the record of the process that is deleted
    */

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/CreateDeploymentMultiplePartitionsTest.java
@@ -472,6 +472,7 @@ public final class CreateDeploymentMultiplePartitionsTest {
                   .limit(1)
                   .getFirst();
           assertThat(record).isNotNull();
+          assertThat(record.getRecordVersion()).isEqualTo(2);
           assertThat(record.getValue().getResourceName()).isEqualTo("process.bpmn");
           assertThat(record.getValue().getVersion()).isEqualTo(1);
           assertThat(record.getValue().getDeploymentKey()).isEqualTo(deployment.getKey());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
@@ -256,6 +256,7 @@ public final class ProcessDeploymentTest {
     final var firstProcessRecord =
         RecordingExporter.processRecords().withBpmnProcessId(processId).getFirst();
     assertThat(firstProcessRecord).isNotNull();
+    assertThat(firstProcessRecord.getRecordVersion()).isEqualTo(2);
     assertThat(firstProcessRecord.getValue().getResourceName()).isEqualTo("process.bpmn");
     assertThat(firstProcessRecord.getValue().getVersion()).isEqualTo(1);
     assertThat(firstProcessRecord.getValue().getDeploymentKey()).isEqualTo(deployment.getKey());
@@ -265,6 +266,7 @@ public final class ProcessDeploymentTest {
     final var secondProcessRecord =
         RecordingExporter.processRecords().withBpmnProcessId(processId2).getFirst();
     assertThat(secondProcessRecord).isNotNull();
+    assertThat(secondProcessRecord.getRecordVersion()).isEqualTo(2);
     assertThat(secondProcessRecord.getValue().getResourceName()).isEqualTo("process2.bpmn");
     assertThat(secondProcessRecord.getValue().getVersion()).isEqualTo(1);
     assertThat(secondProcessRecord.getValue().getDeploymentKey()).isEqualTo(deployment.getKey());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
@@ -258,6 +258,7 @@ public final class ProcessDeploymentTest {
     assertThat(firstProcessRecord).isNotNull();
     assertThat(firstProcessRecord.getValue().getResourceName()).isEqualTo("process.bpmn");
     assertThat(firstProcessRecord.getValue().getVersion()).isEqualTo(1);
+    assertThat(firstProcessRecord.getValue().getDeploymentKey()).isEqualTo(deployment.getKey());
     assertThat(firstProcessRecord.getKey())
         .isEqualTo(firstProcessRecord.getValue().getProcessDefinitionKey());
 
@@ -266,6 +267,7 @@ public final class ProcessDeploymentTest {
     assertThat(secondProcessRecord).isNotNull();
     assertThat(secondProcessRecord.getValue().getResourceName()).isEqualTo("process2.bpmn");
     assertThat(secondProcessRecord.getValue().getVersion()).isEqualTo(1);
+    assertThat(secondProcessRecord.getValue().getDeploymentKey()).isEqualTo(deployment.getKey());
     assertThat(secondProcessRecord.getKey())
         .isEqualTo(secondProcessRecord.getValue().getProcessDefinitionKey());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/ProcessDeploymentTest.java
@@ -259,7 +259,8 @@ public final class ProcessDeploymentTest {
     assertThat(firstProcessRecord.getRecordVersion()).isEqualTo(2);
     assertThat(firstProcessRecord.getValue().getResourceName()).isEqualTo("process.bpmn");
     assertThat(firstProcessRecord.getValue().getVersion()).isEqualTo(1);
-    assertThat(firstProcessRecord.getValue().getDeploymentKey()).isEqualTo(deployment.getKey());
+    assertThat(firstProcessRecord.getValue().getDeploymentKey())
+        .isEqualTo(deployment.getDeploymentKey());
     assertThat(firstProcessRecord.getKey())
         .isEqualTo(firstProcessRecord.getValue().getProcessDefinitionKey());
 
@@ -269,7 +270,8 @@ public final class ProcessDeploymentTest {
     assertThat(secondProcessRecord.getRecordVersion()).isEqualTo(2);
     assertThat(secondProcessRecord.getValue().getResourceName()).isEqualTo("process2.bpmn");
     assertThat(secondProcessRecord.getValue().getVersion()).isEqualTo(1);
-    assertThat(secondProcessRecord.getValue().getDeploymentKey()).isEqualTo(deployment.getKey());
+    assertThat(secondProcessRecord.getValue().getDeploymentKey())
+        .isEqualTo(deployment.getDeploymentKey());
     assertThat(secondProcessRecord.getKey())
         .isEqualTo(secondProcessRecord.getValue().getProcessDefinitionKey());
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/resource/ResourceDeletionTest.java
@@ -872,13 +872,15 @@ public class ResourceDeletionTest {
             ProcessMetadataValue::getBpmnProcessId,
             ProcessMetadataValue::getResourceName,
             ProcessMetadataValue::getVersion,
-            ProcessMetadataValue::getProcessDefinitionKey)
+            ProcessMetadataValue::getProcessDefinitionKey,
+            ProcessMetadataValue::getDeploymentKey)
         .containsOnly(
             tuple(
                 processCreatedRecord.getBpmnProcessId(),
                 processCreatedRecord.getResourceName(),
                 processCreatedRecord.getVersion(),
-                processCreatedRecord.getProcessDefinitionKey()));
+                processCreatedRecord.getProcessDefinitionKey(),
+                processCreatedRecord.getDeploymentKey()));
   }
 
   private void verifyInstanceOfProcessWithIdAndVersionIsCompleted(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/ProcessExecutionCleanStateTest.java
@@ -44,6 +44,7 @@ public final class ProcessExecutionCleanStateTest {
           ZbColumnFamilies.PROCESS_CACHE,
           ZbColumnFamilies.PROCESS_CACHE_BY_ID_AND_VERSION,
           ZbColumnFamilies.PROCESS_CACHE_DIGEST_BY_ID,
+          ZbColumnFamilies.PROCESS_DEFINITION_KEY_BY_PROCESS_ID_AND_DEPLOYMENT_KEY,
           ZbColumnFamilies.MESSAGE_STATS,
           ZbColumnFamilies.MIGRATIONS_STATE);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateMultiTenantTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/deployment/ProcessStateMultiTenantTest.java
@@ -123,6 +123,37 @@ public class ProcessStateMultiTenantTest {
   }
 
   @Test
+  public void shouldStoreProcessDefinitionKeyByProcessIdAndDeploymentKeyForMultipleTenants() {
+    // given
+    final var processKey = keyGenerator.nextKey();
+    final var deploymentKey = keyGenerator.nextKey();
+    final var processId = Strings.newRandomValidBpmnId();
+    final var version = 1;
+    final var tenant1Process =
+        createProcessRecord(TENANT_1, processKey, processId, version)
+            .setDeploymentKey(deploymentKey);
+    final var tenant2Process =
+        createProcessRecord(TENANT_2, processKey, processId, version)
+            .setDeploymentKey(deploymentKey);
+    processState.putProcess(processKey, tenant1Process);
+    processState.putProcess(processKey, tenant2Process);
+
+    // when
+    processState.storeProcessDefinitionKeyByProcessIdAndDeploymentKey(tenant1Process);
+    processState.storeProcessDefinitionKeyByProcessIdAndDeploymentKey(tenant2Process);
+
+    // then
+    final var tenant1DeployedProcess =
+        processState.getProcessByProcessIdAndDeploymentKey(
+            wrapString(processId), deploymentKey, TENANT_1);
+    assertDeployedProcess(tenant1DeployedProcess, TENANT_1, processKey, processId, version);
+    final var tenant2DeployedProcess =
+        processState.getProcessByProcessIdAndDeploymentKey(
+            wrapString(processId), deploymentKey, TENANT_2);
+    assertDeployedProcess(tenant2DeployedProcess, TENANT_2, processKey, processId, version);
+  }
+
+  @Test
   public void shouldUpdateProcessStateForTenant() {
     // given
     final long processKey = keyGenerator.nextKey();

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -142,6 +142,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "deploymentKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -43,6 +43,9 @@
                 },
                 "tenantId": {
                   "type": "keyword"
+                },
+                "deploymentKey": {
+                  "type": "long"
                 }
               }
             },

--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -42,6 +42,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "deploymentKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -142,6 +142,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "deploymentKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-deployment-template.json
@@ -43,6 +43,9 @@
                 },
                 "tenantId": {
                   "type": "keyword"
+                },
+                "deploymentKey": {
+                  "type": "long"
                 }
               }
             },

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-process-template.json
@@ -42,6 +42,9 @@
             },
             "tenantId": {
               "type": "keyword"
+            },
+            "deploymentKey": {
+              "type": "long"
             }
           }
         }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
 import io.camunda.zeebe.msgpack.value.ValueArray;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
@@ -46,14 +48,17 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
+  private final LongProperty keyProp = new LongProperty("key", -1);
+
   public DeploymentRecord() {
-    super(6);
+    super(7);
     declareProperty(resourcesProp)
         .declareProperty(processesMetadataProp)
         .declareProperty(decisionRequirementsMetadataProp)
         .declareProperty(decisionMetadataProp)
         .declareProperty(formMetadataProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(keyProp);
   }
 
   public ValueArray<ProcessMetadata> processesMetadata() {
@@ -145,6 +150,17 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
     }
 
     return metadataList;
+  }
+
+  @Override
+  @JsonIgnore
+  public long getKey() {
+    return keyProp.getValue();
+  }
+
+  public DeploymentRecord setKey(final long key) {
+    keyProp.setValue(key);
+    return this;
   }
 
   public void resetResources() {

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.protocol.impl.record.value.deployment;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.StringProperty;
@@ -153,7 +152,6 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   }
 
   @Override
-  @JsonIgnore
   public long getDeploymentKey() {
     return deploymentKeyProp.getValue();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/DeploymentRecord.java
@@ -48,7 +48,7 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
 
-  private final LongProperty keyProp = new LongProperty("key", -1);
+  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
 
   public DeploymentRecord() {
     super(7);
@@ -58,7 +58,7 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
         .declareProperty(decisionMetadataProp)
         .declareProperty(formMetadataProp)
         .declareProperty(tenantIdProp)
-        .declareProperty(keyProp);
+        .declareProperty(deploymentKeyProp);
   }
 
   public ValueArray<ProcessMetadata> processesMetadata() {
@@ -154,12 +154,12 @@ public final class DeploymentRecord extends UnifiedRecordValue implements Deploy
 
   @Override
   @JsonIgnore
-  public long getKey() {
-    return keyProp.getValue();
+  public long getDeploymentKey() {
+    return deploymentKeyProp.getValue();
   }
 
-  public DeploymentRecord setKey(final long key) {
-    keyProp.setValue(key);
+  public DeploymentRecord setDeploymentKey(final long deploymentKey) {
+    deploymentKeyProp.setValue(deploymentKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -39,16 +39,18 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   private final BooleanProperty isDuplicateProp = new BooleanProperty("isDuplicate", false);
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
 
   public ProcessMetadata() {
-    super(7);
+    super(8);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
         .declareProperty(isDuplicateProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(deploymentKeyProp);
   }
 
   @Override
@@ -88,6 +90,17 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
 
   public ProcessMetadata setDuplicate(final boolean isDuplicate) {
     isDuplicateProp.setValue(isDuplicate);
+    return this;
+  }
+
+  @Override
+  @JsonIgnore
+  public long getDeploymentKey() {
+    return deploymentKeyProp.getValue();
+  }
+
+  public ProcessMetadata setDeploymentKey(final long deploymentKey) {
+    deploymentKeyProp.setValue(deploymentKey);
     return this;
   }
 

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessMetadata.java
@@ -94,7 +94,6 @@ public final class ProcessMetadata extends UnifiedRecordValue implements Process
   }
 
   @Override
-  @JsonIgnore
   public long getDeploymentKey() {
     return deploymentKeyProp.getValue();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/deployment/ProcessRecord.java
@@ -32,16 +32,18 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   private final BinaryProperty resourceProp = new BinaryProperty("resource", new UnsafeBuffer());
   private final StringProperty tenantIdProp =
       new StringProperty("tenantId", TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+  private final LongProperty deploymentKeyProp = new LongProperty("deploymentKey", -1);
 
   public ProcessRecord() {
-    super(7);
+    super(8);
     declareProperty(bpmnProcessIdProp)
         .declareProperty(versionProp)
         .declareProperty(keyProp)
         .declareProperty(resourceNameProp)
         .declareProperty(checksumProp)
         .declareProperty(resourceProp)
-        .declareProperty(tenantIdProp);
+        .declareProperty(tenantIdProp)
+        .declareProperty(deploymentKeyProp);
   }
 
   public ProcessRecord wrap(final ProcessMetadata metadata, final byte[] resource) {
@@ -52,6 +54,7 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
     resourceNameProp.setValue(metadata.getResourceNameBuffer());
     resourceProp.setValue(BufferUtil.wrapArray(resource));
     tenantIdProp.setValue(metadata.getTenantId());
+    deploymentKeyProp.setValue(metadata.getDeploymentKey());
     return this;
   }
 
@@ -83,6 +86,16 @@ public final class ProcessRecord extends UnifiedRecordValue implements Process {
   @Override
   public boolean isDuplicate() {
     return false;
+  }
+
+  @Override
+  public long getDeploymentKey() {
+    return deploymentKeyProp.getValue();
+  }
+
+  public ProcessRecord setDeploymentKey(final long deploymentKey) {
+    deploymentKeyProp.setValue(deploymentKey);
+    return this;
   }
 
   public ProcessRecord setChecksum(final DirectBuffer checksumBuffer) {

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -446,11 +446,50 @@ final class JsonSerializableToJsonTest {
               final DirectBuffer resource = wrapString("contents");
               final String bpmnProcessId = "testProcess";
               final long processDefinitionKey = 123;
-
               final int processVersion = 12;
               final DirectBuffer checksum = wrapString("checksum");
-              final ProcessRecord record = new ProcessRecord();
+              final long deploymentKey = 1234;
 
+              final ProcessRecord record = new ProcessRecord();
+              record
+                  .setResourceName(wrapString(resourceName))
+                  .setResource(resource)
+                  .setBpmnProcessId(wrapString(bpmnProcessId))
+                  .setKey(processDefinitionKey)
+                  .setResourceName(wrapString(resourceName))
+                  .setVersion(processVersion)
+                  .setChecksum(checksum)
+                  .setDeploymentKey(deploymentKey);
+
+              return record;
+            },
+        """
+        {
+          "resourceName": "resource",
+          "resource": "Y29udGVudHM=",
+          "checksum": "Y2hlY2tzdW0=",
+          "bpmnProcessId": "testProcess",
+          "version": 12,
+          "processDefinitionKey": 123,
+          "resourceName": "resource",
+          "duplicate": false,
+          "tenantId": "<default>",
+          "deploymentKey": 1234
+        }
+        """
+      },
+      new Object[] {
+        "ProcessRecord (with empty deployment key)",
+        (Supplier<UnifiedRecordValue>)
+            () -> {
+              final String resourceName = "resource";
+              final DirectBuffer resource = wrapString("contents");
+              final String bpmnProcessId = "testProcess";
+              final long processDefinitionKey = 123;
+              final int processVersion = 12;
+              final DirectBuffer checksum = wrapString("checksum");
+
+              final ProcessRecord record = new ProcessRecord();
               record
                   .setResourceName(wrapString(resourceName))
                   .setResource(resource)
@@ -472,7 +511,8 @@ final class JsonSerializableToJsonTest {
           "processDefinitionKey": 123,
           "resourceName": "resource",
           "duplicate": false,
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "deploymentKey": -1
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -229,7 +229,8 @@ final class JsonSerializableToJsonTest {
             "decisionsMetadata": [],
             "decisionRequirementsMetadata": [],
             "formMetadata": [],
-            "tenantId": "<default>"
+            "tenantId": "<default>",
+            "deploymentKey": -1
           }
         }
         """
@@ -277,7 +278,8 @@ final class JsonSerializableToJsonTest {
               "processesMetadata": [],
               "decisionsMetadata": [],
               "formMetadata": [],
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "deploymentKey": -1
           }
         }
         """
@@ -295,8 +297,10 @@ final class JsonSerializableToJsonTest {
               final long processDefinitionKey = 123;
               final int processVersion = 12;
               final DirectBuffer checksum = wrapString("checksum");
+              final long deploymentKey = 1234;
               final DeploymentRecord record = new DeploymentRecord();
               record
+                  .setDeploymentKey(deploymentKey)
                   .resources()
                   .add()
                   .setResourceName(wrapString(resourceName))
@@ -397,7 +401,8 @@ final class JsonSerializableToJsonTest {
               "tenantId": "<default>"
             }
           ],
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "deploymentKey": 1234
         }
         """
       },
@@ -431,7 +436,8 @@ final class JsonSerializableToJsonTest {
           "decisionsMetadata": [],
           "decisionRequirementsMetadata": [],
           "formMetadata": [],
-          "tenantId": "<default>"
+          "tenantId": "<default>",
+          "deploymentKey": -1
         }
         """
       },
@@ -2063,7 +2069,8 @@ final class JsonSerializableToJsonTest {
             "decisionsMetadata": [],
             "decisionRequirementsMetadata": [],
             "formMetadata": [],
-            "tenantId": "<default>"
+            "tenantId": "<default>",
+            "deploymentKey": -1
           }
         }
         """

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -217,7 +217,8 @@ final class JsonSerializableToJsonTest {
                 "checksum": "Y2hlY2tzdW0=",
                 "processDefinitionKey": 123,
                 "duplicate": false,
-                "tenantId": "<default>"
+                "tenantId": "<default>",
+                "deploymentKey": -1
               }
             ],
             "resources": [
@@ -313,7 +314,8 @@ final class JsonSerializableToJsonTest {
                   .setResourceName(wrapString(resourceName))
                   .setVersion(processVersion)
                   .setChecksum(checksum)
-                  .setDuplicate(true);
+                  .setDuplicate(true)
+                  .setDeploymentKey(deploymentKey);
               record
                   .decisionRequirementsMetadata()
                   .add()
@@ -362,7 +364,8 @@ final class JsonSerializableToJsonTest {
               "processDefinitionKey": 123,
               "resourceName": "resource",
               "duplicate": true,
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "deploymentKey": 1234
             }
           ],
           "decisionsMetadata": [
@@ -2064,7 +2067,8 @@ final class JsonSerializableToJsonTest {
               "resourceName": "my_first_bpmn.bpmn",
               "checksum": "c2hhMQ==",
               "duplicate": false,
-              "tenantId": "<default>"
+              "tenantId": "<default>",
+              "deploymentKey": -1
             }],
             "decisionsMetadata": [],
             "decisionRequirementsMetadata": [],

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -169,7 +169,9 @@ public enum ZbColumnFamilies implements EnumValue {
 
   USER_TASKS(79),
   USER_TASK_STATES(80),
-  COMPENSATION_SUBSCRIPTION(81);
+  COMPENSATION_SUBSCRIPTION(81),
+
+  PROCESS_DEFINITION_KEY_BY_PROCESS_ID_AND_DEPLOYMENT_KEY(82);
 
   private final int value;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
@@ -58,4 +58,9 @@ public interface DeploymentRecordValue extends RecordValue, TenantOwned {
    * @return the deployed forms
    */
   List<FormMetadataValue> getFormMetadata();
+
+  /**
+   * @return the unique key of the deployment
+   */
+  long getKey();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/DeploymentRecordValue.java
@@ -62,5 +62,5 @@ public interface DeploymentRecordValue extends RecordValue, TenantOwned {
   /**
    * @return the unique key of the deployment
    */
-  long getKey();
+  long getDeploymentKey();
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/deployment/ProcessMetadataValue.java
@@ -53,4 +53,9 @@ public interface ProcessMetadataValue extends RecordValue, TenantOwned {
    * return true if the process is a duplicate (and has been deployed previously), false otherwise
    */
   boolean isDuplicate();
+
+  /**
+   * @return the key of the deployment this process was deployed with
+   */
+  long getDeploymentKey();
 }


### PR DESCRIPTION
## Description
Store the deployment key as a new property for deployed processes and add the possibility to find a process by process id and deployment key. This is a prerequisite to be able to properly resolve called processes when the new `deployment` binding type is used (see #19710).

## Related issues
part of #19709 (the current PR covers processes only; similar changes will follow for decisions and forms)