### PR TITLE
test: ensure the REST API configuration options

### DIFF
--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerAnnotationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerAnnotationTest.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @AnalyzeClasses(
     packages = "io.camunda.zeebe.gateway.rest",
     importOptions = ImportOption.DoNotIncludeTests.class)
-public class RestApiDisabledTest {
+public class RestControllerAnnotationTest {
 
   /**
    * This ArchUnit test ensures that any REST API controllers, i.e. classes annotated with the

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.gateway.rest.controller;
+package io.camunda.zeebe.gateway.rest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -15,7 +15,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
     properties = {
       "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
     })
-abstract class RestControllerTest {
+public abstract class RestControllerTest {
 
   @Autowired protected WebTestClient webClient;
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayAndApiDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayAndApiDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "zeebe.broker.gateway.enable=false, camunda.rest.enabled=false")
+public class RestApiBrokerGatewayAndApiDisabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "zeebe.broker.gateway.enable=false")
+public class RestApiBrokerGatewayDisabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.query.SearchQueryResult.Builder;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+abstract class RestApiConfigurationTest extends RestControllerTest {
+
+  static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/process-instances/search";
+  static final String TOPOLOGY_URL = "/v2/topology";
+
+  @MockBean ProcessInstanceServices processInstanceServices;
+  @MockBean BrokerClient brokerClient;
+  @MockBean BrokerTopologyManager topologyManager;
+
+  @BeforeEach
+  void setupServices() {
+    when(processInstanceServices.withAuthentication(any(Authentication.class)))
+        .thenReturn(processInstanceServices);
+    when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+        .thenReturn(new Builder<ProcessInstanceEntity>().build());
+    when(topologyManager.getTopology()).thenReturn(mock(BrokerClusterState.class));
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(value = {ProcessInstanceQueryController.class, TopologyController.class})
+public class RestApiDefaultConfigurationTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldOkForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isOk();
+
+    verify(topologyManager).getTopology();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledAndQueryEnabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledAndQueryEnabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "camunda.rest.enabled=false, camunda.rest.query.enabled=true")
+public class RestApiDisabledAndQueryEnabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "camunda.rest.enabled=false")
+public class RestApiDisabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiQueryEnabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiQueryEnabledTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "camunda.rest.query.enabled=true")
+public class RestApiQueryEnabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldOKForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isOk();
+
+    verify(processInstanceServices).search(any(ProcessInstanceQuery.class));
+  }
+
+  @Test
+  void shouldYieldOkForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isOk();
+
+    verify(topologyManager).getTopology();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.search.sort.DecisionDefinitionSort;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -16,6 +16,7 @@ import io.camunda.service.UserTaskServices;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.controller.util.ResettableJobActivationRequestResponseObserver;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RejectionType;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.List;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -17,6 +17,7 @@ import io.camunda.service.CamundaServiceException;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.service.search.sort.UserTaskSort;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
## Description

Provide automated tests that ensure the C8 REST API and Query API can be enabled and disabled as expected using Spring properties.

## Related issues

closes #20645 
