### PR TITLE
[Backport stable/8.3] Create incident when type expression is null or empty

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import com.google.common.base.Strings;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
@@ -119,7 +120,19 @@ public final class BpmnJobBehavior {
   }
 
   private Either<Failure, String> evalTypeExp(final Expression type, final long scopeKey) {
-    return expressionBehavior.evaluateStringExpression(type, scopeKey);
+    return expressionBehavior
+        .evaluateStringExpression(type, scopeKey)
+        .flatMap(
+            result ->
+                Strings.isNullOrEmpty(result)
+                    ? Either.left(
+                        new Failure(
+                            String.format(
+                                "Expected result of the expression '%s' to be not empty, but was '%s'.",
+                                type.getExpression(), result),
+                            ErrorType.EXTRACT_VALUE_ERROR,
+                            scopeKey))
+                    : Either.right(result));
   }
 
   private Either<Failure, Long> evalRetriesExp(final Expression retries, final long scopeKey) {

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -139,6 +139,36 @@ public class JobWorkerElementIncidentTest {
   }
 
   @Test
+  public void shouldCreateIncidentIfJobTypeExpressionIsEmptyString() {
+    // given
+    ENGINE.deployment().withXmlResource(process(t -> t.zeebeJobTypeExpression("\"\""))).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var recordThatLeadsToIncident =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(elementBuilder.getElementType())
+            .getFirst();
+
+    // then
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentCreated.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage("Expected result of the expression '\"\"' to be not empty, but was ''.")
+        .hasElementId(TASK_ELEMENT_ID)
+        .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .hasJobKey(-1L)
+        .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
+  }
+
+  @Test
   public void shouldResolveIncidentAfterJobTypeExpressionEvaluationFailed() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeJobTypeExpression("x"))).deploy();


### PR DESCRIPTION
# Description
Backport of #20517 to `stable/8.3`.

relates to #18139
original author: @ana-vinogradova-camunda