### PR TITLE
ci: add run assembly profile to release plugin

### DIFF
--- a/.github/workflows/optimize-deploy-artifacts.yml
+++ b/.github/workflows/optimize-deploy-artifacts.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Generate production .tar.gz
       uses: ./.github/actions/run-maven
       with:
-        parameters: install -DskipTests -Dskip.docker
+        parameters: install -DskipTests -Dskip.docker -PrunAssembly
     - name: Build Docker Image
       run: ./.github/optimize/scripts/build-docker-image.sh
     # The SmokeTest is running as part of the "deploy-artifact" job to ensure we only push the artifact on success
@@ -96,7 +96,7 @@ jobs:
     - name: Deploy to Artifactory
       uses: ./.github/actions/run-maven
       with:
-        parameters: deploy -Dskip.fe.build -DskipTests -Dskip.docker
+        parameters: deploy -Dskip.fe.build -DskipTests -Dskip.docker -PrunAssembly
     - name: Docker log dump
       uses: ./.github/actions/docker-logs
       if: always()

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -161,7 +161,7 @@ jobs:
           mvn -f optimize \
             -DpushChanges=false \
             -DskipTests=true \
-            -Prelease,engine-latest \
+            -Prelease,engine-latest,runAssembly \
             release:prepare \
             -Dtag=${TAG} \
             -DreleaseVersion="${RELEASE_VERSION}" \
@@ -184,7 +184,7 @@ jobs:
             -DskipTests=true \
             -B \
             --fail-at-end \
-            -Prelease,engine-latest \
+            -Prelease,engine-latest,runAssembly \
             -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
             release:perform \
             -Darguments="-Dmaven.deploy.skip=${IS_DRY_RUN} -DskipTests -DskipNexusStagingDeployMojo=${IS_DRY_RUN} -B --fail-at-end -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -f pom.xml"


### PR DESCRIPTION
## Description
We recently made the assembly plugin optional since it takes long time to run. For the release, we require the assembly plugin to run so we need to add the profile for that.

<!-- Describe the goal and purpose of this PR. -->
<!-- -->
<!-- For structural or foundational CI changes request review from @cmur2 -->

## Related issues

closes #
