### PR TITLE
feat: support user creation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -54,6 +54,22 @@ component/tasklist:
           - 'tasklist/**'
           - 'tasklist.Dockerfile'
           - 'webapps-common/**'
+component/optimize:
+  - changed-files:
+      - any-glob-to-any-file:
+        - '.ci/docker/test/*'
+        - '.github/ISSUE_TEMPLATE/optimize-*'
+        - '.github/actions/**'
+        - '.github/renovate.json'
+        - '.github/workflows/optimize-*'
+        - 'bom/*'
+        - 'camunda.Dockerfile'
+        - 'dist/**'
+        - 'optimize.Dockerfile'
+        - 'optimize/**'
+        - 'parent/*'
+        - 'pom.xml'
+        - 'webapps-common/**'
 component/build-pipeline:
   - changed-files:
       - any-glob-to-any-file:

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -42,20 +42,20 @@
     },
     {
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["org.opensearch.client", "org.elasticsearch", "co.elastic"],
+      "matchPackageNames": ["org.opensearch.client{/,}**", "org.elasticsearch{/,}**", "co.elastic{/,}**"],
       "matchUpdateTypes": ["minor", "major"],
       "enabled": false
     },
     {
       "description": "Skip lucene major updates to avoid breaking changes.",
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["org.apache.lucene"],
+      "matchPackageNames": ["org.apache.lucene{/,}**"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["com.graphql-java"],
+      "matchPackageNames": ["com.graphql-java{/,}**"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
@@ -68,25 +68,24 @@
     },
     {
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["org.jacoco"],
+      "matchPackageNames": ["org.jacoco{/,}**"],
       "allowedVersions": "!/0.8.9/"
     },
     {
       "description": "Do not update Netty as it is incompatible with grpc-java < 1.65; this can be removed after that",
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["io.netty"],
-      "allowedVersions": "<=4.1.110.Final"
+      "matchPackageNames": ["io.netty{/,}**"]
     },
     {
       "description" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
       "matchManagers": ["maven"],
-      "matchPackagePatterns": [".*"],
+      "matchPackageNames": ["*"],
       "allowedVersions": "!/-SNAPSHOT$/"
     },
     {
       "description" : "Exclude internal Maven modules and Maven dependencies lacking metadata.",
       "matchManagers": ["maven"],
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "io.camunda:operate-parent",
         "io.camunda:operate-qa",
         "io.camunda:operate-qa-migration-tests-parent",
@@ -100,7 +99,7 @@
       "description": "Exclude frontend deps until migration is done in Operate (see issues #17736, #17844, #18851)",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["operate/**"],
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "react-router-dom",
         "msw",
         "@carbon/react"
@@ -117,7 +116,7 @@
       "additionalBranchPrefix": "fe-"
     },
     {
-      "matchPackagePrefixes": ["@types/"],
+      "matchPackageNames": ["@types/{/,}**"],
       "groupName": "definitelyTyped"
     },
     {
@@ -130,7 +129,7 @@
     },
     {
       "matchManagers": ["npm", "nvm"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "matchUpdateTypes": ["patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
@@ -152,7 +151,7 @@
     },
     {
       "description": "Automerge all updates with green CI.",
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "automerge": true,
       "addLabels": ["automerge"]
     }

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -666,7 +666,6 @@
             <!-- Needed for Spring Actuators, and REST API -->
             <dependency>org.springframework.boot:spring-boot-starter-web</dependency>
             <dependency>org.openapitools:jackson-databind-nullable</dependency>
-            <dependency>io.micrometer:micrometer-registry-prometheus-simpleclient</dependency>
             <dependency>jakarta.servlet:jakarta.servlet-api</dependency>
             <dependency>jakarta.annotation:jakarta.annotation-api</dependency>
 

--- a/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
+++ b/dist/src/main/java/io/camunda/zeebe/broker/BrokerModuleConfiguration.java
@@ -15,6 +15,8 @@ import io.camunda.zeebe.broker.system.SystemContext;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
 import java.io.IOException;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,6 +56,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
   private final BrokerShutdownHelper shutdownHelper;
+  private final MeterRegistry meterRegistry;
 
   private Broker broker;
 
@@ -65,7 +68,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
       final ActorScheduler actorScheduler,
       final AtomixCluster cluster,
       final BrokerClient brokerClient,
-      final BrokerShutdownHelper shutdownHelper) {
+      final BrokerShutdownHelper shutdownHelper,
+      final PrometheusMeterRegistry meterRegistry) {
     this.configuration = configuration;
     this.identityConfiguration = identityConfiguration;
     this.springBrokerBridge = springBrokerBridge;
@@ -73,6 +77,7 @@ public class BrokerModuleConfiguration implements CloseableSilently {
     this.cluster = cluster;
     this.brokerClient = brokerClient;
     this.shutdownHelper = shutdownHelper;
+    this.meterRegistry = meterRegistry;
   }
 
   @Bean(destroyMethod = "close")
@@ -84,8 +89,8 @@ public class BrokerModuleConfiguration implements CloseableSilently {
             identityConfiguration,
             actorScheduler,
             cluster,
-            brokerClient);
-
+            brokerClient,
+            meterRegistry);
     springBrokerBridge.registerShutdownHelper(
         errorCode -> shutdownHelper.initiateShutdown(errorCode));
     broker = new Broker(systemContext, springBrokerBridge);

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -55,7 +55,7 @@
     <version.grpc>1.65.1</version.grpc>
     <version.gson>2.11.0</version.gson>
     <version.guava>33.2.1-jre</version.guava>
-    <version.hamcrest>2.2</version.hamcrest>
+    <version.hamcrest>3.0</version.hamcrest>
     <version.httpasyncclient>4.1.5</version.httpasyncclient>
     <version.httpclient>4.5.14</version.httpclient>
     <version.httpclient5>5.3.1</version.httpclient5>

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -388,6 +388,10 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -176,6 +176,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/zeebe/broker/pom.xml
+++ b/zeebe/broker/pom.xml
@@ -393,10 +393,6 @@
       <artifactId>jmh-generator-annprocess</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-registry-prometheus-simpleclient</artifactId>
-    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/Broker.java
@@ -24,12 +24,7 @@ import io.camunda.zeebe.util.LogUtil;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
 import io.camunda.zeebe.util.jar.ExternalJarLoadException;
-import io.micrometer.core.instrument.Clock;
-import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.util.NetUtil;
-import io.prometheus.client.CollectorRegistry;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -65,10 +60,6 @@ public final class Broker implements AutoCloseable {
 
     healthCheckService = new BrokerHealthCheckService(localBroker);
 
-    final MeterRegistry meterRegistry =
-        new PrometheusMeterRegistry(
-            PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
-
     final var startupContext =
         new BrokerStartupContextImpl(
             localBroker,
@@ -82,7 +73,7 @@ public final class Broker implements AutoCloseable {
             systemContext.getBrokerClient(),
             additionalPartitionListeners,
             systemContext.getShutdownTimeout(),
-            meterRegistry);
+            systemContext.getMeterRegistry());
 
     brokerStartupActor = new BrokerStartupActor(startupContext);
     scheduler.submitActor(brokerStartupActor);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/BrokerStartupContext.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.protocol.impl.encoding.BrokerInfo;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.List;
 import org.agrona.concurrent.SnowflakeIdGenerator;
@@ -117,4 +118,6 @@ public interface BrokerStartupContext {
   SnowflakeIdGenerator getRequestIdGenerator();
 
   void setRequestIdGenerator(SnowflakeIdGenerator requestIdGenerator);
+
+  MeterRegistry getMeterRegistry();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/bootstrap/PartitionManagerStep.java
@@ -45,7 +45,8 @@ final class PartitionManagerStep extends AbstractBrokerStartupStep {
             brokerStartupContext.getExporterRepository(),
             brokerStartupContext.getGatewayBrokerTransport(),
             brokerStartupContext.getJobStreamService().jobStreamer(),
-            brokerStartupContext.getClusterConfigurationService());
+            brokerStartupContext.getClusterConfigurationService(),
+            brokerStartupContext.getMeterRegistry());
     concurrencyControl.run(
         () -> {
           try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -12,6 +12,11 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.EnsureUtil;
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import io.prometheus.client.CollectorRegistry;
 import org.slf4j.Logger;
 
 public final class ExporterContext implements Context {
@@ -21,6 +26,7 @@ public final class ExporterContext implements Context {
   private final Logger logger;
   private final Configuration configuration;
   private final int partitionId;
+  private final MeterRegistry meterRegistry;
 
   private RecordFilter filter = DEFAULT_FILTER;
 
@@ -29,6 +35,14 @@ public final class ExporterContext implements Context {
     this.logger = logger;
     this.configuration = configuration;
     this.partitionId = partitionId;
+    meterRegistry =
+        new PrometheusMeterRegistry(
+            PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -12,11 +12,7 @@ import io.camunda.zeebe.exporter.api.context.Context;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.EnsureUtil;
-import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.prometheus.PrometheusConfig;
-import io.micrometer.prometheus.PrometheusMeterRegistry;
-import io.prometheus.client.CollectorRegistry;
 import org.slf4j.Logger;
 
 public final class ExporterContext implements Context {
@@ -31,13 +27,14 @@ public final class ExporterContext implements Context {
   private RecordFilter filter = DEFAULT_FILTER;
 
   public ExporterContext(
-      final Logger logger, final Configuration configuration, final int partitionId) {
+      final Logger logger,
+      final Configuration configuration,
+      final int partitionId,
+      final MeterRegistry meterRegistry) {
     this.logger = logger;
     this.configuration = configuration;
     this.partitionId = partitionId;
-    meterRegistry =
-        new PrometheusMeterRegistry(
-            PrometheusConfig.DEFAULT, CollectorRegistry.defaultRegistry, Clock.SYSTEM);
+    this.meterRegistry = meterRegistry;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import io.camunda.zeebe.util.jar.ExternalJarRepository;
 import io.camunda.zeebe.util.jar.ThreadContextUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -90,7 +91,8 @@ public final class ExporterRepository {
     try {
       final Exporter instance = descriptor.newInstance();
       final ExporterContext context =
-          new ExporterContext(LOG, descriptor.getConfiguration(), NULL_PARTITION_ID);
+          new ExporterContext(
+              LOG, descriptor.getConfiguration(), NULL_PARTITION_ID, new SimpleMeterRegistry());
 
       ThreadContextUtil.runCheckedWithClassLoader(
           () -> instance.configure(context), instance.getClass().getClassLoader());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.jar.ThreadContextUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
@@ -49,13 +50,15 @@ final class ExporterContainer implements Controller {
   ExporterContainer(
       final ExporterDescriptor descriptor,
       final int partitionId,
-      final ExporterInitializationInfo initializationInfo) {
+      final ExporterInitializationInfo initializationInfo,
+      final MeterRegistry meterRegistry) {
     this.initializationInfo = initializationInfo;
     context =
         new ExporterContext(
             Loggers.getExporterLogger(descriptor.getId()),
             descriptor.getConfiguration(),
-            partitionId);
+            partitionId,
+            meterRegistry);
 
     exporter = descriptor.newInstance();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.util.exception.UnrecoverableException;
 import io.camunda.zeebe.util.health.FailureListener;
 import io.camunda.zeebe.util.health.HealthMonitorable;
 import io.camunda.zeebe.util.health.HealthReport;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -86,6 +87,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
   private ScheduledTimer exporterDistributionTimer;
   private final int partitionId;
   private final EventFilter positionsToSkipFilter;
+  private final MeterRegistry meterRegistry;
   // When idle, exporter director is not exporting any records because no exporters are configured.
   // The actor is still running, but it is not actively doing any work.
   private boolean idle;
@@ -96,12 +98,16 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
 
     logStream = Objects.requireNonNull(context.getLogStream());
     partitionId = logStream.getPartitionId();
+    meterRegistry = context.getMeterRegistry();
     containers =
         context.getDescriptors().entrySet().stream()
             .map(
                 descriptorEntry ->
                     new ExporterContainer(
-                        descriptorEntry.getKey(), partitionId, descriptorEntry.getValue()))
+                        descriptorEntry.getKey(),
+                        partitionId,
+                        descriptorEntry.getValue(),
+                        meterRegistry))
             .collect(Collectors.toCollection(ArrayList::new));
     metrics = new ExporterMetrics(partitionId);
     metrics.initializeExporterState(exporterPhase);
@@ -274,7 +280,7 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       final ExporterInitializationInfo initializationInfo,
       final ExporterDescriptor descriptor) {
     final ExporterContainer container =
-        new ExporterContainer(descriptor, partitionId, initializationInfo);
+        new ExporterContainer(descriptor, partitionId, initializationInfo, meterRegistry);
     container.initContainer(actor, metrics, state, exporterPhase);
     try {
       container.configureExporter();

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.broker.system.partitions.PartitionMessagingService;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.api.EventFilter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ public final class ExporterDirectorContext {
   private ExporterMode exporterMode = ExporterMode.ACTIVE; // per default we export records
   private Duration distributionInterval = DEFAULT_DISTRIBUTION_INTERVAL;
   private EventFilter positionsToSkipFilter;
+  private MeterRegistry meterRegistry;
 
   public int getId() {
     return id;
@@ -66,6 +68,10 @@ public final class ExporterDirectorContext {
     return positionsToSkipFilter;
   }
 
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
+  }
+
   public ExporterDirectorContext id(final int id) {
     this.id = id;
     return this;
@@ -89,6 +95,11 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext zeebeDb(final ZeebeDb zeebeDb) {
     this.zeebeDb = zeebeDb;
+    return this;
+  }
+
+  public ExporterDirectorContext meterRegistry(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/PartitionManagerImpl.java
@@ -37,6 +37,7 @@ import io.camunda.zeebe.scheduler.future.ActorFutureCollector;
 import io.camunda.zeebe.scheduler.startup.StartupProcessShutdownException;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthStatus;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -79,7 +80,8 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
       final ExporterRepository exporterRepository,
       final AtomixServerTransport gatewayBrokerTransport,
       final JobStreamer jobStreamer,
-      final ClusterConfigurationService clusterConfigurationService) {
+      final ClusterConfigurationService clusterConfigurationService,
+      final MeterRegistry meterRegistry) {
     this.brokerCfg = brokerCfg;
     this.concurrencyControl = concurrencyControl;
     this.actorSchedulingService = actorSchedulingService;
@@ -107,7 +109,8 @@ public final class PartitionManagerImpl implements PartitionManager, PartitionCh
             listeners,
             partitionRaftListeners,
             topologyManager,
-            featureFlags);
+            featureFlags,
+            meterRegistry);
     managementService =
         new DefaultPartitionManagementService(
             clusterServices.getMembershipService(), clusterServices.getCommunicationService());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/ZeebePartitionFactory.java
@@ -59,6 +59,7 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
@@ -99,6 +100,7 @@ public final class ZeebePartitionFactory {
   private final TopologyManagerImpl topologyManager;
   private final FeatureFlags featureFlags;
   private final List<PartitionRaftListener> partitionRaftListeners;
+  private final MeterRegistry meterRegistry;
 
   public ZeebePartitionFactory(
       final ActorSchedulingService actorSchedulingService,
@@ -113,7 +115,8 @@ public final class ZeebePartitionFactory {
       final List<PartitionListener> partitionListeners,
       final List<PartitionRaftListener> partitionRaftListeners,
       final TopologyManagerImpl topologyManager,
-      final FeatureFlags featureFlags) {
+      final FeatureFlags featureFlags,
+      final MeterRegistry meterRegistry) {
     this.actorSchedulingService = actorSchedulingService;
     this.brokerCfg = brokerCfg;
     this.localBroker = localBroker;
@@ -127,6 +130,7 @@ public final class ZeebePartitionFactory {
     this.partitionRaftListeners = partitionRaftListeners;
     this.topologyManager = topologyManager;
     this.featureFlags = featureFlags;
+    this.meterRegistry = meterRegistry;
   }
 
   public ZeebePartition constructPartition(
@@ -159,7 +163,8 @@ public final class ZeebePartitionFactory {
             new PartitionProcessingState(raftPartition),
             diskSpaceUsageMonitor,
             gatewayBrokerTransport,
-            topologyManager);
+            topologyManager,
+            meterRegistry);
     context.setDynamicPartitionConfig(initialPartitionConfig);
 
     final PartitionTransition newTransitionBehavior = new PartitionTransitionImpl(TRANSITION_STEPS);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/SystemContext.java
@@ -29,6 +29,9 @@ import io.camunda.zeebe.broker.system.configuration.backup.S3BackupStoreConfig;
 import io.camunda.zeebe.broker.system.configuration.partitioning.FixedPartitionCfg;
 import io.camunda.zeebe.broker.system.configuration.partitioning.Scheme;
 import io.camunda.zeebe.scheduler.ActorScheduler;
+import io.camunda.zeebe.util.VisibleForTesting;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
@@ -54,6 +57,7 @@ public final class SystemContext {
   private final ActorScheduler scheduler;
   private final AtomixCluster cluster;
   private final BrokerClient brokerClient;
+  private final MeterRegistry meterRegistry;
 
   public SystemContext(
       final Duration shutdownTimeout,
@@ -61,22 +65,32 @@ public final class SystemContext {
       final IdentityConfiguration identityConfiguration,
       final ActorScheduler scheduler,
       final AtomixCluster cluster,
-      final BrokerClient brokerClient) {
+      final BrokerClient brokerClient,
+      final MeterRegistry meterRegistry) {
     this.shutdownTimeout = shutdownTimeout;
     this.brokerCfg = brokerCfg;
     this.identityConfiguration = identityConfiguration;
     this.scheduler = scheduler;
     this.cluster = cluster;
     this.brokerClient = brokerClient;
+    this.meterRegistry = meterRegistry;
     initSystemContext();
   }
 
+  @VisibleForTesting
   public SystemContext(
       final BrokerCfg brokerCfg,
       final ActorScheduler scheduler,
       final AtomixCluster cluster,
       final BrokerClient brokerClient) {
-    this(DEFAULT_SHUTDOWN_TIMEOUT, brokerCfg, null, scheduler, cluster, brokerClient);
+    this(
+        DEFAULT_SHUTDOWN_TIMEOUT,
+        brokerCfg,
+        null,
+        scheduler,
+        cluster,
+        brokerClient,
+        new SimpleMeterRegistry());
   }
 
   private void initSystemContext() {
@@ -287,5 +301,9 @@ public final class SystemContext {
 
   public Duration getShutdownTimeout() {
     return shutdownTimeout;
+  }
+
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -45,6 +45,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -99,6 +100,7 @@ public class PartitionStartupAndTransitionContextImpl
   private BackupStore backupStore;
   private AdminApiRequestHandler adminApiService;
   private PartitionAdminAccess adminAccess;
+  private final MeterRegistry meterRegistry;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -117,7 +119,8 @@ public class PartitionStartupAndTransitionContextImpl
       final PartitionProcessingState partitionProcessingState,
       final DiskSpaceUsageMonitor diskSpaceUsageMonitor,
       final AtomixServerTransport gatewayBrokerTransport,
-      final TopologyManager topologyManager) {
+      final TopologyManager topologyManager,
+      final MeterRegistry meterRegistry) {
     this.nodeId = nodeId;
     this.clusterCommunicationService = clusterCommunicationService;
     this.raftPartition = raftPartition;
@@ -137,6 +140,7 @@ public class PartitionStartupAndTransitionContextImpl
     this.diskSpaceUsageMonitor = diskSpaceUsageMonitor;
     this.gatewayBrokerTransport = gatewayBrokerTransport;
     this.topologyManager = topologyManager;
+    this.meterRegistry = meterRegistry;
   }
 
   public PartitionAdminControl getPartitionAdminControl() {
@@ -345,6 +349,11 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public void setBackupStore(final BackupStore backupStore) {
     this.backupStore = backupStore;
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionTransitionContext.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.List;
 
@@ -125,4 +126,6 @@ public interface PartitionTransitionContext extends PartitionContext {
   BackupStore getBackupStore();
 
   void setBackupStore(BackupStore backupStore);
+
+  MeterRegistry getMeterRegistry();
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -122,7 +122,8 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
             .partitionMessagingService(context.getMessagingService())
             .descriptors(exporterDescriptors)
             .exporterMode(exporterMode)
-            .positionsToSkipFilter(exporterFilter);
+            .positionsToSkipFilter(exporterFilter)
+            .meterRegistry(context.getMeterRegistry());
 
     final ExporterDirector director =
         exporterDirectorBuilder.apply(exporterCtx, context.getExporterPhase());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -20,6 +20,8 @@ import io.camunda.zeebe.scheduler.ActorControl;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.util.CloseableSilently;
 import io.camunda.zeebe.util.jar.ExternalJarLoadException;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.nio.file.Path;
 import org.agrona.CloseHelper;
@@ -35,6 +37,7 @@ public final class ExporterContainerRuntime implements CloseableSilently {
   private final RuntimeActor actor;
   private final ExportersState state;
   private final ExporterMetrics metrics;
+  private final MeterRegistry meterRegistry;
 
   public ExporterContainerRuntime(final Path storagePath) {
     scheduler = ActorScheduler.newActorScheduler().build();
@@ -49,6 +52,7 @@ public final class ExporterContainerRuntime implements CloseableSilently {
     state = new ExportersState(zeebeDb, zeebeDb.createContext());
     metrics = new ExporterMetrics(1);
     metrics.initializeExporterState(ExporterPhase.EXPORTING);
+    meterRegistry = new SimpleMeterRegistry();
   }
 
   @Override
@@ -74,7 +78,9 @@ public final class ExporterContainerRuntime implements CloseableSilently {
       final ExporterDescriptor descriptor,
       final int partitionId,
       final ExporterInitializationInfo initializationInfo) {
-    final var container = new ExporterContainer(descriptor, partitionId, initializationInfo);
+    final var container =
+        new ExporterContainer(
+            descriptor, partitionId, initializationInfo, new SimpleMeterRegistry());
     container.initContainer(actor.getActorControl(), metrics, state, ExporterPhase.EXPORTING);
 
     return container;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -71,16 +71,28 @@ public final class ExporterContainerRuntime implements CloseableSilently {
 
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor, final int partitionId) {
-    return newContainer(descriptor, partitionId, new ExporterInitializationInfo(0, null));
+    return newContainer(
+        descriptor,
+        partitionId,
+        new ExporterInitializationInfo(0, null),
+        new SimpleMeterRegistry());
   }
 
   public ExporterContainer newContainer(
       final ExporterDescriptor descriptor,
       final int partitionId,
       final ExporterInitializationInfo initializationInfo) {
+    return newContainer(descriptor, partitionId, initializationInfo, new SimpleMeterRegistry());
+  }
+
+  public ExporterContainer newContainer(
+      final ExporterDescriptor descriptor,
+      final int partitionId,
+      final ExporterInitializationInfo initializationInfo,
+      final MeterRegistry meterRegistry) {
+
     final var container =
-        new ExporterContainer(
-            descriptor, partitionId, initializationInfo, new SimpleMeterRegistry());
+        new ExporterContainer(descriptor, partitionId, initializationInfo, meterRegistry);
     container.initContainer(actor.getActorControl(), metrics, state, ExporterPhase.EXPORTING);
 
     return container;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.jar.ExternalJarClassLoader;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -131,7 +132,8 @@ final class ExternalExporterContainerTest {
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
     final var container =
-        new ExporterContainer(descriptor, 0, new ExporterInitializationInfo(0, null));
+        new ExporterContainer(
+            descriptor, 0, new ExporterInitializationInfo(0, null), new SimpleMeterRegistry());
 
     // when
     container.close();

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -151,7 +151,6 @@ final class ExternalExporterContainerTest {
     final var exporterClass = createUnloadedExporter(ExporterWithMetrics.class);
     final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
     final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
-    final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
 
     final var registry = new SimpleMeterRegistry();
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -145,8 +145,46 @@ final class ExternalExporterContainerTest {
         .isInstanceOf(ExternalJarClassLoader.class);
   }
 
+  @Test
+  void shouldRegisterNewMeterInRegistry(final @TempDir File jarDirectory) throws Exception {
+    // given
+    final var exporterClass = createUnloadedExporter(ExporterWithMetrics.class);
+    final var jarFile = exporterClass.toJar(new File(jarDirectory, "exporter.jar"));
+    final var descriptor = runtime.loadExternalExporter(jarFile, EXPORTER_CLASS_NAME);
+    final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
+
+    final var registry = new SimpleMeterRegistry();
+
+    final var container =
+        new ExporterContainer(descriptor, 0, new ExporterInitializationInfo(0, null), registry);
+
+    // when
+    container.configureExporter();
+
+    // then
+    assertThat(registry.getMeters().stream())
+        .filteredOn(meter -> meter.getId().getName().contains("new.counter"))
+        .hasSize(1);
+  }
+
   private Unloaded<TclExporter> createUnloadedExporter() {
-    return new ByteBuddy().subclass(TclExporter.class).name(EXPORTER_CLASS_NAME).make();
+    return createUnloadedExporter(TclExporter.class);
+  }
+
+  private <T extends Exporter> Unloaded<T> createUnloadedExporter(final Class<T> exporterClass) {
+    return new ByteBuddy().subclass(exporterClass).name(EXPORTER_CLASS_NAME).make();
+  }
+
+  public abstract static class ExporterWithMetrics implements Exporter {
+
+    @Override
+    public void configure(final Context context) throws Exception {
+      Exporter.super.configure(context);
+      context.getMeterRegistry().counter("new.counter");
+    }
+
+    @Override
+    public void export(final Record<?> record) {}
   }
 
   // the class must be visible to the generated exporter for ByteBuddy to delegate method invocation

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collection;
 import java.util.List;
 
@@ -73,6 +74,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private BackupStore backupStore;
   private DynamicPartitionConfig partitionConfig;
   private CommandApiService commandApiService;
+  private MeterRegistry meterRegistry;
 
   @Override
   public int getPartitionId() {
@@ -288,6 +290,11 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public void setBackupStore(final BackupStore backupStore) {
     this.backupStore = backupStore;
+  }
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 
   public void setGatewayBrokerTransport(final AtomixServerTransport gatewayBrokerTransport) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/ActivatableJobsPushTest.java
@@ -154,6 +154,11 @@ public class ActivatableJobsPushTest {
         JobIntent.CREATED,
         JobBatchIntent.ACTIVATED);
 
+    await("waiting for the expected number of jobs to be activated")
+        .atMost(MAX_WAIT_TIME_FOR_ACTIVATED_JOBS)
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(() -> assertThat(jobStream.getActivatedJobs()).hasSize(numberOfJobs));
+
     // assert job stream
     jobStream
         .getActivatedJobs()

--- a/zeebe/exporter-api/pom.xml
+++ b/zeebe/exporter-api/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
   </dependencies>
 
   <build>

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -17,10 +17,13 @@ package io.camunda.zeebe.exporter.api.context;
 
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.slf4j.Logger;
 
 /** Encapsulates context associated with the exporter on open. */
 public interface Context {
+
+  MeterRegistry getMeterRegistry();
 
   /**
    * @return pre-configured logger for this exporter

--- a/zeebe/exporter-test/pom.xml
+++ b/zeebe/exporter-test/pom.xml
@@ -27,6 +27,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
     <!-- SpotBugs annotations -->
     <dependency>
       <groupId>net.jcip</groupId>

--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.exporter.test;
 
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 import net.jcip.annotations.NotThreadSafe;
 import org.slf4j.Logger;
@@ -25,6 +26,11 @@ public final class ExporterTestContext implements Context {
 
   private Configuration configuration;
   private RecordFilter recordFilter;
+
+  @Override
+  public MeterRegistry getMeterRegistry() {
+    return null;
+  }
 
   @Override
   public Logger getLogger() {

--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.exporter.test;
 import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Objects;
 import net.jcip.annotations.NotThreadSafe;
 import org.slf4j.Logger;
@@ -26,10 +27,11 @@ public final class ExporterTestContext implements Context {
 
   private Configuration configuration;
   private RecordFilter recordFilter;
+  private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Override
   public MeterRegistry getMeterRegistry() {
-    return null;
+    return meterRegistry;
   }
 
   @Override

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -156,6 +156,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
       <scope>test</scope>

--- a/zeebe/exporters/elasticsearch-exporter/pom.xml
+++ b/zeebe/exporters/elasticsearch-exporter/pom.xml
@@ -156,11 +156,6 @@
     </dependency>
 
     <dependency>
-      <groupId>io.micrometer</groupId>
-      <artifactId>micrometer-core</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>jakarta.json</groupId>
       <artifactId>jakarta.json-api</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerAnnotationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerAnnotationTest.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @AnalyzeClasses(
     packages = "io.camunda.zeebe.gateway.rest",
     importOptions = ImportOption.DoNotIncludeTests.class)
-public class RestApiDisabledTest {
+public class RestControllerAnnotationTest {
 
   /**
    * This ArchUnit test ensures that any REST API controllers, i.e. classes annotated with the

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/RestControllerTest.java
@@ -5,7 +5,7 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.zeebe.gateway.rest.controller;
+package io.camunda.zeebe.gateway.rest;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
@@ -15,7 +15,7 @@ import org.springframework.test.web.reactive.server.WebTestClient;
     properties = {
       "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration"
     })
-abstract class RestControllerTest {
+public abstract class RestControllerTest {
 
   @Autowired protected WebTestClient webClient;
 }

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayAndApiDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayAndApiDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "zeebe.broker.gateway.enable=false, camunda.rest.enabled=false")
+public class RestApiBrokerGatewayAndApiDisabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiBrokerGatewayDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "zeebe.broker.gateway.enable=false")
+public class RestApiBrokerGatewayDisabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ProcessInstanceServices;
+import io.camunda.service.entities.ProcessInstanceEntity;
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.service.search.query.SearchQueryResult.Builder;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+abstract class RestApiConfigurationTest extends RestControllerTest {
+
+  static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/process-instances/search";
+  static final String TOPOLOGY_URL = "/v2/topology";
+
+  @MockBean ProcessInstanceServices processInstanceServices;
+  @MockBean BrokerClient brokerClient;
+  @MockBean BrokerTopologyManager topologyManager;
+
+  @BeforeEach
+  void setupServices() {
+    when(processInstanceServices.withAuthentication(any(Authentication.class)))
+        .thenReturn(processInstanceServices);
+    when(brokerClient.getTopologyManager()).thenReturn(topologyManager);
+    when(processInstanceServices.search(any(ProcessInstanceQuery.class)))
+        .thenReturn(new Builder<ProcessInstanceEntity>().build());
+    when(topologyManager.getTopology()).thenReturn(mock(BrokerClusterState.class));
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDefaultConfigurationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(value = {ProcessInstanceQueryController.class, TopologyController.class})
+public class RestApiDefaultConfigurationTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldOkForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isOk();
+
+    verify(topologyManager).getTopology();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledAndQueryEnabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledAndQueryEnabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "camunda.rest.enabled=false, camunda.rest.query.enabled=true")
+public class RestApiDisabledAndQueryEnabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiDisabledTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "camunda.rest.enabled=false")
+public class RestApiDisabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldNotFoundForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(processInstanceServices);
+  }
+
+  @Test
+  void shouldYieldNotFoundForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isNotFound();
+
+    verifyNoInteractions(topologyManager);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiQueryEnabledTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiQueryEnabledTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.configuration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.service.search.query.ProcessInstanceQuery;
+import io.camunda.zeebe.gateway.rest.controller.ProcessInstanceQueryController;
+import io.camunda.zeebe.gateway.rest.controller.TopologyController;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+
+@WebMvcTest(
+    value = {ProcessInstanceQueryController.class, TopologyController.class},
+    properties = "camunda.rest.query.enabled=true")
+public class RestApiQueryEnabledTest extends RestApiConfigurationTest {
+
+  @Test
+  void shouldYieldOKForQueryApiRequest() {
+    // when
+    webClient
+        .post()
+        .uri(PROCESS_INSTANCES_SEARCH_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isOk();
+
+    verify(processInstanceServices).search(any(ProcessInstanceQuery.class));
+  }
+
+  @Test
+  void shouldYieldOkForTopologyRequest() {
+    // when
+    webClient
+        .get()
+        .uri(TOPOLOGY_URL)
+        .exchange()
+        // then
+        .expectStatus()
+        .isOk();
+
+    verify(topologyManager).getTopology();
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -20,6 +20,7 @@ import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.search.sort.DecisionDefinitionSort;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ErrorMapperTest.java
@@ -16,6 +16,7 @@ import io.camunda.service.UserTaskServices;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.broker.client.api.dto.BrokerError;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.record.ErrorCode;
 import java.net.URI;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerLongPollingTest.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
 import io.camunda.zeebe.gateway.impl.job.LongPollingActivateJobsHandler;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
 import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.gateway.rest.controller.util.ResettableJobActivationRequestResponseObserver;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.record.RejectionType;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/JobControllerTest.java
@@ -16,6 +16,7 @@ import static org.mockito.Mockito.when;
 import io.camunda.service.JobServices;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.search.sort.ProcessInstanceSort;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/TopologyControllerTest.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.gateway.rest.controller;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
 import io.camunda.zeebe.util.VersionUtil;
 import java.util.List;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskControllerTest.java
@@ -17,6 +17,7 @@ import io.camunda.service.CamundaServiceException;
 import io.camunda.service.UserTaskServices;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.zeebe.broker.client.api.dto.BrokerRejection;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.RejectionType;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -19,6 +19,7 @@ import io.camunda.service.search.query.SearchQueryResult.Builder;
 import io.camunda.service.search.query.UserTaskQuery;
 import io.camunda.service.search.sort.UserTaskSort;
 import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -460,9 +460,23 @@
       <artifactId>zeebe-backup-store-azure</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>org.hawkular.agent</groupId>
+      <artifactId>prometheus-scraper</artifactId>
+      <scope>test</scope>
+      <version>0.23.0.Final</version>
+    </dependency>
+
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
-      <artifactId>prometheus-metrics-exporter-common</artifactId>
+      <artifactId>simpleclient</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -460,6 +460,11 @@
       <artifactId>zeebe-backup-store-azure</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>prometheus-metrics-exporter-common</artifactId>
+      <scope>test</scope>
+    </dependency>
 
   </dependencies>
 

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -464,10 +464,9 @@
     <dependency>
       <groupId>org.hawkular.agent</groupId>
       <artifactId>prometheus-scraper</artifactId>
-      <scope>test</scope>
       <version>0.23.0.Final</version>
+      <scope>test</scope>
     </dependency>
-
 
     <dependency>
       <groupId>io.micrometer</groupId>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -462,13 +462,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.hawkular.agent</groupId>
-      <artifactId>prometheus-scraper</artifactId>
-      <version>0.23.0.Final</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
       <scope>test</scope>

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -466,9 +466,16 @@
       <artifactId>micrometer-core</artifactId>
       <scope>test</scope>
     </dependency>
+
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
       <scope>test</scope>
     </dependency>
 

--- a/zeebe/qa/integration-tests/pom.xml
+++ b/zeebe/qa/integration-tests/pom.xml
@@ -466,19 +466,6 @@
       <artifactId>micrometer-core</artifactId>
       <scope>test</scope>
     </dependency>
-
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>simpleclient</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <scope>test</scope>
-    </dependency>
-
   </dependencies>
 
   <build>

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/clustering/ClusteringRule.java
@@ -70,6 +70,7 @@ import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import io.camunda.zeebe.test.util.socket.SocketUtil;
 import io.camunda.zeebe.util.VersionUtil;
 import io.camunda.zeebe.util.exception.UncheckedExecutionException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.netty.util.NetUtil;
 import java.io.File;
 import java.io.IOException;
@@ -366,7 +367,8 @@ public class ClusteringRule extends ExternalResource {
             null,
             scheduler,
             atomixCluster,
-            brokerClient);
+            brokerClient,
+            new SimpleMeterRegistry());
     systemContexts.put(nodeId, systemContext);
 
     final Broker broker =

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -7,13 +7,19 @@
  */
 package io.camunda.zeebe.it.exporter;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.qa.util.actuator.PrometheusActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import io.prometheus.client.CollectorRegistry;
-import io.prometheus.metrics.exporter.common.PrometheusHttpResponse;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import org.hawkular.agent.prometheus.text.TextPrometheusMetricsProcessor;
+import org.hawkular.agent.prometheus.types.MetricFamily;
+import org.hawkular.agent.prometheus.walkers.CollectorPrometheusMetricsWalker;
 import org.junit.jupiter.api.Test;
 
 @ZeebeIntegration
@@ -28,7 +34,25 @@ public class ExporterMetricsIT {
 
   @Test
   public void shouldAddMeterToExporterMetrics() throws IOException {
+    // given
     final var actuator = PrometheusActuator.of(zeebe);
-    final PrometheusHttpResponse response = actuator.metrics();
+
+    // when
+    final var metrics = collectMetrics(actuator.metrics().body().asInputStream());
+    final var addedCounter =
+        metrics.stream()
+            .filter(
+                metric -> metric.getName().equals(ExporterMetricsTestExporter.REGISTERED_COUNTER))
+            .findFirst();
+
+    // then
+    assertThat(addedCounter).isPresent();
+  }
+
+  private List<MetricFamily> collectMetrics(final InputStream metricsPlainText) {
+    final var walker = new CollectorPrometheusMetricsWalker();
+    final var processor = new TextPrometheusMetricsProcessor(metricsPlainText, walker);
+    processor.walk();
+    return walker.getAllMetricFamilies();
   }
 }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -42,7 +42,7 @@ public class ExporterMetricsIT {
     final var addedCounter =
         metrics.stream()
             .filter(
-                metric -> metric.getName().equals(ExporterMetricsTestExporter.REGISTERED_COUNTER))
+                metric -> metric.getName().contains(ExporterMetricsTestExporter.REGISTERED_COUNTER))
             .findFirst();
 
     // then

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.exporter;
+
+import io.camunda.zeebe.qa.util.actuator.PrometheusActuator;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.metrics.exporter.common.PrometheusHttpResponse;
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+public class ExporterMetricsIT {
+
+  @TestZeebe
+  private final TestStandaloneBroker zeebe =
+      new TestStandaloneBroker()
+          .withExporter("foo", cfg -> cfg.setClassName(ExporterMetricsTestExporter.class.getName()))
+          .withBean(
+              "collectorRegistry", CollectorRegistry.defaultRegistry, CollectorRegistry.class);
+
+  @Test
+  public void shouldAddMeterToExporterMetrics() throws IOException {
+    final var actuator = PrometheusActuator.of(zeebe);
+    final PrometheusHttpResponse response = actuator.metrics();
+  }
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -12,9 +12,6 @@ import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import org.apache.commons.io.IOUtils;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -28,15 +25,15 @@ public class ExporterMetricsIT {
               "foo", cfg -> cfg.setClassName(ExporterMetricsTestExporter.class.getName()));
 
   @Test
-  public void shouldAddMeterToExporterMetrics() throws IOException {
+  void shouldAddMeterToExporterMetrics() throws IOException {
     // given
     final var actuator = PrometheusActuator.of(zeebe);
-    final var metricsPlainText =
-        IOUtils.toString(actuator.metrics().body().asInputStream(), StandardCharsets.UTF_8);
 
-    final var metricLines = Arrays.asList(metricsPlainText.split(System.lineSeparator()));
+    // when
+    final var metricsPlainText = actuator.metrics();
 
-    Assertions.assertThat(metricLines.stream())
+    // then
+    Assertions.assertThat(metricsPlainText.lines())
         .filteredOn(line -> line.startsWith(ExporterMetricsTestExporter.REGISTERED_COUNTER))
         .hasSize(1);
   }

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.qa.util.actuator.PrometheusActuator;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
 import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
-import io.prometheus.client.CollectorRegistry;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -25,9 +24,8 @@ public class ExporterMetricsIT {
   @TestZeebe
   private final TestStandaloneBroker zeebe =
       new TestStandaloneBroker()
-          .withExporter("foo", cfg -> cfg.setClassName(ExporterMetricsTestExporter.class.getName()))
-          .withBean(
-              "collectorRegistry", CollectorRegistry.defaultRegistry, CollectorRegistry.class);
+          .withExporter(
+              "foo", cfg -> cfg.setClassName(ExporterMetricsTestExporter.class.getName()));
 
   // TODO: Remove the registry bean addition when spring injects the registry into the broker
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -29,6 +29,8 @@ public class ExporterMetricsIT {
           .withBean(
               "collectorRegistry", CollectorRegistry.defaultRegistry, CollectorRegistry.class);
 
+  // TODO: Remove the registry bean addition when spring injects the registry into the broker
+
   @Test
   public void shouldAddMeterToExporterMetrics() throws IOException {
     // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsIT.java
@@ -27,8 +27,6 @@ public class ExporterMetricsIT {
           .withExporter(
               "foo", cfg -> cfg.setClassName(ExporterMetricsTestExporter.class.getName()));
 
-  // TODO: Remove the registry bean addition when spring injects the registry into the broker
-
   @Test
   public void shouldAddMeterToExporterMetrics() throws IOException {
     // given

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
@@ -16,12 +16,14 @@ import io.micrometer.core.instrument.Counter;
 //  do a http get curl for now to ensure that it is there, but change it to some code access
 public class ExporterMetricsTestExporter implements Exporter {
 
+  public static String REGISTERED_COUNTER = "zeebe_exporter_counter";
+
   public ExporterMetricsTestExporter() {}
 
   @Override
   public void configure(final Context context) throws Exception {
     Exporter.super.configure(context);
-    Counter.builder("zeebe_bar").register(context.getMeterRegistry());
+    Counter.builder(REGISTERED_COUNTER).register(context.getMeterRegistry());
   }
 
   @Override

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
@@ -13,7 +13,6 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.micrometer.core.instrument.Counter;
 
-//  do a http get curl for now to ensure that it is there, but change it to some code access
 public class ExporterMetricsTestExporter implements Exporter {
 
   public static final String REGISTERED_COUNTER = "zeebe_exporter_counter";

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
@@ -16,7 +16,7 @@ import io.micrometer.core.instrument.Counter;
 //  do a http get curl for now to ensure that it is there, but change it to some code access
 public class ExporterMetricsTestExporter implements Exporter {
 
-  public static String REGISTERED_COUNTER = "zeebe_exporter_counter";
+  public static final String REGISTERED_COUNTER = "zeebe_exporter_counter";
 
   public ExporterMetricsTestExporter() {}
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.exporter;
+
+import io.camunda.zeebe.exporter.api.Exporter;
+import io.camunda.zeebe.exporter.api.context.Context;
+import io.camunda.zeebe.exporter.api.context.Controller;
+import io.camunda.zeebe.protocol.record.Record;
+import io.micrometer.core.instrument.Counter;
+
+//  do a http get curl for now to ensure that it is there, but change it to some code access
+public class ExporterMetricsTestExporter implements Exporter {
+
+  public ExporterMetricsTestExporter() {}
+
+  @Override
+  public void configure(final Context context) throws Exception {
+    Exporter.super.configure(context);
+    Counter.builder("zeebe_bar").register(context.getMeterRegistry());
+  }
+
+  @Override
+  public void open(final Controller controller) {
+    Exporter.super.open(controller);
+  }
+
+  @Override
+  public void close() {
+    Exporter.super.close();
+  }
+
+  @Override
+  public void export(final Record<?> record) {}
+}

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/exporter/ExporterMetricsTestExporter.java
@@ -9,7 +9,6 @@ package io.camunda.zeebe.it.exporter;
 
 import io.camunda.zeebe.exporter.api.Exporter;
 import io.camunda.zeebe.exporter.api.context.Context;
-import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.micrometer.core.instrument.Counter;
 
@@ -23,16 +22,6 @@ public class ExporterMetricsTestExporter implements Exporter {
   public void configure(final Context context) throws Exception {
     Exporter.super.configure(context);
     Counter.builder(REGISTERED_COUNTER).register(context.getMeterRegistry());
-  }
-
-  @Override
-  public void open(final Controller controller) {
-    Exporter.super.open(controller);
-  }
-
-  @Override
-  public void close() {
-    Exporter.super.close();
   }
 
   @Override

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -187,5 +187,15 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>prometheus-metrics-exposition-formats</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>prometheus-metrics-exporter-common</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/zeebe/qa/util/pom.xml
+++ b/zeebe/qa/util/pom.xml
@@ -187,15 +187,5 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>prometheus-metrics-exposition-formats</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>io.prometheus</groupId>
-      <artifactId>prometheus-metrics-exporter-common</artifactId>
-    </dependency>
   </dependencies>
 </project>

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.qa.util.actuator;
+
+import feign.Feign;
+import feign.Headers;
+import feign.RequestLine;
+import feign.Response;
+import feign.Retryer;
+import feign.Target.HardCodedTarget;
+import feign.jackson.JacksonDecoder;
+import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.prometheus.metrics.exporter.common.PrometheusHttpResponse;
+
+@SuppressWarnings({"unused", "UnusedReturnValue"})
+public interface PrometheusActuator {
+
+  static PrometheusActuator of(final TestStandaloneBroker node) {
+    return of(node.actuatorUri("prometheus").toString());
+  }
+
+  static io.camunda.zeebe.qa.util.actuator.PrometheusActuator of(final String endpoint) {
+    final var target =
+        new HardCodedTarget<>(io.camunda.zeebe.qa.util.actuator.PrometheusActuator.class, endpoint);
+    return Feign.builder()
+        .encoder(new JacksonEncoder())
+        .decoder(new JacksonDecoder())
+        .retryer(Retryer.NEVER_RETRY)
+        .target(target);
+  }
+
+  @RequestLine("GET")
+  @Headers("Accept: text/plain")
+  PrometheusHttpResponse metrics();
+}

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
@@ -24,9 +24,8 @@ public interface PrometheusActuator {
     return of(node.actuatorUri("prometheus").toString());
   }
 
-  static io.camunda.zeebe.qa.util.actuator.PrometheusActuator of(final String endpoint) {
-    final var target =
-        new HardCodedTarget<>(io.camunda.zeebe.qa.util.actuator.PrometheusActuator.class, endpoint);
+  static PrometheusActuator of(final String endpoint) {
+    final var target = new HardCodedTarget<>(PrometheusActuator.class, endpoint);
     return Feign.builder()
         .encoder(new JacksonEncoder())
         .decoder(new JacksonDecoder())

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
@@ -16,7 +16,6 @@ import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
-import io.prometheus.metrics.exporter.common.PrometheusHttpResponse;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
 public interface PrometheusActuator {
@@ -37,5 +36,5 @@ public interface PrometheusActuator {
 
   @RequestLine("GET")
   @Headers("Accept: text/plain")
-  PrometheusHttpResponse metrics();
+  Response metrics();
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PrometheusActuator.java
@@ -10,11 +10,8 @@ package io.camunda.zeebe.qa.util.actuator;
 import feign.Feign;
 import feign.Headers;
 import feign.RequestLine;
-import feign.Response;
 import feign.Retryer;
 import feign.Target.HardCodedTarget;
-import feign.jackson.JacksonDecoder;
-import feign.jackson.JacksonEncoder;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 
 @SuppressWarnings({"unused", "UnusedReturnValue"})
@@ -26,14 +23,10 @@ public interface PrometheusActuator {
 
   static PrometheusActuator of(final String endpoint) {
     final var target = new HardCodedTarget<>(PrometheusActuator.class, endpoint);
-    return Feign.builder()
-        .encoder(new JacksonEncoder())
-        .decoder(new JacksonDecoder())
-        .retryer(Retryer.NEVER_RETRY)
-        .target(target);
+    return Feign.builder().retryer(Retryer.NEVER_RETRY).target(target);
   }
 
   @RequestLine("GET")
   @Headers("Accept: text/plain")
-  Response metrics();
+  String metrics();
 }

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -70,6 +70,8 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     // we need to hook in at the last minute and set the property as it won't resolve from the
     // config bean
     withProperty("zeebe.broker.gateway.enable", config.getGateway().isEnable());
+    withProperty("management.endpoint.prometheus.enabled", true);
+    withProperty("management.prometheus.metrics.export.enabled", true);
     return super.createSpringBuilder();
   }
 

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/cluster/TestStandaloneBroker.java
@@ -70,8 +70,6 @@ public final class TestStandaloneBroker extends TestSpringApplication<TestStanda
     // we need to hook in at the last minute and set the property as it won't resolve from the
     // config bean
     withProperty("zeebe.broker.gateway.enable", config.getGateway().isEnable());
-    withProperty("management.endpoint.prometheus.enabled", true);
-    withProperty("management.prometheus.metrics.export.enabled", true);
     return super.createSpringBuilder();
   }
 


### PR DESCRIPTION
## Description

To support user creation within the existing Zeebe architecture, we need to implement several new paths of code, these are captured below.

## Checklist

### Acceptance criteria
- [x] A record exists containing the properties [`username`, `name`, `email`, `enabled`]
- [x] A record value exists wrapping the record for a user
- [x] A column family exists for `users`
- [x] A `DbState`, `State`, and `MutableState` exists
- [x] An Intent class exists, implementing the `Intent` class
- [x] A Processor exists, implementing the `TypedRecordProcessor` class
- [x] An Applier exists, implementing the `TypedEventApplier` class
- [x] An Event Processor class exists
  - [x] All user events are distributed to all partitions (hint: `CommandDistributionBehavior`)
- [x] A services class exists, extending the `ApiServices` class
- [x] A Broker request for user creation exists, extending the `BrokerExecuteCommand` class
  - [x] All user events are sent to partition 1 (hint: `setPartitionId(Protocol.DEPLOYMENT_PARTITION)`)
- [x] A method in the services class exists allowing the creation of a user

### Tests
- [x] Given a user with an unknown username, when creating a user, the command is passed
- [x] Given a user with a username already in the system, when creating a user, the command is rejected

## Related issues

closes #20398 
