### PR TITLE
feat: improve import performance for treePathCache

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
+++ b/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
@@ -24,7 +24,7 @@ public class DatabaseInfo implements ApplicationContextAware {
   private static ApplicationContext applicationContext;
   private static DatabaseType current;
 
-  public static DatabaseType getCurrent() {
+  public static synchronized DatabaseType getCurrent() {
     if (current == null) {
       if (applicationContext == null) {
         LOGGER.warn("getCurrent() called on DatabaseInfo before application context has been set");

--- a/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
+++ b/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
@@ -24,6 +24,9 @@ public class DatabaseInfo implements ApplicationContextAware {
   private static ApplicationContext applicationContext;
   private static DatabaseType current;
 
+  @edu.umd.cs.findbugs.annotations.SuppressFBWarnings(
+      value = "LI_LAZY_INIT_STATIC",
+      justification = "We want to avoid the fight for a lock on this method.")
   public static DatabaseType getCurrent() {
     if (current == null) {
       if (applicationContext == null) {

--- a/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
+++ b/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
@@ -24,7 +24,7 @@ public class DatabaseInfo implements ApplicationContextAware {
   private static ApplicationContext applicationContext;
   private static DatabaseType current;
 
-  public static synchronized DatabaseType getCurrent() {
+  public static DatabaseType getCurrent() {
     if (current == null) {
       if (applicationContext == null) {
         LOGGER.warn("getCurrent() called on DatabaseInfo before application context has been set");

--- a/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
+++ b/operate/common/src/main/java/io/camunda/operate/conditions/DatabaseInfo.java
@@ -22,18 +22,21 @@ public class DatabaseInfo implements ApplicationContextAware {
   static final DatabaseType DEFAULT_DATABASE = DatabaseType.Elasticsearch;
   private static final Logger LOGGER = LoggerFactory.getLogger(DatabaseInfo.class);
   private static ApplicationContext applicationContext;
+  private static DatabaseType current;
 
   public static DatabaseType getCurrent() {
-    if (applicationContext == null) {
-      LOGGER.warn("getCurrent() called on DatabaseInfo before application context has been set");
-      return DEFAULT_DATABASE;
+    if (current == null) {
+      if (applicationContext == null) {
+        LOGGER.warn("getCurrent() called on DatabaseInfo before application context has been set");
+        return DEFAULT_DATABASE;
+      }
+      final var code = applicationContext.getEnvironment().getProperty(DATABASE_PROPERTY);
+      current = DatabaseType.byCode(code).orElse(DEFAULT_DATABASE);
     }
-
-    final var code = applicationContext.getEnvironment().getProperty(DATABASE_PROPERTY);
-    return DatabaseType.byCode(code).orElse(DEFAULT_DATABASE);
+    return current;
   }
 
-  public static boolean isCurrent(DatabaseType databaseType) {
+  public static boolean isCurrent(final DatabaseType databaseType) {
     return databaseType == getCurrent();
   }
 
@@ -56,7 +59,8 @@ public class DatabaseInfo implements ApplicationContextAware {
   }
 
   @Override
-  public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+  public void setApplicationContext(final ApplicationContext applicationContext)
+      throws BeansException {
     DatabaseInfo.applicationContext = applicationContext;
   }
 }

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
 import io.camunda.operate.util.SoftHashMap;
+import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -50,13 +51,21 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   @Autowired protected FlowNodeStore flowNodeStore;
   @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   @Autowired private OperateProperties operateProperties;
+  @Autowired private PartitionHolder partitionHolder;
 
   // treePath by flowNodeInstanceKey cache
-  private Map<String, String> treePathCache;
+  private final Map<Integer, Map<String, String>> treePathCaches = new HashMap<>();
 
   @PostConstruct
   private void init() {
-    treePathCache = new SoftHashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize());
+    partitionHolder
+        .getPartitionIds()
+        .forEach(
+            partitionId -> {
+              treePathCaches.put(
+                  partitionId,
+                  new SoftHashMap(operateProperties.getImporter().getFlowNodeTreeCacheSize()));
+            });
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)
@@ -201,19 +210,15 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   private String getParentTreePath(
       final Record record, final ProcessInstanceRecordValue recordValue) {
     String parentTreePath;
+    final var partitionCache = treePathCaches.get(record.getPartitionId());
     // if scopeKey differs from processInstanceKey, then it's inner tree level and we need to search
     // for parent 1st
     if (recordValue.getFlowScopeKey() == recordValue.getProcessInstanceKey()) {
       parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());
     } else {
       // find parent flow node instance
-      parentTreePath = null;
-      // search in cache
-      if (treePathCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()))
-          != null) {
-        parentTreePath =
-            treePathCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()));
-      }
+      parentTreePath =
+          partitionCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()));
       // query from ELS
       if (parentTreePath == null) {
         parentTreePath = flowNodeStore.findParentTreePathFor(recordValue.getFlowScopeKey());
@@ -229,7 +234,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
         parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());
       }
     }
-    treePathCache.put(
+    partitionCache.put(
         ConversionUtils.toStringOrNull(record.getKey()),
         String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
     return parentTreePath;

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -21,7 +21,6 @@ import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
 import io.camunda.operate.util.SoftHashMap;
-import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -51,21 +50,13 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   @Autowired protected FlowNodeStore flowNodeStore;
   @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   @Autowired private OperateProperties operateProperties;
-  @Autowired private PartitionHolder partitionHolder;
 
   // treePath by flowNodeInstanceKey cache
-  private final Map<Integer, Map<String, String>> treePathCaches = new HashMap<>();
+  private Map<String, String> treePathCache;
 
   @PostConstruct
   private void init() {
-    partitionHolder
-        .getPartitionIds()
-        .forEach(
-            partitionId -> {
-              treePathCaches.put(
-                  partitionId,
-                  new SoftHashMap(operateProperties.getImporter().getFlowNodeTreeCacheSize()));
-            });
+    treePathCache = new SoftHashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize());
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)
@@ -210,7 +201,6 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   private String getParentTreePath(
       final Record record, final ProcessInstanceRecordValue recordValue) {
     String parentTreePath;
-    final var partitionCache = treePathCaches.get(record.getPartitionId());
     // if scopeKey differs from processInstanceKey, then it's inner tree level and we need to search
     // for parent 1st
     if (recordValue.getFlowScopeKey() == recordValue.getProcessInstanceKey()) {
@@ -218,7 +208,8 @@ public class FlowNodeInstanceZeebeRecordProcessor {
     } else {
       // find parent flow node instance
       parentTreePath =
-          partitionCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()));
+          treePathCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()));
+
       // query from ELS
       if (parentTreePath == null) {
         parentTreePath = flowNodeStore.findParentTreePathFor(recordValue.getFlowScopeKey());
@@ -234,7 +225,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
         parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());
       }
     }
-    partitionCache.put(
+    treePathCache.put(
         ConversionUtils.toStringOrNull(record.getKey()),
         String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
     return parentTreePath;


### PR DESCRIPTION
## Description

* Cache `DatabaseType` in `DatabaseInfo`
* Avoid double lookup for treePath
* This PR does not contain `treePathCache` per partition. That raises test issues, therefore this comes in another PR.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #20031 , #20027 , #20076 
