### PR TITLE
[Backport stable/8.2] Create incident when type expression is null or empty

### DIFF
--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
+import com.google.common.base.Strings;
 import io.camunda.zeebe.el.Expression;
 import io.camunda.zeebe.engine.metrics.JobMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
@@ -100,10 +101,27 @@ public final class BpmnJobBehavior {
     jobMetrics.jobCreated(jobProperties.getType());
   }
 
+<<<<<<< HEAD
   private Either<Failure, String> evalTypeExp(
       final JobWorkerProperties jobWorkerProperties, final long scopeKey) {
     final Expression type = jobWorkerProperties.getType();
     return expressionBehavior.evaluateStringExpression(type, scopeKey);
+=======
+  private Either<Failure, String> evalTypeExp(final Expression type, final long scopeKey) {
+    return expressionBehavior
+        .evaluateStringExpression(type, scopeKey)
+        .flatMap(
+            result ->
+                Strings.isNullOrEmpty(result)
+                    ? Either.left(
+                        new Failure(
+                            String.format(
+                                "Expected result of the expression '%s' to be not empty, but was '%s'.",
+                                type.getExpression(), result),
+                            ErrorType.EXTRACT_VALUE_ERROR,
+                            scopeKey))
+                    : Either.right(result));
+>>>>>>> 9a6b43c (fix: backporting the changes)
   }
 
   private Either<Failure, Long> evalRetriesExp(

--- a/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import java.time.ZonedDateTime;
@@ -101,13 +102,9 @@ public final class BpmnJobBehavior {
     jobMetrics.jobCreated(jobProperties.getType());
   }
 
-<<<<<<< HEAD
   private Either<Failure, String> evalTypeExp(
       final JobWorkerProperties jobWorkerProperties, final long scopeKey) {
     final Expression type = jobWorkerProperties.getType();
-    return expressionBehavior.evaluateStringExpression(type, scopeKey);
-=======
-  private Either<Failure, String> evalTypeExp(final Expression type, final long scopeKey) {
     return expressionBehavior
         .evaluateStringExpression(type, scopeKey)
         .flatMap(
@@ -121,7 +118,6 @@ public final class BpmnJobBehavior {
                             ErrorType.EXTRACT_VALUE_ERROR,
                             scopeKey))
                     : Either.right(result));
->>>>>>> 9a6b43c (fix: backporting the changes)
   }
 
   private Either<Failure, Long> evalRetriesExp(

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -156,7 +156,6 @@ public class JobWorkerElementIncidentTest {
         .hasErrorMessage("Expected result of the expression '\"\"' to be not empty, but was ''.")
         .hasElementId(TASK_ELEMENT_ID)
         .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
-        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
         .hasJobKey(-1L)
         .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
   }

--- a/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/JobWorkerElementIncidentTest.java
@@ -132,6 +132,36 @@ public class JobWorkerElementIncidentTest {
   }
 
   @Test
+  public void shouldCreateIncidentIfJobTypeExpressionIsEmptyString() {
+    // given
+    ENGINE.deployment().withXmlResource(process(t -> t.zeebeJobTypeExpression("\"\""))).deploy();
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var recordThatLeadsToIncident =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementType(elementBuilder.getElementType())
+            .getFirst();
+
+    // then
+    final var incidentCreated =
+        RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .getFirst();
+
+    Assertions.assertThat(incidentCreated.getValue())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage("Expected result of the expression '\"\"' to be not empty, but was ''.")
+        .hasElementId(TASK_ELEMENT_ID)
+        .hasElementInstanceKey(recordThatLeadsToIncident.getKey())
+        .hasTenantId(TenantOwned.DEFAULT_TENANT_IDENTIFIER)
+        .hasJobKey(-1L)
+        .hasVariableScopeKey(recordThatLeadsToIncident.getKey());
+  }
+
+  @Test
   public void shouldResolveIncidentAfterJobTypeExpressionEvaluationFailed() {
     // given
     ENGINE.deployment().withXmlResource(process(t -> t.zeebeJobTypeExpression("x"))).deploy();


### PR DESCRIPTION
# Description
Backport of #20561 to `stable/8.2`.

relates to #20517 #18139
original author: @backport-action