### PR TITLE
Fix Snyk scanning action for Zeebe

### DIFF
--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -152,7 +152,7 @@ jobs:
           # To avoid exiting on the first failure, we instead flip this to 1 as soon as one of the
           # command fails, and return this at the end; anything non 0 will cause the step to fail
           exitCode=0
-          JAVA_PROJECTS=(bom zeebe/bpmn-model clients/java zeebe/exporter-api zeebe/gateway-protocol-impl zeebe/protocol)
+          JAVA_PROJECTS=(bom clients/java spring-boot-starter-camunda-sdk zeebe/bpmn-model zeebe/exporter-api zeebe/gateway-protocol-impl zeebe/protocol)
 
           # Remember that when called from a sub-shell, the environment/globals are different
           function output() {

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -152,7 +152,7 @@ jobs:
           # To avoid exiting on the first failure, we instead flip this to 1 as soon as one of the
           # command fails, and return this at the end; anything non 0 will cause the step to fail
           exitCode=0
-          JAVA_PROJECTS=(bom bpmn-model clients/java exporter-api gateway-protocol-impl protocol)
+          JAVA_PROJECTS=(bom zeebe/bpmn-model clients/java zeebe/exporter-api zeebe/gateway-protocol-impl zeebe/protocol)
 
           # Remember that when called from a sub-shell, the environment/globals are different
           function output() {

--- a/.github/workflows/zeebe-snyk.yml
+++ b/.github/workflows/zeebe-snyk.yml
@@ -161,6 +161,14 @@ jobs:
             [ "${sarif}" == 'true' ] && echo "--sarif-file-output=sarif-results/${name}.sarif"
           }
 
+          function ensureExists() {
+            local projectFile="$1"
+            if [ ! -f "${projectFile}" ]; then
+              echo "Cannot find project file to scan: [ ${projectFile} ]"
+              exit 1
+            fi
+          }
+
           # Print out command if debug logging is enabled
           set -x
 
@@ -170,16 +178,19 @@ jobs:
           # Since the snyk CLI here pass the command as a string, any parenthesis will break the eval
           # call. As such, we need to double escape the `--project-name` in single quotes
           PROJECT_NAME="zeebe(${TARGET}):clients/go/go.mod"
+          ensureExists "clients/go/go.mod"
           snyk "${SNYK_COMMAND}" --file=clients/go/go.mod "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" 'go')" || exitCode=1
 
           for project in "${JAVA_PROJECTS[@]}"; do
             PROJECT_NAME="zeebe(${TARGET}):${project}/pom.xml"
+            ensureExists "${project}/pom.xml"
             snyk "${SNYK_COMMAND}" --file=${project}/pom.xml "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" "${project/\//-}")" || exitCode=1
           done
 
           # The `container` command does not yet support setting a target reference, as this is a beta
           # feature at the moment. It's added here anyway for now, and hopefully support will come soon.
           PROJECT_NAME="zeebe(${TARGET}):Dockerfile"
+          ensureExists "Dockerfile"
           snyk container "${SNYK_COMMAND}" "${DOCKER_IMAGE}" --file=Dockerfile "'--project-name=${PROJECT_NAME}'" ${SNYK_ARGS} "$(output "${SARIF}" 'docker')" || exitCode=1
 
           # Only fail if we entirely failed to parse the projects


### PR DESCRIPTION
## Description

Fixes the scanning of Snyk modules for Zeebe, which was broken after we moved the modules around. This also adds a check to fail the action if the project file is not found.

It also adds the Spring SDK to the scanned modules since we also want to make sure we have no vulnerabilities there.

## Related issues

closes #20011
