### PR TITLE
docs: mark client query commands as experimental

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -480,15 +480,9 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * <p>This command is only sent via REST over HTTP, not via gRPC <br>
    * <br>
    *
-   * <p><strong>Experimental: This method is under development, and as such using it may have no
-   * effect on the client builder when called. Until this warning is removed, anything described
-   * below may not yet have taken effect, and the interface and its description are subject to
-   * change.</strong>
-   *
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
   CompleteUserTaskCommandStep1 newUserTaskCompleteCommand(long userTaskKey);
 
   /**
@@ -506,15 +500,9 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * <p>This command is only sent via REST over HTTP, not via gRPC <br>
    * <br>
    *
-   * <p><strong>Experimental: This method is under development, and as such using it may have no
-   * effect on the client builder when called. Until this warning is removed, anything described
-   * below may not yet have taken effect, and the interface and its description are subject to
-   * change.</strong>
-   *
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
   AssignUserTaskCommandStep1 newUserTaskAssignCommand(long userTaskKey);
 
   /**
@@ -532,15 +520,9 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * <p>This command is only sent via REST over HTTP, not via gRPC <br>
    * <br>
    *
-   * <p><strong>Experimental: This method is under development, and as such using it may have no
-   * effect on the client builder when called. Until this warning is removed, anything described
-   * below may not yet have taken effect, and the interface and its description are subject to
-   * change.</strong>
-   *
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
   UpdateUserTaskCommandStep1 newUserTaskUpdateCommand(long userTaskKey);
 
   /**
@@ -557,15 +539,9 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * <p>This command is only sent via REST over HTTP, not via gRPC <br>
    * <br>
    *
-   * <p><strong>Experimental: This method is under development, and as such using it may have no
-   * effect on the client builder when called. Until this warning is removed, anything described
-   * below may not yet have taken effect, and the interface and its description are subject to
-   * change.</strong>
-   *
    * @param userTaskKey the key of the user task
    * @return a builder for the command
    */
-  @ExperimentalApi("https://github.com/camunda/camunda/issues/16166")
   UnassignUserTaskCommandStep1 newUserTaskUnassignCommand(long userTaskKey);
 
   /**
@@ -582,7 +558,14 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    *  .send();
    * </pre>
    *
+   * <p><strong>Experimental: This method is under development, and as such using it may have no
+   * effect on the client builder when called. The respective API on compatible clusters is not
+   * enabled by default. Thus, this method doesn't work out of the box with all clusters. Until this
+   * warning is removed, anything described below may not yet have taken effect, and the interface
+   * and its description are subject to change.</strong>
+   *
    * @return a builder for the process instance query
    */
+  @ExperimentalApi("https://github.com/camunda/camunda/issues/20596")
   ProcessInstanceQuery newProcessInstanceQuery();
 }


### PR DESCRIPTION
## Description

Marks the query command for process instance search as experimental in the Java client because the related API is disabled by default. Thus, the method is not yet intended for general use and can be subject to change.

## Related issues

closes #20596 