### PR TITLE
fix: avoid parsing errors during userTask import

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -7,18 +7,19 @@
  */
 package io.camunda.optimize.dto.zeebe.usertask;
 
+import io.camunda.optimize.service.util.DateFormatterUtil;
 import io.camunda.zeebe.protocol.record.value.UserTaskRecordValue;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import lombok.Data;
 import lombok.experimental.FieldNameConstants;
+import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.annotate.JsonIgnore;
 
 @Data
 @FieldNameConstants
+@Slf4j
 public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
 
   private long userTaskKey;
@@ -44,8 +45,13 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
 
   @JsonIgnore
   public OffsetDateTime getDateForDueDate() {
-    return Objects.equals(dueDate, "")
-        ? null
-        : Optional.ofNullable(dueDate).map(OffsetDateTime::parse).orElse(null);
+    return DateFormatterUtil.getOffsetDateTimeFromIsoZoneDateTimeString(dueDate)
+        .orElseGet(
+            () -> {
+              log.info(
+                  "Unable to parse due date of userTask record: {}. UserTask will be imported without dueDate data.",
+                  dueDate);
+              return null;
+            });
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/util/DateFormatterUtil.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/util/DateFormatterUtil.java
@@ -11,6 +11,7 @@ import static io.camunda.optimize.service.db.DatabaseConstants.OPTIMIZE_DATE_FOR
 
 import com.github.sisyphsu.dateparser.DateParserUtils;
 import java.time.OffsetDateTime;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Optional;
@@ -36,6 +37,17 @@ public class DateFormatterUtil {
     try {
       final OffsetDateTime parsedOffsetDateTime = DateParserUtils.parseOffsetDateTime(dateString);
       return Optional.of(parsedOffsetDateTime.format(OPTIMIZE_FORMATTER));
+    } catch (DateTimeParseException ex) {
+      return Optional.empty();
+    }
+  }
+
+  public static Optional<OffsetDateTime> getOffsetDateTimeFromIsoZoneDateTimeString(
+      final String dateString) {
+    try {
+      return Optional.of(
+          ZonedDateTime.parse(dateString, DateTimeFormatter.ISO_ZONED_DATE_TIME)
+              .toOffsetDateTime());
     } catch (DateTimeParseException ex) {
       return Optional.empty();
     }


### PR DESCRIPTION
## Description

We noticed that duedates in zeebe usertask records are provided in format `"2024-07-24T00:00Z[GMT]"`, adjusting parsing accordingly. This also adds skipping of dueDate import if duedate cannot be parsed for some reason. Note for IT, I was not able to add a test case with an invalid format because zeebe API does not allow setting an invalid format, but I figured its still good to have this safeguard. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to [OPT#13927](https://github.com/camunda/camunda-optimize/issues/13927)
