### PR TITLE
build: skip backend pre-integration

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -557,6 +557,7 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-failsafe-plugin</artifactId>
             <configuration>
+              <skip>${skipTests}</skip>
               <excludedGroups>${it.test.excludedGroups}</excludedGroups>
               <groups>${it.test.includedGroups}</groups>
               <forkCount>${test.forkCount}</forkCount>
@@ -637,6 +638,9 @@
                 </configuration>
               </execution>
             </executions>
+            <configuration>
+              <skip>${skipTests}</skip>
+            </configuration>
           </plugin>
           <plugin>
             <groupId>org.codehaus.cargo</groupId>
@@ -681,6 +685,7 @@
                   <goal>copy</goal>
                 </goals>
                 <configuration>
+                  <skip>${skipTests}</skip>
                   <artifactItems>
                     <artifactItem>
                       <groupId>io.camunda.optimize</groupId>
@@ -747,6 +752,9 @@
                 </configuration>
               </execution>
             </executions>
+            <configuration>
+                  <skip>${skipTests}</skip>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
## Description
We skip pre-integration tests on the backend maven project to reduce timeouts on the zeebe CI builds.



<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

closes #
