### PR TITLE
ci: run opened issues automation only for optimize issues

### DIFF
--- a/.github/workflows/optimize-opened-issues-automation.yml
+++ b/.github/workflows/optimize-opened-issues-automation.yml
@@ -6,6 +6,7 @@ jobs:
   optimize-opened-issues-automation:
     name: Opened Issues Automation
     runs-on: ubuntu-latest
+    if: contains(github.event.issue.labels.*.name, 'component/optimize')
     steps:
       - name: Create variables
         id: vars


### PR DESCRIPTION
## Description

These changes are adding a condition to optimize opened issues workflow, to run it only against issues with `component/optimize` label 

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

relates to https://github.com/camunda/camunda-optimize/issues/13888

