### PR TITLE
ci: restrict workflows to their modules of interest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild
+          maven-extra-args: -PskipFrontendBuild -D skipOptimize
           go: false
       - uses: ./.github/actions/build-platform-docker
         id: build-camunda-docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
-      - run: ./mvnw -T1C -B -D skipTests -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
+      - run: ./mvnw -T1C -B -D skipTests -D skipOptimize -P !autoFormat,checkFormat,spotbugs,skipFrontendBuild verify
       - name: Observe build status
         if: always()
         continue-on-error: true
@@ -161,6 +161,7 @@ jobs:
           ./mvnw -T2 -B --no-snapshot-updates
           -D skipITs -D skipQaBuild=true -D skipChecks -D surefire.rerunFailingTestsCount=3
           -D junitThreadCount=16
+          -D skipOptimize
           -P skip-random-tests,parallel-tests,extract-flaky-tests,skipFrontendBuild
           verify
           | tee "${BUILD_OUTPUT_FILE_PATH}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         with:
           go: false
-          maven-extra-args: -T1C -PskipFrontendBuild
+          maven-extra-args: -T1C -PskipFrontendBuild -D skipOptimize
       - name: Create build output log file
         run: echo "BUILD_OUTPUT_FILE_PATH=$(mktemp)" >> $GITHUB_ENV
       - name: Maven Test Build
@@ -334,7 +334,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild -D skipOptimize
+          maven-extra-args: -PskipFrontendBuild
           go: false
       - uses: ./.github/actions/build-platform-docker
         id: build-camunda-docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -T1C -PskipFrontendBuild
+          maven-extra-args: -T1C -PskipFrontendBuild -D skipOptimize
       - uses: ./.github/actions/build-platform-docker
         with:
           repository: localhost:5000/camunda/zeebe
@@ -334,7 +334,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:
-          maven-extra-args: -PskipFrontendBuild
+          maven-extra-args: -PskipFrontendBuild -D skipOptimize
           go: false
       - uses: ./.github/actions/build-platform-docker
         id: build-camunda-docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
           ./mvnw -B -T ${{ matrix.maven-build-threads }} --no-snapshot-updates
           -D forkCount=${{ matrix.maven-test-fork-count }}
           -D maven.javadoc.skip=true
-          -D skipUTs -D skipChecks
+          -D skipUTs -D skipChecks -D skipOptimize
           -D failsafe.rerunFailingTestsCount=3 -D flaky.test.reportDir=failsafe-reports
           -P parallel-tests,extract-flaky-tests,skipFrontendBuild
           -pl ${{ matrix.maven-modules }}

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Generate production .tar.gz
       uses: ./.github/actions/run-maven
       with:
-        parameters: install -DskipTests -Dskip.docker -PrunAssembly
+        parameters: -f optimize/pom.xml install -DskipTests -Dskip.docker -PrunAssembly
 
     - name: Build and push Docker image
       uses: docker/build-push-action@2cdde995de11925a030ce8070c3d77a52ffcf1c0 # v5

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,6 @@
     <module>build-tools</module>
     <module>zeebe</module>
     <module>operate</module>
-    <module>optimize</module>
     <module>tasklist</module>
     <module>identity</module>
     <module>webapps-common</module>
@@ -86,6 +85,19 @@
       </activation>
       <modules>
         <module>qa</module>
+      </modules>
+    </profile>
+
+    <profile>
+      <id>include-optimize</id>
+      <activation>
+        <property>
+          <name>skipOptimize</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <modules>
+        <module>optimize</module>
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
## Description

The objective of this PR is to let various workflows work against the modules they are meant to, excluding the rest of the modules from their scope. In particular:
* optimize is being excluded from the workflows where it's not needed, shortening the runtime of such workflows to avoid unnecessary timeouts
* the optimize docker test is being restricted to only work against the optimize module

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)
