### PR TITLE
[Backport stable/8.3] Dont use object mapper in DTO to ES / OS

### DIFF
--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchClient.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.exporter.dto.BulkIndexResponse.Error;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Actions;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Delete;
+import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.DeleteAction;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Phases;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyRequest.Policy;
 import io.camunda.zeebe.exporter.dto.PutIndexLifecycleManagementPolicyResponse;
@@ -243,7 +244,7 @@ class ElasticsearchClient implements AutoCloseable {
   static PutIndexLifecycleManagementPolicyRequest buildPutIndexLifecycleManagementPolicyRequest(
       final String minimumAge) {
     return new PutIndexLifecycleManagementPolicyRequest(
-        new Policy(new Phases(new Delete(minimumAge, new Actions(new ObjectMapper())))));
+        new Policy(new Phases(new Delete(minimumAge, new Actions(new DeleteAction())))));
   }
 
   private <T> T sendRequest(final Request request, final Class<T> responseType) throws IOException {

--- a/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyRequest.java
+++ b/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/dto/PutIndexLifecycleManagementPolicyRequest.java
@@ -14,5 +14,7 @@ public record PutIndexLifecycleManagementPolicyRequest(Policy policy) {
 
   public record Delete(String min_age, Actions actions) {}
 
-  public record Actions(Object delete) {}
+  public record Actions(DeleteAction delete) {}
+
+  public record DeleteAction() {}
 }


### PR DESCRIPTION
# Description
Backport of #20560 to `stable/8.3`.

relates to #20556
original author: @korthout