### PR TITLE
refactor: add missing junit extension

### DIFF
--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDynamicConfigTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterDynamicConfigTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.greaterThan;
 
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.camunda.zeebe.test.util.junit.AutoCloseResources.AutoCloseResource;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
@@ -18,6 +19,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@ZeebeIntegration
 final class ExporterDynamicConfigTest {
 
   @TestZeebe private final TestStandaloneBroker zeebe = new TestStandaloneBroker();


### PR DESCRIPTION
## Description

I honestly have no idea how this was working, but this adds the missing JUnit extension declaration for this class.
