### PR TITLE
fix: set unique keys for output variable rows

### DIFF
--- a/operate/client/e2e-playwright/pages/DecisionInstance.ts
+++ b/operate/client/e2e-playwright/pages/DecisionInstance.ts
@@ -6,16 +6,47 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-import {Page} from '@playwright/test';
+import {Locator, Page} from '@playwright/test';
+import {Paths} from 'modules/Routes';
 
 export class DecisionInstance {
   private page: Page;
+  readonly decisionPanel: Locator;
+  readonly drdPanel: Locator;
+  readonly inputVariables: Locator;
+  readonly outputVariables: Locator;
+  readonly resultTab: Locator;
+  readonly inputsOutputsTab: Locator;
+  readonly result: Locator;
 
   constructor(page: Page) {
     this.page = page;
+    this.decisionPanel = this.page.getByRole('region', {
+      name: 'decision panel',
+    });
+    this.drdPanel = this.page.getByRole('region', {name: 'drd panel'});
+    this.inputVariables = this.page.getByRole('region', {
+      name: 'input variables',
+    });
+    this.outputVariables = this.page.getByRole('region', {
+      name: 'output variables',
+    });
+    this.result = this.page.getByTestId('results-json-viewer');
+    this.resultTab = this.page.getByRole('tab', {name: /result/i});
+    this.inputsOutputsTab = this.page.getByRole('tab', {
+      name: /inputs and outputs/i,
+    });
   }
 
   async closeDrdPanel() {
-    await this.page.getByRole('button', {name: /close drd panel/i}).click();
+    await this.drdPanel.getByRole('button', {name: /close drd panel/i}).click();
+  }
+
+  async navigateToDecisionInstance({
+    decisionInstanceKey,
+  }: {
+    decisionInstanceKey: string;
+  }) {
+    await this.page.goto('.' + Paths.decisionInstance(decisionInstanceKey));
   }
 }

--- a/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
+++ b/operate/client/e2e-playwright/tests/batchMoveModification.spec.ts
@@ -156,7 +156,7 @@ test.describe('Process Instance Batch Modification', () => {
               data: {
                 active: true,
                 running: true,
-                processIds: ['2251799813685249'],
+                processIds: [initialData.processDefinitionKey],
                 activityId: 'shipArticles',
                 ids: processInstanceKeys,
               },

--- a/operate/client/e2e-playwright/tests/decisionInstance.mocks.ts
+++ b/operate/client/e2e-playwright/tests/decisionInstance.mocks.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {zeebeGrpcApi} from '../api/zeebe-grpc';
+
+const {deployDecisions} = zeebeGrpcApi;
+
+const setup = async () => {
+  const {deployments} = await deployDecisions(['decisions_v_2.dmn']);
+
+  const decision1Key = deployments[0]?.decision.decisionKey;
+  const decision2Key = deployments[1]?.decision.decisionKey;
+
+  return {
+    decision1Key,
+    decision2Key,
+  };
+};
+
+export {setup};

--- a/operate/client/e2e-playwright/tests/decisionInstance.spec.ts
+++ b/operate/client/e2e-playwright/tests/decisionInstance.spec.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {setup} from './decisionInstance.mocks';
+import {test} from '../test-fixtures';
+import {SETUP_WAITING_TIME} from './constants';
+import {expect} from '@playwright/test';
+import {config} from '../config';
+import {zeebeGrpcApi} from '../api/zeebe-grpc';
+
+test.describe('Decision Instance', () => {
+  let initialData: Awaited<ReturnType<typeof setup>>;
+  let decisionInstanceKey: string;
+
+  test.beforeAll(async ({request}) => {
+    test.setTimeout(SETUP_WAITING_TIME);
+    initialData = await setup();
+
+    await expect
+      .poll(
+        async () => {
+          const response = await request.get(
+            `${config.endpoint}/v1/decision-definitions/${initialData.decision1Key}`,
+          );
+
+          return response.status();
+        },
+        {timeout: SETUP_WAITING_TIME},
+      )
+      .toBe(200);
+
+    const evaluationResponse = await zeebeGrpcApi.evaluateDecision({
+      decisionKey: initialData.decision1Key!,
+      variables: {input: 'foo'},
+    });
+    //@ts-ignore
+    decisionInstanceKey = evaluationResponse.decisionInstanceKey;
+
+    // Wait for decision instances to be available in Operate
+    await Promise.all(
+      [`${decisionInstanceKey}-1`, `${decisionInstanceKey}-2`].map(
+        async (instanceKey) =>
+          await expect
+            .poll(
+              async () => {
+                const response = await request.get(
+                  `${config.endpoint}/v1/decision-instances/${instanceKey}`,
+                );
+
+                return response.status();
+              },
+              {timeout: SETUP_WAITING_TIME},
+            )
+            .toBe(200),
+      ),
+    );
+  });
+
+  test('Switching between decisions', async ({decisionInstancePage}) => {
+    await decisionInstancePage.navigateToDecisionInstance({
+      decisionInstanceKey: `${decisionInstanceKey}-1`,
+    });
+
+    const {drdPanel, decisionPanel, inputVariables, outputVariables} =
+      decisionInstancePage;
+
+    await expect(drdPanel.getByText('Decision 1')).toBeVisible();
+    await expect(drdPanel.getByText('Decision 2')).toBeVisible();
+    await expect(decisionPanel.getByText('Decision 1')).toBeVisible();
+    await expect(decisionPanel.getByText('Decision 2')).not.toBeVisible();
+
+    /**
+     * input variables assertions (Decision 1)
+     */
+    const inputVariable1Row = inputVariables.getByRole('row').nth(1);
+    const inputVariable1Name = inputVariable1Row.getByRole('cell').nth(0);
+    const inputVariable1Value = inputVariable1Row.getByRole('cell').nth(1);
+    await expect(inputVariables.getByRole('row')).toHaveCount(2);
+    await expect(inputVariable1Name).toHaveText('input');
+    await expect(inputVariable1Value).toHaveText('"foo"');
+
+    /**
+     * output variables assertions (Decision 1)
+     */
+    const outputVariable1Row = outputVariables.getByRole('row').nth(1);
+    const outputVariable2Row = outputVariables.getByRole('row').nth(2);
+    const outputVariable1Rule = outputVariable1Row.getByRole('cell').nth(0);
+    const outputVariable1Name = outputVariable1Row.getByRole('cell').nth(1);
+    const outputVariable1Value = outputVariable1Row.getByRole('cell').nth(2);
+    const outputVariable2Rule = outputVariable2Row.getByRole('cell').nth(0);
+    const outputVariable2Name = outputVariable2Row.getByRole('cell').nth(1);
+    const outputVariable2Value = outputVariable2Row.getByRole('cell').nth(2);
+    await expect(outputVariables.getByRole('row')).toHaveCount(3);
+    await expect(outputVariable1Rule).toHaveText('1');
+    await expect(outputVariable1Name).toHaveText('output');
+    await expect(outputVariable1Value).toHaveText('"bar"');
+    await expect(outputVariable2Rule).toHaveText('2');
+    await expect(outputVariable2Name).toHaveText('output');
+    await expect(outputVariable2Value).toHaveText('"baz"');
+
+    /**
+     * result assertion (Decision 1)
+     */
+    await decisionInstancePage.resultTab.click();
+    await expect(decisionInstancePage.result).toHaveText(/\["bar","baz"\]/);
+
+    await drdPanel.getByText('Decision 2').click();
+    await decisionInstancePage.inputsOutputsTab.click();
+    await expect(decisionPanel.getByText('Decision 1')).not.toBeVisible();
+    await expect(decisionPanel.getByText('Decision 2')).toBeVisible();
+
+    /**
+     * output variables assertions (Decision 2)
+     */
+    await expect(outputVariables.getByRole('row')).toHaveCount(3);
+    await expect(outputVariable1Rule).toHaveText('2');
+    await expect(outputVariable1Name).toHaveText('output');
+    await expect(outputVariable1Value).toHaveText('"bar"');
+    await expect(outputVariable2Rule).toHaveText('2');
+    await expect(outputVariable2Name).toHaveText('output2');
+    await expect(outputVariable2Value).toHaveText('"baz"');
+
+    /**
+     * result assertion (Decision 2)
+     */
+    await decisionInstancePage.resultTab.click();
+    await expect(decisionInstancePage.result).toHaveText(
+      /\[{"output":"bar","output2":"baz"}\]/,
+    );
+
+    await drdPanel.getByText('Decision 1').click();
+    await decisionInstancePage.inputsOutputsTab.click();
+
+    /**
+     * output variables assertions (Decision 2)
+     */
+    await expect(outputVariables.getByRole('row')).toHaveCount(3);
+    await expect(outputVariable1Rule).toHaveText('1');
+    await expect(outputVariable1Name).toHaveText('output');
+    await expect(outputVariable1Value).toHaveText('"bar"');
+    await expect(outputVariable2Rule).toHaveText('2');
+    await expect(outputVariable2Name).toHaveText('output');
+    await expect(outputVariable2Value).toHaveText('"baz"');
+  });
+});

--- a/operate/client/e2e-playwright/tests/decisionInstances.mocks.ts
+++ b/operate/client/e2e-playwright/tests/decisionInstances.mocks.ts
@@ -15,18 +15,24 @@ const setup = async () => {
   const decisionV2 = await deployDecisions(['decisions_v_2.dmn']);
 
   return {
-    decisionKeys: [
+    decisions: [
       ...(decisionV1.deployments ?? [])
         //@ts-expect-error Property 'Metadata' does not exist on type 'DecisionDeployment'.ts(2339)
         .filter(({Metadata}) => Metadata === 'decision')
         .map(({decision}) => {
-          return decision.decisionKey;
+          return {
+            key: decision.decisionKey,
+            version: decision.version.toString(),
+          };
         }),
       ...(decisionV2.deployments ?? [])
         //@ts-expect-error Property 'Metadata' does not exist on type 'DecisionDeployment'.ts(2339)
         .filter(({Metadata}) => Metadata === 'decision')
         .map(({decision}) => {
-          return decision.decisionKey;
+          return {
+            key: decision.decisionKey,
+            version: decision.version.toString(),
+          };
         }),
     ],
   };

--- a/operate/client/e2e-playwright/tests/decisionInstances.spec.ts
+++ b/operate/client/e2e-playwright/tests/decisionInstances.spec.ts
@@ -12,31 +12,42 @@ import {SETUP_WAITING_TIME} from './constants';
 import {expect} from '@playwright/test';
 import {config} from '../config';
 
-test.beforeAll(async ({request}) => {
-  test.setTimeout(SETUP_WAITING_TIME);
-  const {decisionKeys} = await setup();
-
-  await Promise.all(
-    decisionKeys.map(
-      async (decisionKey) =>
-        await expect
-          .poll(
-            async () => {
-              const response = await request.get(
-                `${config.endpoint}/v1/decision-definitions/${decisionKey}`,
-              );
-
-              return response.status();
-            },
-            {timeout: SETUP_WAITING_TIME},
-          )
-          .toBe(200),
-    ),
-  );
-});
-
 test.describe('Decision Instances', () => {
+  let initialData: Awaited<ReturnType<typeof setup>>;
+
+  test.beforeAll(async ({request}) => {
+    test.setTimeout(SETUP_WAITING_TIME);
+    initialData = await setup();
+    const {decisions} = initialData;
+
+    await Promise.all(
+      decisions.map(
+        async (decision) =>
+          await expect
+            .poll(
+              async () => {
+                const response = await request.get(
+                  `${config.endpoint}/v1/decision-definitions/${decision.key}`,
+                );
+
+                return response.status();
+              },
+              {timeout: SETUP_WAITING_TIME},
+            )
+            .toBe(200),
+      ),
+    );
+  });
+
   test('Switch between Decision versions', async ({decisionsPage}) => {
+    const {decisions} = initialData;
+    const [
+      decision1Version1,
+      decision2Version1,
+      decision1Version2,
+      decision2Version2,
+    ] = decisions;
+
     await decisionsPage.navigateToDecisions({
       searchParams: {
         evaluated: 'true',
@@ -45,7 +56,7 @@ test.describe('Decision Instances', () => {
     });
 
     await decisionsPage.selectDecision('Decision 1');
-    await decisionsPage.selectVersion('1');
+    await decisionsPage.selectVersion(decision1Version1!.version);
     await expect(
       decisionsPage.decisionViewer.getByText('Decision 1'),
     ).toBeVisible();
@@ -53,7 +64,7 @@ test.describe('Decision Instances', () => {
       decisionsPage.decisionViewer.getByText('Version 1'),
     ).toBeVisible();
 
-    await decisionsPage.selectVersion('2');
+    await decisionsPage.selectVersion(decision1Version2!.version);
     await expect(
       decisionsPage.decisionViewer.getByText('Decision 1'),
     ).toBeVisible();
@@ -67,7 +78,7 @@ test.describe('Decision Instances', () => {
       decisionsPage.decisionViewer.getByText('Decision 2'),
     ).toBeVisible();
 
-    await decisionsPage.selectVersion('1');
+    await decisionsPage.selectVersion(decision2Version1!.version);
     await expect(
       decisionsPage.decisionViewer.getByText('Decision 2'),
     ).toBeVisible();
@@ -75,7 +86,7 @@ test.describe('Decision Instances', () => {
       decisionsPage.decisionViewer.getByText('Version 1'),
     ).toBeVisible();
 
-    await decisionsPage.selectVersion('2');
+    await decisionsPage.selectVersion(decision2Version2!.version);
 
     await expect(
       decisionsPage.decisionViewer.getByText('Decision 2'),

--- a/operate/client/e2e-playwright/tests/resources/decisions_v_2.dmn
+++ b/operate/client/e2e-playwright/tests/resources/decisions_v_2.dmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Decisions" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.4.2" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:biodi="http://bpmn.io/schema/dmn/biodi/2.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Decisions" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.1.0">
   <decision id="Decision_1" name="Decision 1">
-    <decisionTable id="DecisionTable_0q1ija9" hitPolicy="FIRST">
+    <decisionTable id="DecisionTable_0q1ija9" hitPolicy="COLLECT">
       <input id="Input_1" biodi:width="190">
         <inputExpression id="InputExpression_1" typeRef="string">
           <text>input</text>
@@ -24,6 +24,14 @@
           <text>"bar"</text>
         </outputEntry>
       </rule>
+      <rule id="DecisionRule_1waaksc">
+        <inputEntry id="UnaryTests_123ng7i">
+          <text>"foo"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_0vtifd8">
+          <text>"baz"</text>
+        </outputEntry>
+      </rule>
     </decisionTable>
   </decision>
   <decision id="Decision_2" name="Decision 2">
@@ -39,11 +47,23 @@
           <text>"foo"</text>
         </inputValues>
       </input>
-      <output id="OutputClause_1mncnxr" name="outout" typeRef="string">
+      <output id="OutputClause_1mncnxr" name="output" typeRef="string">
         <outputValues id="UnaryTests_1pzzcto">
           <text>"bar"</text>
         </outputValues>
       </output>
+      <output id="OutputClause_0kf4cjf" label="output2" name="output2" typeRef="string" />
+      <rule id="DecisionRule_0gmxo7c">
+        <inputEntry id="UnaryTests_1xn32yh">
+          <text>"bar"</text>
+        </inputEntry>
+        <outputEntry id="LiteralExpression_18626pp">
+          <text>"baz"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_1hn9h4g">
+          <text>"bar"</text>
+        </outputEntry>
+      </rule>
       <rule id="DecisionRule_1t96xjw">
         <description>Version 2</description>
         <inputEntry id="UnaryTests_1cidmy0">
@@ -51,6 +71,9 @@
         </inputEntry>
         <outputEntry id="LiteralExpression_1rbbzgc">
           <text>"bar"</text>
+        </outputEntry>
+        <outputEntry id="LiteralExpression_0n7652y">
+          <text>"baz"</text>
         </outputEntry>
       </rule>
     </decisionTable>

--- a/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/DecisionPanel/index.tsx
@@ -34,7 +34,11 @@ const DecisionPanel: React.FC = observer(() => {
   };
 
   return (
-    <Section data-testid="decision-panel" tabIndex={0}>
+    <Section
+      data-testid="decision-panel"
+      aria-label="decision panel"
+      tabIndex={0}
+    >
       {decisionInstance?.state === 'FAILED' && (
         <IncidentBanner data-testid="incident-banner">
           {decisionInstance.errorMessage}

--- a/operate/client/src/App/DecisionInstance/DrdPanel/index.tsx
+++ b/operate/client/src/App/DecisionInstance/DrdPanel/index.tsx
@@ -88,7 +88,7 @@ const DrdPanel: React.FC<Props> = ({children}) => {
 
   return (
     <Container>
-      <Panel data-testid="drd-panel" ref={containerRef}>
+      <Panel data-testid="drd-panel" aria-label="drd panel" ref={containerRef}>
         {children}
       </Panel>
       <Handle ref={handleRef} />

--- a/operate/client/src/App/DecisionInstance/DrdPanel/styled.ts
+++ b/operate/client/src/App/DecisionInstance/DrdPanel/styled.ts
@@ -26,7 +26,7 @@ const Handle = styled.div`
   height: 100%;
 `;
 
-const Panel = styled.div`
+const Panel = styled.section`
   width: 540px;
   border-left: solid 1px var(--cds-border-subtle-01);
   &.resizing {

--- a/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
+++ b/operate/client/src/App/DecisionInstance/VariablesPanel/InputsAndOutputs/index.tsx
@@ -70,7 +70,7 @@ const InputsAndOutputs: React.FC = observer(() => {
         direction={SplitDirection.Horizontal}
         minWidths={[panelMinWidth, panelMinWidth]}
       >
-        <Panel>
+        <Panel aria-label="input variables">
           {status !== 'error' && <Title>Inputs</Title>}
           {status === 'initial' && (
             <Skeleton
@@ -108,7 +108,7 @@ const InputsAndOutputs: React.FC = observer(() => {
             )}
           {status === 'error' && <ErrorMessage />}
         </Panel>
-        <Panel>
+        <Panel aria-label="output variables">
           {status !== 'error' && <Title>Outputs</Title>}
           {status === 'initial' && (
             <Skeleton
@@ -118,15 +118,15 @@ const InputsAndOutputs: React.FC = observer(() => {
           )}
           {status === 'fetched' && decisionInstance?.state !== 'FAILED' && (
             <StructuredList
-              label="Inputs"
+              label="Outputs"
               headerSize="sm"
               isFlush={false}
               headerColumns={outputMappingsColumns}
               rows={
                 decisionInstance?.evaluatedOutputs.map(
-                  ({ruleIndex, name, value}) => {
+                  ({id, ruleId, ruleIndex, name, value}) => {
                     return {
-                      key: ruleIndex.toString(),
+                      key: `${id}--${ruleId}`,
                       columns: [
                         {
                           cellContent: ruleIndex,


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

- Provide a unique key to the rows of `StructuredList` component.
- Add e2e test for decision instance view which covers the bug
- Make other e2e tests more resilient

The reason for the bug was that the key property which was provided to the StructuredList row components. This led to the duplicated rows described in the issue.

## Related issues

closes #17024 
