### PR TITLE
fix: resetting a reader does not invalidate returned entries

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingExporterTransistor.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingExporterTransistor.java
@@ -54,7 +54,7 @@ public final class ProcessingExporterTransistor implements StreamProcessorLifecy
 
   @Override
   public void onClose() {
-    executorService.shutdownNow();
+    executorService.close();
   }
 
   private void onNewEventCommitted() {

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import java.util.NoSuchElementException;
+import net.jcip.annotations.NotThreadSafe;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -21,6 +22,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * <p>This implementation assumes that blocks have no padding - they contain a contiguous series of
  * {@link LoggedEvent} which fits exactly within the block.
  */
+@NotThreadSafe
 final class LogStreamReaderImpl implements LogStreamReader {
   private final LogStorageReader reader;
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -200,6 +200,6 @@ final class LogStreamReaderImpl implements LogStreamReader {
   }
 
   private boolean isEventBufferValid(final DirectBuffer eventBuffer) {
-    return eventBuffer.addressOffset() != 0;
+    return eventBuffer.capacity() > 0;
   }
 }

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -24,22 +24,16 @@ import org.agrona.concurrent.UnsafeBuffer;
 final class LogStreamReaderImpl implements LogStreamReader {
   private final LogStorageReader reader;
 
-  private final LoggedEventImpl currentEvent;
-  private final DirectBuffer currentEventBuffer;
+  private LoggedEventImpl currentEvent;
+  private DirectBuffer currentEventBuffer;
 
-  private final LoggedEventImpl nextEvent;
-  private final DirectBuffer nextEventBuffer;
+  private LoggedEventImpl nextEvent;
+  private DirectBuffer nextEventBuffer;
 
   private int nextEventOffset;
 
   LogStreamReaderImpl(final LogStorageReader reader) {
     this.reader = reader;
-
-    currentEvent = new LoggedEventImpl();
-    currentEventBuffer = new UnsafeBuffer();
-
-    nextEvent = new LoggedEventImpl();
-    nextEventBuffer = new UnsafeBuffer();
 
     reset();
     seekToFirstEvent();
@@ -147,6 +141,14 @@ final class LogStreamReaderImpl implements LogStreamReader {
   }
 
   @Override
+  public LoggedEvent peekNext() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return nextEvent;
+  }
+
+  @Override
   public void close() {
     reset();
     reader.close();
@@ -168,19 +170,14 @@ final class LogStreamReaderImpl implements LogStreamReader {
     return -1;
   }
 
-  @Override
-  public LoggedEvent peekNext() {
-    if (!hasNext()) {
-      throw new NoSuchElementException();
-    }
-    return nextEvent;
-  }
-
   private void reset() {
-    currentEventBuffer.wrap(0, 0);
-    currentEvent.wrap(currentEventBuffer, 0);
+    currentEvent = new LoggedEventImpl();
+    currentEventBuffer = new UnsafeBuffer();
 
-    nextEventBuffer.wrap(0, 0);
+    nextEvent = new LoggedEventImpl();
+    nextEventBuffer = new UnsafeBuffer();
+
+    currentEvent.wrap(currentEventBuffer, 0);
     nextEvent.wrap(nextEventBuffer, 0);
     nextEventOffset = 0;
   }


### PR DESCRIPTION
## Description

This makes `LogStreamReader` safer to use by preventing that closing or otherwise resetting the reader does not invalidate previously returned entries.

## Related issues

closes #20555
