### PR TITLE
ci: observe build status for Zeebe deploy jobs

### DIFF
--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -642,6 +642,16 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ steps.secrets.outputs.ARTIFACTS_USR }}
           MAVEN_PASSWORD: ${{ steps.secrets.outputs.ARTIFACTS_PSW }}
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
   deploy-docker-snapshot:
     name: Deploy snapshot Docker image
     needs: [ test-summary ]
@@ -705,6 +715,15 @@ jobs:
         run: ./mvnw -pl zeebe/benchmarks/project jib:build -P starter
       - name: Build Worker Image
         run: ./mvnw -pl zeebe/benchmarks/project jib:build -P worker
+      - name: Observe build status
+        if: always()
+        continue-on-error: true
+        uses: ./.github/actions/observe-build-status
+        with:
+          build_status: ${{ job.status }}
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
   deploy-snyk-projects:
     name: Deploy Snyk development projects
     needs: [ test-summary ]


### PR DESCRIPTION
These jobs fail from time to time, we should observe them so that we have some data.