### PR TITLE
test: stabilize operations and cal activities e2e tests

### DIFF
--- a/operate/client/e2e-playwright/tests/callActivities.spec.ts
+++ b/operate/client/e2e-playwright/tests/callActivities.spec.ts
@@ -58,7 +58,7 @@ test.describe('Call Activities', () => {
     const instancesList = page.getByTestId('data-list');
 
     await expect(instancesList.getByRole('row')).toHaveCount(1);
-    await expect(instancesList.getByText('Called Process')).toBeVisible();
+    await expect(instancesList.getByText('CalledProcess')).toBeVisible();
 
     const calledProcessInstanceId = await instancesList
       .getByRole('row')
@@ -106,7 +106,7 @@ test.describe('Call Activities', () => {
 
     await popover
       .getByRole('link', {
-        name: /view called process instance/i,
+        name: /view calledProcess instance/i,
       })
       .click();
 
@@ -115,14 +115,14 @@ test.describe('Call Activities', () => {
       instanceHeader.getByText(calledProcessInstanceId),
     ).toBeVisible();
     await expect(
-      instanceHeader.getByText('Called Process', {
+      instanceHeader.getByText('CalledProcess', {
         exact: true,
       }),
     ).toBeVisible();
 
     // Expect correct instance history
     await expect(
-      instanceHistory.getByText('Called Process', {
+      instanceHistory.getByText('CalledProcess', {
         exact: true,
       }),
     ).toBeVisible();

--- a/operate/client/e2e-playwright/tests/operationsPanel.mocks.ts
+++ b/operate/client/e2e-playwright/tests/operationsPanel.mocks.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {zeebeGrpcApi} from '../api/zeebe-grpc';
+
+const {deployProcesses, createSingleInstance} = zeebeGrpcApi;
+
+async function createDemoInstances() {
+  await deployProcesses(['operationsProcessA.bpmn']);
+
+  const singleOperationInstance = await createSingleInstance(
+    'operationsProcessA',
+    1,
+  );
+
+  return {singleOperationInstance};
+}
+
+export {createDemoInstances};

--- a/operate/client/e2e-playwright/tests/operationsPanel.spec.ts
+++ b/operate/client/e2e-playwright/tests/operationsPanel.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {SETUP_WAITING_TIME} from './constants';
+import {createDemoInstances} from './operationsPanel.mocks';
+import {test} from '../test-fixtures';
+import {expect} from '@playwright/test';
+import {config} from '../config';
+import {ENDPOINTS} from './api/endpoints';
+
+let initialData: Awaited<ReturnType<typeof createDemoInstances>>;
+
+test.beforeAll(async ({request}) => {
+  test.setTimeout(SETUP_WAITING_TIME);
+  initialData = await createDemoInstances();
+
+  const {processInstanceKey} = initialData.singleOperationInstance;
+
+  // create demo operations
+  await Promise.all(
+    [...new Array(50)].map(async () => {
+      const response = await request.post(
+        ENDPOINTS.createOperation(processInstanceKey),
+        {
+          data: {
+            operationType: 'RESOLVE_INCIDENT',
+          },
+        },
+      );
+
+      return response;
+    }),
+  );
+
+  // wait until all operations are created
+  await expect
+    .poll(
+      async () => {
+        const response = await request.post(
+          `${config.endpoint}/api/batch-operations`,
+          {
+            data: {
+              pageSize: 50,
+            },
+          },
+        );
+        const operations = await response.json();
+        return operations.length;
+      },
+      {timeout: SETUP_WAITING_TIME},
+    )
+    .toBe(50);
+});
+
+test.beforeEach(async ({page, dashboardPage}) => {
+  await dashboardPage.navigateToDashboard();
+  await page.getByRole('link', {name: /processes/i}).click();
+});
+
+test.describe('Operations Panel', () => {
+  test('infinite scrolling', async ({page, commonPage}) => {
+    await commonPage.expandOperationsPanel();
+    await expect(page.getByTestId('operations-entry')).toHaveCount(20);
+    await page.getByTestId('operations-entry').nth(19).scrollIntoViewIfNeeded();
+    await expect(page.getByTestId('operations-entry')).toHaveCount(40);
+  });
+});

--- a/operate/client/e2e-playwright/tests/operationsPanel.spec.ts
+++ b/operate/client/e2e-playwright/tests/operationsPanel.spec.ts
@@ -21,6 +21,20 @@ test.beforeAll(async ({request}) => {
 
   const {processInstanceKey} = initialData.singleOperationInstance;
 
+  // wait until single operation instances is created and in incident state
+  await expect
+    .poll(
+      async () => {
+        const response = await request.get(
+          `${config.endpoint}/v1/process-instances/${processInstanceKey}`,
+        );
+        const {incident} = await response.json();
+        return incident;
+      },
+      {timeout: SETUP_WAITING_TIME},
+    )
+    .toBeTruthy();
+
   // create demo operations
   await Promise.all(
     [...new Array(50)].map(async () => {

--- a/operate/client/e2e-playwright/tests/resources/calledProcess.bpmn
+++ b/operate/client/e2e-playwright/tests/resources/calledProcess.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0n2h6sh" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.0.0-nightly.20220316" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
-  <bpmn:process id="CalledProcess" name="Called Process" isExecutable="true">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0n2h6sh" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.22.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="1.0.0">
+  <bpmn:process id="CalledProcess" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Process started">
       <bpmn:outgoing>Flow_12mbzc8</bpmn:outgoing>
     </bpmn:startEvent>


### PR DESCRIPTION
## Description

- split up operations panel tests from operations tests. These tests were operating on the same process instance which led to interferences
- stabilize operations tests: tests are now waiting until the process instance is in incident state before the incident is resolved 
- stabilize call activities test (always using bpmn process id now, see [comment](https://github.com/camunda/camunda/issues/19375#issuecomment-2271090371)) 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #19377
closes #19375
