### PR TITLE
fix: use endDate as indicator for a finished operation [8.5 backport]

### DIFF
--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.test.tsx
@@ -354,6 +354,7 @@ describe('OperationsEntry', () => {
       <OperationsEntry
         operation={{
           ...OPERATIONS.EDIT,
+          endDate: null,
           operationsTotalCount: 10,
           operationsFinishedCount: 0,
         }}
@@ -380,6 +381,7 @@ describe('OperationsEntry', () => {
       <OperationsEntry
         operation={{
           ...OPERATIONS.EDIT,
+          endDate: null,
           operationsTotalCount: 10,
           operationsFinishedCount: 5,
         }}

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/index.tsx
@@ -76,6 +76,7 @@ const OperationsEntry: React.FC<Props> = ({operation}) => {
   const {fakeProgressPercentage, isComplete} = useLoadingProgress({
     totalCount: operationsTotalCount,
     finishedCount: operationsFinishedCount,
+    isFinished: endDate !== null,
   });
 
   const label = TYPE_LABELS[type];

--- a/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
+++ b/operate/client/src/modules/components/OperationsPanel/OperationsEntry/useLoadingProgress.ts
@@ -17,12 +17,21 @@
 
 import {useState, useRef, useEffect} from 'react';
 
+/**
+ * Returns a (faked) progress percentage and an isComplete indicator
+ * based on totalCount, finishedCount and isFinished parameters.
+ *
+ * isFinished means the operation itself is finished
+ * isComplete is true when the visual progress has finished
+ */
 const useLoadingProgress = ({
   totalCount,
   finishedCount,
+  isFinished,
 }: {
   totalCount: number;
   finishedCount: number;
+  isFinished: boolean;
 }) => {
   const [fakeProgressPercentage, setFakeProgressPercentage] = useState(0);
   const [isComplete, setIsComplete] = useState(totalCount === finishedCount);
@@ -64,11 +73,7 @@ const useLoadingProgress = ({
   }, [fakeProgressPercentage, totalCount, finishedCount]);
 
   useEffect(() => {
-    if (
-      totalCount === finishedCount &&
-      !initialCompleteRef.current &&
-      !isComplete
-    ) {
+    if (isFinished && !initialCompleteRef.current && !isComplete) {
       setFakeProgressPercentage(100);
       completedTimeoutId.current = setTimeout(() => {
         setIsComplete(true);
@@ -81,7 +86,7 @@ const useLoadingProgress = ({
         completedTimeoutId.current = null;
       }
     };
-  }, [totalCount, finishedCount, isComplete]);
+  }, [isFinished, isComplete]);
 
   return {fakeProgressPercentage, isComplete};
 };


### PR DESCRIPTION
## Description

8.5 backport for https://github.com/camunda/camunda/pull/20736

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to https://github.com/camunda/operate/issues/4182
