### PR TITLE
Fix flaky shouldSaveBackupWithManyFiles

### DIFF
--- a/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
+++ b/zeebe/backup-stores/s3/src/test/java/io/camunda/zeebe/backup/s3/BackupUploadIT.java
@@ -26,7 +26,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.RandomUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.testcontainers.containers.localstack.LocalStackContainer;
@@ -85,7 +84,6 @@ final class BackupUploadIT {
   }
 
   @Test
-  @Disabled("https://github.com/camunda/camunda/issues/18177")
   void shouldSaveBackupWithManyFiles() throws IOException {
     // given
     // Default values for the configuration
@@ -118,9 +116,12 @@ final class BackupUploadIT {
     final var s2 = Files.createFile(tempDir.resolve("snapshot/snapshot-file-2"));
 
     for (int i = 0; i < numberOfSegments; i++) {
-      largeNumberOfSegments.put(
-          "segment-file-%d".formatted(i),
-          Files.createFile(tempDir.resolve("segments/segment-file-%d".formatted(i))));
+      final var seg =
+          Files.createFile(tempDir.resolve(("segments/segment" + "-file-%d").formatted(i)));
+      largeNumberOfSegments.put("segment-file-%d".formatted(i), seg);
+      // We need to actually write some bytes onto the file, see issue:
+      // https://github.com/camunda/camunda/issues/18177
+      Files.write(seg, RandomUtils.nextBytes(16));
     }
 
     return new BackupImpl(


### PR DESCRIPTION
## Description

```
Caused by: software.amazon.awssdk.core.exception.SdkClientException: Unable to execute HTTP request: Duplicate handler name: HttpStreamsClientHandler#0-body-subscriber
```
A solution for this problem was already found https://github.com/aws/aws-sdk-java-v2/issues/1903#issuecomment-2249693722.

> Apparently if a client sends Expect: 100-continue with Content-Length: 0, a server can send the response right away. This is specified in https://datatracker.ietf.org/doc/html/rfc7231#section-5.1.1

In this specific test we were sending 4 000 empty files, we are getting the response immediately and releasing the channels to the pool before these are complete, which makes the probability of using the same channel twice quite high.

I tried to run the same test without using empty files (16 Bytes for example) and the issue no longer happens (tested locally for more than 300 runs, while without the fix, it fails every 5 or 10 runs).
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/18177
