### PR TITLE
Migrate intermediate message catch event

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -216,7 +216,7 @@ public class ProcessInstanceMigrationMigrateProcessor
     final long processInstanceKey = elementInstanceRecord.getProcessInstanceKey();
     final var elementId = elementInstanceRecord.getElementId();
 
-    requireSupportedElementType(elementInstanceRecord, processInstanceKey);
+    requireSupportedElementType(elementInstanceRecord, processInstanceKey, sourceProcessDefinition);
 
     final String targetElementId = sourceElementIdToTargetElementId.get(elementId);
     requireNonNullTargetElementId(targetElementId, processInstanceKey, elementId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -39,7 +39,6 @@ import io.camunda.zeebe.engine.state.message.ProcessMessageSubscription;
 import io.camunda.zeebe.msgpack.spec.MsgPackHelper;
 import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
-import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
@@ -425,8 +424,8 @@ public class ProcessInstanceMigrationMigrateProcessor
             // We will migrate this mapped catch event, so we don't want to unsubscribe from it
             // avoid reusing the subscription directly as any access to the state (e.g. #get) will
             // overwrite it
-            final ProcessMessageSubscription copySubscription =
-                copyProcessMessageSubscription(subscription);
+            final var copySubscription = new ProcessMessageSubscription();
+            copySubscription.copyFrom(subscription);
             processMessageSubscriptionsToMigrate.add(copySubscription);
             return false;
           }
@@ -532,18 +531,6 @@ public class ProcessInstanceMigrationMigrateProcessor
           messageSubscription,
           List.of(processMessageSubscriptionRecord.getSubscriptionPartitionId()));
     }
-  }
-
-  private static ProcessMessageSubscription copyProcessMessageSubscription(
-      final ProcessMessageSubscription subscription) {
-    final ProcessMessageSubscription copySubscription = new ProcessMessageSubscription();
-    final ProcessMessageSubscriptionRecord subscriptionRecord =
-        new ProcessMessageSubscriptionRecord();
-    subscriptionRecord.wrap(subscription.getRecord());
-    copySubscription.setRecord(subscriptionRecord);
-    copySubscription.setKey(subscription.getKey());
-    copySubscription.setState(subscription.getState());
-    return copySubscription;
   }
 
   private void appendIncidentMigratedEvent(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -226,13 +226,6 @@ public class ProcessInstanceMigrationMigrateProcessor
         targetProcessDefinition, targetElementId, elementInstance, processInstanceKey);
     requireUnchangedFlowScope(
         elementInstanceState, elementInstanceRecord, targetProcessDefinition, targetElementId);
-    requireNoIntermediateCatchEventInSource(
-        sourceProcessDefinition, elementInstanceRecord, EnumSet.of(BpmnEventType.MESSAGE));
-    requireNoIntermediateCatchEventInTarget(
-        targetProcessDefinition,
-        targetElementId,
-        elementInstanceRecord,
-        EnumSet.of(BpmnEventType.MESSAGE));
     requireNoBoundaryEventInSource(
         sourceProcessDefinition,
         elementInstanceRecord,

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIntermediateCatchEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateIntermediateCatchEventTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.util.Map;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateIntermediateCatchEventTest {
+
+  @Rule public final EngineRule engine = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldWriteMessageSubscriptionMigratedEvent() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .intermediateCatchEvent(
+                        "catch1",
+                        c -> c.message(m -> m.name("msg1").zeebeCorrelationKeyExpression("key1")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .intermediateCatchEvent(
+                        "catch2",
+                        c -> c.message(m -> m.name("msg2").zeebeCorrelationKeyExpression("key2")))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(Map.of("key1", "key1"))
+            .create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("catch1", "catch2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("msg1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("catch2")
+        .describedAs("Expect that the correlation key is not re-evaluated")
+        .hasCorrelationKey("key1");
+
+    Assertions.assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("msg1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the correlation key is not re-evaluated")
+        .hasCorrelationKey("key1");
+  }
+
+  @Test
+  public void shouldCorrelateMessageSubscriptionAfterMigration() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .intermediateCatchEvent(
+                        "catch1",
+                        c -> c.message(m -> m.name("msg1").zeebeCorrelationKeyExpression("key1")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .intermediateCatchEvent(
+                        "catch2",
+                        c -> c.message(m -> m.name("msg2").zeebeCorrelationKeyExpression("key2")))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId(processId)
+            .withVariables(Map.of("key1", "key1"))
+            .create();
+
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // when
+    engine
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("catch1", "catch2")
+        .migrate();
+
+    // then
+    Assertions.assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("msg1")
+                .getFirst())
+        .isNotNull();
+    Assertions.assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.MIGRATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("msg1")
+                .getFirst())
+        .isNotNull();
+
+    engine.message().withName("msg1").withCorrelationKey("key1").publish();
+
+    Assertions.assertThat(
+            RecordingExporter.processMessageSubscriptionRecords(
+                    ProcessMessageSubscriptionIntent.CORRELATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("msg1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasBpmnProcessId(targetProcessId)
+        .hasElementId("catch2")
+        .describedAs("Expect that the correlation key is not re-evaluated")
+        .hasCorrelationKey("key1");
+
+    Assertions.assertThat(
+            RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.CORRELATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withMessageName("msg1")
+                .getFirst()
+                .getValue())
+        .describedAs("Expect that the process definition is updated")
+        .hasBpmnProcessId(targetProcessId)
+        .describedAs("Expect that the correlation key is not re-evaluated")
+        .hasCorrelationKey("key1");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
@@ -12,6 +12,7 @@ import static io.camunda.zeebe.protocol.record.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.engine.util.RecordToWrite;
 import io.camunda.zeebe.model.bpmn.Bpmn;
@@ -20,6 +21,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationMappingInstruction;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceMigrationRecord;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
@@ -29,12 +31,15 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessMessageSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.TimerRecordValue;
 import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import java.time.Duration;
+import org.assertj.core.api.Assertions;
 import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -908,6 +913,139 @@ public class MigrateProcessInstanceConcurrentNoBatchingTest {
             tuple("B_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple("end_v1", ProcessInstanceIntent.ELEMENT_COMPLETED),
             tuple(processId, ProcessInstanceIntent.ELEMENT_COMPLETED));
+  }
+
+  @Test
+  public void shouldRejectMigrationForActiveCatchEventAttachedToEventBasedGateway() {
+    // given
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent()
+                    .eventBasedGateway("A")
+                    .intermediateCatchEvent(
+                        "MSG_1",
+                        e -> e.message(m -> m.name("msg_1").zeebeCorrelationKeyExpression("key")))
+                    .endEvent()
+                    .moveToLastGateway()
+                    .intermediateCatchEvent(
+                        "MSG_2",
+                        e -> e.message(m -> m.name("msg_2").zeebeCorrelationKeyExpression("key")))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .eventBasedGateway("A")
+                    .intermediateCatchEvent(
+                        "MSG_1",
+                        e -> e.message(m -> m.name("msg_1").zeebeCorrelationKeyExpression("key")))
+                    .endEvent()
+                    .moveToLastGateway()
+                    .intermediateCatchEvent(
+                        "MSG_2",
+                        e -> e.message(m -> m.name("msg_2").zeebeCorrelationKeyExpression("key")))
+                    .endEvent()
+                    .moveToLastGateway()
+                    .intermediateCatchEvent(
+                        "MSG_3",
+                        e -> e.message(m -> m.name("msg_3").zeebeCorrelationKeyExpression("key")))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVariable("key", "key1").create();
+
+    final var eventBasedGateway =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId("A")
+            .getFirst();
+
+    // Await until the process instance is fully subscribed to both messages
+    RecordingExporter.processMessageSubscriptionRecords(ProcessMessageSubscriptionIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementInstanceKey(eventBasedGateway.getKey())
+        .skip(1)
+        .await();
+
+    // we generate a key for the intermediate catch event so we can activate it using events
+    final var keyGenerator =
+        ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator();
+    final var intermediateCatchEventKey = keyGenerator.nextKey();
+
+    // we need to stop the engine to ensure events are applied after writing the records directly
+    ENGINE.stop();
+
+    // when the event-based gateway is completed, the intermediate catch event is activated
+    // and the migration is attempted while the intermediate catch event is active
+    ENGINE.writeRecords(
+        RecordToWrite.event()
+            .key(eventBasedGateway.getKey())
+            .processInstance(
+                ProcessInstanceIntent.ELEMENT_COMPLETING, eventBasedGateway.getValue()),
+        RecordToWrite.event()
+            .key(eventBasedGateway.getKey())
+            .processInstance(ProcessInstanceIntent.ELEMENT_COMPLETED, eventBasedGateway.getValue()),
+        RecordToWrite.event()
+            .key(intermediateCatchEventKey)
+            .processInstance(
+                ProcessInstanceIntent.ELEMENT_ACTIVATING,
+                new ProcessInstanceRecord()
+                    .setProcessDefinitionKey(eventBasedGateway.getValue().getProcessDefinitionKey())
+                    .setBpmnProcessId(processId)
+                    .setElementId("MSG_1")
+                    .setBpmnElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+                    .setBpmnEventType(BpmnEventType.MESSAGE)
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setFlowScopeKey(processInstanceKey)),
+        RecordToWrite.event()
+            .key(intermediateCatchEventKey)
+            .processInstance(
+                ProcessInstanceIntent.ELEMENT_ACTIVATED,
+                new ProcessInstanceRecord()
+                    .setProcessDefinitionKey(eventBasedGateway.getValue().getProcessDefinitionKey())
+                    .setBpmnProcessId(processId)
+                    .setElementId("MSG_1")
+                    .setBpmnElementType(BpmnElementType.INTERMEDIATE_CATCH_EVENT)
+                    .setBpmnEventType(BpmnEventType.MESSAGE)
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setFlowScopeKey(processInstanceKey)),
+        RecordToWrite.command()
+            .key(processInstanceKey)
+            .migration(
+                new ProcessInstanceMigrationRecord()
+                    .setProcessInstanceKey(processInstanceKey)
+                    .setTargetProcessDefinitionKey(targetProcessDefinitionKey)
+                    .addMappingInstruction(
+                        new ProcessInstanceMigrationMappingInstruction()
+                            .setSourceElementId("A")
+                            .setTargetElementId("A"))));
+    ENGINE.start();
+
+    // then
+    final var rejection =
+        RecordingExporter.processInstanceMigrationRecords(ProcessInstanceMigrationIntent.MIGRATE)
+            .withProcessInstanceKey(processInstanceKey)
+            .onlyCommandRejections()
+            .getFirst();
+
+    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
+    Assertions.assertThat(rejection.getRejectionReason())
+        .contains(
+            String.format(
+                """
+                Expected to migrate process instance '%s' but active element with id 'MSG_1' \
+                is an intermediate catch event attached to an event-based gateway. \
+                Migrating active events attached to an event-based gateway is not possible yet.""",
+                processInstanceKey));
   }
 
   private static String createMigrationRejectionDueConcurrentModificationReason(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceUnsupportedElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceUnsupportedElementsTest.java
@@ -80,9 +80,9 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
         .contains(
             String.format(
                 """
-      Expected to migrate process instance '%s' \
-      but active element with id '%s' is intermediate catch event of type '%s'. \
-      Migrating active elements with intermediate catch event of these types is not possible yet.""",
+                Expected to migrate process instance '%s' \
+                but active element with id '%s' is intermediate catch event of type '%s'. \
+                Migrating active intermediate catch event of this type is not possible yet.""",
                 processInstanceKey, "timer1", "TIMER"));
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

Allows for the migration of active [intermediate message catch events](https://docs.camunda.io/docs/components/modeler/bpmn/message-events/#intermediate-message-catch-events).

An active intermediate message catch event requires a mapping instruction, just like other active elements.

This explicitly does not yet support the migration of active intermediate message catch events that are attached to an [event-based gateway](https://docs.camunda.io/docs/components/modeler/bpmn/event-based-gateways/). This can could occur when the migration is requested in a race with a message correlation for that same catch event. This case is explicitly rejected for now.

## Related issues

closes #19716 
