### PR TITLE
feat: resolve deployment-bound resource links

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -82,6 +82,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
         new EventTriggerBehavior(
             processingState.getKeyGenerator(), catchEventBehavior, writers, processingState);
 
+    stateBehavior = new BpmnStateBehavior(processingState, variableBehavior);
+
     bpmnDecisionBehavior =
         new BpmnDecisionBehavior(
             decisionBehavior,
@@ -89,9 +91,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
             eventTriggerBehavior,
             writers.state(),
             processingState.getKeyGenerator(),
-            expressionBehavior);
-
-    stateBehavior = new BpmnStateBehavior(processingState, variableBehavior);
+            expressionBehavior,
+            stateBehavior);
 
     stateTransitionGuard = new ProcessInstanceStateTransitionGuard(stateBehavior);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -16,8 +16,10 @@ import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableCalledDecision;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.state.deployment.PersistedDecision;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
@@ -38,6 +40,7 @@ public final class BpmnDecisionBehavior {
   private final StateWriter stateWriter;
   private final KeyGenerator keyGenerator;
   private final ExpressionProcessor expressionBehavior;
+  private final BpmnStateBehavior stateBehavior;
 
   public BpmnDecisionBehavior(
       final DecisionBehavior decisionBehavior,
@@ -45,7 +48,8 @@ public final class BpmnDecisionBehavior {
       final EventTriggerBehavior eventTriggerBehavior,
       final StateWriter stateWriter,
       final KeyGenerator keyGenerator,
-      final ExpressionProcessor expressionBehavior) {
+      final ExpressionProcessor expressionBehavior,
+      final BpmnStateBehavior stateBehavior) {
 
     variableState = processingState.getVariableState();
     this.decisionBehavior = decisionBehavior;
@@ -53,6 +57,7 @@ public final class BpmnDecisionBehavior {
     this.stateWriter = stateWriter;
     this.keyGenerator = keyGenerator;
     this.expressionBehavior = expressionBehavior;
+    this.stateBehavior = stateBehavior;
   }
 
   /**
@@ -73,10 +78,10 @@ public final class BpmnDecisionBehavior {
 
     final var decisionId = decisionIdOrFailure.get();
     final var decisionOrFailure =
-        decisionBehavior.findDecisionByIdAndTenant(decisionId, context.getTenantId());
+        findDecisionByIdAndBindingType(decisionId, element.getBindingType(), context);
     final Either<Failure, ParsedDecisionRequirementsGraph> drgOrFailure =
         decisionOrFailure
-            .flatMap(decision -> decisionBehavior.findParsedDrgByDecision(decision))
+            .flatMap(decisionBehavior::findParsedDrgByDecision)
             // any failures above have the same error type and the correct scope
             // decisions invoked by business rule tasks have a different error type
             .mapLeft(
@@ -117,6 +122,31 @@ public final class BpmnDecisionBehavior {
         });
 
     return resultOrFailure;
+  }
+
+  private Either<Failure, PersistedDecision> findDecisionByIdAndBindingType(
+      final String decisionId,
+      final ZeebeBindingType bindingType,
+      final BpmnElementContext context) {
+    return switch (bindingType) {
+      case deployment -> getDecisionVersionInSameDeployment(decisionId, context);
+      case latest -> getLatestDecisionVersion(decisionId, context.getTenantId());
+    };
+  }
+
+  private Either<Failure, PersistedDecision> getDecisionVersionInSameDeployment(
+      final String decisionId, final BpmnElementContext context) {
+    return stateBehavior
+        .getDeploymentKey(context.getProcessDefinitionKey(), context.getTenantId())
+        .flatMap(
+            deploymentKey ->
+                decisionBehavior.findDecisionByIdAndDeploymentKeyAndTenant(
+                    decisionId, deploymentKey, context.getTenantId()));
+  }
+
+  private Either<Failure, PersistedDecision> getLatestDecisionVersion(
+      final String decisionId, final String tenantId) {
+    return decisionBehavior.findLatestDecisionByIdAndTenant(decisionId, tenantId);
   }
 
   private Either<Failure, String> evalDecisionIdExpression(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -87,7 +87,6 @@ public final class BpmnJobBehavior {
   public Either<Failure, JobProperties> evaluateJobExpressions(
       final JobWorkerProperties jobWorkerProps, final BpmnElementContext context) {
     final var scopeKey = context.getElementInstanceKey();
-    final var tenantId = context.getTenantId();
     return Either.<Failure, JobProperties>right(new JobProperties())
         .flatMap(p -> evalTypeExp(jobWorkerProps.getType(), scopeKey).map(p::type))
         .flatMap(p -> evalRetriesExp(jobWorkerProps.getRetries(), scopeKey).map(p::retries))
@@ -123,7 +122,10 @@ public final class BpmnJobBehavior {
             p ->
                 userTaskBehavior
                     .evaluateFormIdExpressionToFormKey(
-                        jobWorkerProps.getFormId(), scopeKey, tenantId)
+                        jobWorkerProps.getFormId(),
+                        scopeKey,
+                        jobWorkerProps.getBindingType(),
+                        context)
                     .map(key -> Objects.toString(key, null))
                     .map(p::formKey));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -140,6 +140,13 @@ public final class BpmnStateBehavior {
     return Optional.ofNullable(process);
   }
 
+  public Optional<DeployedProcess> getProcessByProcessIdAndDeploymentKey(
+      final DirectBuffer processId, final long deploymentKey, final String tenantId) {
+    final var process =
+        processState.getProcessByProcessIdAndDeploymentKey(processId, deploymentKey, tenantId);
+    return Optional.ofNullable(process);
+  }
+
   public Optional<ElementInstance> getCalledChildInstance(final BpmnElementContext context) {
     final var elementInstance = getElementInstance(context);
     final var calledChildInstanceKey = elementInstance.getCalledChildInstanceKey();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
 import io.camunda.zeebe.engine.processing.bpmn.BpmnElementContext;
 import io.camunda.zeebe.engine.processing.bpmn.BpmnProcessingException;
+import io.camunda.zeebe.engine.processing.common.Failure;
 import io.camunda.zeebe.engine.processing.deployment.model.element.ExecutableEndEvent;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 import io.camunda.zeebe.engine.state.deployment.DeployedProcess;
@@ -19,6 +20,7 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.state.immutable.VariableState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.util.Either;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -145,6 +147,22 @@ public final class BpmnStateBehavior {
     final var process =
         processState.getProcessByProcessIdAndDeploymentKey(processId, deploymentKey, tenantId);
     return Optional.ofNullable(process);
+  }
+
+  public Either<Failure, Long> getDeploymentKey(
+      final long processDefinitionKey, final String tenantId) {
+    return getProcess(processDefinitionKey, tenantId)
+        .map(DeployedProcess::getDeploymentKey)
+        .<Either<Failure, Long>>map(Either::right)
+        .orElseGet(
+            () ->
+                // should actually never happen if deployed process was persisted correctly, but
+                // just in case
+                Either.left(
+                    new Failure(
+                        String.format(
+                            "Expected to find deployment key for process definition key %s and tenant %s, but not found.",
+                            processDefinitionKey, tenantId))));
   }
 
   public Optional<ElementInstance> getCalledChildInstance(final BpmnElementContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.engine.state.immutable.FormState;
 import io.camunda.zeebe.engine.state.immutable.UserTaskState.LifecycleState;
 import io.camunda.zeebe.engine.state.instance.ElementInstance;
 import io.camunda.zeebe.engine.state.mutable.MutableUserTaskState;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
@@ -32,7 +33,6 @@ import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +73,6 @@ public final class BpmnUserTaskBehavior {
       final ExecutableUserTask element, final BpmnElementContext context) {
     final var userTaskProps = element.getUserTaskProperties();
     final var scopeKey = context.getElementInstanceKey();
-    final var tenantId = context.getTenantId();
     return Either.<Failure, UserTaskProperties>right(new UserTaskProperties())
         .flatMap(
             p -> evaluateAssigneeExpression(userTaskProps.getAssignee(), scopeKey).map(p::assignee))
@@ -92,7 +91,11 @@ public final class BpmnUserTaskBehavior {
                     .map(p::followUpDate))
         .flatMap(
             p ->
-                evaluateFormIdExpressionToFormKey(userTaskProps.getFormId(), scopeKey, tenantId)
+                evaluateFormIdExpressionToFormKey(
+                        userTaskProps.getFormId(),
+                        scopeKey,
+                        userTaskProps.getBindingType(),
+                        context)
                     .map(p::formKey))
         .flatMap(
             p ->
@@ -168,7 +171,10 @@ public final class BpmnUserTaskBehavior {
   }
 
   public Either<Failure, Long> evaluateFormIdExpressionToFormKey(
-      final Expression formIdExpression, final long scopeKey, final String tenantId) {
+      final Expression formIdExpression,
+      final long scopeKey,
+      final ZeebeBindingType bindingType,
+      final BpmnElementContext context) {
     if (formIdExpression == null) {
       return Either.right(null);
     }
@@ -176,24 +182,60 @@ public final class BpmnUserTaskBehavior {
         .evaluateStringExpression(formIdExpression, scopeKey)
         .flatMap(
             formId -> {
-              final Optional<PersistedForm> latestFormById =
-                  formState.findLatestFormById(wrapString(formId), tenantId);
-              return latestFormById
-                  .<Either<Failure, Long>>map(
-                      persistedForm -> Either.right(persistedForm.getFormKey()))
-                  .orElseGet(
-                      () ->
-                          Either.left(
-                              new Failure(
-                                  String.format(
-                                      "Expected to find a form with id '%s',"
-                                          + " but no form with this id is found,"
-                                          + " at least a form with this id should be available."
-                                          + " To resolve the Incident please deploy a form with the same id",
-                                      formId),
-                                  ErrorType.FORM_NOT_FOUND,
-                                  scopeKey)));
+              final var form = findFormByIdAndBindingType(formId, bindingType, context, scopeKey);
+              return form.map(PersistedForm::getFormKey);
             });
+  }
+
+  private Either<Failure, PersistedForm> findFormByIdAndBindingType(
+      final String formId,
+      final ZeebeBindingType bindingType,
+      final BpmnElementContext context,
+      final long scopeKey) {
+    return switch (bindingType) {
+      case deployment -> findFormByIdInSameDeployment(formId, context, scopeKey);
+      case latest -> findLatestFormById(formId, context.getTenantId(), scopeKey);
+    };
+  }
+
+  private Either<Failure, PersistedForm> findFormByIdInSameDeployment(
+      final String formId, final BpmnElementContext context, final long scopeKey) {
+    return stateBehavior
+        .getDeploymentKey(context.getProcessDefinitionKey(), context.getTenantId())
+        .flatMap(
+            deploymentKey ->
+                formState
+                    .findFormByIdAndDeploymentKey(
+                        wrapString(formId), deploymentKey, context.getTenantId())
+                    .<Either<Failure, PersistedForm>>map(Either::right)
+                    .orElseGet(
+                        () ->
+                            Either.left(
+                                new Failure(
+                                    String.format(
+                                        "Expected to find a form with id '%s' in deployment %s, but not found.",
+                                        formId, deploymentKey),
+                                    ErrorType.FORM_NOT_FOUND,
+                                    scopeKey))));
+  }
+
+  private Either<Failure, PersistedForm> findLatestFormById(
+      final String formId, final String tenantId, final long scopeKey) {
+    return formState
+        .findLatestFormById(wrapString(formId), tenantId)
+        .<Either<Failure, PersistedForm>>map(Either::right)
+        .orElseGet(
+            () ->
+                Either.left(
+                    new Failure(
+                        String.format(
+                            "Expected to find a form with id '%s',"
+                                + " but no form with this id is found,"
+                                + " at least a form with this id should be available."
+                                + " To resolve the Incident please deploy a form with the same id",
+                            formId),
+                        ErrorType.FORM_NOT_FOUND,
+                        scopeKey)));
   }
 
   public Either<Failure, String> evaluateExternalFormReferenceExpression(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -213,7 +213,12 @@ public final class BpmnUserTaskBehavior {
                             Either.left(
                                 new Failure(
                                     String.format(
-                                        "Expected to find a form with id '%s' in deployment %s, but not found.",
+                                        """
+                                        Expected to use a form with id '%s' with binding type 'deployment', \
+                                        but no such form found in the deployment with key %s which contained the current process. \
+                                        To resolve this incident, migrate the process instance to a process definition \
+                                        that is deployed together with the intended form to use.\
+                                        """,
                                         formId, deploymentKey),
                                     ErrorType.FORM_NOT_FOUND,
                                     scopeKey))));

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -224,7 +224,12 @@ public final class CallActivityProcessor
                             Either.left(
                                 new Failure(
                                     String.format(
-                                        "Expected process with BPMN process id '%s' to be deployed with deployment %s, but not found.",
+                                        """
+                                        Expected to call process with BPMN process id '%s' with binding type 'deployment', \
+                                        but no such process found in the deployment with key %s which contained the current process. \
+                                        To resolve this incident, migrate the process instance to a process definition \
+                                        that is deployed together with the intended process definition to call.\
+                                        """,
                                         BufferUtil.bufferAsString(processId), deploymentKey),
                                     ErrorType.CALLED_ELEMENT_ERROR))));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -50,12 +50,24 @@ public class DecisionBehavior {
     this.metrics = metrics;
   }
 
-  public Either<Failure, PersistedDecision> findDecisionByIdAndTenant(
+  public Either<Failure, PersistedDecision> findLatestDecisionByIdAndTenant(
       final String decisionId, final String tenantId) {
     return Either.ofOptional(
             decisionState.findLatestDecisionByIdAndTenant(
                 BufferUtil.wrapString(decisionId), tenantId))
         .orElse(new Failure("no decision found for id '%s'".formatted(decisionId)))
+        .mapLeft(failure -> formatDecisionLookupFailure(failure, decisionId));
+  }
+
+  public Either<Failure, PersistedDecision> findDecisionByIdAndDeploymentKeyAndTenant(
+      final String decisionId, final long deploymentKey, final String tenantId) {
+    return Either.ofOptional(
+            decisionState.findDecisionByIdAndDeploymentKey(
+                tenantId, BufferUtil.wrapString(decisionId), deploymentKey))
+        .orElse(
+            new Failure(
+                "no decision found for id '%s' in deployment %s"
+                    .formatted(decisionId, deploymentKey)))
         .mapLeft(failure -> formatDecisionLookupFailure(failure, decisionId));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -66,9 +66,13 @@ public class DecisionBehavior {
                 tenantId, BufferUtil.wrapString(decisionId), deploymentKey))
         .orElse(
             new Failure(
-                "no decision found for id '%s' in deployment %s"
-                    .formatted(decisionId, deploymentKey)))
-        .mapLeft(failure -> formatDecisionLookupFailure(failure, decisionId));
+                """
+                Expected to evaluate decision '%s' with binding type 'deployment', \
+                but no such decision found in the deployment with key %s which contained the current process. \
+                To resolve this incident, migrate the process instance to a process definition \
+                that is deployed together with the intended decision to evaluate.\
+                """
+                    .formatted(decisionId, deploymentKey)));
   }
 
   public Either<Failure, PersistedDecision> findDecisionByKeyAndTenant(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
@@ -8,12 +8,14 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 
 public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
     implements ExecutableCalledDecision {
 
   private Expression decisionId;
   private String resultVariable;
+  private ZeebeBindingType bindingType;
 
   public ExecutableBusinessRuleTask(final String id) {
     super(id);
@@ -37,5 +39,15 @@ public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
   @Override
   public void setResultVariable(final String resultVariable) {
     this.resultVariable = resultVariable;
+  }
+
+  @Override
+  public ZeebeBindingType getBindingType() {
+    return bindingType;
+  }
+
+  @Override
+  public void setBindingType(final ZeebeBindingType bindingType) {
+    this.bindingType = bindingType;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 
 public class ExecutableCallActivity extends ExecutableActivity {
 
@@ -21,6 +22,8 @@ public class ExecutableCallActivity extends ExecutableActivity {
    * Call Activity IDs in all the processes in one BPMN deployment resource.
    */
   private int lexicographicIndex;
+
+  private ZeebeBindingType bindingType;
 
   public ExecutableCallActivity(final String id) {
     super(id);
@@ -58,5 +61,13 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   public void setLexicographicIndex(final int index) {
     lexicographicIndex = index;
+  }
+
+  public ZeebeBindingType getBindingType() {
+    return bindingType;
+  }
+
+  public void setBindingType(final ZeebeBindingType bindingType) {
+    this.bindingType = bindingType;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 
 /** A representation of an element that calls a decision. For example, a business rule task. */
 public interface ExecutableCalledDecision {
@@ -19,4 +20,8 @@ public interface ExecutableCalledDecision {
   String getResultVariable();
 
   void setResultVariable(String resultVariable);
+
+  ZeebeBindingType getBindingType();
+
+  void setBindingType(ZeebeBindingType bindingType);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/UserTaskProperties.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/UserTaskProperties.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.deployment.model.element;
 
 import io.camunda.zeebe.el.Expression;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import java.util.Map;
 
 /** The properties of a user task element. */
@@ -21,6 +22,7 @@ public class UserTaskProperties {
   private Expression followUpDate;
   private Expression formId;
   private Map<String, String> taskHeaders = Map.of();
+  private ZeebeBindingType bindingType;
 
   public Expression getAssignee() {
     return assignee;
@@ -86,6 +88,14 @@ public class UserTaskProperties {
     this.taskHeaders = taskHeaders;
   }
 
+  public ZeebeBindingType getBindingType() {
+    return bindingType;
+  }
+
+  public void setBindingType(final ZeebeBindingType bindingType) {
+    this.bindingType = bindingType;
+  }
+
   public void wrap(final UserTaskProperties userTaskProperties) {
     setAssignee(userTaskProperties.getAssignee());
     setCandidateGroups(userTaskProperties.getCandidateGroups());
@@ -95,5 +105,6 @@ public class UserTaskProperties {
     setFollowUpDate(userTaskProperties.getFollowUpDate());
     setFormId(userTaskProperties.getFormId());
     setTaskHeaders(userTaskProperties.getTaskHeaders());
+    setBindingType(userTaskProperties.getBindingType());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
@@ -32,11 +32,11 @@ public final class CallActivityTransformer implements ModelElementTransformer<Ca
     final ExecutableCallActivity callActivity =
         process.getElementById(element.getId(), ExecutableCallActivity.class);
 
-    transformProcessId(element, callActivity, context.getExpressionLanguage());
+    transformCalledElement(element, callActivity, context.getExpressionLanguage());
     transformLexicographicIndex(element, context.getProcesses(), callActivity);
   }
 
-  private void transformProcessId(
+  private void transformCalledElement(
       final CallActivity element,
       final ExecutableCallActivity callActivity,
       final ExpressionLanguage expressionLanguage) {
@@ -56,6 +56,9 @@ public final class CallActivityTransformer implements ModelElementTransformer<Ca
     final var propagateAllParentVariablesEnabled =
         calledElement.isPropagateAllParentVariablesEnabled();
     callActivity.setPropagateAllParentVariablesEnabled(propagateAllParentVariablesEnabled);
+
+    final var bindingType = calledElement.getBindingType();
+    callActivity.setBindingType(bindingType);
   }
 
   private static void transformLexicographicIndex(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -58,6 +58,7 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     transformTaskSchedule(element, userTaskProperties);
     transformTaskFormId(element, userTaskProperties);
     transformModelTaskHeaders(element, userTaskProperties);
+    transformBindingType(element, userTaskProperties);
 
     if (isZeebeUserTask) {
       transformExternalReference(element, userTaskProperties);
@@ -241,6 +242,16 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
           userTaskProperties.setExternalFormReference(externalReferenceExpression);
         }
       }
+    }
+  }
+
+  private void transformBindingType(
+      final UserTask element, final UserTaskProperties userTaskProperties) {
+    final ZeebeFormDefinition formDefinition =
+        element.getSingleExtensionElement(ZeebeFormDefinition.class);
+
+    if (formDefinition != null) {
+      userTaskProperties.setBindingType(formDefinition.getBindingType());
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
@@ -30,5 +30,8 @@ public final class CalledDecisionTransformer {
 
     final var resultVariable = calledDecision.getResultVariable();
     executableElement.setResultVariable(resultVariable);
+
+    final var bindingType = calledDecision.getBindingType();
+    executableElement.setBindingType(bindingType);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/dmn/DecisionEvaluationEvaluteProcessor.java
@@ -93,7 +93,7 @@ public class DecisionEvaluationEvaluteProcessor
     final long decisionKey = record.getDecisionKey();
 
     if (!decisionId.isEmpty()) {
-      return decisionBehavior.findDecisionByIdAndTenant(decisionId, record.getTenantId());
+      return decisionBehavior.findLatestDecisionByIdAndTenant(decisionId, record.getTenantId());
       // TODO: expand DecisionState API to find decisions by ID AND VERSION (#11230)
     } else if (decisionKey > -1L) {
       return decisionBehavior.findDecisionByKeyAndTenant(decisionKey, record.getTenantId());

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.CallActivityBuilder;
 import io.camunda.zeebe.model.bpmn.builder.ServiceTaskBuilder;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RejectionType;
@@ -127,14 +128,21 @@ public final class CallActivityTest {
   }
 
   @Test
-  public void shouldCreateInstanceOfLatestVersionOfCalledElement() {
+  public void shouldCreateInstanceOfLatestVersionOfCalledElementIfBindingTypeNotSet() {
     // given
-    final var processChildV2 =
+    final var parentProcess = parentProcess(CallActivityBuilder::done);
+    final var childProcessV1 =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v1").endEvent().done();
+    final var childProcessV2 =
         Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v2").endEvent().done();
-
-    final var secondDeployment =
-        ENGINE.deployment().withXmlResource("wf-child.bpmn", processChildV2).deploy();
-    final var secondVersion = secondDeployment.getValue().getProcessesMetadata().get(0);
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-parent.bpmn", parentProcess)
+        .withXmlResource("wf-child.bpmn", childProcessV1)
+        .deploy();
+    final var deployment =
+        ENGINE.deployment().withXmlResource("wf-child.bpmn", childProcessV2).deploy();
+    final var latestDeployedVersion = deployment.getValue().getProcessesMetadata().getFirst();
 
     // when
     final var processInstanceKey =
@@ -142,8 +150,68 @@ public final class CallActivityTest {
 
     // then
     Assertions.assertThat(getChildInstanceOf(processInstanceKey))
-        .hasVersion(secondVersion.getVersion())
-        .hasProcessDefinitionKey(secondVersion.getProcessDefinitionKey());
+        .hasVersion(latestDeployedVersion.getVersion())
+        .hasProcessDefinitionKey(latestDeployedVersion.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldCreateInstanceOfLatestVersionOfCalledElementForBindingTypeLatest() {
+    // given
+    final var parentProcess =
+        parentProcess(builder -> builder.zeebeBindingType(ZeebeBindingType.latest));
+    final var childProcessV1 =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v1").endEvent().done();
+    final var childProcessV2 =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v2").endEvent().done();
+    ENGINE
+        .deployment()
+        .withXmlResource("wf-parent.bpmn", parentProcess)
+        .withXmlResource("wf-child.bpmn", childProcessV1)
+        .deploy();
+    final var deployment =
+        ENGINE.deployment().withXmlResource("wf-child.bpmn", childProcessV2).deploy();
+    final var latestDeployedVersion = deployment.getValue().getProcessesMetadata().getFirst();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID_PARENT).create();
+
+    // then
+    Assertions.assertThat(getChildInstanceOf(processInstanceKey))
+        .hasVersion(latestDeployedVersion.getVersion())
+        .hasProcessDefinitionKey(latestDeployedVersion.getProcessDefinitionKey());
+  }
+
+  @Test
+  public void shouldCreateInstanceOfVersionInSameDeploymentForBindingTypeDeployment() {
+    // given
+    final var parentProcess =
+        parentProcess(builder -> builder.zeebeBindingType(ZeebeBindingType.deployment));
+    final var childProcessV1 =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v1").endEvent().done();
+    final var childProcessV2 =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v2").endEvent().done();
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource("wf-parent.bpmn", parentProcess)
+            .withXmlResource("wf-child.bpmn", childProcessV1)
+            .deploy();
+    final var versionInSameDeployment =
+        deployment.getValue().getProcessesMetadata().stream()
+            .filter(metadata -> PROCESS_ID_CHILD.equals(metadata.getBpmnProcessId()))
+            .findFirst()
+            .orElseThrow();
+    ENGINE.deployment().withXmlResource("wf-child.bpmn", childProcessV2).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID_PARENT).create();
+
+    // then
+    Assertions.assertThat(getChildInstanceOf(processInstanceKey))
+        .hasVersion(versionInSameDeployment.getVersion())
+        .hasProcessDefinitionKey(versionInSameDeployment.getProcessDefinitionKey());
   }
 
   @Test
@@ -471,6 +539,46 @@ public final class CallActivityTest {
     // then
     Assertions.assertThat(getChildInstanceOf(processInstanceKey))
         .hasBpmnProcessId(PROCESS_ID_CHILD);
+  }
+
+  @Test
+  public void shouldCreateInstanceOfCalledElementWithExpressionAndBindingTypeDeployment() {
+    // given
+    final var childProcessV1 =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v1").endEvent().done();
+    final var childProcessV2 =
+        Bpmn.createExecutableProcess(PROCESS_ID_CHILD).startEvent("v2").endEvent().done();
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                "wf-parent.bpmn",
+                parentProcess(
+                    callActivity ->
+                        callActivity
+                            .zeebeProcessIdExpression("processId")
+                            .zeebeBindingType(ZeebeBindingType.deployment)))
+            .withXmlResource("wf-child.bpmn", childProcessV1)
+            .deploy();
+    final var versionInSameDeployment =
+        deployment.getValue().getProcessesMetadata().stream()
+            .filter(metadata -> PROCESS_ID_CHILD.equals(metadata.getBpmnProcessId()))
+            .findFirst()
+            .orElseThrow();
+    ENGINE.deployment().withXmlResource("wf-child.bpmn", childProcessV2).deploy();
+
+    // when
+    final var processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID_PARENT)
+            .withVariable("processId", PROCESS_ID_CHILD)
+            .create();
+
+    // then
+    Assertions.assertThat(getChildInstanceOf(processInstanceKey))
+        .hasBpmnProcessId(PROCESS_ID_CHILD)
+        .hasProcessDefinitionKey(versionInSameDeployment.getProcessDefinitionKey());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
@@ -35,6 +37,7 @@ public class JobBasedUserTaskFormTest {
 
   private static final String PROCESS_ID = "process";
   private static final String TEST_FORM_1 = "/form/test-form-1.form";
+  private static final String TEST_FORM_1_V2 = "/form/test-form-1_v2.form";
   private static final String TEST_FORM_2 = "/form/test-form-2.form";
   private static final String FORM_ID_1 = "Form_0w7r08e";
   private static final String FORM_ID_2 = "Form_6s1b76p";
@@ -46,14 +49,78 @@ public class JobBasedUserTaskFormTest {
   @Test
   public void shouldActivateUserTaskIfFormIsAlreadyDeployed() {
     // given
-    deployForm(TEST_FORM_1);
+    final var form = deployForm(TEST_FORM_1);
     deployProcess(FORM_ID_1);
 
     // when
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // then
-    assertUserTaskActivation(processInstanceKey);
+    assertUserTaskActivation(processInstanceKey, form.getFormKey());
+  }
+
+  @Test
+  public void shouldActivateUserTaskWithLatestFormVersionIfBindingTypeNotSet() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).withXmlClasspathResource(TEST_FORM_1).deploy();
+    final var latestForm = deployForm(TEST_FORM_1_V2);
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertUserTaskActivation(processInstanceKey, latestForm.getFormKey());
+  }
+
+  @Test
+  public void shouldActivateUserTaskWithLatestFormVersionForBindingTypeLatest() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.latest)
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).withXmlClasspathResource(TEST_FORM_1).deploy();
+    final var latestForm = deployForm(TEST_FORM_1_V2);
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertUserTaskActivation(processInstanceKey, latestForm.getFormKey());
+  }
+
+  @Test
+  public void shouldActivateUserTaskWithFormVersionInSameDeploymentForBindingTypeDeployment() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.deployment)
+            .endEvent()
+            .done();
+    final var deployment =
+        ENGINE.deployment().withXmlResource(process).withXmlClasspathResource(TEST_FORM_1).deploy();
+    final var formInSameDeployment = deployment.getValue().getFormMetadata().getFirst();
+    deployForm(TEST_FORM_1_V2);
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertUserTaskActivation(processInstanceKey, formInSameDeployment.getFormKey());
   }
 
   @Test
@@ -66,7 +133,13 @@ public class JobBasedUserTaskFormTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // then
-    assertFormIncident(processInstanceKey, formId);
+    assertFormIncident(
+        processInstanceKey,
+        """
+            Expected to find a form with id '%s', but no form with this id is found, \
+            at least a form with this id should be available. \
+            To resolve the Incident please deploy a form with the same id"""
+            .formatted(formId));
   }
 
   @Test
@@ -75,10 +148,17 @@ public class JobBasedUserTaskFormTest {
     deployProcess(FORM_ID_2);
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var incidentCreated = assertFormIncident(processInstanceKey, FORM_ID_2);
+    final var incidentCreated =
+        assertFormIncident(
+            processInstanceKey,
+            """
+            Expected to find a form with id '%s', but no form with this id is found, \
+            at least a form with this id should be available. \
+            To resolve the Incident please deploy a form with the same id"""
+                .formatted(FORM_ID_2));
 
     // when
-    deployForm(TEST_FORM_2);
+    final var form = deployForm(TEST_FORM_2);
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentCreated.getKey()).resolve();
 
     // then
@@ -89,7 +169,31 @@ public class JobBasedUserTaskFormTest {
             tuple(incidentCreated.getKey(), IncidentIntent.CREATED),
             tuple(incidentCreated.getKey(), IncidentIntent.RESOLVED));
 
-    assertUserTaskActivation(processInstanceKey);
+    assertUserTaskActivation(processInstanceKey, form.getFormKey());
+  }
+
+  @Test
+  public void shouldRaiseAnIncidentIfFormIsNotDeployedInSameDeploymentForBindingTypeDeployment() {
+    // given
+    deployForm(TEST_FORM_1);
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.deployment)
+            .endEvent()
+            .done();
+    final var deployment = ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertFormIncident(
+        processInstanceKey,
+        "Expected to find a form with id '%s' in deployment %s, but not found."
+            .formatted(FORM_ID_1, deployment.getKey()));
   }
 
   private void deployProcess(final String formId) {
@@ -104,17 +208,21 @@ public class JobBasedUserTaskFormTest {
     ENGINE.deployment().withXmlResource(processWithFormId).deploy();
   }
 
-  private void deployForm(final String formPath) {
+  private FormMetadataValue deployForm(final String formPath) {
     final var deploymentEvent = ENGINE.deployment().withJsonClasspathResource(formPath).deploy();
 
     Assertions.assertThat(deploymentEvent)
         .hasIntent(DeploymentIntent.CREATED)
         .hasValueType(ValueType.DEPLOYMENT)
         .hasRecordType(RecordType.EVENT);
+
+    final var formMetadata = deploymentEvent.getValue().getFormMetadata();
+    assertThat(formMetadata).hasSize(1);
+    return formMetadata.getFirst();
   }
 
   private Record<IncidentRecordValue> assertFormIncident(
-      final long processInstanceKey, final String formId) {
+      final long processInstanceKey, final String expectedErrorMessage) {
     final var incidentCreated =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -122,21 +230,20 @@ public class JobBasedUserTaskFormTest {
 
     assertThat(incidentCreated.getValue())
         .extracting(r -> tuple(r.getErrorType(), r.getErrorMessage()))
-        .isEqualTo(
-            tuple(
-                ErrorType.FORM_NOT_FOUND,
-                String.format(
-                    "Expected to find a form with id '%s', but no form with this id is found, at least a form with this id should be available. To resolve the Incident please deploy a form with the same id",
-                    formId)));
+        .isEqualTo(tuple(ErrorType.FORM_NOT_FOUND, expectedErrorMessage));
 
     return incidentCreated;
   }
 
-  private void assertUserTaskActivation(final long processInstanceKey) {
+  private void assertUserTaskActivation(final long processInstanceKey, final long expectedFormKey) {
     assertThat(RecordingExporter.jobRecords().withProcessInstanceKey(processInstanceKey).limit(1))
         .extracting(jobRecord -> jobRecord.getValue().getCustomHeaders())
         .isNotNull()
-        .anyMatch(headers -> headers.containsKey("io.camunda.zeebe:formKey"));
+        .anyMatch(
+            headers ->
+                headers
+                    .getOrDefault("io.camunda.zeebe:formKey", "")
+                    .equals(String.valueOf(expectedFormKey)));
 
     assertThat(
             RecordingExporter.processInstanceRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
@@ -192,7 +192,12 @@ public class JobBasedUserTaskFormTest {
     // then
     assertFormIncident(
         processInstanceKey,
-        "Expected to find a form with id '%s' in deployment %s, but not found."
+        """
+        Expected to use a form with id '%s' with binding type 'deployment', \
+        but no such form found in the deployment with key %s which contained the current process. \
+        To resolve this incident, migrate the process instance to a process definition \
+        that is deployed together with the intended form to use.\
+        """
             .formatted(FORM_ID_1, deployment.getKey()));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
@@ -196,7 +196,12 @@ public class NativeUserTaskFormTest {
     // then
     assertFormIncident(
         processInstanceKey,
-        "Expected to find a form with id '%s' in deployment %s, but not found."
+        """
+        Expected to use a form with id '%s' with binding type 'deployment', \
+        but no such form found in the deployment with key %s which contained the current process. \
+        To resolve this incident, migrate the process instance to a process definition \
+        that is deployed together with the intended form to use.\
+        """
             .formatted(FORM_ID_1, deployment.getKey()));
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/NativeUserTaskFormTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordType;
@@ -23,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
+import io.camunda.zeebe.protocol.record.value.deployment.FormMetadataValue;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import org.junit.ClassRule;
@@ -35,6 +37,7 @@ public class NativeUserTaskFormTest {
 
   private static final String PROCESS_ID = "process";
   private static final String TEST_FORM_1 = "/form/test-form-1.form";
+  private static final String TEST_FORM_1_V2 = "/form/test-form-1_v2.form";
   private static final String TEST_FORM_2 = "/form/test-form-2.form";
   private static final String FORM_ID_1 = "Form_0w7r08e";
   private static final String FORM_ID_2 = "Form_6s1b76p";
@@ -46,14 +49,81 @@ public class NativeUserTaskFormTest {
   @Test
   public void shouldActivateUserTaskIfFormIsAlreadyDeployed() {
     // given
-    deployForm(TEST_FORM_1);
+    final var form = deployForm(TEST_FORM_1);
     deployProcess(FORM_ID_1);
 
     // when
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // then
-    assertUserTaskActivation(processInstanceKey);
+    assertUserTaskActivation(processInstanceKey, form.getFormKey());
+  }
+
+  @Test
+  public void shouldActivateUserTaskWithLatestFormVersionIfBindingTypeNotSet() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeUserTask()
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).withXmlClasspathResource(TEST_FORM_1).deploy();
+    final var latestForm = deployForm(TEST_FORM_1_V2);
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertUserTaskActivation(processInstanceKey, latestForm.getFormKey());
+  }
+
+  @Test
+  public void shouldActivateUserTaskWithLatestFormVersionForBindingTypeLatest() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.latest)
+            .zeebeUserTask()
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).withXmlClasspathResource(TEST_FORM_1).deploy();
+    final var latestForm = deployForm(TEST_FORM_1_V2);
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertUserTaskActivation(processInstanceKey, latestForm.getFormKey());
+  }
+
+  @Test
+  public void shouldActivateUserTaskWithFormVersionInSameDeploymentForBindingTypeDeployment() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.deployment)
+            .zeebeUserTask()
+            .endEvent()
+            .done();
+    final var deployment =
+        ENGINE.deployment().withXmlResource(process).withXmlClasspathResource(TEST_FORM_1).deploy();
+    final var formInSameDeployment = deployment.getValue().getFormMetadata().getFirst();
+    deployForm(TEST_FORM_1_V2);
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertUserTaskActivation(processInstanceKey, formInSameDeployment.getFormKey());
   }
 
   @Test
@@ -66,7 +136,13 @@ public class NativeUserTaskFormTest {
     final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
 
     // then
-    assertFormIncident(processInstanceKey, formId);
+    assertFormIncident(
+        processInstanceKey,
+        """
+            Expected to find a form with id '%s', but no form with this id is found, \
+            at least a form with this id should be available. \
+            To resolve the Incident please deploy a form with the same id"""
+            .formatted(formId));
   }
 
   @Test
@@ -75,10 +151,17 @@ public class NativeUserTaskFormTest {
     deployProcess(FORM_ID_2);
 
     final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
-    final var incidentCreated = assertFormIncident(processInstanceKey, FORM_ID_2);
+    final var incidentCreated =
+        assertFormIncident(
+            processInstanceKey,
+            """
+                Expected to find a form with id '%s', but no form with this id is found, \
+                at least a form with this id should be available. \
+                To resolve the Incident please deploy a form with the same id"""
+                .formatted(FORM_ID_2));
 
     // when
-    deployForm(TEST_FORM_2);
+    final var form = deployForm(TEST_FORM_2);
     ENGINE.incident().ofInstance(processInstanceKey).withKey(incidentCreated.getKey()).resolve();
 
     // then
@@ -89,7 +172,32 @@ public class NativeUserTaskFormTest {
             tuple(incidentCreated.getKey(), IncidentIntent.CREATED),
             tuple(incidentCreated.getKey(), IncidentIntent.RESOLVED));
 
-    assertUserTaskActivation(processInstanceKey);
+    assertUserTaskActivation(processInstanceKey, form.getFormKey());
+  }
+
+  @Test
+  public void shouldRaiseAnIncidentIfFormIsNotDeployedInSameDeploymentForBindingTypeDeployment() {
+    // given
+    deployForm(TEST_FORM_1);
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.deployment)
+            .zeebeUserTask()
+            .endEvent()
+            .done();
+    final var deployment = ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertFormIncident(
+        processInstanceKey,
+        "Expected to find a form with id '%s' in deployment %s, but not found."
+            .formatted(FORM_ID_1, deployment.getKey()));
   }
 
   private void deployProcess(final String formId) {
@@ -105,17 +213,21 @@ public class NativeUserTaskFormTest {
     ENGINE.deployment().withXmlResource(processWithFormId).deploy();
   }
 
-  private void deployForm(final String formPath) {
+  private FormMetadataValue deployForm(final String formPath) {
     final var deploymentEvent = ENGINE.deployment().withJsonClasspathResource(formPath).deploy();
 
     Assertions.assertThat(deploymentEvent)
         .hasIntent(DeploymentIntent.CREATED)
         .hasValueType(ValueType.DEPLOYMENT)
         .hasRecordType(RecordType.EVENT);
+
+    final var formMetadata = deploymentEvent.getValue().getFormMetadata();
+    assertThat(formMetadata).hasSize(1);
+    return formMetadata.getFirst();
   }
 
   private Record<IncidentRecordValue> assertFormIncident(
-      final long processInstanceKey, final String formId) {
+      final long processInstanceKey, final String expectedErrorMessage) {
     final var incidentCreated =
         RecordingExporter.incidentRecords(IncidentIntent.CREATED)
             .withProcessInstanceKey(processInstanceKey)
@@ -123,25 +235,19 @@ public class NativeUserTaskFormTest {
 
     assertThat(incidentCreated.getValue())
         .extracting(r -> tuple(r.getErrorType(), r.getErrorMessage()))
-        .isEqualTo(
-            tuple(
-                ErrorType.FORM_NOT_FOUND,
-                String.format(
-                    "Expected to find a form with id '%s', but no form with this id is found, at least a form with this id should be available. To resolve the Incident please deploy a form with the same id",
-                    formId)));
+        .isEqualTo(tuple(ErrorType.FORM_NOT_FOUND, expectedErrorMessage));
 
     return incidentCreated;
   }
 
-  private void assertUserTaskActivation(final long processInstanceKey) {
-    assertThat(
-            RecordingExporter.userTaskRecords()
-                .withProcessInstanceKey(processInstanceKey)
-                .limit(1)
-                .getFirst()
-                .getValue()
-                .getFormKey())
-        .isGreaterThan(-1L);
+  private void assertUserTaskActivation(final long processInstanceKey, final long expectedFormKey) {
+    final var userTaskRecord =
+        RecordingExporter.userTaskRecords()
+            .withProcessInstanceKey(processInstanceKey)
+            .limit(1)
+            .getFirst()
+            .getValue();
+    assertThat(userTaskRecord.getFormKey()).isEqualTo(expectedFormKey);
 
     assertThat(
             RecordingExporter.processInstanceRecords()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.BusinessRuleTaskBuilder;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.DecisionIntent;
@@ -107,6 +108,42 @@ public class BusinessRuleTaskIncidentTest {
             Expected to evaluate decision 'unknown_decision_id', \
             but no decision found for id 'unknown_decision_id'\
             """);
+  }
+
+  @Test
+  public void shouldCreateIncidentIfDecisionNotDeployedInSameDeploymentForBindingTypeDeployment() {
+    // given
+    engine.deployment().withXmlClasspathResource(DMN_RESOURCE).deploy();
+    final var deployment =
+        engine
+            .deployment()
+            .withXmlResource(
+                processWithBusinessRuleTask(
+                    b ->
+                        b.zeebeCalledDecisionId(DECISION_ID)
+                            .zeebeBindingType(ZeebeBindingType.deployment)
+                            .zeebeResultVariable(RESULT_VARIABLE)))
+            .deploy();
+
+    // when
+    final long processInstanceKey = engine.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    final var taskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.BUSINESS_RULE_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, taskActivating.getKey())
+        .hasErrorType(ErrorType.CALLED_DECISION_ERROR)
+        .hasErrorMessage(
+            """
+            Expected to evaluate decision 'jedi_or_sith', \
+            but no decision found for id 'jedi_or_sith' in deployment \
+            """
+                + deployment.getKey());
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/BusinessRuleTaskIncidentTest.java
@@ -140,10 +140,12 @@ public class BusinessRuleTaskIncidentTest {
         .hasErrorType(ErrorType.CALLED_DECISION_ERROR)
         .hasErrorMessage(
             """
-            Expected to evaluate decision 'jedi_or_sith', \
-            but no decision found for id 'jedi_or_sith' in deployment \
+            Expected to evaluate decision '%s' with binding type 'deployment', \
+            but no such decision found in the deployment with key %s which contained the current process. \
+            To resolve this incident, migrate the process instance to a process definition \
+            that is deployed together with the intended decision to evaluate.\
             """
-                + deployment.getKey());
+                .formatted(DECISION_ID, deployment.getKey()));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -114,11 +114,13 @@ public final class CallActivityIncidentTest {
     assertIncidentCreated(incident, elementInstance)
         .hasErrorType(ErrorType.CALLED_ELEMENT_ERROR)
         .hasErrorMessage(
-            "Expected process with BPMN process id '"
-                + childProcessId
-                + "' to be deployed with deployment "
-                + deployment.getKey()
-                + ", but not found.");
+            """
+            Expected to call process with BPMN process id '%s' with binding type 'deployment', \
+            but no such process found in the deployment with key %s which contained the current process. \
+            To resolve this incident, migrate the process instance to a process definition \
+            that is deployed together with the intended process definition to call.\
+            """
+                .formatted(childProcessId, deployment.getKey()));
   }
 
   @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/CallActivityIncidentTest.java
@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeBindingType;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
@@ -83,6 +84,41 @@ public final class CallActivityIncidentTest {
             "Expected process with BPMN process id '"
                 + childProcessId
                 + "' to be deployed, but not found.");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfProcessIsNotDeployedInSameDeploymentForBindingTypeDeployment() {
+    // given
+    final var childProcessId = Strings.newRandomValidBpmnId();
+    final var childProcess = Bpmn.createExecutableProcess(childProcessId).startEvent().done();
+    ENGINE.deployment().withXmlResource("wf-child.bpmn", childProcess).deploy();
+    final var parentProcess =
+        Bpmn.createExecutableProcess(parentProcessId)
+            .startEvent()
+            .callActivity(
+                "call",
+                c -> c.zeebeProcessId(childProcessId).zeebeBindingType(ZeebeBindingType.deployment))
+            .done();
+    final var deployment =
+        ENGINE.deployment().withXmlResource("wf-parent.bpmn", parentProcess).deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(parentProcessId).create();
+
+    // then
+    final Record<IncidentRecordValue> incident = getIncident(processInstanceKey);
+    final Record<ProcessInstanceRecordValue> elementInstance =
+        getCallActivityInstance(processInstanceKey);
+
+    assertIncidentCreated(incident, elementInstance)
+        .hasErrorType(ErrorType.CALLED_ELEMENT_ERROR)
+        .hasErrorMessage(
+            "Expected process with BPMN process id '"
+                + childProcessId
+                + "' to be deployed with deployment "
+                + deployment.getKey()
+                + ", but not found.");
   }
 
   @Test


### PR DESCRIPTION
## Description
Adds support for resource links that use the new `deployment` binding type:
- called processes in call activities
- called decisions in business rule tasks
- linked forms in user tasks

When `deployment` binding is used, the target resources are expected to be deployed together with the process from which they are linked/called. If they are not found inside the same deployment, an incident will be raised.

## Related issues
Closes #19710