### PR TITLE
Removed combined checksum

### DIFF
--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
@@ -34,6 +34,7 @@ public final class SnapshotChunkImpl
   private int totalCount;
   private String chunkName;
   private long checksum;
+  private long snapshotChecksum;
   private long fileBlockPosition;
   private long totalFileSize;
 
@@ -44,6 +45,7 @@ public final class SnapshotChunkImpl
     totalCount = chunk.getTotalCount();
     chunkName = chunk.getChunkName();
     checksum = chunk.getChecksum();
+    snapshotChecksum = 0;
     content.wrap(chunk.getContent());
     fileBlockPosition = chunk.getFileBlockPosition();
     totalFileSize = chunk.getTotalFileSize();
@@ -65,6 +67,7 @@ public final class SnapshotChunkImpl
 
     totalCount = SnapshotChunkDecoder.totalCountNullValue();
     checksum = SnapshotChunkDecoder.checksumNullValue();
+    snapshotChecksum = SnapshotChunkDecoder.snapshotChecksumNullValue();
     fileBlockPosition = SnapshotChunkDecoder.fileBlockPositionNullValue();
     totalFileSize = SnapshotChunkDecoder.totalFileSizeNullValue();
 
@@ -95,6 +98,7 @@ public final class SnapshotChunkImpl
         .snapshotId(snapshotId)
         .chunkName(chunkName)
         .checksum(checksum)
+        .snapshotChecksum(snapshotChecksum)
         .putContent(content, 0, content.capacity());
   }
 
@@ -108,6 +112,7 @@ public final class SnapshotChunkImpl
     snapshotId = decoder.snapshotId();
     chunkName = decoder.chunkName();
     checksum = decoder.checksum();
+    snapshotChecksum = decoder.snapshotChecksum();
 
     if (decoder.contentLength() > 0) {
       decoder.wrapContent(content);

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
@@ -34,7 +34,6 @@ public final class SnapshotChunkImpl
   private int totalCount;
   private String chunkName;
   private long checksum;
-  private long snapshotChecksum;
   private long fileBlockPosition;
   private long totalFileSize;
 
@@ -45,7 +44,6 @@ public final class SnapshotChunkImpl
     totalCount = chunk.getTotalCount();
     chunkName = chunk.getChunkName();
     checksum = chunk.getChecksum();
-    snapshotChecksum = chunk.getSnapshotChecksum();
     content.wrap(chunk.getContent());
     fileBlockPosition = chunk.getFileBlockPosition();
     totalFileSize = chunk.getTotalFileSize();
@@ -67,7 +65,6 @@ public final class SnapshotChunkImpl
 
     totalCount = SnapshotChunkDecoder.totalCountNullValue();
     checksum = SnapshotChunkDecoder.checksumNullValue();
-    snapshotChecksum = SnapshotChunkDecoder.snapshotChecksumNullValue();
     fileBlockPosition = SnapshotChunkDecoder.fileBlockPositionNullValue();
     totalFileSize = SnapshotChunkDecoder.totalFileSizeNullValue();
 
@@ -98,7 +95,6 @@ public final class SnapshotChunkImpl
         .snapshotId(snapshotId)
         .chunkName(chunkName)
         .checksum(checksum)
-        .snapshotChecksum(snapshotChecksum)
         .putContent(content, 0, content.capacity());
   }
 
@@ -112,7 +108,6 @@ public final class SnapshotChunkImpl
     snapshotId = decoder.snapshotId();
     chunkName = decoder.chunkName();
     checksum = decoder.checksum();
-    snapshotChecksum = decoder.snapshotChecksum();
 
     if (decoder.contentLength() > 0) {
       decoder.wrapContent(content);
@@ -142,11 +137,6 @@ public final class SnapshotChunkImpl
   @Override
   public byte[] getContent() {
     return BufferUtil.bufferAsArray(content);
-  }
-
-  @Override
-  public long getSnapshotChecksum() {
-    return snapshotChecksum;
   }
 
   @Override
@@ -181,8 +171,6 @@ public final class SnapshotChunkImpl
         + '\''
         + ", checksum="
         + checksum
-        + ", snapshotChecksum="
-        + snapshotChecksum
         + ", fileBlockPosition="
         + fileBlockPosition
         + ", totalFileSize="

--- a/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/main/java/io/atomix/raft/snapshot/impl/SnapshotChunkImpl.java
@@ -34,7 +34,6 @@ public final class SnapshotChunkImpl
   private int totalCount;
   private String chunkName;
   private long checksum;
-  private long snapshotChecksum;
   private long fileBlockPosition;
   private long totalFileSize;
 
@@ -45,7 +44,6 @@ public final class SnapshotChunkImpl
     totalCount = chunk.getTotalCount();
     chunkName = chunk.getChunkName();
     checksum = chunk.getChecksum();
-    snapshotChecksum = 0;
     content.wrap(chunk.getContent());
     fileBlockPosition = chunk.getFileBlockPosition();
     totalFileSize = chunk.getTotalFileSize();
@@ -67,7 +65,6 @@ public final class SnapshotChunkImpl
 
     totalCount = SnapshotChunkDecoder.totalCountNullValue();
     checksum = SnapshotChunkDecoder.checksumNullValue();
-    snapshotChecksum = SnapshotChunkDecoder.snapshotChecksumNullValue();
     fileBlockPosition = SnapshotChunkDecoder.fileBlockPositionNullValue();
     totalFileSize = SnapshotChunkDecoder.totalFileSizeNullValue();
 
@@ -91,6 +88,8 @@ public final class SnapshotChunkImpl
   public void write(final MutableDirectBuffer buffer, final int offset) {
     super.write(buffer, offset);
 
+    // The snapshot checksum is 0 for backwards compatibility reasons, when sending chunk data to
+    // brokers on older versions which checks on the snapshot checksum.
     encoder
         .totalCount(totalCount)
         .fileBlockPosition(fileBlockPosition)
@@ -98,7 +97,7 @@ public final class SnapshotChunkImpl
         .snapshotId(snapshotId)
         .chunkName(chunkName)
         .checksum(checksum)
-        .snapshotChecksum(snapshotChecksum)
+        .snapshotChecksum(0)
         .putContent(content, 0, content.capacity());
   }
 
@@ -112,7 +111,6 @@ public final class SnapshotChunkImpl
     snapshotId = decoder.snapshotId();
     chunkName = decoder.chunkName();
     checksum = decoder.checksum();
-    snapshotChecksum = decoder.snapshotChecksum();
 
     if (decoder.contentLength() > 0) {
       decoder.wrapContent(content);

--- a/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
+++ b/zeebe/atomix/cluster/src/main/resources/snapshot-schema.xml
@@ -18,6 +18,7 @@
   <sbe:message name="SnapshotChunk" id="4">
     <field name="totalCount" id="0" type="int32"/>
     <field name="checksum" id="1" type="uint64"/>
+    <!-- snapshotChecksum is deprecated and not used anymore, here for backwards compatibility  -->
     <field name="snapshotChecksum" id="5" type="uint64" sinceVersion="2"/>
     <field name="fileBlockPosition" id="6" type="uint64" sinceVersion="3"/>
     <field name="totalFileSize" id="7" type="uint64" sinceVersion="3"/>

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -17,6 +17,7 @@ package io.atomix.raft.snapshot;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
@@ -24,6 +25,7 @@ import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import io.camunda.zeebe.snapshots.SnapshotId;
 import io.camunda.zeebe.snapshots.SnapshotMetadata;
 import io.camunda.zeebe.snapshots.SnapshotReservation;
+import io.camunda.zeebe.snapshots.impl.SfvChecksumImpl;
 import io.camunda.zeebe.util.StringUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
 import java.nio.ByteBuffer;
@@ -47,7 +49,7 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
   private final Checksum checksumCalculator = new CRC32C();
   private final Set<SnapshotReservation> reservations = new CopyOnWriteArraySet<>();
 
-  private long checksum;
+  private MutableChecksumsSFV checksum;
 
   InMemorySnapshot(final TestSnapshotStore testSnapshotStore, final String snapshotId) {
     this.testSnapshotStore = testSnapshotStore;
@@ -170,7 +172,7 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
   }
 
   @Override
-  public long getChecksum() {
+  public MutableChecksumsSFV getChecksums() {
     return checksum;
   }
 
@@ -217,7 +219,7 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
   @Override
   public ActorFuture<PersistedSnapshot> persist() {
     testSnapshotStore.newSnapshot(this);
-    checksum = checksumCalculator.getValue();
+    checksum = new SfvChecksumImpl();
     return CompletableActorFuture.completed(this);
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/InMemorySnapshot.java
@@ -17,7 +17,7 @@ package io.atomix.raft.snapshot;
 
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
-import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
+import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.ReceivedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunk;
@@ -49,7 +49,7 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
   private final Checksum checksumCalculator = new CRC32C();
   private final Set<SnapshotReservation> reservations = new CopyOnWriteArraySet<>();
 
-  private MutableChecksumsSFV checksum;
+  private ImmutableChecksumsSFV checksum;
 
   InMemorySnapshot(final TestSnapshotStore testSnapshotStore, final String snapshotId) {
     this.testSnapshotStore = testSnapshotStore;
@@ -172,7 +172,7 @@ public final class InMemorySnapshot implements PersistedSnapshot, ReceivedSnapsh
   }
 
   @Override
-  public MutableChecksumsSFV getChecksums() {
+  public ImmutableChecksumsSFV getChecksums() {
     return checksum;
   }
 

--- a/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
+++ b/zeebe/atomix/cluster/src/test/java/io/atomix/raft/snapshot/TestSnapshotChunkImpl.java
@@ -58,11 +58,6 @@ class TestSnapshotChunkImpl implements SnapshotChunk {
   }
 
   @Override
-  public long getSnapshotChecksum() {
-    return 0;
-  }
-
-  @Override
   public long getFileBlockPosition() {
     return 0;
   }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
@@ -28,4 +28,12 @@ public interface ImmutableChecksumsSFV {
    * @return the map containing the individual file checksums
    */
   SortedMap<String, Long> getChecksums();
+
+  /**
+   * Returns if all file checksums match exactly.
+   *
+   * @param o The other checksum
+   * @return boolean denoting match
+   */
+  boolean sameChecksums(ImmutableChecksumsSFV o);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/ImmutableChecksumsSFV.java
@@ -18,11 +18,6 @@ import java.util.SortedMap;
 public interface ImmutableChecksumsSFV {
 
   /**
-   * @return a combined CRC32C checksum over all files (for backwards compatibility)
-   */
-  long getCombinedValue();
-
-  /**
    * Write the checksum collection in SFV format to the given output stream.
    *
    * @param stream in which the data will be written to

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/MutableChecksumsSFV.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/MutableChecksumsSFV.java
@@ -47,12 +47,4 @@ public interface MutableChecksumsSFV extends ImmutableChecksumsSFV {
    * @param checksum check of file given
    */
   void updateFromChecksum(final Path filePath, final long checksum);
-
-  /**
-   * Returns if all file checksums match exactly.
-   *
-   * @param o The other checksum
-   * @return boolean denoting match
-   */
-  boolean sameChecksums(ImmutableChecksumsSFV o);
 }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
@@ -72,11 +72,11 @@ public interface PersistedSnapshot {
   String getId();
 
   /**
-   * Returns the checksum of the snapshot, which can be used to verify integrity.
+   * Returns the checksums of the snapshot files, which can be used to verify integrity.
    *
-   * @return the checksum of the snapshot
+   * @return the checksum of the snapshot files
    */
-  long getChecksum();
+  MutableChecksumsSFV getChecksums();
 
   /**
    * SnapshotMetadata includes information related to a snapshot.

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/PersistedSnapshot.java
@@ -76,7 +76,7 @@ public interface PersistedSnapshot {
    *
    * @return the checksum of the snapshot files
    */
-  MutableChecksumsSFV getChecksums();
+  ImmutableChecksumsSFV getChecksums();
 
   /**
    * SnapshotMetadata includes information related to a snapshot.

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/SnapshotChunk.java
@@ -36,11 +36,6 @@ public interface SnapshotChunk {
   byte[] getContent();
 
   /**
-   * @return the checksum of the entire snapshot
-   */
-  long getSnapshotChecksum();
-
-  /**
    * @return the index of the part of the chunk contents.
    */
   long getFileBlockPosition();

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedReceivedSnapshot.java
@@ -35,7 +35,6 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
   private final FileBasedSnapshotStoreImpl snapshotStore;
 
   private final FileBasedSnapshotId snapshotId;
-  private long expectedSnapshotChecksum;
   private int expectedTotalCount;
   private FileBasedSnapshotMetadata metadata;
   private ByteBuffer metadataBuffer;
@@ -51,7 +50,6 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
     this.snapshotStore = snapshotStore;
     this.directory = directory;
     this.actor = actor;
-    expectedSnapshotChecksum = Long.MIN_VALUE;
     expectedTotalCount = Integer.MIN_VALUE;
     writtenMetadataBytes = 0;
   }
@@ -72,9 +70,6 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
 
   private void applyInternal(final SnapshotChunk snapshotChunk) throws SnapshotWriteException {
     checkSnapshotIdIsValid(snapshotChunk.getSnapshotId());
-
-    final long currentSnapshotChecksum = snapshotChunk.getSnapshotChecksum();
-    checkSnapshotChecksumIsValid(currentSnapshotChecksum);
 
     final var currentTotalCount = snapshotChunk.getTotalCount();
     checkTotalCountIsValid(currentTotalCount);
@@ -144,20 +139,6 @@ public class FileBasedReceivedSnapshot implements ReceivedSnapshot {
           String.format(
               "Expected to have checksum %d for snapshot chunk %s (%s), but calculated %d",
               expectedChecksum, chunkName, snapshotId, actualChecksum));
-    }
-  }
-
-  private void checkSnapshotChecksumIsValid(final long currentSnapshotChecksum)
-      throws SnapshotWriteException {
-    if (expectedSnapshotChecksum == Long.MIN_VALUE) {
-      expectedSnapshotChecksum = currentSnapshotChecksum;
-    }
-
-    if (expectedSnapshotChecksum != currentSnapshotChecksum) {
-      throw new SnapshotWriteException(
-          String.format(
-              "Expected snapshot chunk with equal snapshot checksum %d, but got chunk with snapshot checksum %d.",
-              expectedSnapshotChecksum, currentSnapshotChecksum));
     }
   }
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.snapshots.impl;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
@@ -34,7 +35,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   private final Path directory;
   private final Path checksumFile;
-  private final MutableChecksumsSFV checksums;
+  private final ImmutableChecksumsSFV checksums;
   private final FileBasedSnapshotId snapshotId;
   private final SnapshotMetadata metadata;
   private final Consumer<FileBasedSnapshot> onSnapshotDeleted;
@@ -114,7 +115,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   }
 
   @Override
-  public MutableChecksumsSFV getChecksums() {
+  public ImmutableChecksumsSFV getChecksums() {
     return checksums;
   }
 

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -10,6 +10,7 @@ package io.camunda.zeebe.snapshots.impl;
 import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
@@ -33,7 +34,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
   private final Path directory;
   private final Path checksumFile;
-  private final long checksum;
+  private final MutableChecksumsSFV checksums;
   private final FileBasedSnapshotId snapshotId;
   private final SnapshotMetadata metadata;
   private final Consumer<FileBasedSnapshot> onSnapshotDeleted;
@@ -46,14 +47,14 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   FileBasedSnapshot(
       final Path directory,
       final Path checksumFile,
-      final long checksum,
+      final MutableChecksumsSFV checksums,
       final FileBasedSnapshotId snapshotId,
       final SnapshotMetadata metadata,
       final Consumer<FileBasedSnapshot> onSnapshotDeleted,
       final ConcurrencyControl actor) {
     this.directory = directory;
     this.checksumFile = checksumFile;
-    this.checksum = checksum;
+    this.checksums = checksums;
     this.snapshotId = snapshotId;
     this.metadata = metadata;
     this.onSnapshotDeleted = onSnapshotDeleted;
@@ -86,7 +87,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   @Override
   public SnapshotChunkReader newChunkReader() {
     try {
-      return new FileBasedSnapshotChunkReader(directory, checksum);
+      return new FileBasedSnapshotChunkReader(directory);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }
@@ -113,8 +114,8 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   }
 
   @Override
-  public long getChecksum() {
-    return checksum;
+  public MutableChecksumsSFV getChecksums() {
+    return checksums;
   }
 
   @Override
@@ -164,7 +165,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   public int hashCode() {
     int result = getDirectory().hashCode();
     result = 31 * result + checksumFile.hashCode();
-    result = 31 * result + (int) (getChecksum() ^ (getChecksum() >>> 32));
     result = 31 * result + getSnapshotId().hashCode();
     return result;
   }
@@ -180,7 +180,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
 
     final FileBasedSnapshot that = (FileBasedSnapshot) o;
 
-    if (getChecksum() != that.getChecksum()) {
+    if (!getChecksums().sameChecksums(that.getChecksums())) {
       return false;
     }
     if (!getDirectory().equals(that.getDirectory())) {
@@ -199,8 +199,6 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
         + directory
         + ", checksumFile="
         + checksumFile
-        + ", checksum="
-        + checksum
         + ", snapshotId="
         + snapshotId
         + ", metadata="

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshot.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
-import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.SnapshotChunkReader;
 import io.camunda.zeebe.snapshots.SnapshotException.SnapshotNotFoundException;
@@ -48,7 +47,7 @@ public final class FileBasedSnapshot implements PersistedSnapshot {
   FileBasedSnapshot(
       final Path directory,
       final Path checksumFile,
-      final MutableChecksumsSFV checksums,
+      final ImmutableChecksumsSFV checksums,
       final FileBasedSnapshotId snapshotId,
       final SnapshotMetadata metadata,
       final Consumer<FileBasedSnapshot> onSnapshotDeleted,

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReader.java
@@ -30,23 +30,19 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
   private long offset;
   private NavigableSet<CharSequence> chunksView;
   private final int totalCount;
-  private final long snapshotChecksum;
   private final String snapshotID;
   private long maximumChunkSize;
 
-  public FileBasedSnapshotChunkReader(final Path directory, final long checksum)
-      throws IOException {
-    this(directory, checksum, Long.MAX_VALUE);
+  public FileBasedSnapshotChunkReader(final Path directory) throws IOException {
+    this(directory, Long.MAX_VALUE);
   }
 
-  FileBasedSnapshotChunkReader(
-      final Path directory, final long checksum, final long maximumChunkSize) throws IOException {
+  FileBasedSnapshotChunkReader(final Path directory, final long maximumChunkSize)
+      throws IOException {
     this.directory = directory;
     chunks = collectChunks(directory);
     totalCount = chunks.size();
     chunksView = new TreeSet<>(chunks);
-
-    snapshotChecksum = checksum;
 
     snapshotID = directory.getFileName().toString();
 
@@ -124,13 +120,7 @@ public final class FileBasedSnapshotChunkReader implements SnapshotChunkReader {
       }
 
       return SnapshotChunkUtil.createSnapshotChunkFromFileChunk(
-          snapshotID,
-          totalCount,
-          snapshotChecksum,
-          fileName,
-          buffer,
-          fileBlockPosition,
-          fileLength);
+          snapshotID, totalCount, fileName, buffer, fileBlockPosition, fileLength);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
-import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
+import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
@@ -476,7 +476,7 @@ public final class FileBasedSnapshotStoreImpl {
 
   FileBasedSnapshot persistNewSnapshot(
       final FileBasedSnapshotId snapshotId,
-      final MutableChecksumsSFV mutableChecksumsSFV,
+      final ImmutableChecksumsSFV immutableChecksumsSFV,
       final FileBasedSnapshotMetadata metadata) {
     final var currentPersistedSnapshot = currentPersistedSnapshotRef.get();
 
@@ -500,7 +500,7 @@ public final class FileBasedSnapshotStoreImpl {
       final var tmpChecksumPath =
           checksumPath.resolveSibling(checksumPath.getFileName().toString() + TMP_CHECKSUM_SUFFIX);
       try {
-        SnapshotChecksum.persist(tmpChecksumPath, mutableChecksumsSFV);
+        SnapshotChecksum.persist(tmpChecksumPath, immutableChecksumsSFV);
         FileUtil.moveDurably(tmpChecksumPath, checksumPath);
       } catch (final IOException e) {
         rollbackPartialSnapshot(destination);
@@ -511,7 +511,7 @@ public final class FileBasedSnapshotStoreImpl {
           new FileBasedSnapshot(
               destination,
               checksumPath,
-              mutableChecksumsSFV,
+              immutableChecksumsSFV,
               snapshotId,
               metadata,
               this::onSnapshotDeleted,

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreImpl.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.snapshots.CRC32CChecksumProvider;
-import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
+import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.PersistableSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshot;
 import io.camunda.zeebe.snapshots.PersistedSnapshotListener;
@@ -202,13 +202,7 @@ public final class FileBasedSnapshotStoreImpl {
 
       final var metadata = collectMetadata(path, snapshotId);
       return new FileBasedSnapshot(
-          path,
-          checksumPath,
-          actualChecksum.getCombinedValue(),
-          snapshotId,
-          metadata,
-          this::onSnapshotDeleted,
-          actor);
+          path, checksumPath, actualChecksum, snapshotId, metadata, this::onSnapshotDeleted, actor);
     } catch (final Exception e) {
       LOGGER.warn("Could not load snapshot in {}", path, e);
       return null;
@@ -482,7 +476,7 @@ public final class FileBasedSnapshotStoreImpl {
 
   FileBasedSnapshot persistNewSnapshot(
       final FileBasedSnapshotId snapshotId,
-      final ImmutableChecksumsSFV immutableChecksumsSFV,
+      final MutableChecksumsSFV mutableChecksumsSFV,
       final FileBasedSnapshotMetadata metadata) {
     final var currentPersistedSnapshot = currentPersistedSnapshotRef.get();
 
@@ -506,7 +500,7 @@ public final class FileBasedSnapshotStoreImpl {
       final var tmpChecksumPath =
           checksumPath.resolveSibling(checksumPath.getFileName().toString() + TMP_CHECKSUM_SUFFIX);
       try {
-        SnapshotChecksum.persist(tmpChecksumPath, immutableChecksumsSFV);
+        SnapshotChecksum.persist(tmpChecksumPath, mutableChecksumsSFV);
         FileUtil.moveDurably(tmpChecksumPath, checksumPath);
       } catch (final IOException e) {
         rollbackPartialSnapshot(destination);
@@ -517,7 +511,7 @@ public final class FileBasedSnapshotStoreImpl {
           new FileBasedSnapshot(
               destination,
               checksumPath,
-              immutableChecksumsSFV.getCombinedValue(),
+              mutableChecksumsSFV,
               snapshotId,
               metadata,
               this::onSnapshotDeleted,

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SfvChecksumImpl.java
@@ -7,8 +7,6 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-
 import io.camunda.zeebe.snapshots.ImmutableChecksumsSFV;
 import io.camunda.zeebe.snapshots.MutableChecksumsSFV;
 import java.io.IOException;
@@ -33,10 +31,8 @@ import org.agrona.IoUtil;
  * compatibility with 'combinedChecksum' field.
  * https://en.wikipedia.org/wiki/Simple_file_verification
  */
-final class SfvChecksumImpl implements MutableChecksumsSFV {
+public final class SfvChecksumImpl implements MutableChecksumsSFV {
 
-  public static final String FORMAT_NUMBER_OF_FILES_LINE =
-      "; number of files used for combined value = %d\n";
   private static final String SFV_HEADER =
       """
 ; This is an SFC checksum file for all files in the given directory.
@@ -45,33 +41,13 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
 """;
   private static final String FORMAT_SNAPSHOT_DIRECTORY_LINE = "; snapshot directory = %s\n";
   private static final String FORMAT_FILE_CRC_LINE = "%s   %s\n";
-  private static final String FORMAT_COMBINED_VALUE_LINE = "; combinedValue = %s\n";
   private static final String FILE_CRC_SEPARATOR_REGEX = " {3}";
   private static final Pattern FILE_CRC_PATTERN =
       Pattern.compile("(.*)" + FILE_CRC_SEPARATOR_REGEX + "([0-9a-fA-F]{1,16})");
-  private static final Pattern COMBINED_VALUE_PATTERN =
-      Pattern.compile(".*combinedValue\\s+=\\s+([0-9a-fA-F]{1,16})");
-  private Checksum combinedChecksum;
   private final SortedMap<String, Long> checksums = new TreeMap<>();
   private String snapshotDirectoryComment;
 
-  /**
-   * creates an immutable and pre-defined checksum
-   *
-   * @param combinedChecksum pre-defined checksum
-   */
-  public SfvChecksumImpl(final long combinedChecksum) {
-    this.combinedChecksum = new PreDefinedImmutableChecksum(combinedChecksum);
-  }
-
-  public SfvChecksumImpl() {
-    combinedChecksum = new CRC32C();
-  }
-
-  @Override
-  public long getCombinedValue() {
-    return combinedChecksum.getValue();
-  }
+  public SfvChecksumImpl() {}
 
   @Override
   public void write(final OutputStream stream) throws IOException {
@@ -80,9 +56,6 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
     if (snapshotDirectoryComment != null) {
       writer.printf(FORMAT_SNAPSHOT_DIRECTORY_LINE, snapshotDirectoryComment);
     }
-    writer.printf(FORMAT_COMBINED_VALUE_LINE, Long.toHexString(combinedChecksum.getValue()));
-    writer.printf(FORMAT_NUMBER_OF_FILES_LINE, checksums.size());
-
     for (final Entry<String, Long> entry : checksums.entrySet()) {
       writer.printf(FORMAT_FILE_CRC_LINE, entry.getKey(), Long.toHexString(entry.getValue()));
     }
@@ -100,12 +73,7 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
 
   @Override
   public String toString() {
-    return "SfvChecksumImpl{"
-        + "combinedChecksum="
-        + combinedChecksum.getValue()
-        + ", checksums="
-        + checksums
-        + '}';
+    return "SfvChecksumImpl{" + ", checksums=" + checksums + '}';
   }
 
   public void setSnapshotDirectoryComment(final String headerComment) {
@@ -115,16 +83,12 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
   @Override
   public void updateFromFile(final Path filePath) throws IOException {
     final String fileName = filePath.getFileName().toString();
-    final byte[] chunkId = fileName.getBytes(UTF_8);
-    combinedChecksum.update(chunkId);
 
     final Checksum checksum = new CRC32C();
     final ByteBuffer readBuffer = ByteBuffer.allocate(IoUtil.BLOCK_SIZE);
     try (final FileChannel channel = FileChannel.open(filePath, StandardOpenOption.READ)) {
       readBuffer.clear();
       while (channel.read(readBuffer) > 0) {
-        readBuffer.flip();
-        combinedChecksum.update(readBuffer);
         readBuffer.flip();
         checksum.update(readBuffer);
         readBuffer.clear();
@@ -135,10 +99,8 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
 
   @Override
   public void updateFromBytes(final String fileName, final byte[] bytes) {
-    combinedChecksum.update(fileName.getBytes(UTF_8));
     final Checksum checksum = new CRC32C();
     checksum.update(bytes);
-    combinedChecksum.update(bytes);
     checksums.put(fileName, checksum.getValue());
   }
 
@@ -146,20 +108,16 @@ final class SfvChecksumImpl implements MutableChecksumsSFV {
   public void updateFromSfvFile(final String... lines) {
     for (String line : lines) {
       line = line.trim();
+
       if (line.startsWith(";")) {
-        final Matcher matcher = COMBINED_VALUE_PATTERN.matcher(line);
-        if (matcher.find()) {
-          final String hexString = matcher.group(1);
-          final long crc = Long.parseLong(hexString, 16);
-          combinedChecksum = new PreDefinedImmutableChecksum(crc);
-        }
-      } else {
-        final Matcher matcher = FILE_CRC_PATTERN.matcher(line);
-        if (matcher.find()) {
-          final Long crc = Long.parseLong(matcher.group(2), 16);
-          final String fileName = matcher.group(1).trim();
-          checksums.put(fileName, crc);
-        }
+        continue;
+      }
+
+      final Matcher matcher = FILE_CRC_PATTERN.matcher(line);
+      if (matcher.find()) {
+        final Long crc = Long.parseLong(matcher.group(2), 16);
+        final String fileName = matcher.group(1).trim();
+        checksums.put(fileName, crc);
       }
     }
   }

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksum.java
@@ -28,11 +28,6 @@ final class SnapshotChecksum {
 
   public static ImmutableChecksumsSFV read(final Path checksumPath) throws IOException {
     try (final RandomAccessFile checksumFile = new RandomAccessFile(checksumPath.toFile(), "r")) {
-      if (checksumFile.length() == 8) {
-        // compatibility mode
-        final long combinedChecksum = checksumFile.readLong();
-        return new SfvChecksumImpl(combinedChecksum);
-      }
       final SfvChecksumImpl sfvChecksum = new SfvChecksumImpl();
       String line;
       while ((line = checksumFile.readLine()) != null) {

--- a/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
+++ b/zeebe/snapshot/src/main/java/io/camunda/zeebe/snapshots/impl/SnapshotChunkUtil.java
@@ -28,7 +28,6 @@ final class SnapshotChunkUtil {
   static SnapshotChunk createSnapshotChunkFromFileChunk(
       final String snapshotId,
       final int totalCount,
-      final long snapshotChecksum,
       final String fileName,
       final byte[] fileData,
       final long fileBlockPosition,
@@ -36,14 +35,7 @@ final class SnapshotChunkUtil {
 
     final long checksum = createChecksum(fileData);
     return new SnapshotChunkImpl(
-        snapshotId,
-        totalCount,
-        fileName,
-        checksum,
-        fileData,
-        snapshotChecksum,
-        fileBlockPosition,
-        totalFileSize);
+        snapshotId, totalCount, fileName, checksum, fileData, fileBlockPosition, totalFileSize);
   }
 
   private static final class SnapshotChunkImpl implements SnapshotChunk {
@@ -51,7 +43,6 @@ final class SnapshotChunkUtil {
     private final int totalCount;
     private final String chunkName;
     private final byte[] content;
-    private final long snapshotChecksum;
     private final long checksum;
     private final long fileBlockPosition;
     private final long totalFileSize;
@@ -62,7 +53,6 @@ final class SnapshotChunkUtil {
         final String chunkName,
         final long checksum,
         final byte[] content,
-        final long snapshotChecksum,
         final long fileBlockPosition,
         final long totalFileSize) {
       this.snapshotId = snapshotId;
@@ -70,7 +60,6 @@ final class SnapshotChunkUtil {
       this.chunkName = chunkName;
       this.checksum = checksum;
       this.content = content;
-      this.snapshotChecksum = snapshotChecksum;
       this.fileBlockPosition = fileBlockPosition;
       this.totalFileSize = totalFileSize;
     }
@@ -98,11 +87,6 @@ final class SnapshotChunkUtil {
     @Override
     public byte[] getContent() {
       return content;
-    }
-
-    @Override
-    public long getSnapshotChecksum() {
-      return snapshotChecksum;
     }
 
     @Override

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
@@ -14,7 +14,7 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
   private String snapshotId;
   private Integer totalCount;
   private Long checksum;
-  private Long snapshotChecksum;
+  private MutableChecksumsSFV snapshotChecksum;
   private byte[] contents;
 
   private SnapshotChunkWrapper(final SnapshotChunk wrappedChunk) {
@@ -44,10 +44,10 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
     return wrapper;
   }
 
-  public static SnapshotChunk withSnapshotChecksum(
-      final SnapshotChunk wrappedChunk, final Long snapshotChecksum) {
+  public static SnapshotChunk withSnapshotChecksums(
+      final SnapshotChunk wrappedChunk, final MutableChecksumsSFV snapshotChecksums) {
     final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
-    wrapper.snapshotChecksum = snapshotChecksum;
+    wrapper.snapshotChecksum = snapshotChecksums;
 
     return wrapper;
   }
@@ -95,14 +95,6 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
       return wrappedChunk.getContent();
     }
     return contents;
-  }
-
-  @Override
-  public long getSnapshotChecksum() {
-    if (snapshotChecksum == null) {
-      return wrappedChunk.getSnapshotChecksum();
-    }
-    return snapshotChecksum;
   }
 
   @Override

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/SnapshotChunkWrapper.java
@@ -14,7 +14,6 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
   private String snapshotId;
   private Integer totalCount;
   private Long checksum;
-  private MutableChecksumsSFV snapshotChecksum;
   private byte[] contents;
 
   private SnapshotChunkWrapper(final SnapshotChunk wrappedChunk) {
@@ -40,14 +39,6 @@ public final class SnapshotChunkWrapper implements SnapshotChunk {
   public static SnapshotChunk withChecksum(final SnapshotChunk wrappedChunk, final Long checksum) {
     final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
     wrapper.checksum = checksum;
-
-    return wrapper;
-  }
-
-  public static SnapshotChunk withSnapshotChecksums(
-      final SnapshotChunk wrappedChunk, final MutableChecksumsSFV snapshotChecksums) {
-    final var wrapper = new SnapshotChunkWrapper(wrappedChunk);
-    wrapper.snapshotChecksum = snapshotChecksums;
 
     return wrapper;
   }

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotChunkReaderTest.java
@@ -98,7 +98,6 @@ public final class FileBasedSnapshotChunkReaderTest {
             .isEqualTo(nextId);
         assertThat(chunk.getSnapshotId()).isEqualTo(snapshotDirectory.getFileName().toString());
         assertThat(chunk.getTotalCount()).isEqualTo(SNAPSHOT_CHUNK.size());
-        assertThat(chunk.getSnapshotChecksum()).isEqualTo(SNAPSHOT_CHECKSUM);
         assertThat(chunk.getChecksum())
             .isEqualTo(SnapshotChunkUtil.createChecksum(chunk.getContent()));
         assertThat(snapshotDirectory.resolve(chunk.getChunkName()))
@@ -356,7 +355,7 @@ public final class FileBasedSnapshotChunkReaderTest {
       Files.writeString(path, SNAPSHOT_CHUNK.get(chunk));
     }
 
-    return new FileBasedSnapshotChunkReader(snapshotDirectory, SNAPSHOT_CHECKSUM, chunkSize);
+    return new FileBasedSnapshotChunkReader(snapshotDirectory, chunkSize);
   }
 
   private FileBasedSnapshotChunkReader newReader() throws IOException {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotStoreTest.java
@@ -140,7 +140,7 @@ public class FileBasedSnapshotStoreTest {
   public void shouldNotLoadCorruptedSnapshot() throws Exception {
     // given
     final var persistedSnapshot = (FileBasedSnapshot) takeTransientSnapshot().persist().join();
-    SnapshotChecksum.persist(persistedSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
+    SnapshotChecksum.persist(persistedSnapshot.getChecksumPath(), new SfvChecksumImpl());
 
     // when
     snapshotStore.close();
@@ -171,7 +171,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(rootDirectory);
     final var corruptOlderSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
+    SnapshotChecksum.persist(corruptOlderSnapshot.getChecksumPath(), new SfvChecksumImpl());
 
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, snapshotStore).persist().join();
@@ -219,7 +219,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(rootDirectory);
 
     // when - corrupting old snapshot and adding new valid snapshot
-    SnapshotChecksum.persist(olderSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
+    SnapshotChecksum.persist(olderSnapshot.getChecksumPath(), new SfvChecksumImpl());
     final var newerSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(2, otherStore).persist().join();
 
@@ -237,7 +237,7 @@ public class FileBasedSnapshotStoreTest {
     final var otherStore = createStore(rootDirectory);
     final var corruptSnapshot =
         (FileBasedSnapshot) takeTransientSnapshot(1, otherStore).persist().join();
-    SnapshotChecksum.persist(corruptSnapshot.getChecksumPath(), new SfvChecksumImpl(0xCAFEL));
+    SnapshotChecksum.persist(corruptSnapshot.getChecksumPath(), new SfvChecksumImpl());
 
     // when
     snapshotStore.close();

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedSnapshotTest.java
@@ -122,7 +122,13 @@ public final class FileBasedSnapshotTest {
     SnapshotChecksum.persist(checksumPath, SnapshotChecksum.calculate(snapshotPath));
 
     return new FileBasedSnapshot(
-        snapshotPath, checksumPath, 1L, metadata, null, s -> {}, actor.getActorControl());
+        snapshotPath,
+        checksumPath,
+        new SfvChecksumImpl(),
+        metadata,
+        null,
+        s -> {},
+        actor.getActorControl());
   }
 
   static class TestActor extends Actor {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/FileBasedTransientSnapshotTest.java
@@ -295,9 +295,9 @@ public class FileBasedTransientSnapshotTest {
 
     // then
     assertThat(secondSnapshot).as("did persist the same snapshot twice").isEqualTo(firstSnapshot);
-    assertThat(secondSnapshot.getChecksum())
+    assertThat(secondSnapshot.getChecksums().sameChecksums(firstSnapshot.getChecksums()))
         .as("the content of the snapshot remains unchanged")
-        .isEqualTo(firstSnapshot.getChecksum());
+        .isTrue();
     assertThat(snapshotsDir)
         .asInstanceOf(DirectoryAssert.factory())
         .as("snapshots directory only contains snapshot %s", firstSnapshot.getId())

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SfvChecksumTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SfvChecksumTest.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.snapshots.impl;
 
-import static io.camunda.zeebe.snapshots.impl.SnapshotChecksumTest.createChunk;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -32,29 +31,9 @@ public class SfvChecksumTest {
   }
 
   @Test
-  public void shouldUseDefaultValueZeroWhenInitialized() {
-    // given
-    // when
-    // then
-    assertThat(sfvChecksum.getCombinedValue()).isEqualTo(0);
-  }
-
-  @Test
-  public void shouldReadCombinedValueFromComment() {
-    // given
-    final String[] sfvLines = {"; a simple comment to be ignored", "; combinedValue = bbaaccdd"};
-
-    // when
-    sfvChecksum.updateFromSfvFile(sfvLines);
-
-    // then
-    assertThat(sfvChecksum.getCombinedValue()).isEqualTo(0xbbaaccddL);
-  }
-
-  @Test
   public void shouldReadAndWriteSameValues() throws IOException {
     // given
-    final String[] givenSfvLines = {"; combinedValue = 12345678", "file1   aabbccdd"};
+    final String[] givenSfvLines = {"file1   aabbccdd"};
     sfvChecksum.updateFromSfvFile(givenSfvLines);
 
     final var arrayOutputStream = new ByteArrayOutputStream();
@@ -66,13 +45,12 @@ public class SfvChecksumTest {
 
     // then
     assertThat(actualSfVlines).contains(givenSfvLines[0]);
-    assertThat(actualSfVlines).contains(givenSfvLines[1]);
   }
 
   @Test
   public void shouldThrowExceptionOnWriteWhenFlushFails() throws IOException {
     // given
-    final String[] givenSfvLines = {"; combinedValue = 12345678", "file1   aabbccdd"};
+    final String[] givenSfvLines = {"file1   aabbccdd"};
     sfvChecksum.updateFromSfvFile(givenSfvLines);
 
     // when then throw
@@ -84,7 +62,7 @@ public class SfvChecksumTest {
   @Test
   public void shouldThrowExceptionOnWriteWhenWriteFails() throws IOException {
     // given
-    final String[] givenSfvLines = {"; combinedValue = 12345678", "file1   aabbccdd"};
+    final String[] givenSfvLines = {"file1   aabbccdd"};
     sfvChecksum.updateFromSfvFile(givenSfvLines);
 
     // when then throw
@@ -123,20 +101,6 @@ public class SfvChecksumTest {
         .contains("; You might use cksfv or another tool to validate these files manually.");
     assertThat(serialized)
         .contains("; This is an automatically created file - please do NOT modify.");
-  }
-
-  @Test
-  public void shouldThrowExceptionWhenUsingPreDefinedChecksumFromSfv() throws IOException {
-    // given
-    final var folder = temporaryFolder.newFolder().toPath();
-    createChunk(folder, "file1.txt");
-
-    // when
-    sfvChecksum.updateFromSfvFile("; combinedValue = 12341234");
-
-    // then
-    assertThatThrownBy(() -> sfvChecksum.updateFromFile(folder))
-        .isInstanceOf(UnsupportedOperationException.class);
   }
 
   private static final class FailingFlushOutputStream extends OutputStream {

--- a/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
+++ b/zeebe/snapshot/src/test/java/io/camunda/zeebe/snapshots/impl/SnapshotChecksumTest.java
@@ -15,11 +15,7 @@ import io.camunda.zeebe.test.util.STracer.Syscall;
 import io.camunda.zeebe.test.util.asserts.strace.FSyncTraceAssert;
 import io.camunda.zeebe.test.util.asserts.strace.STracerAssert;
 import io.camunda.zeebe.util.FileUtil;
-import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.IOException;
-import java.io.RandomAccessFile;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -69,51 +65,50 @@ public final class SnapshotChecksumTest {
   @Test
   void shouldGenerateTheSameChecksumForOneFile() throws Exception {
     // given
-    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
+    final var expectedChecksums = SnapshotChecksum.calculate(singleFileSnapshot);
 
     // when
-    final var actual = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
+    final var actual = SnapshotChecksum.calculate(singleFileSnapshot);
 
     // then
-    assertThat(actual).isEqualTo(expectedChecksum);
+    assertThat(expectedChecksums.sameChecksums(actual)).isTrue();
   }
 
   @Test
   void shouldGenerateDifferentChecksumWhenFileNameIsDifferent() throws Exception {
     // given
-    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
+    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot);
 
     // when
     Files.move(singleFileSnapshot.resolve("file1.txt"), singleFileSnapshot.resolve("renamed"));
-    final var actual = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
+    final var actual = SnapshotChecksum.calculate(singleFileSnapshot);
 
     // then
-    assertThat(actual).isNotEqualTo(expectedChecksum);
+    assertThat(expectedChecksum.sameChecksums(actual)).isFalse();
   }
 
   @Test
   void shouldGenerateTheSameChecksumForMultipleFiles() throws Exception {
     // given
-    final var expectedChecksum =
-        SnapshotChecksum.calculate(multipleFileSnapshot).getCombinedValue();
+    final var expectedChecksum = SnapshotChecksum.calculate(multipleFileSnapshot);
 
     // when
-    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot).getCombinedValue();
+    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot);
 
     // then
-    assertThat(actual).isEqualTo(expectedChecksum);
+    assertThat(expectedChecksum.sameChecksums(actual)).isTrue();
   }
 
   @Test
   void shouldGenerateDifferentChecksumForDifferentFiles() throws Exception {
     // given
-    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot).getCombinedValue();
+    final var expectedChecksum = SnapshotChecksum.calculate(singleFileSnapshot);
 
     // when
-    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot).getCombinedValue();
+    final var actual = SnapshotChecksum.calculate(multipleFileSnapshot);
 
     // then
-    assertThat(actual).isNotEqualTo(expectedChecksum);
+    assertThat(expectedChecksum.sameChecksums(actual)).isFalse();
   }
 
   @Test
@@ -127,7 +122,7 @@ public final class SnapshotChecksumTest {
     final var actual = SnapshotChecksum.read(checksumPath);
 
     // then
-    assertThat(actual.getCombinedValue()).isEqualTo(expectedChecksum.getCombinedValue());
+    assertThat(expectedChecksum.sameChecksums(actual)).isTrue();
   }
 
   /**
@@ -171,10 +166,10 @@ public final class SnapshotChecksumTest {
 
     // when
     Files.delete(corruptedSnapshot.resolve("file1.txt"));
-    final var actualChecksum = SnapshotChecksum.calculate(corruptedSnapshot).getCombinedValue();
+    final var actualChecksum = SnapshotChecksum.calculate(corruptedSnapshot);
 
     // then
-    assertThat(actualChecksum).isNotEqualTo(expectedChecksum.getCombinedValue());
+    assertThat(expectedChecksum.sameChecksums(actualChecksum)).isFalse();
   }
 
   @Test
@@ -186,51 +181,14 @@ public final class SnapshotChecksumTest {
     Files.writeString(file, largeData, StandardOpenOption.CREATE, StandardOpenOption.WRITE);
 
     final Checksum checksum = new CRC32C();
-    checksum.update("file".getBytes(StandardCharsets.UTF_8));
     checksum.update(Files.readAllBytes(file));
     final var expected = checksum.getValue();
 
     // when
-    final var actual = SnapshotChecksum.calculate(largeSnapshot).getCombinedValue();
+    final var actual = SnapshotChecksum.calculate(largeSnapshot);
 
     // then
-    assertThat(actual).isEqualTo(expected);
-  }
-
-  @Test
-  void shouldReadFormerSimpleChecksumFile() throws IOException {
-    // given
-    final Path temp = createTempDir("temp");
-    final File tempFile = new File(temp.toFile(), "checksum");
-    final long expectedChecksum = 0xccaaffeeL;
-    try (final RandomAccessFile file = new RandomAccessFile(tempFile, "rw")) {
-      file.writeLong(expectedChecksum);
-    }
-
-    // when
-    final ImmutableChecksumsSFV sfvChecksum = SnapshotChecksum.read(tempFile.toPath());
-    final long combinedValue = sfvChecksum.getCombinedValue();
-
-    // then
-    assertThat(combinedValue).isEqualTo(expectedChecksum);
-  }
-
-  @Test
-  void shouldWriteTheNumberOfFiles() throws IOException {
-    // given
-    final var folder = createTempDir("folder");
-    createChunk(folder, "file1.txt");
-    createChunk(folder, "file2.txt");
-    createChunk(folder, "file3.txt");
-    final ImmutableChecksumsSFV sfvChecksum = SnapshotChecksum.calculate(folder);
-    final var arrayOutputStream = new ByteArrayOutputStream();
-    sfvChecksum.write(arrayOutputStream);
-
-    // when
-    final String serialized = arrayOutputStream.toString(StandardCharsets.UTF_8);
-
-    // then
-    assertThat(serialized).contains("; number of files used for combined value = 3");
+    assertThat(actual.getChecksums().get("file")).isEqualTo(expected);
   }
 
   @Test
@@ -252,8 +210,7 @@ public final class SnapshotChecksumTest {
     final ImmutableChecksumsSFV checksumCalculatedAtOnce = SnapshotChecksum.calculate(folder);
 
     // then
-    assertThat(checksumCalculatedInSteps.getCombinedValue())
-        .isEqualTo(checksumCalculatedAtOnce.getCombinedValue());
+    assertThat(checksumCalculatedInSteps.sameChecksums(checksumCalculatedAtOnce)).isTrue();
   }
 
   private Path createTempDir(final String name) throws IOException {


### PR DESCRIPTION
## Description

Removed combined checksum as it is not used anymore instead where needed the actual file checksums are passed along and equality is checked. 

In addition removing any reference to it in the reading and writing of the checksum files where it mentions combined value in the comments.

For the sake of backwards compatibility, current snapshot chunks sent to other brokers must include the `snapshotChecksum` field as brokers on an older version will check this value. It will be left to a default value so that all checks on old versioned brokers pass but the field should eventually be removed.

## Checklist

## Related issues

closes #20100
