### PR TITLE
Write MessageCorrelation NOT_CORRELATED response upon MessageSubscription CORRELATE rejection

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -108,7 +108,11 @@ public final class MessageEventProcessors {
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.REJECT,
             new MessageSubscriptionRejectProcessor(
-                messageState, subscriptionState, subscriptionCommandSender, writers))
+                messageState,
+                subscriptionState,
+                messageCorrelationState,
+                subscriptionCommandSender,
+                writers))
         .onCommand(
             ValueType.MESSAGE_CORRELATION,
             MessageCorrelationIntent.CORRELATE,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -228,7 +228,8 @@ public final class EventAppliers implements EventApplier {
   private void registerMessageCorrelationAppliers(final MutableProcessingState state) {
     register(MessageCorrelationIntent.CORRELATING, new MessageCorrelationCorrelatingApplier(state));
     register(MessageCorrelationIntent.CORRELATED, new MessageCorrelationCorrelatedApplier(state));
-    register(MessageCorrelationIntent.NOT_CORRELATED, NOOP_EVENT_APPLIER);
+    register(
+        MessageCorrelationIntent.NOT_CORRELATED, new MessageCorrelationNotCorrelatedApplier(state));
   }
 
   private void registerMessageSubscriptionAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageCorrelationNotCorrelatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/MessageCorrelationNotCorrelatedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableMessageCorrelationState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.message.MessageCorrelationRecord;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+
+class MessageCorrelationNotCorrelatedApplier
+    implements TypedEventApplier<MessageCorrelationIntent, MessageCorrelationRecord> {
+
+  private final MutableMessageCorrelationState messageCorrelationState;
+
+  public MessageCorrelationNotCorrelatedApplier(final MutableProcessingState state) {
+    messageCorrelationState = state.getMessageCorrelationState();
+  }
+
+  @Override
+  public void applyState(final long key, final MessageCorrelationRecord value) {
+    messageCorrelationState.removeMessageCorrelation(value.getMessageKey());
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationRejectionTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.message;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
+import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Duration;
+import java.util.UUID;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class MessageCorrelationRejectionTest {
+  @Rule public final EngineRule engine = EngineRule.multiplePartition(2);
+
+  @Test
+  public void shouldWriteNotCorrelatedEvent() {
+    // given - a process instance on partition 1 that waits for a message published on 2
+    final var correlationKey = "correlationKey";
+
+    final var messageName = "message-" + UUID.randomUUID();
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent("receive-message")
+            .message(m -> m.name(messageName).zeebeCorrelationKeyExpression("key"))
+            .endEvent("end")
+            .done();
+    engine.deployment().withXmlResource(process).deploy();
+
+    final var processInstanceKey =
+        engine
+            .processInstance()
+            .ofBpmnProcessId("process")
+            .withVariable("key", correlationKey)
+            .create();
+
+    // given - MESSAGE_SUBSCRIPTION.CORRELATE messages from partition 2 to partition 1 is dropped
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) ->
+            !(receiverPartitionId == 2 && intent == MessageSubscriptionIntent.CORRELATE));
+
+    // when - A message correlate command is send and some time passes
+    engine
+        .messageCorrelation()
+        .withName(messageName)
+        .withCorrelationKey(correlationKey)
+        .expectNothing()
+        .correlate();
+    engine.increaseTime(Duration.ofMinutes(10));
+    RecordingExporter.messageSubscriptionRecords(MessageSubscriptionIntent.REJECT)
+        .withProcessInstanceKey(processInstanceKey)
+        .await();
+
+    // then - Message is NOT_CORRELATED
+    assertThat(
+            RecordingExporter.messageCorrelationRecords(MessageCorrelationIntent.NOT_CORRELATED)
+                .withName(messageName)
+                .withCorrelationKey(correlationKey)
+                .exists())
+        .isTrue();
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationRejectionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageCorrelationRejectionTest.java
@@ -37,17 +37,17 @@ public final class MessageCorrelationRejectionTest {
             .done();
     engine.deployment().withXmlResource(process).deploy();
 
+    // MESSAGE_SUBSCRIPTION.CORRELATE messages from partition 2 to partition 1 is dropped
+    engine.interceptInterPartitionCommands(
+        (receiverPartitionId, valueType, intent, recordKey, command) ->
+            !(receiverPartitionId == 2 && intent == MessageSubscriptionIntent.CORRELATE));
+
     final var processInstanceKey =
         engine
             .processInstance()
             .ofBpmnProcessId("process")
             .withVariable("key", correlationKey)
             .create();
-
-    // given - MESSAGE_SUBSCRIPTION.CORRELATE messages from partition 2 to partition 1 is dropped
-    engine.interceptInterPartitionCommands(
-        (receiverPartitionId, valueType, intent, recordKey, command) ->
-            !(receiverPartitionId == 2 && intent == MessageSubscriptionIntent.CORRELATE));
 
     // when - A message correlate command is send and some time passes
     engine

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
@@ -35,6 +35,12 @@ public final class MessageCorrelationClient {
               .withPartitionId(message.partitionId)
               .withCorrelationKey(message.correlationKey)
               .getFirst();
+  private static final Function<Message, Record<MessageCorrelationRecordValue>> EXPECT_NOTHING =
+      (message) ->
+          RecordingExporter.messageCorrelationRecords(MessageCorrelationIntent.CORRELATE)
+              .withPartitionId(message.partitionId)
+              .withCorrelationKey(message.correlationKey)
+              .getFirst();
   private static final int NOT_SET = -1;
   private final MessageCorrelationRecord messageCorrelationRecord;
   private final CommandWriter writer;
@@ -86,6 +92,11 @@ public final class MessageCorrelationClient {
 
   public MessageCorrelationClient expectNotCorrelated() {
     expectation = NOT_CORRELATED;
+    return this;
+  }
+
+  public MessageCorrelationClient expectNothing() {
+    expectation = EXPECT_NOTHING;
     return this;
   }
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
If the MessageSubscription CORRELATE command gets rejected we must make sure we notify the client about the correlation. There is 2 possiblities:

1. Another subscription to correlate against is found:
    - We do nothing. This other subscription gets the chance to correlate and will write a response if necessary
2. No other subscription is found:
    - We write the MessageCorrelation.NOT_CORRELATED event and response to the client.  


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #20176
