### PR TITLE
test: increase assertion timeout duration to reduce the chances of flakiness in ProcessInstanceAssertTest

### DIFF
--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -57,7 +57,7 @@ public class ProcessInstanceAssertTest {
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
     CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofMillis(100));
+    CamundaAssert.setAssertionTimeout(Duration.ofMillis(200));
   }
 
   @AfterEach


### PR DESCRIPTION
## Description

`shouldFailIfActive` verifies the assertion is at least retried one more time. If the test runner is too slow this retry might not happen before timeout. Increasing the assertion timeout here should reduce the chances of this flakiness

More details could be found [here](https://github.com/camunda/camunda/issues/20486#issuecomment-2258269429) 

## Related issues

closes #20486
