### PR TITLE
simplify maven build for optimize

### DIFF
--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Generate production .tar.gz
       uses: ./.github/actions/run-maven
       with:
-        parameters: install -DskipTests -Dskip.docker
+        parameters: install -DskipTests -Dskip.docker -PrunAssembly
 
     - name: Build and push Docker image
       uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5

--- a/optimize-distro/pom.xml
+++ b/optimize-distro/pom.xml
@@ -16,6 +16,7 @@
   <properties>
     <exclude.from.config>OptimizeLicense.txt</exclude.from.config>
     <elasticsearch.demo.version>8.9.0</elasticsearch.demo.version>
+    <assembly.skipAssembly>true</assembly.skipAssembly>
   </properties>
 
   <dependencies>
@@ -36,6 +37,12 @@
       <id>add-license-key</id>
       <properties>
         <exclude.from.config />
+      </properties>
+    </profile>
+    <profile>
+      <id>runAssembly</id>
+      <properties>
+        <assembly.skipAssembly>false</assembly.skipAssembly>
       </properties>
     </profile>
   </profiles>
@@ -145,7 +152,7 @@
               <url>https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${elasticsearch.demo.version}-windows-x86_64.zip</url>
               <unpack>true</unpack>
               <outputDirectory>${project.build.directory}</outputDirectory>
-              <readTimeOut>1200000</readTimeOut>
+              <skip>true</skip>
             </configuration>
           </execution>
         </executions>

--- a/optimize/client/pom.xml
+++ b/optimize/client/pom.xml
@@ -58,7 +58,20 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <!-- skip spotless formatter as client has its own formatter -->
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <configuration>
+            <skip>true</skip>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
+
    <profiles>
     <profile>
       <id>skipFrontendBuild</id>


### PR DESCRIPTION
## Description
This PR skips running spotless on the front-end directory and removes the assembly plugin.
This is needed to make the build run faster and avoid having timeouts
<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

closes #
