### PR TITLE
Reset RecordingExporter before each ZeebeIntegration test setup

### DIFF
--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/junit/ZeebeIntegrationExtension.java
@@ -27,7 +27,6 @@ import java.util.function.Predicate;
 import org.agrona.CloseHelper;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.BeforeTestExecutionCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ExtensionContext.Namespace;
 import org.junit.jupiter.api.extension.ExtensionContext.Store;
@@ -59,7 +58,7 @@ import org.slf4j.LoggerFactory;
  * <p>See {@link TestZeebe} for annotation parameters.
  */
 final class ZeebeIntegrationExtension
-    implements BeforeAllCallback, BeforeEachCallback, BeforeTestExecutionCallback, TestWatcher {
+    implements BeforeAllCallback, BeforeEachCallback, TestWatcher {
 
   private static final Logger LOG = LoggerFactory.getLogger(ZeebeIntegrationExtension.class);
 
@@ -92,16 +91,13 @@ final class ZeebeIntegrationExtension
         lookupApplications(extensionContext, testInstance, ModifierSupport::isNotStatic);
     manageClusters(extensionContext, clusters);
     manageApplications(extensionContext, nodes);
+
+    RecordingExporter.reset();
   }
 
   @Override
   public void testFailed(final ExtensionContext context, final Throwable cause) {
     RecordLogger.logRecords();
-  }
-
-  @Override
-  public void beforeTestExecution(final ExtensionContext extensionContext) {
-    RecordingExporter.reset();
   }
 
   private Iterable<ClusterResource> lookupClusters(


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

This PR unflakes one (and potentially more) `@ZeebeIntegration` integration test that relied on `RecordingExporter` in the `@BeforeEach` test setup.

In the test setup, we sometimes deploy a process, create a process instance, and await some situation. Typically, we use the `RecordingExporter` to verify that these things happened. It's important that the records recorded by the `RecordingExporter` are specific to this test, because otherwise the assertions might not be specific enough. Additionally, the exporter may not be able to deal with streams of records for "fresh" engines where the position of newly exported records starts from `1` again.

To ensure that the `RecordingExporter` contains only the data from the specific test, we clear the records it recorded using the `RecordingExporter.reset()` method. However, this previously happened only after any user-defined setup methods have been executed for that test. In this case, after `@BeforeEach`.

By moving the `RecordingExporter.reset()` call to before the setup methods, we ensure that the `RecordingExporter` is fresh at the start of the test setup, and that the test setup can use the `RecordingExporter` for assertions about the test setup.

This PR was created together with @ana-vinogradova-camunda @mustafadagher @koevskinikola and @remcowesterhoud during our mob programming session.

## Related issues

closes #17668 
