### PR TITLE
fix: use endDate as indicator for a finished operation

### DIFF
--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
@@ -331,6 +331,7 @@ describe('OperationsEntry', () => {
       <OperationsEntry
         operation={{
           ...OPERATIONS.EDIT,
+          endDate: null,
           operationsTotalCount: 10,
           operationsFinishedCount: 0,
         }}
@@ -357,6 +358,7 @@ describe('OperationsEntry', () => {
       <OperationsEntry
         operation={{
           ...OPERATIONS.EDIT,
+          endDate: null,
           operationsTotalCount: 10,
           operationsFinishedCount: 5,
         }}

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
@@ -64,6 +64,7 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
   const {fakeProgressPercentage, isComplete} = useLoadingProgress({
     totalCount: operationsTotalCount,
     finishedCount: operationsFinishedCount,
+    isFinished: endDate !== null,
   });
 
   const label = TYPE_LABELS[type];

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
@@ -8,12 +8,21 @@
 
 import {useState, useRef, useEffect} from 'react';
 
+/**
+ * Returns a (faked) progress percentage and an isComplete indicator
+ * based on totalCount, finishedCount and isFinished parameters.
+ *
+ * isFinished means the operation itself is finished
+ * isComplete is true when the visual progress has finished
+ */
 const useLoadingProgress = ({
   totalCount,
   finishedCount,
+  isFinished,
 }: {
   totalCount: number;
   finishedCount: number;
+  isFinished: boolean;
 }) => {
   const [fakeProgressPercentage, setFakeProgressPercentage] = useState(0);
   const [isComplete, setIsComplete] = useState(totalCount === finishedCount);
@@ -55,11 +64,7 @@ const useLoadingProgress = ({
   }, [fakeProgressPercentage, totalCount, finishedCount]);
 
   useEffect(() => {
-    if (
-      totalCount === finishedCount &&
-      !initialCompleteRef.current &&
-      !isComplete
-    ) {
+    if (isFinished && !initialCompleteRef.current && !isComplete) {
       setFakeProgressPercentage(100);
       completedTimeoutId.current = setTimeout(() => {
         setIsComplete(true);
@@ -72,7 +77,7 @@ const useLoadingProgress = ({
         completedTimeoutId.current = null;
       }
     };
-  }, [totalCount, finishedCount, isComplete]);
+  }, [isFinished, isComplete]);
 
   return {fakeProgressPercentage, isComplete};
 };


### PR DESCRIPTION
## Description

With this PR the indication if an operation is shown as completed in the UI has changed

_Before:_ An operation was complete when the total count of operation instances equals the finished count.

_After:_ An operation is complete when there is an end date set for the operation.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/operate/issues/4182
