### PR TITLE
Dont use object mapper in DTO to ES / OS

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.exporter.dto.BulkIndexResponse.Error;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Actions;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Delete;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.DeleteAction;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Phases;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Policy;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyResponse;
@@ -243,7 +244,7 @@ class ElasticsearchClient implements AutoCloseable {
   static PutIndexLifecycleManagementPolicyRequest buildPutIndexLifecycleManagementPolicyRequest(
       final String minimumAge) {
     return new PutIndexLifecycleManagementPolicyRequest(
-        new Policy(new Phases(new Delete(minimumAge, new Actions(new ObjectMapper())))));
+        new Policy(new Phases(new Delete(minimumAge, new Actions(new DeleteAction())))));
   }
 
   private <T> T sendRequest(final Request request, final Class<T> responseType) throws IOException {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyRequest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyRequest.java
@@ -14,5 +14,7 @@ public record PutIndexLifecycleManagementPolicyRequest(Policy policy) {
 
   public record Delete(String min_age, Actions actions) {}
 
-  public record Actions(Object delete) {}
+  public record Actions(DeleteAction delete) {}
+
+  public record DeleteAction() {}
 }

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/OpensearchClient.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyReq
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.IsmTemplate;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.Action;
+import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.DeleteAction;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.Transition;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.Transition.Conditions;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyResponse;
@@ -300,7 +301,7 @@ public class OpensearchClient implements AutoCloseable {
                     ISM_DELETE_STATE, new Conditions(configuration.retention.getMinimumAge()))));
     final var deleteState =
         new State(
-            ISM_DELETE_STATE, List.of(new Action(new ObjectMapper())), Collections.emptyList());
+            ISM_DELETE_STATE, List.of(new Action(new DeleteAction())), Collections.emptyList());
     final var policy =
         new Policy(
             configuration.retention.getPolicyDescription(),

--- a/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/PutIndexStateManagementPolicyRequest.java
+++ b/zeebe/exporters/opensearch-exporter/src/main/java/io/camunda/zeebe/exporter/opensearch/dto/PutIndexStateManagementPolicyRequest.java
@@ -20,7 +20,9 @@ public record PutIndexStateManagementPolicyRequest(Policy policy) {
 
     public record State(String name, List<Action> actions, List<Transition> transitions) {
 
-      public record Action(Object delete) {}
+      public record Action(DeleteAction delete) {}
+
+      public record DeleteAction() {}
 
       public record Transition(
           @JsonProperty("state_name") String stateName, Conditions conditions) {

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestClient.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyReq
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.IsmTemplate;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.Action;
+import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.DeleteAction;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.Transition;
 import io.camunda.zeebe.exporter.opensearch.dto.PutIndexStateManagementPolicyRequest.Policy.State.Transition.Conditions;
 import io.camunda.zeebe.exporter.opensearch.dto.Template;
@@ -157,7 +158,7 @@ final class TestClient implements CloseableSilently {
             List.of(new Transition(ISM_DELETE_STATE, new Conditions(minimumAge))));
     final var deleteState =
         new State(
-            ISM_DELETE_STATE, List.of(new Action(new ObjectMapper())), Collections.emptyList());
+            ISM_DELETE_STATE, List.of(new Action(new DeleteAction())), Collections.emptyList());
     final var policy =
         new Policy(
             config.retention.getPolicyDescription(),


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

Use a record to represent an empty object rather than `new ObjectMapper()` in the DTO used to put the ILM/ISM for Elasticsearch and OpenSearch.

## Related issues

closes #20556 
