### PR TITLE
ci: add easy approximate build duration tracking for observability

### DIFF
--- a/.github/actions/observe-build-status/action.yml
+++ b/.github/actions/observe-build-status/action.yml
@@ -49,11 +49,26 @@ runs:
         exportEnv: false # we rely on step outputs, no need for environment variables
         secrets: |
           secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
+
+    - name: Get build duration in milliseconds
+      id: get-build-duration-millis
+      shell: bash
+      run: |
+        duration=$(expr $(date +'%s') - $(date --reference "$GITHUB_ACTION_PATH" +"%s"))
+
+        # only submit plausible durations below 72 hours
+        if [ $duration -le 259200 ]; then
+          echo "result=$(expr $duration \* 1000)" >> $GITHUB_OUTPUT
+        else
+          echo "result=" >> $GITHUB_OUTPUT
+        fi
+
     - uses: camunda/infra-global-github-actions/submit-build-status@main
       if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
       with:
         job_name_override: "${{ inputs.job_name }}"
         build_status: "${{ inputs.build_status }}"
+        build_duration_millis: "${{ steps.get-build-duration-millis.outputs.result }}"
         user_reason: "${{ inputs.user_reason }}"
         user_description: "${{ inputs.user_description }}"
         gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"


### PR DESCRIPTION
## Description

Current status: the CI Health backend already can store the information about the "build duration" along the build status for each GHA job - but this information is currently not measured nor submitted.

Goal of this PR: 1st iteration on the topic to provide an approximate "build duration" measurement (precision: minutes) that is a quick win.

Idea: having approximate build duration data is already much more valuable than having none in identifying CI runtimes and slow CI jobs on the scale of minutes, e.g. does a job take 10minutes or 20 or even more is helpful to know. This allows checking for [Unified CI timing](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria).

Approach of this PR:

1. take Unix epoch timestamp for approx. start time of a GHA job (done via last modification timestamp of a directory created on `git checkout`)
1. take Unix epoch timestamp for approx. end time of a GHA job (done via taking current time of running the `observe-build-status` action)
1. calculate the difference between both and submit it at the correct granularity of milliseconds (even though the source data is only second/minute-precision)

No visualization yet, just collection for now (automatically in all workflows that use `observe-build-status`):

![image](https://github.com/user-attachments/assets/4d49563d-fac9-43e0-aa29-1010d6ddc4ac)

Relies on https://github.com/camunda/infra-global-github-actions/pull/235 to submit the data.

## Related issues

Related to https://github.com/camunda/camunda/issues/18210
