### PR TITLE
[Backport stable/8.4] Add intermediate throw event `StraightThroughProcessingLoopValidator`

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidator.java
@@ -42,14 +42,19 @@ public final class StraightThroughProcessingLoopValidator {
           BpmnElementType.END_EVENT,
           BpmnElementType.SUB_PROCESS,
           BpmnElementType.MULTI_INSTANCE_BODY,
-          BpmnElementType.CALL_ACTIVITY);
+          BpmnElementType.CALL_ACTIVITY,
+          BpmnElementType.INTERMEDIATE_THROW_EVENT);
 
   /**
    * Loops must contain any of the rejected element types for it to be considered a loop. This makes
    * sure we don't reject deployments containing a loop of just gateways.
    */
   private static final EnumSet<BpmnElementType> REJECTED_ELEMENT_TYPES =
-      EnumSet.of(BpmnElementType.MANUAL_TASK, BpmnElementType.TASK, BpmnElementType.CALL_ACTIVITY);
+      EnumSet.of(
+          BpmnElementType.MANUAL_TASK,
+          BpmnElementType.TASK,
+          BpmnElementType.CALL_ACTIVITY,
+          BpmnElementType.INTERMEDIATE_THROW_EVENT);
 
   /**
    * Validates a list of processes for straight-through processing loops. These are loops of

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/ReachEndOfLogTest.java
@@ -56,8 +56,11 @@ public class ReachEndOfLogTest {
         .withXmlResource(
             Bpmn.createExecutableProcess("process")
                 .startEvent()
-                .intermediateThrowEvent("test")
+                .exclusiveGateway("test")
+                .defaultFlow()
                 .connectTo("test")
+                .sequenceFlowId("sf2")
+                .condition("= false")
                 .endEvent()
                 .done())
         .deploy();


### PR DESCRIPTION
# Description
Backport of #20316 to `stable/8.4`.

relates to #20308
original author: @remcowesterhoud