### PR TITLE
refactor: remove superficial Eithers from REST API

### DIFF
--- a/zeebe/gateway-rest/pom.xml
+++ b/zeebe/gateway-rest/pom.xml
@@ -132,11 +132,6 @@
 
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>identity-common</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.camunda</groupId>
       <artifactId>camunda-authentication</artifactId>
       <scope>test</scope>
     </dependency>

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -12,15 +12,11 @@ import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.valida
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateAssignmentRequest;
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateUpdateRequest;
 
-import io.camunda.identity.automation.usermanagement.CamundaGroup;
-import io.camunda.identity.automation.usermanagement.CamundaUserWithPassword;
 import io.camunda.service.JobServices.ActivateJobsRequest;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.security.auth.Authentication.Builder;
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
 import io.camunda.zeebe.auth.impl.Authorization;
-import io.camunda.zeebe.gateway.protocol.rest.CamundaGroupRequest;
-import io.camunda.zeebe.gateway.protocol.rest.CamundaUserWithPasswordRequest;
 import io.camunda.zeebe.gateway.protocol.rest.Changeset;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobErrorRequest;
@@ -32,6 +28,7 @@ import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -40,14 +37,13 @@ import org.springframework.http.ResponseEntity;
 
 public class RequestMapper {
 
-  public static Either<ProblemDetail, CompleteUserTaskRequest> toUserTaskCompletionRequest(
+  public static CompleteUserTaskRequest toUserTaskCompletionRequest(
       final UserTaskCompletionRequest completionRequest, final long userTaskKey) {
 
-    return Either.right(
-        new CompleteUserTaskRequest(
-            userTaskKey,
-            getMapOrEmpty(completionRequest, UserTaskCompletionRequest::getVariables),
-            getStringOrEmpty(completionRequest, UserTaskCompletionRequest::getAction)));
+    return new CompleteUserTaskRequest(
+        userTaskKey,
+        getMapOrEmpty(completionRequest, UserTaskCompletionRequest::getVariables),
+        getStringOrEmpty(completionRequest, UserTaskCompletionRequest::getAction));
   }
 
   public static Either<ProblemDetail, AssignUserTaskRequest> toUserTaskAssignmentRequest(
@@ -59,84 +55,71 @@ public class RequestMapper {
     final boolean allowOverride =
         assignmentRequest.getAllowOverride() == null || assignmentRequest.getAllowOverride();
 
-    return validateAssignmentRequest(assignmentRequest)
-        .<Either<ProblemDetail, AssignUserTaskRequest>>map(Either::left)
-        .orElseGet(
-            () ->
-                Either.right(
-                    new AssignUserTaskRequest(
-                        userTaskKey,
-                        assignmentRequest.getAssignee(),
-                        actionValue.isBlank() ? "assign" : actionValue,
-                        allowOverride)));
+    return getResult(
+        validateAssignmentRequest(assignmentRequest),
+        () ->
+            new AssignUserTaskRequest(
+                userTaskKey,
+                assignmentRequest.getAssignee(),
+                actionValue.isBlank() ? "assign" : actionValue,
+                allowOverride));
   }
 
-  public static Either<ProblemDetail, AssignUserTaskRequest> toUserTaskUnassignmentRequest(
-      final long userTaskKey) {
-    return Either.right(new AssignUserTaskRequest(userTaskKey, "", "unassign", true));
+  public static AssignUserTaskRequest toUserTaskUnassignmentRequest(final long userTaskKey) {
+    return new AssignUserTaskRequest(userTaskKey, "", "unassign", true);
   }
 
   public static Either<ProblemDetail, UpdateUserTaskRequest> toUserTaskUpdateRequest(
       final UserTaskUpdateRequest updateRequest, final long userTaskKey) {
 
-    return validateUpdateRequest(updateRequest)
-        .<Either<ProblemDetail, UpdateUserTaskRequest>>map(Either::left)
-        .orElseGet(
-            () ->
-                Either.right(
-                    new UpdateUserTaskRequest(
-                        userTaskKey,
-                        getRecordWithChangedAttributes(updateRequest),
-                        getStringOrEmpty(updateRequest, UserTaskUpdateRequest::getAction))));
+    return getResult(
+        validateUpdateRequest(updateRequest),
+        () ->
+            new UpdateUserTaskRequest(
+                userTaskKey,
+                getRecordWithChangedAttributes(updateRequest),
+                getStringOrEmpty(updateRequest, UserTaskUpdateRequest::getAction)));
   }
 
   public static Either<ProblemDetail, ActivateJobsRequest> toJobsActivationRequest(
       final JobActivationRequest activationRequest) {
 
-    final var validationErrorResponse = validateJobActivationRequest(activationRequest);
-    return validationErrorResponse
-        .<Either<ProblemDetail, ActivateJobsRequest>>map(Either::left)
-        .orElseGet(
-            () ->
-                Either.right(
-                    new ActivateJobsRequest(
-                        activationRequest.getType(),
-                        activationRequest.getMaxJobsToActivate(),
-                        getStringListOrEmpty(activationRequest, JobActivationRequest::getTenantIds),
-                        activationRequest.getTimeout(),
-                        getStringOrEmpty(activationRequest, JobActivationRequest::getWorker),
-                        getStringListOrEmpty(
-                            activationRequest, JobActivationRequest::getFetchVariable),
-                        getLongOrZero(
-                            activationRequest, JobActivationRequest::getRequestTimeout))));
+    return getResult(
+        validateJobActivationRequest(activationRequest),
+        () ->
+            new ActivateJobsRequest(
+                activationRequest.getType(),
+                activationRequest.getMaxJobsToActivate(),
+                getStringListOrEmpty(activationRequest, JobActivationRequest::getTenantIds),
+                activationRequest.getTimeout(),
+                getStringOrEmpty(activationRequest, JobActivationRequest::getWorker),
+                getStringListOrEmpty(activationRequest, JobActivationRequest::getFetchVariable),
+                getLongOrZero(activationRequest, JobActivationRequest::getRequestTimeout)));
   }
 
-  public static Either<ProblemDetail, FailJobRequest> toJobFailRequest(
+  public static FailJobRequest toJobFailRequest(
       final JobFailRequest failRequest, final long jobKey) {
 
-    return Either.right(
-        new FailJobRequest(
-            jobKey,
-            getIntOrZero(failRequest, JobFailRequest::getRetries),
-            getStringOrEmpty(failRequest, JobFailRequest::getErrorMessage),
-            getLongOrZero(failRequest, JobFailRequest::getRetryBackOff),
-            getMapOrEmpty(failRequest, JobFailRequest::getVariables)));
+    return new FailJobRequest(
+        jobKey,
+        getIntOrZero(failRequest, JobFailRequest::getRetries),
+        getStringOrEmpty(failRequest, JobFailRequest::getErrorMessage),
+        getLongOrZero(failRequest, JobFailRequest::getRetryBackOff),
+        getMapOrEmpty(failRequest, JobFailRequest::getVariables));
   }
 
   public static Either<ProblemDetail, ErrorJobRequest> toJobErrorRequest(
       final JobErrorRequest errorRequest, final long jobKey) {
 
     final var validationErrorResponse = validateJobErrorRequest(errorRequest);
-    return validationErrorResponse
-        .<Either<ProblemDetail, ErrorJobRequest>>map(Either::left)
-        .orElseGet(
-            () ->
-                Either.right(
-                    new ErrorJobRequest(
-                        jobKey,
-                        errorRequest.getErrorCode(),
-                        getStringOrEmpty(errorRequest, JobErrorRequest::getErrorMessage),
-                        getMapOrEmpty(errorRequest, JobErrorRequest::getVariables))));
+    return getResult(
+        validationErrorResponse,
+        () ->
+            new ErrorJobRequest(
+                jobKey,
+                errorRequest.getErrorCode(),
+                getStringOrEmpty(errorRequest, JobErrorRequest::getErrorMessage),
+                getMapOrEmpty(errorRequest, JobErrorRequest::getVariables)));
   }
 
   public static CompletableFuture<ResponseEntity<Object>> executeServiceMethod(
@@ -149,7 +132,7 @@ public class RequestMapper {
                     .orElseGet(result));
   }
 
-  public static CompletableFuture<ResponseEntity<Object>> executeServiceMethodWithNoContenResult(
+  public static CompletableFuture<ResponseEntity<Object>> executeServiceMethodWithNoContentResult(
       final Supplier<CompletableFuture<?>> method) {
     return RequestMapper.executeServiceMethod(method, () -> ResponseEntity.noContent().build());
   }
@@ -165,6 +148,13 @@ public class RequestMapper {
             .withClaim(Authorization.AUTHORIZED_TENANTS, authorizedTenants)
             .encode();
     return new Builder().token(token).tenants(authorizedTenants).build();
+  }
+
+  public static <T> Either<ProblemDetail, T> getResult(
+      final Optional<ProblemDetail> error, final Supplier<T> resultSupplier) {
+    return error
+        .<Either<ProblemDetail, T>>map(Either::left)
+        .orElseGet(() -> Either.right(resultSupplier.get()));
   }
 
   private static UserTaskRecord getRecordWithChangedAttributes(
@@ -187,24 +177,6 @@ public class RequestMapper {
       record.setFollowUpDate(changeset.getFollowUpDate()).setFollowUpDateChanged();
     }
     return record;
-  }
-
-  public static CamundaUserWithPassword toUserWithPassword(
-      final CamundaUserWithPasswordRequest dto) {
-    final CamundaUserWithPassword camundaUserWithPassword = new CamundaUserWithPassword();
-
-    camundaUserWithPassword.setId(dto.getId());
-    camundaUserWithPassword.setUsername(dto.getUsername());
-    camundaUserWithPassword.setPassword(dto.getPassword());
-    camundaUserWithPassword.setName(dto.getName());
-    camundaUserWithPassword.setEmail(dto.getEmail());
-    camundaUserWithPassword.setEnabled(dto.getEnabled());
-
-    return camundaUserWithPassword;
-  }
-
-  public static CamundaGroup toGroup(final CamundaGroupRequest groupRequest) {
-    return new CamundaGroup(groupRequest.getId(), groupRequest.getName());
   }
 
   private static <R> Map<String, Object> getMapOrEmpty(
@@ -235,20 +207,20 @@ public class RequestMapper {
   }
 
   public record CompleteUserTaskRequest(
-      long userTaskKey, Map<String, Object> variables, String action) {}
+      final long userTaskKey, final Map<String, Object> variables, final String action) {}
 
-  public record UpdateUserTaskRequest(long userTaskKey, UserTaskRecord changeset, String action) {}
+  public record UpdateUserTaskRequest(final long userTaskKey, final UserTaskRecord changeset, final String action) {}
 
   public record AssignUserTaskRequest(
-      long userTaskKey, String assignee, String action, boolean allowOverride) {}
+      final long userTaskKey, final String assignee, final String action, final boolean allowOverride) {}
 
   public record FailJobRequest(
-      long jobKey,
-      int retries,
-      String errorMessage,
-      Long retryBackoff,
-      Map<String, Object> variables) {}
+      final long jobKey,
+      final int retries,
+      final String errorMessage,
+      final Long retryBackoff,
+      final Map<String, Object> variables) {}
 
   public record ErrorJobRequest(
-      long jobKey, String errorCode, String errorMessage, Map<String, Object> variables) {}
+      final long jobKey, final String errorCode, final String errorMessage, final Map<String, Object> variables) {}
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -207,20 +207,20 @@ public class RequestMapper {
   }
 
   public record CompleteUserTaskRequest(
-      final long userTaskKey, final Map<String, Object> variables, final String action) {}
+      long userTaskKey, Map<String, Object> variables, String action) {}
 
-  public record UpdateUserTaskRequest(final long userTaskKey, final UserTaskRecord changeset, final String action) {}
+  public record UpdateUserTaskRequest(long userTaskKey, UserTaskRecord changeset, String action) {}
 
   public record AssignUserTaskRequest(
-      final long userTaskKey, final String assignee, final String action, final boolean allowOverride) {}
+      long userTaskKey, String assignee, String action, boolean allowOverride) {}
 
   public record FailJobRequest(
-      final long jobKey,
-      final int retries,
-      final String errorMessage,
-      final Long retryBackoff,
-      final Map<String, Object> variables) {}
+      long jobKey,
+      int retries,
+      String errorMessage,
+      Long retryBackoff,
+      Map<String, Object> variables) {}
 
   public record ErrorJobRequest(
-      final long jobKey, final String errorCode, final String errorMessage, final Map<String, Object> variables) {}
+      long jobKey, String errorCode, String errorMessage, Map<String, Object> variables) {}
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/ResponseMapper.java
@@ -9,12 +9,8 @@ package io.camunda.zeebe.gateway.rest;
 
 import static io.camunda.zeebe.util.buffer.BufferUtil.bufferAsString;
 
-import io.camunda.identity.automation.usermanagement.CamundaGroup;
-import io.camunda.identity.automation.usermanagement.CamundaUser;
 import io.camunda.zeebe.gateway.impl.job.JobActivationResult;
 import io.camunda.zeebe.gateway.protocol.rest.ActivatedJob;
-import io.camunda.zeebe.gateway.protocol.rest.CamundaGroupResponse;
-import io.camunda.zeebe.gateway.protocol.rest.CamundaUserResponse;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.msgpack.value.LongValue;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -58,24 +54,6 @@ public final class ResponseMapper {
         .variables(job.getVariables())
         .customHeaders(job.getCustomHeadersObjectMap())
         .tenantId(job.getTenantId());
-  }
-
-  public static CamundaUserResponse toUserResponse(final CamundaUser camundaUser) {
-    final CamundaUserResponse camundaUserDto = new CamundaUserResponse();
-    camundaUserDto.setId(camundaUser.getId());
-    camundaUserDto.setUsername(camundaUser.getUsername());
-    camundaUserDto.setName(camundaUser.getName());
-    camundaUserDto.setEmail(camundaUser.getEmail());
-    camundaUserDto.setEnabled(camundaUser.isEnabled());
-
-    return camundaUserDto;
-  }
-
-  public static CamundaGroupResponse toGroupResponse(final CamundaGroup group) {
-    final CamundaGroupResponse camundaGroupResponse = new CamundaGroupResponse();
-    camundaGroupResponse.setId(group.id());
-    camundaGroupResponse.setName(group.name());
-    return camundaGroupResponse;
   }
 
   static class RestJobActivationResult implements JobActivationResult<JobActivationResponse> {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -58,8 +58,7 @@ public class JobController {
   public CompletableFuture<ResponseEntity<Object>> failureJob(
       @PathVariable final long jobKey,
       @RequestBody(required = false) final JobFailRequest failureRequest) {
-    return RequestMapper.toJobFailRequest(failureRequest, jobKey)
-        .fold(this::failJob, RestErrorMapper::mapProblemToCompletedResponse);
+    return failJob(RequestMapper.toJobFailRequest(failureRequest, jobKey));
   }
 
   @PostMapping(
@@ -86,7 +85,7 @@ public class JobController {
   }
 
   private CompletableFuture<ResponseEntity<Object>> failJob(final FailJobRequest failJobRequest) {
-    return RequestMapper.executeServiceMethodWithNoContenResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             jobServices
                 .withAuthentication(RequestMapper.getAuthentication())
@@ -100,7 +99,7 @@ public class JobController {
 
   private CompletableFuture<ResponseEntity<Object>> errorJob(
       final ErrorJobRequest errorJobRequest) {
-    return RequestMapper.executeServiceMethodWithNoContenResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             jobServices
                 .withAuthentication(RequestMapper.getAuthentication())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -46,8 +46,8 @@ public class UserTaskController {
       @PathVariable final long userTaskKey,
       @RequestBody(required = false) final UserTaskCompletionRequest completionRequest) {
 
-    return RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey)
-        .fold(this::completeUserTask, RestErrorMapper::mapProblemToCompletedResponse);
+    return completeUserTask(
+        RequestMapper.toUserTaskCompletionRequest(completionRequest, userTaskKey));
   }
 
   @PostMapping(
@@ -66,8 +66,7 @@ public class UserTaskController {
   public CompletableFuture<ResponseEntity<Object>> unassignUserTask(
       @PathVariable final long userTaskKey) {
 
-    return RequestMapper.toUserTaskUnassignmentRequest(userTaskKey)
-        .fold(this::unassignUserTask, RestErrorMapper::mapProblemToCompletedResponse);
+    return unassignUserTask(RequestMapper.toUserTaskUnassignmentRequest(userTaskKey));
   }
 
   @PatchMapping(
@@ -84,7 +83,7 @@ public class UserTaskController {
 
   private CompletableFuture<ResponseEntity<Object>> assignUserTask(
       final AssignUserTaskRequest request) {
-    return RequestMapper.executeServiceMethodWithNoContenResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices
                 .withAuthentication(RequestMapper.getAuthentication())
@@ -97,7 +96,7 @@ public class UserTaskController {
 
   private CompletableFuture<ResponseEntity<Object>> completeUserTask(
       final CompleteUserTaskRequest request) {
-    return RequestMapper.executeServiceMethodWithNoContenResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices
                 .withAuthentication(RequestMapper.getAuthentication())
@@ -106,7 +105,7 @@ public class UserTaskController {
 
   private CompletableFuture<ResponseEntity<Object>> unassignUserTask(
       final AssignUserTaskRequest request) {
-    return RequestMapper.executeServiceMethodWithNoContenResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices
                 .withAuthentication(RequestMapper.getAuthentication())
@@ -115,7 +114,7 @@ public class UserTaskController {
 
   private CompletableFuture<ResponseEntity<Object>> updateUserTask(
       final UpdateUserTaskRequest request) {
-    return RequestMapper.executeServiceMethodWithNoContenResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             userTaskServices
                 .withAuthentication(RequestMapper.getAuthentication())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -18,4 +18,7 @@ public final class ErrorMessages {
   public static final String ERROR_MESSAGE_EMPTY_ATTRIBUTE = "No %s provided";
   public static final String ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE =
       "The value for %s is '%s' but must be %s";
+  public static final String ERROR_SORT_FIELD_MUST_NOT_BE_NULL = "Sort field must not be null";
+  public static final String ERROR_UNKNOWN_SORT_BY = "Unknown sortBy: %s";
+  public static final String ERROR_UNKNOWN_SORT_ORDER = "Unknown sortOrder: %s";
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -278,7 +278,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
             """
         {
           "type": "about:blank",
-          "title": "Bad Request",
+          "title": "INVALID_ARGUMENT",
           "status": 400,
           "detail": "Unknown sortBy: unknownField.",
           "instance": "%s"

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -280,7 +280,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
           "type": "about:blank",
           "title": "Bad Request",
           "status": 400,
-          "detail": "Unknown sortBy: unknownField",
+          "detail": "Unknown sortBy: unknownField.",
           "instance": "%s"
         }""",
             DECISION_DEFINITIONS_SEARCH_URL);

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -186,7 +186,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             """
         {
           "type": "about:blank",
-          "title": "Bad Request",
+          "title": "INVALID_ARGUMENT",
           "status": 400,
           "detail": "Unknown sortOrder: dsc.",
           "instance": "%s"
@@ -228,7 +228,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             """
         {
           "type": "about:blank",
-          "title": "Bad Request",
+          "title": "INVALID_ARGUMENT",
           "status": 400,
           "detail": "Unknown sortBy: tenantId.",
           "instance": "%s"
@@ -269,7 +269,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
             """
         {
           "type": "about:blank",
-          "title": "Bad Request",
+          "title": "INVALID_ARGUMENT",
           "status": 400,
           "detail": "Sort field must not be null.",
           "instance": "%s"

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -188,7 +188,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           "type": "about:blank",
           "title": "Bad Request",
           "status": 400,
-          "detail": "Unknown sortOrder: dsc",
+          "detail": "Unknown sortOrder: dsc.",
           "instance": "%s"
         }""",
             PROCESS_INSTANCES_SEARCH_URL);
@@ -230,7 +230,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           "type": "about:blank",
           "title": "Bad Request",
           "status": 400,
-          "detail": "Unknown sortBy: tenantId",
+          "detail": "Unknown sortBy: tenantId.",
           "instance": "%s"
         }""",
             PROCESS_INSTANCES_SEARCH_URL);
@@ -271,7 +271,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           "type": "about:blank",
           "title": "Bad Request",
           "status": 400,
-          "detail": "Sort field must not be null",
+          "detail": "Sort field must not be null.",
           "instance": "%s"
         }""",
             PROCESS_INSTANCES_SEARCH_URL);


### PR DESCRIPTION
## Description

* Removes Either types that don't serve any function to make the code easier to understand.
* Extracts error messages into the dedicated class for consistency and builds error responses
  consistently for search requests as well.
* Removes unused methods from the REST mappers for cleaner code.

## Related issues

n/a
