### PR TITLE
Elasticsearch metrics now export using micrometer core library.

### DIFF
--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.test;
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Objects;
 import net.jcip.annotations.NotThreadSafe;
 import org.slf4j.Logger;
@@ -26,10 +27,11 @@ public final class ExporterTestContext implements Context {
 
   private Configuration configuration;
   private RecordFilter recordFilter;
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Override
   public MeterRegistry getMeterRegistry() {
-    return null;
+    return meterRegistry;
   }
 
   @Override

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -57,11 +57,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-util</artifactId>
     </dependency>

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -62,6 +62,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchExporter.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.ZoneOffset;
@@ -51,6 +52,7 @@ public class ElasticsearchExporter implements Exporter {
   private ElasticsearchExporterConfiguration configuration;
   private ElasticsearchClient client;
   private ElasticsearchRecordCounters recordCounters;
+  private MeterRegistry registry;
 
   private long lastPosition = -1;
   private boolean indexTemplatesCreated;
@@ -66,6 +68,7 @@ public class ElasticsearchExporter implements Exporter {
 
     context.setFilter(new ElasticsearchRecordFilter(configuration));
     indexTemplatesCreated = false;
+    registry = context.getMeterRegistry();
   }
 
   @Override
@@ -180,7 +183,7 @@ public class ElasticsearchExporter implements Exporter {
 
   // TODO: remove this and instead allow client to be inject-able for testing
   protected ElasticsearchClient createClient() {
-    return new ElasticsearchClient(configuration);
+    return new ElasticsearchClient(configuration, registry);
   }
 
   private void flushAndReschedule() {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.exporter;
 
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import io.prometheus.client.Counter;
 import io.prometheus.client.Gauge;
 import io.prometheus.client.Histogram;
@@ -49,9 +51,11 @@ public class ElasticsearchMetrics {
           .register();
 
   private final String partitionIdLabel;
+  private final MeterRegistry meterRegistry;
 
-  public ElasticsearchMetrics(final int partitionId) {
+  public ElasticsearchMetrics(final int partitionId, final MeterRegistry registry) {
     partitionIdLabel = String.valueOf(partitionId);
+    meterRegistry = registry;
   }
 
   public Histogram.Timer measureFlushDuration() {

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -7,70 +7,71 @@
  */
 package io.camunda.zeebe.exporter;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
-import io.prometheus.client.Counter;
-import io.prometheus.client.Gauge;
-import io.prometheus.client.Histogram;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class ElasticsearchMetrics {
-  private static final String NAMESPACE = "zeebe_elasticsearch_exporter";
+  private static final String NAMESPACE = "zeebe.elasticsearch.exporter";
   private static final String PARTITION_LABEL = "partition";
-
-  private static final Histogram FLUSH_DURATION =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("flush_duration_seconds")
-          .help("Flush duration of bulk exporters in seconds")
-          .labelNames(PARTITION_LABEL)
-          .register();
-
-  private static final Counter FAILED_FLUSH =
-      Counter.build()
-          .namespace(NAMESPACE)
-          .name("failed_flush")
-          .help("Number of failed flush operations")
-          .labelNames(PARTITION_LABEL)
-          .register();
-
-  private static final Histogram BULK_SIZE =
-      Histogram.build()
-          .namespace(NAMESPACE)
-          .name("bulk_size")
-          .help("Exporter bulk size")
-          .buckets(10, 100, 1_000, 10_000, 100_000)
-          .labelNames(PARTITION_LABEL)
-          .register();
-
-  private static final Gauge BULK_MEMORY_SIZE =
-      Gauge.build()
-          .namespace(NAMESPACE)
-          .name("bulk_memory_size")
-          .help("Exporter bulk memory size")
-          .labelNames(PARTITION_LABEL)
-          .register();
 
   private final String partitionIdLabel;
   private final MeterRegistry meterRegistry;
+  private final AtomicInteger BULK_MEMORY_SIZE = new AtomicInteger(0);
+  private final Timer FLUSH_DURATION;
+  private final DistributionSummary BULK_SIZE;
+  private final Counter FAILED_FLUSH;
 
   public ElasticsearchMetrics(final int partitionId, final MeterRegistry registry) {
     partitionIdLabel = String.valueOf(partitionId);
     meterRegistry = registry;
+
+    Gauge.builder(meterName("bulk.memory.size"), BULK_MEMORY_SIZE, AtomicInteger::get)
+        .tags(PARTITION_LABEL, partitionIdLabel)
+        .description("Exporter bulk memory size")
+        .register(meterRegistry);
+
+    FLUSH_DURATION =
+        Timer.builder(meterName("flush.duration.seconds"))
+            .description("Flush duration of bulk exporters in seconds")
+            .tags(PARTITION_LABEL, partitionIdLabel)
+            .publishPercentileHistogram()
+            .register(meterRegistry);
+
+    BULK_SIZE =
+        DistributionSummary.builder(meterName("bulk.size"))
+            .description("Exporter bulk size")
+            .tags(PARTITION_LABEL, partitionIdLabel)
+            .serviceLevelObjectives(10, 100, 1_000, 10_000, 100_000)
+            .register(meterRegistry);
+
+    FAILED_FLUSH =
+        Counter.builder(meterName("failed.flush"))
+            .description("Number of failed flush operations")
+            .tags(PARTITION_LABEL, partitionIdLabel)
+            .register(meterRegistry);
   }
 
-  public Histogram.Timer measureFlushDuration() {
-    return FLUSH_DURATION.labels(partitionIdLabel).startTimer();
+  public void measureFlushDuration(final Runnable flushFunction) {
+    FLUSH_DURATION.record(flushFunction);
   }
 
   public void recordBulkSize(final int bulkSize) {
-    BULK_SIZE.labels(partitionIdLabel).observe(bulkSize);
+    BULK_SIZE.record(bulkSize);
   }
 
   public void recordBulkMemorySize(final int bulkMemorySize) {
-    BULK_MEMORY_SIZE.labels(partitionIdLabel).set(bulkMemorySize);
+    BULK_MEMORY_SIZE.set(bulkMemorySize);
   }
 
   public void recordFailedFlush() {
-    FAILED_FLUSH.labels(partitionIdLabel).inc();
+    FAILED_FLUSH.increment();
+  }
+
+  private String meterName(final String name) {
+    return NAMESPACE + "." + name;
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientIT.java
@@ -17,6 +17,8 @@ import io.camunda.zeebe.exporter.TestClient.IndexTemplatesDto.IndexTemplateWrapp
 import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
@@ -50,6 +52,7 @@ final class ElasticsearchClientIT {
   private final TemplateReader templateReader = new TemplateReader(config);
   private final RecordIndexRouter indexRouter = new RecordIndexRouter(config.index);
   private final BulkIndexRequest bulkRequest = new BulkIndexRequest();
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   private TestClient testClient;
   private ElasticsearchClient client;
@@ -68,7 +71,8 @@ final class ElasticsearchClientIT {
             RestClientFactory.of(config),
             indexRouter,
             templateReader,
-            new ElasticsearchMetrics(PARTITION_ID));
+            null,
+            new SimpleMeterRegistry());
   }
 
   @AfterEach
@@ -156,7 +160,7 @@ final class ElasticsearchClientIT {
 
     // when
     // force recreating the client
-    final var authenticatedClient = new ElasticsearchClient(config, bulkRequest);
+    final var authenticatedClient = new ElasticsearchClient(config, meterRegistry);
     authenticatedClient.putComponentTemplate();
 
     // then

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/ElasticsearchClientTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.exporter.dto.Template;
 import io.camunda.zeebe.protocol.jackson.ZeebeProtocolModule;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.test.broker.protocol.ProtocolFactory;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
@@ -64,7 +65,8 @@ final class ElasticsearchClientTest {
           restClient,
           indexRouter,
           templateReader,
-          new ElasticsearchMetrics(PARTITION_ID));
+          null,
+          new SimpleMeterRegistry());
 
   @ParameterizedTest(name = "{0}")
   @MethodSource("io.camunda.zeebe.exporter.TestSupport#provideValueTypes")


### PR DESCRIPTION
## Description

The metrics for the elastic search exporter now use the micrometer core library so if the consumer of the metrics ever changes from prometheus it would be the work of pointing to the exported metrics.

## Related issues

relates to #18467 
