### PR TITLE
ci: use stable and main branch names instead of maintenance and master

### DIFF
--- a/.github/ISSUE_TEMPLATE/optimize-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/optimize-bug_report.md
@@ -1,10 +1,11 @@
 ---
+
 name: Optimize Bug report
 about: Report a problem about Optimize and help us fix it.
 title: ""
 labels: ["kind/bug", "qa:pendingVerification", "component/optimize"]
 assignees: ""
----
+-------------
 
 ### Describe the bug
 
@@ -60,7 +61,6 @@ Is this bug reproducible?
 #### Review Resources
 
 <!-- When in review, the resources to be used for review should be listed here) -->
-
 - Feature PR: {Link to PR targeting the main branch}
 - Preview environments: {Link(s) to preview environments}
 
@@ -81,3 +81,4 @@ Is this bug reproducible?
 - [ ] All Review stages are successfully completed
 - [ ] All associated PRs are merged to the main branch(es) and stable branches
 - [ ] The correct version labels are applied to the issue
+

--- a/.github/ISSUE_TEMPLATE/optimize-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/optimize-bug_report.md
@@ -79,5 +79,5 @@ Is this bug reproducible?
 ### Completion
 
 - [ ] All Review stages are successfully completed
-- [ ] All associated PRs are merged to the main branch(es) and maintenance branches
+- [ ] All associated PRs are merged to the main branch(es) and stable branches
 - [ ] The correct version labels are applied to the issue

--- a/.github/ISSUE_TEMPLATE/optimize-epic.md
+++ b/.github/ISSUE_TEMPLATE/optimize-epic.md
@@ -1,15 +1,15 @@
 ---
+
 name: Optimize Epic
 about: This issue is used to track the progress of an Optimize Epic
 title: 🎯
 labels: ["kind/epic", "component/optimize"]
 assignees: ""
----
+-------------
 
 ### Summary
 
 <!-- Add links to related issues or other resources  -->
-
 - Product Hub issue:
 - PDP Steps tracking doc:
 
@@ -35,7 +35,6 @@ commands by writing `/help` as a comment on this issue.
 #### Review Resources
 
 <!-- When in review, the resources to be used for review should be listed here) -->
-
 - Feature PR: {Link to PR targeting the main branch}
 - Preview environments: {Link(s) to preview environments}
 
@@ -62,3 +61,4 @@ commands by writing `/help` as a comment on this issue.
 - All Review stages are successfully completed
 - [ ] All associated PRs are merged to the main branch(es) and stable branches
 - [ ] The correct version labels are applied to the issue
+

--- a/.github/ISSUE_TEMPLATE/optimize-epic.md
+++ b/.github/ISSUE_TEMPLATE/optimize-epic.md
@@ -60,5 +60,5 @@ commands by writing `/help` as a comment on this issue.
 ### Completion
 
 - All Review stages are successfully completed
-- [ ] All associated PRs are merged to the main branch(es) and maintenance branches
+- [ ] All associated PRs are merged to the main branch(es) and stable branches
 - [ ] The correct version labels are applied to the issue

--- a/.github/ISSUE_TEMPLATE/optimize-task.md
+++ b/.github/ISSUE_TEMPLATE/optimize-task.md
@@ -1,10 +1,11 @@
 ---
+
 name: Optimize Task
 about: Describe a task for the technical issue - it may be individual issue or be connected to epic.
 title: ""
 labels: ["kind/task", "component/optimize"]
 assignees: ""
----
+-------------
 
 ### Context
 
@@ -44,7 +45,6 @@ commands by writing `/help` as a comment on this issue.
 #### Review Resources
 
 <!-- When in review, the resources to be used for review should be listed here) -->
-
 - Feature PR: {Link to PR targeting the main branch}
 - Preview environments: {Link(s) to preview environments}
 
@@ -65,3 +65,4 @@ commands by writing `/help` as a comment on this issue.
 - [ ] All Review stages are successfully completed
 - [ ] All associated PRs are merged to the main branch(es) and stable branches
 - [ ] The correct version labels are applied to the issue
+

--- a/.github/ISSUE_TEMPLATE/optimize-task.md
+++ b/.github/ISSUE_TEMPLATE/optimize-task.md
@@ -63,5 +63,5 @@ commands by writing `/help` as a comment on this issue.
 ### Completion
 
 - [ ] All Review stages are successfully completed
-- [ ] All associated PRs are merged to the main branch(es) and maintenance branches
+- [ ] All associated PRs are merged to the main branch(es) and stable branches
 - [ ] The correct version labels are applied to the issue

--- a/.github/actions/generate-changelog/README.md
+++ b/.github/actions/generate-changelog/README.md
@@ -10,7 +10,7 @@ This actions gets a branch for which we want to generate changelog, finds last t
 
 | Input  |                   Description                    | Required | Default |
 |--------|--------------------------------------------------|----------|---------|
-| branch | A branch for which we want to generate changelog | true     | main  |
+| branch | A branch for which we want to generate changelog | true     | main    |
 
 ### Outputs
 

--- a/.github/actions/generate-changelog/README.md
+++ b/.github/actions/generate-changelog/README.md
@@ -10,7 +10,7 @@ This actions gets a branch for which we want to generate changelog, finds last t
 
 | Input  |                   Description                    | Required | Default |
 |--------|--------------------------------------------------|----------|---------|
-| branch | A branch for which we want to generate changelog | true     | master  |
+| branch | A branch for which we want to generate changelog | true     | main  |
 
 ### Outputs
 
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
-          ref: ${{ github.event.inputs.branch || 'master' }}
+          ref: ${{ github.event.inputs.branch || 'main' }}
       - name: Calculate changelog
         uses: ./.github/actions/generate-changelog
         id: changelog

--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -5,7 +5,7 @@ inputs:
   branch:
     description: "Branch to use"
     required: true
-    default: "master"
+    default: "main"
   from:
     description: "Tag Name or Commit SHA of previous release (optional)"
 outputs:

--- a/.github/actions/git-environment/README.md
+++ b/.github/actions/git-environment/README.md
@@ -17,16 +17,16 @@ action itself takes 2 seconds but GitHub only bills full minutes.
 
 ### Inputs
 
-| Input               | Description                                          | Required | Default                     |
-| ------------------- | ---------------------------------------------------- | -------- | --------------------------- |
+|        Input        |                     Description                      | Required |           Default           |
+|---------------------|------------------------------------------------------|----------|-----------------------------|
 | stable_branch_regex | A bash regex provided to determine the stable branch | false    | ^stable\/([0-9]+\.[0-9]+)$  |
-| main_branch_regex   | A bash regex provided to determine the main branch   | false    | ^main$                    |
+| main_branch_regex   | A bash regex provided to determine the main branch   | false    | ^main$                      |
 | branch              | A provided branch name                               | false    | defaults to github.ref_name |
 
 ### Outputs
 
-| Output                   | Description                                                                             |
-| ------------------------ | --------------------------------------------------------------------------------------- |
+|          Output          |                                       Description                                       |
+|--------------------------|-----------------------------------------------------------------------------------------|
 | stable_version           | If it's a stable branch, which stable version it is                                     |
 | is_stable_branch         | Whether the provided branch is a stable branch                                          |
 | is_main_branch           | Whether the provided branch is a main branch                                            |
@@ -71,3 +71,4 @@ jobs:
           } >> "$GITHUB_ENV"
   ...
 ```
+

--- a/.github/actions/git-environment/README.md
+++ b/.github/actions/git-environment/README.md
@@ -17,24 +17,24 @@ action itself takes 2 seconds but GitHub only bills full minutes.
 
 ### Inputs
 
-|          Input           |                        Description                        | Required |             Default             |
-|--------------------------|-----------------------------------------------------------|----------|---------------------------------|
-| maintenance_branch_regex | A bash regex provided to determine the maintenance branch | false    | ^maintenance\/([0-9]+\.[0-9]+)$ |
-| main_branch_regex        | A bash regex provided to determine the main branch        | false    | ^master$                        |
-| branch                   | A provided branch name                                    | false    | defaults to github.ref_name     |
+| Input               | Description                                          | Required | Default                     |
+| ------------------- | ---------------------------------------------------- | -------- | --------------------------- |
+| stable_branch_regex | A bash regex provided to determine the stable branch | false    | ^stable\/([0-9]+\.[0-9]+)$  |
+| main_branch_regex   | A bash regex provided to determine the main branch   | false    | ^main$                    |
+| branch              | A provided branch name                               | false    | defaults to github.ref_name |
 
 ### Outputs
 
-|            Output             |                                       Description                                       |
-|-------------------------------|-----------------------------------------------------------------------------------------|
-| maintenance_version           | If it's a maintenance branch, which maintenance version it is                           |
-| is_maintenance_branch         | Whether the provided branch is a maintenance branch                                     |
-| is_main_branch                | Whether the provided branch is a main branch                                            |
-| is_main_or_maintenance_branch | Whether the provided branch is a main or maintenance branch                             |
-| branch_slug                   | The sanitized branch - everything lowercase and anything not a-z0-9- is replaced with - |
-| git_commit_hash               | The git commit hash                                                                     |
-| image_tag                     | Depending on main/maintenance returns hash or branch-slug                               |
-| latest_tag                    | If maintenance returns maintenance-version-latest else latest                           |
+| Output                   | Description                                                                             |
+| ------------------------ | --------------------------------------------------------------------------------------- |
+| stable_version           | If it's a stable branch, which stable version it is                                     |
+| is_stable_branch         | Whether the provided branch is a stable branch                                          |
+| is_main_branch           | Whether the provided branch is a main branch                                            |
+| is_main_or_stable_branch | Whether the provided branch is a main or stable branch                                  |
+| branch_slug              | The sanitized branch - everything lowercase and anything not a-z0-9- is replaced with - |
+| git_commit_hash          | The git commit hash                                                                     |
+| image_tag                | Depending on main/stable returns hash or branch-slug                                    |
+| latest_tag               | If stable returns stable-version-latest else latest                                     |
 
 ## Example of using the action
 
@@ -44,10 +44,10 @@ jobs:
     name: Define global values
     runs-on: ubuntu-latest
     outputs:
-      maintenance_version: ${{ steps.define-values.outputs.maintenance_version }}
-      is_maintenance_branch: ${{ steps.define-values.outputs.is_maintenance_branch }}
+      stable_version: ${{ steps.define-values.outputs.stable_version }}
+      is_stable_branch: ${{ steps.define-values.outputs.is_stable_branch }}
       is_main_branch: ${{ steps.define-values.outputs.is_main_branch }}
-      is_main_or_maintenance_branch: ${{ steps.define-values.outputs.is_main_or_maintenance_branch }}
+      is_main_or_stable_branch: ${{ steps.define-values.outputs.is_main_or_stable_branch }}
       branch_slug: ${{ steps.define-values.outputs.branch_slug }}
       git_commit_hash: ${{ steps.define-values.outputs.git_commit_hash }}
       image_tag: ${{ steps.define-values.outputs.image_tag }}
@@ -71,4 +71,3 @@ jobs:
           } >> "$GITHUB_ENV"
   ...
 ```
-

--- a/.github/actions/git-environment/action.yml
+++ b/.github/actions/git-environment/action.yml
@@ -2,30 +2,30 @@ name: Get Environment
 description: |
   Exposes common values for consumption in conditions of other jobs in a workflow.
 inputs:
-  maintenance_branch_regex:
-    description: 'A bash regex provided to determine the maintenance branch'
-    default: ^maintenance\/([0-9]+\.[0-9]+)$
+  stable_branch_regex:
+    description: 'A bash regex provided to determine the stable branch'
+    default: ^stable\/([0-9]+\.[0-9]+)$
     required: false
   main_branch_regex:
     description: 'A bash regex provided to determine the main branch'
-    default: ^master$
+    default: ^main$
     required: false
   branch:
     description: 'Defaults to github.ref_name'
     required: false
 outputs:
-  maintenance_version:
-    value: ${{ steps.define-values.outputs.maintenance_version }}
-    description: "If it's a maintenance branch, which maintenance version it is"
-  is_maintenance_branch:
-    value: ${{ steps.define-values.outputs.is_maintenance_branch }}
-    description: "Whether the provided branch is a maintenance branch"
+  stable_version:
+    value: ${{ steps.define-values.outputs.stable_version }}
+    description: "If it's a stable branch, which stable version it is"
+  is_stable_branch:
+    value: ${{ steps.define-values.outputs.is_stable_branch }}
+    description: "Whether the provided branch is a stable branch"
   is_main_branch:
     value: ${{ steps.define-values.outputs.is_main_branch }}
     description: "Whether the provided branch is a main branch"
-  is_main_or_maintenance_branch:
-    value: ${{ steps.define-values.outputs.is_main_or_maintenance_branch }}
-    description: "Whether the provided branch is a main or maintenance branch"
+  is_main_or_stable_branch:
+    value: ${{ steps.define-values.outputs.is_main_or_stable_branch }}
+    description: "Whether the provided branch is a main or stable branch"
   branch_slug:
     value: ${{ steps.define-values.outputs.branch_slug }}
     description: "The sanitized branch - everything lowercase and anything not a-z0-9- is replaced with -"
@@ -34,10 +34,10 @@ outputs:
     description: "The git commit hash "
   image_tag:
     value: ${{ steps.define-values.outputs.image_tag }}
-    description: "Depending on main/maintenance returns hash or branch-slug"
+    description: "Depending on main/stable returns hash or branch-slug"
   latest_tag:
     value: ${{ steps.define-values.outputs.latest_tag }}
-    description: "If maintenance returns maintenance-version-latest else latest"
+    description: "If stable returns stable-version-latest else latest"
 
 runs:
   using: composite
@@ -49,5 +49,5 @@ runs:
       ${{ github.action_path }}/env.sh
     env:
       branch: ${{ inputs.branch || github.ref_name }}
-      maintenance_branch_regex: ${{ inputs.maintenance_branch_regex }}
+      stable_branch_regex: ${{ inputs.stable_branch_regex }}
       main_branch_regex: ${{ inputs.main_branch_regex }}

--- a/.github/actions/git-environment/env.sh
+++ b/.github/actions/git-environment/env.sh
@@ -1,33 +1,30 @@
 #!/bin/bash
 
-# isMaintenanceBranch
-if [[ $branch =~ $maintenance_branch_regex ]];
-then
-    maintenance_version=${BASH_REMATCH[1]}
-    echo "maintenance_version=${maintenance_version}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
-    is_maintenance_branch=true
+# isStableBranch
+if [[ $branch =~ $stable_branch_regex ]]; then
+    stable_version=${BASH_REMATCH[1]}
+    echo "stable_version=${stable_version}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
+    is_stable_branch=true
 else
-    is_maintenance_branch=false
+    is_stable_branch=false
 fi
-echo "is_maintenance_branch=${is_maintenance_branch}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
+echo "is_stable_branch=${is_stable_branch}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 
 # isMainBranch
-if  [[ $branch =~ $main_branch_regex ]];
-then
+if [[ $branch =~ $main_branch_regex ]]; then
     is_main_branch=true
 else
     is_main_branch=false
 fi
 echo "is_main_branch=${is_main_branch}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 
-# isMainOrMaintenanceBranch
-if $is_main_branch || $is_maintenance_branch;
-then
-    is_main_or_maintenance_branch=true
+# isMainOrStableBranch
+if $is_main_branch || $is_stable_branch; then
+    is_main_or_stable_branch=true
 else
-    is_main_or_maintenance_branch=false
+    is_main_or_stable_branch=false
 fi
-echo "is_main_or_maintenance_branch=${is_main_or_maintenance_branch}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
+echo "is_main_or_stable_branch=${is_main_or_stable_branch}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 
 # getBranchSlug
 branch_slug=$(echo "${branch,,}" | sed "s/[^a-z0-9-]/-/g")
@@ -38,17 +35,15 @@ git_commit_hash=$(git rev-parse --verify HEAD)
 echo "git_commit_hash=${git_commit_hash}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 
 # getImageTag
-if $is_main_or_maintenance_branch;
-then
+if $is_main_or_stable_branch; then
     echo "image_tag=${git_commit_hash}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 else
     echo "image_tag=branch-${branch_slug}" | tee -a "$GITHUB_ENV" "$GITHUB_OUTPUT"
 fi
 
 # getLatestTag
-if $is_maintenance_branch;
-then
-    latest_tag="${maintenance_version}-latest"
+if $is_stable_branch; then
+    latest_tag="${stable_version}-latest"
 else
     latest_tag="latest"
 fi

--- a/.github/optimize/scripts/create-release-branch.sh
+++ b/.github/optimize/scripts/create-release-branch.sh
@@ -35,14 +35,14 @@ git config --global user.email "${GITHUB_ACTOR_ID}+${GITHUB_ACTOR}@users.noreply
 if [[ "$RELEASE_TYPE" == "minor" || "$RELEASE_TYPE" == "major" ]]; then
   git remote set-url origin https://$GITHUB_ACTOR_ID:$GITHUB_APP_PRIVATE_KEY@github.com/camunda/camunda-optimize-examples.git
   git fetch
-  git checkout master
+  git checkout main
   git checkout -b release/$RELEASE_VERSION
   git push origin release/$RELEASE_VERSION
 fi
 
 git remote set-url origin "https://${GITHUB_ACTOR_ID}:${GITHUB_APP_PRIVATE_KEY}@github.com/camunda/camunda-optimize.git"
 git fetch
-git checkout master
+git checkout main
 # We need to pull with rebase here because we changed the remote from examples to optimize main repo and we need to override the changes
 git pull --rebase
 mvn -B gitflow:release-start -DpushRemote=true -DdevelopmentVersion="${NEXT_DEVELOPMENT_VERSION}-SNAPSHOT" -DreleaseVersion=${RELEASE_VERSION}

--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -34,7 +34,7 @@ jobs:
           echo "DOCKER_LATEST_TAG=${{ steps.define-values.outputs.latest_tag }}"
           echo "DOCKER_TAG=${{ steps.define-values.outputs.image_tag }}"
           echo "VERSION=${{ steps.pom-info.outputs.project_version }}"
-          echo "PUSH_LATEST_TAG=${{ steps.define-values.outputs.is_main_or_maintenance_branch }}"
+          echo "PUSH_LATEST_TAG=${{ steps.define-values.outputs.is_main_or_stable_branch }}"
           echo "IS_MAIN=${{ steps.define-values.outputs.is_main_branch }}"
           echo "REVISION=${{ steps.define-values.outputs.git_commit_hash }}"
         } >> "$GITHUB_ENV"
@@ -91,7 +91,7 @@ jobs:
         version: ${{ env.VERSION }}
         date: ${{ env.DATE }}
         revision: ${{ env.REVISION }}
-    # We're running under the same condition of main / maintenance
+    # We're running under the same condition of main / stable
     # We have all dependencies presents, therefore doesn't justify another job
     - name: Deploy to Artifactory
       uses: ./.github/actions/run-maven

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -551,7 +551,7 @@
         <configuration>
           <gitFlowConfig>
             <productionBranch>optimize-latest</productionBranch>
-            <developmentBranch>test-optimize-release</developmentBranch>
+            <developmentBranch>main</developmentBranch>
             <supportBranchPrefix>stable/</supportBranchPrefix>
             <releaseBranchPrefix>release/optimize-</releaseBranchPrefix>
           </gitFlowConfig>

--- a/optimize/pom.xml
+++ b/optimize/pom.xml
@@ -552,7 +552,7 @@
           <gitFlowConfig>
             <productionBranch>optimize-latest</productionBranch>
             <developmentBranch>test-optimize-release</developmentBranch>
-            <supportBranchPrefix>maintenance/</supportBranchPrefix>
+            <supportBranchPrefix>stable/</supportBranchPrefix>
             <releaseBranchPrefix>release/optimize-</releaseBranchPrefix>
           </gitFlowConfig>
           <commitDevelopmentVersionAtStart>true</commitDevelopmentVersionAtStart>

--- a/optimize/upgrade/README.md
+++ b/optimize/upgrade/README.md
@@ -6,7 +6,7 @@ Elasticsearch.
 
 ## Running the Upgrade
 
-To run the upgrade, you can run the `upgrade.sh` or the `upgrade.bat` script found in the [distro upgrade folder](https://github.com/camunda/camunda-optimize/tree/master/distro/src/upgrade).
+To run the upgrade, you can run the `upgrade.sh` or the `upgrade.bat` script found in the [distro upgrade folder](https://github.com/camunda/camunda/tree/main/optimize-distro/src/upgrade).
 
 ## Run the tests
 

--- a/optimize/util/dependency-doc-creation/README.md
+++ b/optimize/util/dependency-doc-creation/README.md
@@ -2,7 +2,7 @@ This projects creates enables you to automatically create a third party dependen
 
 # Prerequisites
 
-* node (check [here](https://github.com/camunda/camunda-optimize/blob/master/client/README.md) for the version)
+* node (check [here](https://github.com/camunda/camunda/blob/main/optimize/client/README.md) for the version)
 * maven 3+
 * bash
 * java 11


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

THis PR renames `master` branch to `main` and `maintenance` to `stable` in optimize files, to meet the monorepo standards

## Related issues

relates to # https://github.com/camunda/camunda-optimize/issues/13938