### PR TITLE
ci: observe aborted jobs for runner problems

### DIFF
--- a/.github/actions/observe-aborted-jobs/action.yml
+++ b/.github/actions/observe-aborted-jobs/action.yml
@@ -1,0 +1,44 @@
+# This action expects the code to have been checked out beforehand, e.g. via actions/checkout@v4
+#
+# This action expects certain secrets to be provided:
+#   - VAULT_ADDR
+#   - VAULT_ROLE_ID
+#   - VAULT_SECRET_ID
+---
+name: Observe Aborted Jobs
+description: Checks failed jobs of a GHA workflow for runner problems and submits https://confluence.camunda.com/display/HAN/CI+Analytics data on their behalf
+
+inputs:
+  secret_vault_address:
+    description: 'Secret vault url'
+    required: false
+  secret_vault_roleId:
+    description: 'Secret vault roleId'
+    required: false
+  secret_vault_secretId:
+    description: 'Secret vault ID'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Import Secrets
+      id: secrets
+      uses: hashicorp/vault-action@v3.0.0
+      if: |
+        inputs.secret_vault_address != ''
+        && inputs.secret_vault_roleId != ''
+        && inputs.secret_vault_secretId != ''
+      with:
+        url: ${{ inputs.secret_vault_address }}
+        method: approle
+        roleId: ${{ inputs.secret_vault_roleId }}
+        secretId: ${{ inputs.secret_vault_secretId }}
+        exportEnv: false # we rely on step outputs, no need for environment variables
+        secrets: |
+          secret/data/products/zeebe/ci/ci-analytics gcloud_sa_key;
+
+    - uses: camunda/infra-global-github-actions/submit-aborted-gha-status@main
+      if: ${{ always() && steps.secrets.outputs.gcloud_sa_key != '' }}
+      with:
+        gcp_credentials_json: "${{ steps.secrets.outputs.gcloud_sa_key }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,6 +427,14 @@ jobs:
       - java-checks
       - build-platform-frontend
     steps:
+      - uses: actions/checkout@v4
+      - name: Check for aborted jobs
+        continue-on-error: true
+        uses: ./.github/actions/observe-aborted-jobs
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 
   notify-if-failed:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -600,7 +600,16 @@ jobs:
       - go-apidiff
       - docker-checks
     steps:
+      - uses: actions/checkout@v4
+      - name: Check for aborted jobs
+        continue-on-error: true
+        uses: ./.github/actions/observe-aborted-jobs
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
+
   deploy-snapshots:
     name: Deploy snapshot artifacts
     needs: [ test-summary ]


### PR DESCRIPTION
## Description

Outcome of https://github.com/camunda/camunda/pull/20530 integrating the new https://github.com/camunda/infra-global-github-actions/tree/main/submit-aborted-gha-status into Unified CI + Zeebe CI.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #18210
