### PR TITLE
Create incident when type expression is null or empty

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import com.google.common.base.Strings;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
@@ -27,6 +28,7 @@ import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -172,7 +174,19 @@ public final class BpmnJobBehavior {
   }
 
   private Either<Failure, String> evalTypeExp(final Expression type, final long scopeKey) {
-    return expressionBehavior.evaluateStringExpression(type, scopeKey);
+    return expressionBehavior
+        .evaluateStringExpression(type, scopeKey)
+        .flatMap(
+            result ->
+                Strings.isNullOrEmpty(result)
+                    ? Either.left(
+                        new Failure(
+                            String.format(
+                                "Expected result of the expression '%s' to be not empty, but was '%s'.",
+                                type.getExpression(), result),
+                            ErrorType.EXTRACT_VALUE_ERROR,
+                            scopeKey))
+                    : Either.right(result));
   }
 
   private Either<Failure, Long> evalRetriesExp(final Expression retries, final long scopeKey) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -182,8 +182,8 @@ public final class BpmnJobBehavior {
                     ? Either.left(
                         new Failure(
                             String.format(
-                                "Expected result of the expression '%s' to be not empty, but was '%s'.",
-                                type.getExpression(), result),
+                                "Expected result of the expression '%s' to be a not-empty string, but was an empty string.",
+                                type.getExpression()),
                             ErrorType.EXTRACT_VALUE_ERROR,
                             scopeKey))
                     : Either.right(result));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -160,7 +160,8 @@ public class JobWorkerElementIncidentTest {
 
     Assertions.assertThat(incidentCreated.getValue())
         .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
-        .hasErrorMessage("Expected result of the expression '\"\"' to be not empty, but was ''.")
+        .hasErrorMessage(
+            "Expected result of the expression '\"\"' to be a not-empty string, but was an empty string.")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
         .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -139,6 +139,36 @@ public class JobWorkerElementIncidentTest {
   }
 
   @Test
+  public void shouldCreateIncidentIfJobTypeExpressionIsEmptyString() {
+    // given
+    ENGINE.deployment().withXmlResource(process(t -> t.zeebeJobTypeExpression("\"\""))).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var recordThatLeadsToIncident =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(elementBuilder.getElementType())
+            .getFirst();
+
+    // then
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentCreated.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage("Expected result of the expression '\"\"' to be not empty, but was ''.")
+        .hasElementId(TASK_ELEMENT_ID)
+        .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .hasJobKey(-1L)
+        .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
+  }
+
+  @Test
   public void shouldResolveIncidentAfterJobTypeExpressionEvaluationFailed() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeJobTypeExpression("x"))).deploy();


### PR DESCRIPTION
Create incident when type expression is null or empty

## Description

Currently, type expression check happens at a later stage (`DbJobState` -> `makeJobActivatable`) and results in `java.lang.IllegalArgumentException: type must not be empty` if type is empty.
The expected behavior would be to create an incident during activation if the type expression evaluates to a blank string.

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

closes #18139
