### PR TITLE
[Backport stable/8.2] fix: resetting a reader does not invalidate returned entries

### DIFF
--- a/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -75,6 +75,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -486,7 +487,13 @@ public final class EngineRule extends ExternalResource {
 
     @Override
     public void onClose() {
-      executorService.shutdownNow();
+      executorService.shutdown();
+      try {
+        executorService.awaitTermination(1, TimeUnit.HOURS);
+      } catch (final InterruptedException e) {
+        executorService.shutdownNow();
+        throw new RuntimeException(e);
+      }
     }
 
     private void onNewEventCommitted() {

--- a/logstreams/pom.xml
+++ b/logstreams/pom.xml
@@ -62,6 +62,11 @@
       <artifactId>zeebe-msgpack-value</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>net.jcip</groupId>
+      <artifactId>jcip-annotations</artifactId>
+    </dependency>
+
     <!-- Test dependencies -->
     <dependency>
       <groupId>io.camunda</groupId>

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import java.util.NoSuchElementException;
+import net.jcip.annotations.NotThreadSafe;
 import org.agrona.DirectBuffer;
 import org.agrona.concurrent.UnsafeBuffer;
 
@@ -21,6 +22,7 @@ import org.agrona.concurrent.UnsafeBuffer;
  * <p>This implementation assumes that blocks have no padding - they contain a contiguous series of
  * {@link LoggedEvent} which fits exactly within the block.
  */
+@NotThreadSafe
 final class LogStreamReaderImpl implements LogStreamReader {
   private final LogStorageReader reader;
 

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -200,6 +200,6 @@ final class LogStreamReaderImpl implements LogStreamReader {
   }
 
   private boolean isEventBufferValid(final DirectBuffer eventBuffer) {
-    return eventBuffer.addressOffset() != 0;
+    return eventBuffer.capacity() > 0;
   }
 }

--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderImpl.java
@@ -24,22 +24,16 @@ import org.agrona.concurrent.UnsafeBuffer;
 final class LogStreamReaderImpl implements LogStreamReader {
   private final LogStorageReader reader;
 
-  private final LoggedEventImpl currentEvent;
-  private final DirectBuffer currentEventBuffer;
+  private LoggedEventImpl currentEvent;
+  private DirectBuffer currentEventBuffer;
 
-  private final LoggedEventImpl nextEvent;
-  private final DirectBuffer nextEventBuffer;
+  private LoggedEventImpl nextEvent;
+  private DirectBuffer nextEventBuffer;
 
   private int nextEventOffset;
 
   LogStreamReaderImpl(final LogStorageReader reader) {
     this.reader = reader;
-
-    currentEvent = new LoggedEventImpl();
-    currentEventBuffer = new UnsafeBuffer();
-
-    nextEvent = new LoggedEventImpl();
-    nextEventBuffer = new UnsafeBuffer();
 
     reset();
     seekToFirstEvent();
@@ -147,6 +141,14 @@ final class LogStreamReaderImpl implements LogStreamReader {
   }
 
   @Override
+  public LoggedEvent peekNext() {
+    if (!hasNext()) {
+      throw new NoSuchElementException();
+    }
+    return nextEvent;
+  }
+
+  @Override
   public void close() {
     reset();
     reader.close();
@@ -168,19 +170,14 @@ final class LogStreamReaderImpl implements LogStreamReader {
     return -1;
   }
 
-  @Override
-  public LoggedEvent peekNext() {
-    if (!hasNext()) {
-      throw new NoSuchElementException();
-    }
-    return nextEvent;
-  }
-
   private void reset() {
-    currentEventBuffer.wrap(0, 0);
-    currentEvent.wrap(currentEventBuffer, 0);
+    currentEvent = new LoggedEventImpl();
+    currentEventBuffer = new UnsafeBuffer();
 
-    nextEventBuffer.wrap(0, 0);
+    nextEvent = new LoggedEventImpl();
+    nextEventBuffer = new UnsafeBuffer();
+
+    currentEvent.wrap(currentEventBuffer, 0);
     nextEvent.wrap(nextEventBuffer, 0);
     nextEventOffset = 0;
   }

--- a/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderTest.java
+++ b/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStreamReaderTest.java
@@ -19,6 +19,8 @@ import io.camunda.zeebe.logstreams.log.LoggedEvent;
 import io.camunda.zeebe.logstreams.util.LogStreamReaderRule;
 import io.camunda.zeebe.logstreams.util.LogStreamRule;
 import io.camunda.zeebe.logstreams.util.TestEntry;
+import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.util.ByteValue;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -419,6 +421,24 @@ public final class LogStreamReaderTest {
 
     // when / then
     assertThatThrownBy(reader::peekNext).isInstanceOf(NoSuchElementException.class);
+  }
+
+  @Test
+  public void shouldNotInvalidateEventsOnClose() {
+    // given
+    writer.tryWrite(TestEntry.ofDefaults()).get();
+    writer.tryWrite(TestEntry.ofDefaults()).get();
+    final var event = reader.next();
+    final var nextEvent = reader.peekNext();
+
+    // when
+    reader.close();
+
+    // then
+    assertThatCode(() -> event.readValue(new UnifiedRecordValue(1))).doesNotThrowAnyException();
+    assertThatCode(() -> event.readMetadata(new RecordMetadata())).doesNotThrowAnyException();
+    assertThatCode(() -> nextEvent.readValue(new UnifiedRecordValue(1))).doesNotThrowAnyException();
+    assertThatCode(() -> nextEvent.readMetadata(new RecordMetadata())).doesNotThrowAnyException();
   }
 
   private long writeEvents(final int eventCount) {


### PR DESCRIPTION
# Description
Backport of #20720 to `stable/8.2`.

relates to #20555
original author: @lenaschoenburg