### PR TITLE
ci: remove reduntant spring-boot-maven-plugin config

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -740,9 +740,6 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-        <configuration>
-          <wait>1000</wait>
-        </configuration>
         <executions>
           <execution>
             <id>build-info</id>


### PR DESCRIPTION
This change was originally made to fix a workflow that could not complete in time.
Now such a workflow is succeeding without the need for this.
The affected workflow was `Operate E2E Tests / test (pull_request)` (note: it will not trigger in this PR)