### PR TITLE
feat: Add metrics support for EL jobs

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/metrics/JobMetrics.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.engine.metrics;
 
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.prometheus.client.Counter;
 
 public final class JobMetrics {
@@ -16,7 +17,7 @@ public final class JobMetrics {
           .namespace("zeebe")
           .name("job_events_total")
           .help("Number of job events")
-          .labelNames("action", "partition", "type")
+          .labelNames("action", "partition", "type", "job_kind")
           .register();
 
   private final String partitionIdLabel;
@@ -25,44 +26,44 @@ public final class JobMetrics {
     partitionIdLabel = String.valueOf(partitionId);
   }
 
-  private void jobEvent(final String action, final String type) {
-    JOB_EVENTS.labels(action, partitionIdLabel, type).inc();
+  private void jobEvent(final String action, final String type, final JobKind jobKind) {
+    JOB_EVENTS.labels(action, partitionIdLabel, type, jobKind.name()).inc();
   }
 
-  public void jobCreated(final String type) {
-    jobEvent("created", type);
+  public void jobCreated(final String type, final JobKind jobKind) {
+    jobEvent("created", type, jobKind);
   }
 
-  public void jobActivated(final String type, final int activatedJobs) {
-    JOB_EVENTS.labels("activated", partitionIdLabel, type).inc(activatedJobs);
+  public void jobActivated(final String type, final JobKind jobKind, final int activatedJobs) {
+    JOB_EVENTS.labels("activated", partitionIdLabel, type, jobKind.name()).inc(activatedJobs);
   }
 
-  public void jobTimedOut(final String type) {
-    jobEvent("timed out", type);
+  public void jobTimedOut(final String type, final JobKind jobKind) {
+    jobEvent("timed out", type, jobKind);
   }
 
-  public void jobCompleted(final String type) {
-    jobEvent("completed", type);
+  public void jobCompleted(final String type, final JobKind jobKind) {
+    jobEvent("completed", type, jobKind);
   }
 
-  public void jobFailed(final String type) {
-    jobEvent("failed", type);
+  public void jobFailed(final String type, final JobKind jobKind) {
+    jobEvent("failed", type, jobKind);
   }
 
-  public void jobCanceled(final String type) {
-    jobEvent("canceled", type);
+  public void jobCanceled(final String type, final JobKind jobKind) {
+    jobEvent("canceled", type, jobKind);
   }
 
-  public void jobErrorThrown(final String type) {
-    jobEvent("error thrown", type);
+  public void jobErrorThrown(final String type, final JobKind jobKind) {
+    jobEvent("error thrown", type, jobKind);
   }
 
-  public void jobNotification(final String type) {
-    jobEvent("workers notified", type);
+  public void jobNotification(final String type, final JobKind jobKind) {
+    jobEvent("workers notified", type, jobKind);
   }
 
-  public void jobPush(final String type) {
-    jobEvent("pushed", type);
+  public void jobPush(final String type, final JobKind jobKind) {
+    jobEvent("pushed", type, jobKind);
   }
 
   /** Clears the metrics counter. You probably only want to use this during testing. */

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -154,7 +154,7 @@ public final class BpmnJobBehavior {
         JobKind.BPMN_ELEMENT,
         JobListenerEventType.UNSPECIFIED,
         element.getJobWorkerProperties().getTaskHeaders());
-    jobMetrics.jobCreated(jobProperties.getType());
+    jobMetrics.jobCreated(jobProperties.getType(), JobKind.BPMN_ELEMENT);
   }
 
   public void createNewExecutionListenerJob(
@@ -172,7 +172,7 @@ public final class BpmnJobBehavior {
         JobKind.EXECUTION_LISTENER,
         jobListenerEventType,
         Collections.emptyMap());
-    jobMetrics.jobCreated(jobProperties.getType());
+    jobMetrics.jobCreated(jobProperties.getType(), JobKind.EXECUTION_LISTENER);
   }
 
   private Either<Failure, String> evalTypeExp(final Expression type, final long scopeKey) {
@@ -276,7 +276,7 @@ public final class BpmnJobBehavior {
       // Note that this logic is duplicated in JobCancelProcessor, if you change this please change
       // it there as well.
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.CANCELED, job);
-      jobMetrics.jobCanceled(job.getType());
+      jobMetrics.jobCanceled(job.getType(), job.getJobKind());
     }
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCancelProcessor.java
@@ -37,7 +37,7 @@ public final class JobCancelProcessor implements CommandProcessor<JobRecord> {
       // Note that this logic is duplicated in BpmnJobBehavior, if you change this please change
       // it there as well.
       commandControl.accept(JobIntent.CANCELED, job);
-      jobMetrics.jobCanceled(job.getType());
+      jobMetrics.jobCanceled(job.getType(), job.getJobKind());
     } else {
       commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, jobKey));
     }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobCompleteProcessor.java
@@ -100,6 +100,6 @@ public final class JobCompleteProcessor implements CommandProcessor<JobRecord> {
     job.setVariables(command.getValue().getVariablesBuffer());
 
     commandControl.accept(JobIntent.COMPLETED, job);
-    jobMetrics.jobCompleted(job.getType());
+    jobMetrics.jobCompleted(job.getType(), job.getJobKind());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobFailProcessor.java
@@ -130,7 +130,7 @@ public final class JobFailProcessor implements TypedRecordProcessor<JobRecord> {
     }
     stateWriter.appendFollowUpEvent(jobKey, JobIntent.FAILED, failedJob);
     responseWriter.writeEventOnCommand(jobKey, JobIntent.FAILED, failedJob, record);
-    jobMetrics.jobFailed(failedJob.getType());
+    jobMetrics.jobFailed(failedJob.getType(), failedJob.getJobKind());
 
     setFailedVariables(failedJob);
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobThrowErrorProcessor.java
@@ -98,7 +98,7 @@ public class JobThrowErrorProcessor implements CommandProcessor<JobRecord> {
       final long jobKey,
       final Intent intent,
       final JobRecord job) {
-    jobMetrics.jobErrorThrown(job.getType());
+    jobMetrics.jobErrorThrown(job.getType(), job.getJobKind());
 
     final var serviceTaskInstanceKey = job.getElementId();
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -54,7 +54,7 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
 
     if (state == State.ACTIVATED && hasTimedOut(job)) {
       stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMED_OUT, job);
-      jobMetrics.jobTimedOut(job.getType());
+      jobMetrics.jobTimedOut(job.getType(), job.getJobKind());
       jobActivationBehavior.publishWork(jobKey, job);
     } else {
       final var reason =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/metrics/JobMetricsTest.java
@@ -9,20 +9,32 @@ package io.camunda.zeebe.engine.metrics;
 
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
 
 import io.camunda.zeebe.engine.util.EngineRule;
 import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.JobKind;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
+@RunWith(Parameterized.class)
 public class JobMetricsTest {
 
   @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
@@ -31,19 +43,44 @@ public class JobMetricsTest {
   private static final String TASK_ID = "task";
   private static final String JOB_TYPE = "job";
 
+  @Parameter public JobMetricsTestScenario scenario;
   @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
 
-  @BeforeClass
-  public static void deployProcess() {
-    ENGINE
-        .deployment()
-        .withXmlResource(
-            Bpmn.createExecutableProcess(PROCESS_ID)
-                .startEvent()
-                .serviceTask(TASK_ID, t -> t.zeebeJobTypeExpression("jobType"))
-                .endEvent()
-                .done())
-        .deploy();
+  @Parameters(name = "{index}: {0}")
+  public static Collection<Object[]> parameters() {
+    return Arrays.asList(
+        new Object[][] {
+          {
+            JobMetricsTestScenario.of(
+                JobKind.BPMN_ELEMENT,
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .serviceTask(TASK_ID, t -> t.zeebeJobTypeExpression("jobType"))
+                    .endEvent()
+                    .done())
+          },
+          {
+            JobMetricsTestScenario.of(
+                JobKind.EXECUTION_LISTENER,
+                Bpmn.createExecutableProcess(PROCESS_ID)
+                    .startEvent()
+                    .manualTask(TASK_ID)
+                    .zeebeExecutionListener(el -> el.start().typeExpression("jobType"))
+                    .endEvent()
+                    .done())
+          }
+        });
+  }
+
+  @Test
+  public void allCountsStartAtNull() {
+    assertThat(jobMetric("created", JOB_TYPE, scenario.jobKind)).isNull();
+    assertThat(jobMetric("activated", JOB_TYPE, scenario.jobKind)).isNull();
+    assertThat(jobMetric("timed out", JOB_TYPE, scenario.jobKind)).isNull();
+    assertThat(jobMetric("completed", JOB_TYPE, scenario.jobKind)).isNull();
+    assertThat(jobMetric("failed", JOB_TYPE, scenario.jobKind)).isNull();
+    assertThat(jobMetric("canceled", JOB_TYPE, scenario.jobKind)).isNull();
+    assertThat(jobMetric("error thrown", JOB_TYPE, scenario.jobKind)).isNull();
   }
 
   @Before
@@ -52,44 +89,36 @@ public class JobMetricsTest {
   }
 
   @Test
-  public void allCountsStartAtNull() {
-    assertThat(jobMetric("created", JOB_TYPE)).isNull();
-    assertThat(jobMetric("activated", JOB_TYPE)).isNull();
-    assertThat(jobMetric("timed out", JOB_TYPE)).isNull();
-    assertThat(jobMetric("completed", JOB_TYPE)).isNull();
-    assertThat(jobMetric("failed", JOB_TYPE)).isNull();
-    assertThat(jobMetric("canceled", JOB_TYPE)).isNull();
-    assertThat(jobMetric("error thrown", JOB_TYPE)).isNull();
-  }
-
-  @Test
   public void shouldCountCreated() {
     // when
+    ENGINE.deployment().withXmlResource(scenario.process).deploy();
     createProcessInstanceWithJob(JOB_TYPE);
 
     // then
-    assertThat(jobMetric("created", JOB_TYPE)).isNotNull().isEqualTo(1);
+    assertThat(jobMetric("created", JOB_TYPE, scenario.jobKind)).isEqualTo(1);
   }
 
   @Test
   public void shouldCountActivated() {
     // given
+    ENGINE.deployment().withXmlResource(scenario.process).deploy();
 
     // the job type must be unique, because other tests may also have created jobs that can be
     // activated. We can't depend on the unique process instance when activating a batch of jobs.
-    final String jobType = JOB_TYPE + "_activated";
+    final String jobType = String.format("%s_%s_activated", JOB_TYPE, scenario.jobKind);
     createProcessInstanceWithJob(jobType);
 
     // when
     ENGINE.jobs().withType(jobType).activate();
 
     // then
-    assertThat(jobMetric("activated", jobType)).isNotNull().isEqualTo(1);
+    assertThat(jobMetric("activated", jobType, scenario.jobKind)).isEqualTo(1);
   }
 
   @Test
   public void shouldCountTimedOut() {
     // given
+    ENGINE.deployment().withXmlResource(scenario.process).deploy();
     final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
 
     final var timeout = Duration.ofMinutes(10);
@@ -101,7 +130,7 @@ public class JobMetricsTest {
             .activate()
             .getValue()
             .getJobs()
-            .get(0);
+            .getFirst();
 
     // when
     // We need to add 1 ms as the deadline needs to be < the current time. Without the extra 1 ms
@@ -117,36 +146,39 @@ public class JobMetricsTest {
         .await();
 
     // then
-    assertThat(jobMetric("timed out", JOB_TYPE)).isNotNull().isEqualTo(1);
+    assertThat(jobMetric("timed out", JOB_TYPE, scenario.jobKind)).isEqualTo(1);
   }
 
   @Test
   public void shouldCountCompleted() {
     // given
+    ENGINE.deployment().withXmlResource(scenario.process).deploy();
     final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
 
     // when
     ENGINE.job().ofInstance(processInstanceKey).withType(JOB_TYPE).complete();
 
     // then
-    assertThat(jobMetric("completed", JOB_TYPE)).isNotNull().isEqualTo(1);
+    assertThat(jobMetric("completed", JOB_TYPE, scenario.jobKind)).isEqualTo(1);
   }
 
   @Test
   public void shouldCountFailed() {
     // given
+    ENGINE.deployment().withXmlResource(scenario.process).deploy();
     final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
 
     // when
     ENGINE.job().ofInstance(processInstanceKey).withType(JOB_TYPE).fail();
 
     // then
-    assertThat(jobMetric("failed", JOB_TYPE)).isNotNull().isEqualTo(1);
+    assertThat(jobMetric("failed", JOB_TYPE, scenario.jobKind)).isEqualTo(1);
   }
 
   @Test
   public void shouldCountCanceled() {
     // given
+    ENGINE.deployment().withXmlResource(scenario.process).deploy();
     final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
 
     // when
@@ -156,19 +188,24 @@ public class JobMetricsTest {
         .await();
 
     // then
-    assertThat(jobMetric("canceled", JOB_TYPE)).isNotNull().isEqualTo(1);
+    assertThat(jobMetric("canceled", JOB_TYPE, scenario.jobKind)).isEqualTo(1);
   }
 
   @Test
   public void shouldCountErrorThrown() {
+    // Skip test for `JobKind.EXECUTION_LISTENER` as error throwing functionality
+    // is not supported for this job kind.
+    assumeThat(scenario.jobKind, is(not(equalTo(JobKind.EXECUTION_LISTENER))));
+
     // given
+    ENGINE.deployment().withXmlResource(scenario.process).deploy();
     final long processInstanceKey = createProcessInstanceWithJob(JOB_TYPE);
 
     // when
     ENGINE.job().ofInstance(processInstanceKey).withType(JOB_TYPE).throwError();
 
     // then
-    assertThat(jobMetric("error thrown", JOB_TYPE)).isNotNull().isEqualTo(1);
+    assertThat(jobMetric("error thrown", JOB_TYPE, scenario.jobKind)).isEqualTo(1);
   }
 
   /**
@@ -192,11 +229,24 @@ public class JobMetricsTest {
     return processInstanceKey;
   }
 
-  private static Double jobMetric(final String action, final String type) {
+  private static Double jobMetric(final String action, final String type, final JobKind jobKind) {
     return MetricsTestHelper.readMetricValue(
         "zeebe_job_events_total",
         entry("action", action),
         entry("partition", "1"),
-        entry("type", type));
+        entry("type", type),
+        entry("job_kind", jobKind.name()));
+  }
+
+  record JobMetricsTestScenario(JobKind jobKind, BpmnModelInstance process) {
+    @Override
+    public String toString() {
+      return jobKind.name();
+    }
+
+    private static JobMetricsTestScenario of(
+        final JobKind jobKind, final BpmnModelInstance process) {
+      return new JobMetricsTestScenario(jobKind, process);
+    }
   }
 }


### PR DESCRIPTION
## Description
This PR introduces enhanced metrics support for Execution Listener jobs within the Zeebe workflow engine. The main additions include:

- **Metrics enhancement**: Added a `jobKind` label to job metrics, allowing for differentiation between BPMN element, Task Listener, and Execution Listener jobs.
- **Test enhancements**: The `JobMetricsTests` class has been refactored to use parameterized testing, now also testing metrics for jobs with the `EXECUTION_LISTENER` job kind.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #16240 
