### PR TITLE
Add a job update REST endpoint

### DIFF
--- a/service/src/main/java/io/camunda/service/JobServices.java
+++ b/service/src/main/java/io/camunda/service/JobServices.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerActivateJobsRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerCompleteJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerFailJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerThrowErrorRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRequest;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.ResponseObserver;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -93,6 +94,11 @@ public final class JobServices<T> extends ApiServices<JobServices<T>> {
   public CompletableFuture<JobRecord> completeJob(
       final long jobKey, final Map<String, Object> variables) {
     return sendBrokerRequest(new BrokerCompleteJobRequest(jobKey, getDocumentOrEmpty(variables)));
+  }
+
+  public CompletableFuture<JobRecord> updateJob(
+      final long jobKey, final Integer retries, final Long timeout) {
+    return sendBrokerRequest(new BrokerUpdateJobRequest(jobKey, retries, timeout));
   }
 
   public record ActivateJobsRequest(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -84,6 +84,8 @@ public final class JobEventProcessors {
             JobIntent.UPDATE_TIMEOUT,
             new JobUpdateTimeoutProcessor(processingState, writers))
         .onCommand(
+            ValueType.JOB, JobIntent.UPDATE, new JobUpdateProcessor(processingState, writers))
+        .onCommand(
             ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(processingState, jobMetrics))
         .onCommand(
             ValueType.JOB,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.engine.state.immutable.ProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
+
+  private static final String NO_JOB_FOUND_MESSAGE =
+      "Expected to update job with key '%d', but no such job was found";
+  private static final String NEGATIVE_RETRIES_MESSAGE =
+      "Expected to update job with key '%d' with a positive amount of retries, "
+          + "but the amount given was '%d'";
+
+  private final JobState jobState;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+
+  public JobUpdateProcessor(final ProcessingState state, final Writers writers) {
+    jobState = state.getJobState();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+  }
+
+  @Override
+  public void processRecord(final TypedRecord<JobRecord> command) {
+    final long key = command.getKey();
+    final int retries = command.getValue().getRetries();
+    final long timeout = command.getValue().getTimeout();
+    final var job = jobState.getJob(key, command.getAuthorizations());
+
+    if (job == null) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(key));
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(key));
+      return;
+    }
+
+    // Handle retries
+    if (retries > 0) {
+      job.setRetries(retries);
+      stateWriter.appendFollowUpEvent(key, JobIntent.RETRIES_UPDATED, job);
+      responseWriter.writeEventOnCommand(key, JobIntent.RETRIES_UPDATED, job, command);
+    }
+    // Handle timeout
+    final long oldDeadline = job.getDeadline();
+    if (timeout > -0 && jobState.jobDeadlineExists(key, oldDeadline)) {
+      final long newDeadline = ActorClock.currentTimeMillis() + job.getTimeout();
+      job.setDeadline(newDeadline);
+      stateWriter.appendFollowUpEvent(key, JobIntent.TIMEOUT_UPDATED, job);
+      responseWriter.writeEventOnCommand(key, JobIntent.TIMEOUT_UPDATED, job, command);
+    }
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -216,6 +216,7 @@ public final class EventAppliers implements EventApplier {
     register(JobIntent.TIMED_OUT, new JobTimedOutApplier(state));
     register(JobIntent.RECURRED_AFTER_BACKOFF, new JobRecurredApplier(state));
     register(JobIntent.TIMEOUT_UPDATED, new JobTimeoutUpdatedApplier(state));
+    register(JobIntent.UPDATED, new JobNoopApplier());
     register(JobIntent.MIGRATED, new JobMigratedApplier(state));
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobNoopApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/JobNoopApplier.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+
+public class JobNoopApplier implements TypedEventApplier<JobIntent, JobRecord> {
+
+  @Override
+  public void applyState(final long key, final JobRecord value) {
+    // this applier is used to handle JobIntent.UPDATED, there is nothing to do here.
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.test.util.Strings;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Duration;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class JobUpdateTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String PROCESS_ID = "process";
+  private static String jobType;
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  @Before
+  public void setup() {
+    jobType = Strings.newRandomValidBpmnId();
+  }
+
+  @Test
+  public void shouldUpdateJob() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final int retries = 5;
+    final long timeout = Duration.ofMinutes(5).toMillis();
+
+    final var batchRecord = ENGINE.jobs().withType(jobType).activate();
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE.job().withKey(jobKey).withRetries(retries).withTimeout(timeout).update();
+
+    // then
+    assertThat(RecordingExporter.jobRecords().limit(4))
+        .extracting(Record::getIntent)
+        .containsSubsequence(
+            JobIntent.CREATED,
+            JobIntent.UPDATE,
+            JobIntent.RETRIES_UPDATED,
+            JobIntent.TIMEOUT_UPDATED);
+  }
+
+  @Test
+  public void shouldUpdateJobWithOnlyRetries() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final int retries = 5;
+
+    final var batchRecord = ENGINE.jobs().withType(jobType).activate();
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE.job().withKey(jobKey).withRetries(retries).update();
+
+    // then
+    assertThat(RecordingExporter.jobRecords().limit(4))
+        .extracting(Record::getIntent)
+        .containsSubsequence(JobIntent.CREATED, JobIntent.UPDATE, JobIntent.RETRIES_UPDATED)
+        .doesNotContain(JobIntent.TIMEOUT_UPDATED);
+  }
+
+  @Test
+  public void shouldUpdateJobWithOnlyTimeout() {
+    // given
+    ENGINE.createJob(jobType, PROCESS_ID);
+    final long timeout = Duration.ofMinutes(5).toMillis();
+
+    final var batchRecord = ENGINE.jobs().withType(jobType).activate();
+    final long jobKey = batchRecord.getValue().getJobKeys().get(0);
+
+    // when
+    ENGINE.job().withKey(jobKey).withTimeout(timeout).update();
+
+    // then
+    assertThat(RecordingExporter.jobRecords().limit(4))
+        .extracting(Record::getIntent)
+        .containsSubsequence(JobIntent.CREATED, JobIntent.UPDATE, JobIntent.TIMEOUT_UPDATED)
+        .doesNotContain(JobIntent.RETRIES_UPDATED);
+  }
+
+  @Test
+  public void shouldRejectUpdateTimoutIfJobNotFound() {
+    // given
+    final long jobKey = 123L;
+    final int retries = 3;
+    final long timeout = Duration.ofMinutes(10).toMillis();
+
+    // when
+    final var jobRecord =
+        ENGINE
+            .job()
+            .withKey(jobKey)
+            .withRetries(retries)
+            .withTimeout(timeout)
+            .expectRejection()
+            .update();
+
+    // then
+    Assertions.assertThat(jobRecord)
+        .hasRejectionType(RejectionType.NOT_FOUND)
+        .hasRejectionReason(
+            "Expected to update job with key '%d', but no such job was found".formatted(jobKey));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/JobClient.java
@@ -181,6 +181,14 @@ public final class JobClient {
     return expectation.apply(position);
   }
 
+  public Record<JobRecordValue> update() {
+    final long jobKey = findJobKey();
+    final long position =
+        writer.writeCommand(
+            jobKey, JobIntent.UPDATE, jobRecord, authorizedTenantIds.toArray(new String[0]));
+    return expectation.apply(position);
+  }
+
   public Record<JobRecordValue> throwError() {
     final long jobKey = findJobKey();
     final long position =

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/EndpointManager.java
@@ -64,6 +64,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRe
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
@@ -379,6 +381,16 @@ public final class EndpointManager {
         request,
         RequestMapper::toUpdateJobTimeoutRequest,
         ResponseMapper::toUpdateJobTimeoutResponse,
+        responseObserver);
+  }
+
+  public void updateJob(
+      final UpdateJobRequest request,
+      final ServerStreamObserver<UpdateJobResponse> responseObserver) {
+    sendRequest(
+        request,
+        RequestMapper::toUpdateJobRequest,
+        ResponseMapper::toUpdateJobResponse,
         responseObserver);
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/GatewayGrpcService.java
@@ -47,6 +47,8 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.TopologyResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
@@ -204,6 +206,13 @@ public class GatewayGrpcService extends GatewayImplBase {
       final UpdateJobTimeoutRequest request,
       final StreamObserver<UpdateJobTimeoutResponse> responseObserver) {
     endpointManager.updateJobTimeout(
+        request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
+  }
+
+  @Override
+  public void updateJob(
+      final UpdateJobRequest request, final StreamObserver<UpdateJobResponse> responseObserver) {
+    endpointManager.updateJob(
         request, ErrorMappingStreamObserver.ofStreamObserver(responseObserver));
   }
 

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/RequestMapper.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.gateway.impl.broker.request.BrokerPublishMessageRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerResolveIncidentRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerSetVariablesRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerThrowErrorRequest;
+import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.impl.broker.request.BrokerUpdateJobTimeoutRequest;
 import io.camunda.zeebe.gateway.interceptors.InterceptorUtil;
@@ -50,6 +51,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.Resource;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.StreamActivatedJobsRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorRequest;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesRequest;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutRequest;
 import io.camunda.zeebe.msgpack.value.StringValue;
@@ -133,6 +135,16 @@ public final class RequestMapper extends RequestUtil {
       final UpdateJobTimeoutRequest grpcRequest) {
     final var brokerRequest =
         new BrokerUpdateJobTimeoutRequest(grpcRequest.getJobKey(), grpcRequest.getTimeout());
+    if (grpcRequest.hasOperationReference()) {
+      brokerRequest.setOperationReference(grpcRequest.getOperationReference());
+    }
+    return brokerRequest;
+  }
+
+  public static BrokerUpdateJobRequest toUpdateJobRequest(final UpdateJobRequest grpcRequest) {
+    final var brokerRequest =
+        new BrokerUpdateJobRequest(
+            grpcRequest.getJobKey(), grpcRequest.getRetries(), grpcRequest.getTimeout());
     if (grpcRequest.hasOperationReference()) {
       brokerRequest.setOperationReference(grpcRequest.getOperationReference());
     }

--- a/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
+++ b/zeebe/gateway-grpc/src/main/java/io/camunda/zeebe/gateway/ResponseMapper.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.PublishMessageRespons
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ResolveIncidentResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.SetVariablesResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.ThrowErrorResponse;
+import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobRetriesResponse;
 import io.camunda.zeebe.gateway.protocol.GatewayOuterClass.UpdateJobTimeoutResponse;
 import io.camunda.zeebe.msgpack.value.LongValue;
@@ -159,6 +160,11 @@ public final class ResponseMapper {
   public static UpdateJobTimeoutResponse toUpdateJobTimeoutResponse(
       final long key, final JobRecord brokerResponse) {
     return UpdateJobTimeoutResponse.getDefaultInstance();
+  }
+
+  public static UpdateJobResponse toUpdateJobResponse(
+      final long key, final JobRecord brokerResponse) {
+    return UpdateJobResponse.getDefaultInstance();
   }
 
   public static FailJobResponse toFailJobResponse(final long key, final JobRecord brokerResponse) {

--- a/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
+++ b/zeebe/gateway-protocol-impl/src/main/resources/gateway-service-config.json
@@ -34,7 +34,8 @@
         {"service": "gateway_protocol.Gateway", "method": "SetVariables"},
         {"service": "gateway_protocol.Gateway", "method": "ThrowError"},
         {"service": "gateway_protocol.Gateway", "method": "UpdateJobRetries"},
-        {"service": "gateway_protocol.Gateway", "method": "UpdateJobTimeout"}
+        {"service": "gateway_protocol.Gateway", "method": "UpdateJobTimeout"},
+        {"service": "gateway_protocol.Gateway", "method": "UpdateJob"}
       ],
       "waitForReady": true,
       "retryPolicy": {

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -569,6 +569,20 @@ message UpdateJobTimeoutRequest {
 message UpdateJobTimeoutResponse {
 }
 
+message UpdateJobRequest {
+  // the unique job identifier, as obtained through ActivateJobs
+  int64 jobKey = 1;
+  // the new amount of retries for the job; must be positive
+  int32 retries = 2;
+  // the duration of the new timeout in ms, starting from the current moment
+  int64 timeout = 3;
+  // a reference key chosen by the user and will be part of all records resulted from this operation
+  optional uint64 operationReference = 4;
+}
+
+message UpdateJobResponse {
+}
+
 message SetVariablesRequest {
   // the unique identifier of a particular element; can be the process instance key (as
   // obtained during instance creation), or a given element, such as a service task (see
@@ -981,6 +995,20 @@ service Gateway {
       - no deadline exists for the given job key
  */
   rpc UpdateJobTimeout (UpdateJobTimeoutRequest) returns (UpdateJobTimeoutResponse) {
+  }
+
+  /*
+  Updates the number of retries a job has left and the deadline of a job using the timeout (in ms) provided.
+
+  Errors:
+    NOT_FOUND:
+      - no job exists with the given key
+
+    INVALID_ARGUMENT:
+      - retries is not greater than 0
+      - no deadline exists for the given job key
+ */
+  rpc UpdateJob (UpdateJobRequest) returns (UpdateJobResponse) {
   }
 
   /*

--- a/zeebe/gateway-protocol/src/main/proto/proto.lock
+++ b/zeebe/gateway-protocol/src/main/proto/proto.lock
@@ -1108,6 +1108,34 @@
             "name": "UpdateJobTimeoutResponse"
           },
           {
+            "name": "UpdateJobRequest",
+            "fields": [
+              {
+                "id": 1,
+                "name": "jobKey",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "retries",
+                "type": "int32"
+              },
+              {
+                "id": 3,
+                "name": "timeout",
+                "type": "int64"
+              },
+              {
+                "id": 4,
+                "name": "operationReference",
+                "type": "uint64"
+              }
+            ]
+          },
+          {
+            "name": "UpdateJobResponse"
+          },
+          {
             "name": "SetVariablesRequest",
             "fields": [
               {
@@ -1436,6 +1464,11 @@
                 "name": "UpdateJobTimeout",
                 "in_type": "UpdateJobTimeoutRequest",
                 "out_type": "UpdateJobTimeoutResponse"
+              },
+              {
+                "name": "UpdateJob",
+                "in_type": "UpdateJobRequest",
+                "out_type": "UpdateJobResponse"
               },
               {
                 "name": "DeleteResource",

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1198,6 +1198,8 @@ components:
       properties:
         changeset:
           $ref: "#/components/schemas/JobChangeset"
+      required:
+        - changeset
     JobChangeset:
       description: |
         JSON object with changed job attribute values.
@@ -1212,7 +1214,6 @@ components:
 
         The job cannot be completed or failed with this endpoint, use the Complete job or Fail job endpoints instead.
       type: object
-      nullable: true
       additionalProperties: true
       properties:
         retries:

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -230,6 +230,58 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+  /jobs/{jobKey}:
+    patch:
+      tags:
+        - Job
+      summary: Update a job
+      description: Update a job with the given key.
+      parameters:
+        - name: jobKey
+          in: path
+          required: true
+          description: The key of the job to update.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JobUpdateRequest"
+      responses:
+        '204':
+          description: The job was updated successfully.
+        '400':
+          description: >
+            The provided data is not valid.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        '404':
+          description: The job with the jobKey is not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        '409':
+          description: >
+            The job with the given key is in the wrong state currently.
+            More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        '500':
+          description: >
+            An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+
   /incidents/{incidentKey}/resolution:
     post:
       tags:
@@ -267,6 +319,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+
   /user-tasks/{userTaskKey}/completion:
     post:
       tags:
@@ -1140,6 +1193,39 @@ components:
           description: The variables to complete the job with.
           type: object
           nullable: true
+    JobUpdateRequest:
+      type: object
+      properties:
+        changeset:
+          $ref: "#/components/schemas/JobChangeset"
+    JobChangeset:
+      description: |
+        JSON object with changed job attribute values.
+
+        The following attributes can be adjusted with this endpoint, additional attributes
+        will be ignored:
+
+        * `retries` - The new amount of retries for the job; must be a positive number.
+        * `timeout` - The duration of the new timeout in ms, starting from the current moment.
+
+        Providing any of those attributes with a null value or omitting it preserves the persisted attribute’s value.
+
+        The job cannot be completed or failed with this endpoint, use the Complete job or Fail job endpoints instead.
+      type: object
+      nullable: true
+      additionalProperties: true
+      properties:
+        retries:
+          type: integer
+          format: int32
+          description: The new amount of retries for the job; must be a positive number.
+          nullable: true
+        timeout:
+          type: integer
+          format: int64
+          description: The duration of the new timeout in ms, starting from the current moment.
+          nullable: true
+
     ProblemDetail:
       description: >
         A Problem detail object as described in [RFC 9457](https://www.rfc-editor.org/rfc/rfc9457).

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -135,16 +135,13 @@ public class RequestMapper {
   public static Either<ProblemDetail, UpdateJobRequest> toJobUpdateRequest(
       final JobUpdateRequest updateRequest, final long jobKey) {
     final var validationJobUpdateResponse = validateJobUpdateRequest(updateRequest);
-    return validationJobUpdateResponse
-        .<Either<ProblemDetail, UpdateJobRequest>>map(Either::left)
-        .orElseGet(
-            () ->
-                Either.right(
-                    new UpdateJobRequest(
-                        jobKey,
-                        getIntOrZero(updateRequest, r -> updateRequest.getChangeset().getRetries()),
-                        getLongOrZero(
-                            updateRequest, r -> updateRequest.getChangeset().getTimeout()))));
+    return getResult(
+        validationJobUpdateResponse,
+        () ->
+            new UpdateJobRequest(
+                jobKey,
+                getIntOrZero(updateRequest, r -> updateRequest.getChangeset().getRetries()),
+                getLongOrZero(updateRequest, r -> updateRequest.getChangeset().getTimeout())));
   }
 
   public static CompletableFuture<ResponseEntity<Object>> executeServiceMethod(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -14,15 +14,18 @@ import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.protocol.rest.JobCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobErrorRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobFailRequest;
+import io.camunda.zeebe.gateway.protocol.rest.JobUpdateRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper;
 import io.camunda.zeebe.gateway.rest.RequestMapper.CompleteJobRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper.ErrorJobRequest;
 import io.camunda.zeebe.gateway.rest.RequestMapper.FailJobRequest;
+import io.camunda.zeebe.gateway.rest.RequestMapper.UpdateJobRequest;
 import io.camunda.zeebe.gateway.rest.RestErrorMapper;
 import java.util.concurrent.CompletableFuture;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -83,6 +86,16 @@ public class JobController {
     return completeJob(RequestMapper.toJobCompletionRequest(completionRequest, jobKey));
   }
 
+  @PatchMapping(
+      path = "/{jobKey}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE},
+      consumes = MediaType.APPLICATION_JSON_VALUE)
+  public CompletableFuture<ResponseEntity<Object>> updateJob(
+      @PathVariable final long jobKey, @RequestBody final JobUpdateRequest jobUpdateRequest) {
+    return RequestMapper.toJobUpdateRequest(jobUpdateRequest, jobKey)
+        .fold(this::updateJob, RestErrorMapper::mapProblemToCompletedResponse);
+  }
+
   private CompletableFuture<ResponseEntity<Object>> activateJobs(
       final ActivateJobsRequest activationRequest) {
     final var result = new CompletableFuture<ResponseEntity<Object>>();
@@ -129,5 +142,17 @@ public class JobController {
             jobServices
                 .withAuthentication(RequestMapper.getAuthentication())
                 .completeJob(completeJobRequest.jobKey(), completeJobRequest.variables()));
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> updateJob(
+      final UpdateJobRequest updateJobRequest) {
+    return RequestMapper.executeServiceMethodWithNoContenResult(
+        () ->
+            jobServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .updateJob(
+                    updateJobRequest.jobKey(),
+                    updateJobRequest.retries(),
+                    updateJobRequest.timeout()));
   }
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -146,7 +146,7 @@ public class JobController {
 
   private CompletableFuture<ResponseEntity<Object>> updateJob(
       final UpdateJobRequest updateJobRequest) {
-    return RequestMapper.executeServiceMethodWithNoContenResult(
+    return RequestMapper.executeServiceMethodWithNoContentResult(
         () ->
             jobServices
                 .withAuthentication(RequestMapper.getAuthentication())

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -23,4 +23,6 @@ public final class ErrorMessages {
   public static final String ERROR_UNKNOWN_SORT_ORDER = "Unknown sortOrder: %s";
   public static final String ERROR_SEARCH_BEFORE_AND_AFTER =
       "Both searchAfter and searchBefore cannot be set at the same time";
+  public static final String ERROR_MESSAGE_AT_LEAST_ONE_FIELD =
+      "At least one field between %s is required";
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/ErrorMessages.java
@@ -23,6 +23,5 @@ public final class ErrorMessages {
   public static final String ERROR_UNKNOWN_SORT_ORDER = "Unknown sortOrder: %s";
   public static final String ERROR_SEARCH_BEFORE_AND_AFTER =
       "Both searchAfter and searchBefore cannot be set at the same time";
-  public static final String ERROR_MESSAGE_AT_LEAST_ONE_FIELD =
-      "At least one field between %s is required";
+  public static final String ERROR_MESSAGE_AT_LEAST_ONE_FIELD = "At least one of %s is required";
 }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/JobRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/JobRequestValidator.java
@@ -61,9 +61,7 @@ public final class JobRequestValidator {
     final List<String> violations = new ArrayList<>();
     final JobChangeset changeset = updateRequest.getChangeset();
     if (changeset.getRetries() == null && changeset.getTimeout() == null) {
-      violations.add(
-          ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(
-              String.join(", ", List.of("retries", "timeout"))));
+      violations.add(ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(List.of("retries", "timeout")));
     }
     if (changeset.getRetries() != null && changeset.getRetries() < 1) {
       violations.add(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/JobRequestValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/JobRequestValidator.java
@@ -7,12 +7,15 @@
  */
 package io.camunda.zeebe.gateway.rest.validator;
 
+import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_AT_LEAST_ONE_FIELD;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_EMPTY_ATTRIBUTE;
 import static io.camunda.zeebe.gateway.rest.validator.ErrorMessages.ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE;
 import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.createProblemDetail;
 
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
+import io.camunda.zeebe.gateway.protocol.rest.JobChangeset;
 import io.camunda.zeebe.gateway.protocol.rest.JobErrorRequest;
+import io.camunda.zeebe.gateway.protocol.rest.JobUpdateRequest;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +52,28 @@ public final class JobRequestValidator {
     // errorCode can't be null or empty
     if (errorRequest.getErrorCode() == null || errorRequest.getErrorCode().isBlank()) {
       violations.add(ERROR_MESSAGE_EMPTY_ATTRIBUTE.formatted("errorCode"));
+    }
+    return createProblemDetail(violations);
+  }
+
+  public static Optional<ProblemDetail> validateJobUpdateRequest(
+      final JobUpdateRequest updateRequest) {
+    final List<String> violations = new ArrayList<>();
+    final JobChangeset changeset = updateRequest.getChangeset();
+    if (changeset.getRetries() == null && changeset.getTimeout() == null) {
+      violations.add(
+          ERROR_MESSAGE_AT_LEAST_ONE_FIELD.formatted(
+              String.join(", ", List.of("retries", "timeout"))));
+    }
+    if (changeset.getRetries() != null && changeset.getRetries() < 1) {
+      violations.add(
+          ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
+              "retries", changeset.getRetries(), "greater than 0"));
+    }
+    if (changeset.getTimeout() != null && changeset.getTimeout() < 1) {
+      violations.add(
+          ERROR_MESSAGE_INVALID_ATTRIBUTE_VALUE.formatted(
+              "timeout", changeset.getTimeout(), "greater than 0"));
     }
     return createProblemDetail(violations);
   }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -435,7 +435,7 @@ public class JobControllerTest extends RestControllerTest {
           "type": "about:blank",
           "status": 400,
           "title": "INVALID_ARGUMENT",
-          "detail": "At least one field between retries, timeout is required.",
+          "detail": "At least one of [retries, timeout] is required.",
           "instance": "%s"
         }"""
             .formatted(JOBS_BASE_URL + "/1");
@@ -486,6 +486,35 @@ public class JobControllerTest extends RestControllerTest {
         .accept(MediaType.APPLICATION_JSON)
         .contentType(MediaType.APPLICATION_JSON)
         .bodyValue(request)
+        .exchange()
+        .expectStatus()
+        .isBadRequest()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_PROBLEM_JSON)
+        .expectBody()
+        .json(expectedBody);
+  }
+
+  @Test
+  void shouldRejectUpdateJobNoBody() {
+    // given
+    final var expectedBody =
+        """
+        {
+          "type": "about:blank",
+          "status": 400,
+          "title": "Bad Request",
+          "detail": "Required request body is missing",
+          "instance": "%s"
+        }"""
+            .formatted(JOBS_BASE_URL + "/1");
+
+    // when/then
+    webClient
+        .patch()
+        .uri(JOBS_BASE_URL + "/1")
+        .accept(MediaType.APPLICATION_JSON)
+        .contentType(MediaType.APPLICATION_JSON)
         .exchange()
         .expectStatus()
         .isBadRequest()

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/request/BrokerUpdateJobRequest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker.request;
+
+import io.camunda.zeebe.broker.client.api.dto.BrokerExecuteCommand;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.util.buffer.BufferWriter;
+import org.agrona.DirectBuffer;
+
+public class BrokerUpdateJobRequest extends BrokerExecuteCommand<JobRecord> {
+
+  private final JobRecord requestDto = new JobRecord();
+
+  public BrokerUpdateJobRequest(final long jobKey, final int retries, final long timeout) {
+    super(ValueType.JOB, JobIntent.UPDATE);
+    request.setKey(jobKey);
+    requestDto.setRetries(retries);
+    requestDto.setTimeout(timeout);
+  }
+
+  @Override
+  public BufferWriter getRequestWriter() {
+    return requestDto;
+  }
+
+  @Override
+  protected JobRecord toResponseDto(final DirectBuffer buffer) {
+    final JobRecord responseDto = new JobRecord();
+    responseDto.wrap(buffer);
+    return responseDto;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -49,7 +49,9 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
   UPDATE_TIMEOUT((short) 17),
   TIMEOUT_UPDATED((short) 18),
 
-  MIGRATED((short) 19);
+  MIGRATED((short) 19),
+
+  UPDATE((short) 20);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -109,6 +111,8 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
         return TIMEOUT_UPDATED;
       case 19:
         return MIGRATED;
+      case 20:
+        return UPDATE;
       default:
         return UNKNOWN;
     }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/JobIntent.java
@@ -51,7 +51,8 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
 
   MIGRATED((short) 19),
 
-  UPDATE((short) 20);
+  UPDATE((short) 20),
+  UPDATED((short) 21);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -113,6 +114,8 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
         return MIGRATED;
       case 20:
         return UPDATE;
+      case 21:
+        return UPDATED;
       default:
         return UNKNOWN;
     }
@@ -137,6 +140,7 @@ public enum JobIntent implements ProcessInstanceRelatedIntent {
       case YIELDED:
       case TIMEOUT_UPDATED:
       case MIGRATED:
+      case UPDATED:
         return true;
       default:
         return false;


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Add an endpoint to the REST API for update a job.

The gRPC endpoints for updating a job are 2:
- `UpdateJobRetries`
- `UpdateJobTimeout`

Since we want to provide to users an unique endpoint to updates job retries and timeout, the final solution include also the implementation of a new gRPC endpoint for updating those fields in the same command/request

Why this decision ?

For mainly two reasons:
- Waiting for completing the two command on REST API side was tricky and not easy to implement 
- We want to provide atomicity, this means that if one of the updates result in an error Zeebe should rollback to the previous state without updating the other field

For achieve this we introduced a new gRPC command `UpdateJob`

```
message UpdateJobRequest {
  // the unique job identifier, as obtained through ActivateJobs
  int64 jobKey = 1;
  // the new amount of retries for the job; must be positive
  int32 retries = 2;
  // the duration of the new timeout in ms, starting from the current moment
  int64 timeout = 3;
  // a reference key chosen by the user and will be part of all records resulted from this operation
  optional uint64 operationReference = 4;
}
```
A new JobIntent `UPDATE` was also introduced, event with this intent are handled by a new Processor that simply split the command into the already existing JobIntent `RETRIES_UPDATED` and `TIMEOUT_UPDATE`. In this way we are reusing the same appliers of the "old" two commands

## Related issues

closes #20083 
