### PR TITLE
ci: run optimize commands only for optimize issues

### DIFF
--- a/.github/workflows/optimize-commands-dispatch.yml
+++ b/.github/workflows/optimize-commands-dispatch.yml
@@ -4,6 +4,7 @@ on:
     types: [created]
 jobs:
   optimize-commands-dispatch:
+    if: ${{ contains(github.event.issue.labels.*.name, 'component/optimize') }}
     name: Dispatch Command
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

This PR adds checks for the Optimize commands so they can be only used under component/optimize labeled issues

## Related issues

relates to https://github.com/camunda/camunda-optimize/issues/13888
