### PR TITLE
ci: undo Optimize workarounds in Tasklist and Operate WFs

### DIFF
--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Build backend
         # Currently, the e2e environment of operate conflicts with the optimize build. For the moment,
         # we're excluding optimize from the build, not to impact this operate's workflow.
-        run: mvn clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true -pl '!optimize,!optimize-distro,!optimize/client,!optimize/upgrade,!optimize/backend,!optimize/util,!optimize/util/dependency-doc-creation,!optimize/util/optimize-commons,!optimize/plugins,!optimize/plugins/plugin,!optimize/plugins/optimize-test-plugins/optimize-main-test-plugin,!optimize/plugins/optimize-test-plugins/optimize-pluginloading-test-plugin'
+        run: mvn clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Operate
         run: mvn -q -B spring-boot:start -pl dist -Dspring-boot.run.fork=true -Dspring-boot.run.main-class=io.camunda.application.StandaloneOperate
         env:

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Build backend
         # Currently, the e2e environment of tasklist conflicts with the optimize build. For the moment,
         # we're excluding optimize from the build, not to impact this tasklist's workflow.
-        run: mvn clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true -pl '!optimize,!optimize-distro,!optimize/client,!optimize/upgrade,!optimize/backend,!optimize/util,!optimize/util/dependency-doc-creation,!optimize/util/optimize-commons,!optimize/plugins,!optimize/plugins/plugin,!optimize/plugins/optimize-test-plugins/optimize-main-test-plugin,!optimize/plugins/optimize-test-plugins/optimize-pluginloading-test-plugin'
+        run: mvn clean install -T1C -DskipChecks -P -docker,skipFrontendBuild -DskipTests=true -B -DskipRemoteStaging=true -Dmaven.deploy.skip=true
       - name: Start Tasklist
         run: mvn -q -B spring-boot:start -pl dist -Dspring-boot.run.main-class=io.camunda.application.StandaloneTasklist -Dspring-boot.run.fork=true -Dspring-boot.run.profiles=e2e-test -Dspring-boot.run.arguments="--camunda.tasklist.cloud.clusterId=449ac2ad-d3c6-4c73-9c68-7752e39ae616 --camunda.tasklist.csrfPreventionEnabled=false"
       - name: Python setup


### PR DESCRIPTION
## Description

As the option `-DskipTests` has been extended to work within Optimize too and we removed the `optimize/qa` module, nothing clashes with the Tasklist and Operate workflows. Hence, the workaround that excluded Optimize from those builds can be removed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
