### PR TITLE
identity test container env clean up

### DIFF
--- a/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/IdentityTester.java
+++ b/tasklist/qa/integration-tests/src/test/java/io/camunda/tasklist/util/IdentityTester.java
@@ -285,6 +285,10 @@ public abstract class IdentityTester extends SessionlessTasklistZeebeIntegration
     Environment.system().remove("ZEEBE_CLIENT_SECRET");
     Environment.system().remove("ZEEBE_TOKEN_AUDIENCE");
     Environment.system().remove("ZEEBE_AUTHORIZATION_SERVER_URL");
+    io.camunda.zeebe.client.impl.util.Environment.system().remove("ZEEBE_CLIENT_ID");
+    io.camunda.zeebe.client.impl.util.Environment.system().remove("ZEEBE_CLIENT_SECRET");
+    io.camunda.zeebe.client.impl.util.Environment.system().remove("ZEEBE_TOKEN_AUDIENCE");
+    io.camunda.zeebe.client.impl.util.Environment.system().remove("ZEEBE_AUTHORIZATION_SERVER_URL");
     testContainerUtil.stopIdentity(testContext);
   }
 }


### PR DESCRIPTION
In similar fashion to the environment setup upon the creation of the Identity Test Container for Tasklist tests, perform the respective cleanup on Test Container termination. 

## Related
PR #20373 
Respective [commit](https://github.com/camunda/camunda/pull/20373/commits/1cbba10c1f51837f394f93f87863dbf16d89a658) 