### PR TITLE
ci: Netty can be upgraded again

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -72,11 +72,6 @@
       "allowedVersions": "!/0.8.9/"
     },
     {
-      "description": "Do not update Netty as it is incompatible with grpc-java < 1.65; this can be removed after that",
-      "matchManagers": ["maven"],
-      "matchPackageNames": ["io.netty{/,}**"]
-    },
-    {
       "description" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
       "matchManagers": ["maven"],
       "matchPackageNames": ["*"],


### PR DESCRIPTION
## Description

`grpc-java` is now recent enough, see https://github.com/camunda/camunda/blob/3a47c6ef9e287417b870adf7d304be618aa8e226/parent/pom.xml#L55

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
