### PR TITLE
refactor: job update processors

### DIFF
--- a/clients/go/cmd/zbctl/testdata/update_unknown_job_timeout.golden
+++ b/clients/go/cmd/zbctl/testdata/update_unknown_job_timeout.golden
@@ -1,1 +1,1 @@
-Error: rpc error: code = NotFound desc = Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job deadline with key '2251799813685253', but no such job was found
+Error: rpc error: code = NotFound desc = Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job with key '2251799813685253', but no such job was found

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviors.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.engine.processing.common.CatchEventBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.variable.VariableBehavior;
 
 public interface BpmnBehaviors {
@@ -55,4 +56,6 @@ public interface BpmnBehaviors {
   BpmnUserTaskBehavior userTaskBehavior();
 
   BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour();
+
+  JobUpdateBehaviour jobUpdateBehaviour();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBehaviorsImpl.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.common.ElementActivationBehavior;
 import io.camunda.zeebe.engine.processing.common.EventTriggerBehavior;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
+import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.processing.streamprocessor.JobStreamer;
 import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
@@ -47,6 +48,7 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   private final BpmnSignalBehavior signalBehavior;
   private final BpmnUserTaskBehavior userTaskBehavior;
   private final BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour;
+  private final JobUpdateBehaviour jobUpdateBehaviour;
 
   public BpmnBehaviorsImpl(
       final MutableProcessingState processingState,
@@ -176,6 +178,8 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
     compensationSubscriptionBehaviour =
         new BpmnCompensationSubscriptionBehaviour(
             processingState.getKeyGenerator(), processingState, writers, stateBehavior);
+
+    jobUpdateBehaviour = new JobUpdateBehaviour(processingState.getJobState(), writers);
   }
 
   @Override
@@ -276,5 +280,10 @@ public final class BpmnBehaviorsImpl implements BpmnBehaviors {
   @Override
   public BpmnCompensationSubscriptionBehaviour compensationSubscriptionBehaviour() {
     return compensationSubscriptionBehaviour;
+  }
+
+  @Override
+  public JobUpdateBehaviour jobUpdateBehaviour() {
+    return jobUpdateBehaviour;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -78,7 +78,7 @@ public final class JobEventProcessors {
             new JobTimeOutProcessor(
                 processingState, writers, jobMetrics, bpmnBehaviors.jobActivationBehavior()))
         .onCommand(
-            ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(processingState))
+            ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(processingState, writers))
         .onCommand(
             ValueType.JOB,
             JobIntent.UPDATE_TIMEOUT,

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -31,7 +31,6 @@ public final class JobEventProcessors {
       final JobMetrics jobMetrics,
       final EngineConfiguration config) {
 
-    final var jobState = processingState.getJobState();
     final var keyGenerator = processingState.getKeyGenerator();
 
     final EventHandle eventHandle =
@@ -78,13 +77,17 @@ public final class JobEventProcessors {
             new JobTimeOutProcessor(
                 processingState, writers, jobMetrics, bpmnBehaviors.jobActivationBehavior()))
         .onCommand(
-            ValueType.JOB, JobIntent.UPDATE_RETRIES, new JobUpdateRetriesProcessor(processingState, writers))
+            ValueType.JOB,
+            JobIntent.UPDATE_RETRIES,
+            new JobUpdateRetriesProcessor(bpmnBehaviors.jobUpdateBehaviour()))
         .onCommand(
             ValueType.JOB,
             JobIntent.UPDATE_TIMEOUT,
-            new JobUpdateTimeoutProcessor(processingState, writers))
+            new JobUpdateTimeoutProcessor(bpmnBehaviors.jobUpdateBehaviour()))
         .onCommand(
-            ValueType.JOB, JobIntent.UPDATE, new JobUpdateProcessor(processingState, writers))
+            ValueType.JOB,
+            JobIntent.UPDATE,
+            new JobUpdateProcessor(bpmnBehaviors.jobUpdateBehaviour()))
         .onCommand(
             ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(processingState, jobMetrics))
         .onCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobEventProcessors.java
@@ -79,15 +79,15 @@ public final class JobEventProcessors {
         .onCommand(
             ValueType.JOB,
             JobIntent.UPDATE_RETRIES,
-            new JobUpdateRetriesProcessor(bpmnBehaviors.jobUpdateBehaviour()))
+            new JobUpdateRetriesProcessor(bpmnBehaviors.jobUpdateBehaviour(), writers))
         .onCommand(
             ValueType.JOB,
             JobIntent.UPDATE_TIMEOUT,
-            new JobUpdateTimeoutProcessor(bpmnBehaviors.jobUpdateBehaviour()))
+            new JobUpdateTimeoutProcessor(bpmnBehaviors.jobUpdateBehaviour(), writers))
         .onCommand(
             ValueType.JOB,
             JobIntent.UPDATE,
-            new JobUpdateProcessor(bpmnBehaviors.jobUpdateBehaviour()))
+            new JobUpdateProcessor(bpmnBehaviors.jobUpdateBehaviour(), writers))
         .onCommand(
             ValueType.JOB, JobIntent.CANCEL, new JobCancelProcessor(processingState, jobMetrics))
         .onCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -45,7 +45,7 @@ public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
               jobUpdateBehaviour.updateJobRetries(jobKey, job, command).ifPresent(errors::add);
               final long timeout = command.getValue().getTimeout();
               // if no timeout is provided (the default value is -1L), no update
-              if (timeout > -1L) {
+              if (timeout > 0) {
                 jobUpdateBehaviour.updateJobTimeout(jobKey, job, command).ifPresent(errors::add);
               }
               if (errors.isEmpty()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -7,70 +7,34 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
 
-  private static final String NO_JOB_FOUND_MESSAGE =
-      "Expected to update job with key '%d', but no such job was found";
+  private final JobUpdateBehaviour jobUpdateBehaviour;
 
-  private final JobState jobState;
-  private final StateWriter stateWriter;
-  private final TypedRejectionWriter rejectionWriter;
-  private final TypedResponseWriter responseWriter;
-
-  public JobUpdateProcessor(final ProcessingState state, final Writers writers) {
-    jobState = state.getJobState();
-    stateWriter = writers.state();
-    rejectionWriter = writers.rejection();
-    responseWriter = writers.response();
+  public JobUpdateProcessor(final JobUpdateBehaviour jobUpdateBehaviour) {
+    this.jobUpdateBehaviour = jobUpdateBehaviour;
   }
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    final long key = command.getKey();
-    final int retries = command.getValue().getRetries();
-    final long timeout = command.getValue().getTimeout();
-    final var job = jobState.getJob(key, command.getAuthorizations());
-    boolean isJobUpdated = false;
+    final long jobKey = command.getKey();
 
-    if (job == null) {
-      rejectionWriter.appendRejection(
-          command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(key));
-      responseWriter.writeRejectionOnCommand(
-          command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(key));
+    final var jobRecord = jobUpdateBehaviour.getJobOrAppendRejection(jobKey, command);
+    if (jobRecord == null) {
       return;
     }
-
-    // Handle retries
-    if (retries > 0) {
-      job.setRetries(retries);
-      stateWriter.appendFollowUpEvent(key, JobIntent.RETRIES_UPDATED, job);
-      isJobUpdated = true;
-    }
-    // Handle timeout
-    final long oldDeadline = job.getDeadline();
-    if (timeout > -0 && jobState.jobDeadlineExists(key, oldDeadline)) {
-      final long newDeadline = ActorClock.currentTimeMillis() + job.getTimeout();
-      job.setDeadline(newDeadline);
-      stateWriter.appendFollowUpEvent(key, JobIntent.TIMEOUT_UPDATED, job);
-      isJobUpdated = true;
-    }
-
-    if (isJobUpdated) {
-      stateWriter.appendFollowUpEvent(key, JobIntent.UPDATED, job);
-      responseWriter.writeEventOnCommand(key, JobIntent.UPDATED, job, command);
+    final var updatedRetries = jobUpdateBehaviour.updateJobRetries(jobKey, jobRecord, command);
+    final var updatedTimeout = jobUpdateBehaviour.updateJobTimeout(jobKey, jobRecord, command);
+    // if retries or timeout are updated the command is rejected
+    if (updatedRetries || updatedTimeout) {
+      jobUpdateBehaviour.completeJobUpdate(jobKey, jobRecord, command);
+    } else {
+      jobUpdateBehaviour.rejectJobUpdate(command);
     }
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -9,19 +9,59 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.util.ArrayList;
+import java.util.List;
 
 public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
 
   private final JobUpdateBehaviour jobUpdateBehaviour;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+  private final StateWriter stateWriter;
 
-  public JobUpdateProcessor(final JobUpdateBehaviour jobUpdateBehaviour) {
+  public JobUpdateProcessor(final JobUpdateBehaviour jobUpdateBehaviour, final Writers writers) {
     this.jobUpdateBehaviour = jobUpdateBehaviour;
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
+    stateWriter = writers.state();
   }
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    jobUpdateBehaviour.completeJobUpdate(command);
+    final long jobKey = command.getKey();
+    jobUpdateBehaviour
+        .getJob(jobKey, command)
+        .ifRightOrLeft(
+            job -> {
+              final List<String> errors = new ArrayList<>();
+              jobUpdateBehaviour.updateJobRetries(jobKey, job, command).ifPresent(errors::add);
+              final long timeout = command.getValue().getTimeout();
+              // if no timeout is provided (the default value is -1L), no update
+              if (timeout > -1L) {
+                jobUpdateBehaviour.updateJobTimeout(jobKey, job, command).ifPresent(errors::add);
+              }
+              if (errors.isEmpty()) {
+                stateWriter.appendFollowUpEvent(jobKey, JobIntent.UPDATED, job);
+                responseWriter.writeEventOnCommand(jobKey, JobIntent.UPDATED, job, command);
+              } else {
+                final String errorMessage = String.join(", ", errors);
+                rejectionWriter.appendRejection(
+                    command, RejectionType.INVALID_ARGUMENT, errorMessage);
+                responseWriter.writeRejectionOnCommand(
+                    command, RejectionType.INVALID_ARGUMENT, errorMessage);
+              }
+            },
+            errorMessage -> {
+              responseWriter.writeRejectionOnCommand(
+                  command, RejectionType.NOT_FOUND, errorMessage);
+            });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateProcessor.java
@@ -22,19 +22,6 @@ public class JobUpdateProcessor implements TypedRecordProcessor<JobRecord> {
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    final long jobKey = command.getKey();
-
-    final var jobRecord = jobUpdateBehaviour.getJobOrAppendRejection(jobKey, command);
-    if (jobRecord == null) {
-      return;
-    }
-    final var updatedRetries = jobUpdateBehaviour.updateJobRetries(jobKey, jobRecord, command);
-    final var updatedTimeout = jobUpdateBehaviour.updateJobTimeout(jobKey, jobRecord, command);
-    // if retries or timeout are updated the command is rejected
-    if (updatedRetries || updatedTimeout) {
-      jobUpdateBehaviour.completeJobUpdate(jobKey, jobRecord, command);
-    } else {
-      jobUpdateBehaviour.rejectJobUpdate(command);
-    }
+    jobUpdateBehaviour.completeJobUpdate(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -22,13 +22,6 @@ public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<Job
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    final long jobKey = command.getKey();
-
-    final var jobRecord = jobUpdateBehaviour.getJobOrAppendRejection(jobKey, command);
-    if (jobRecord == null) {
-      return;
-    }
-    jobUpdateBehaviour.updateJobRetries(jobKey, jobRecord, command);
-    jobUpdateBehaviour.writeUpdateJobRetriesResponse(jobKey, jobRecord, command);
+    jobUpdateBehaviour.completeJobUpdateRetries(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -9,19 +9,49 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<JobRecord> {
 
   private final JobUpdateBehaviour jobUpdateBehaviour;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
 
-  public JobUpdateRetriesProcessor(final JobUpdateBehaviour jobUpdateBehaviour) {
+  public JobUpdateRetriesProcessor(
+      final JobUpdateBehaviour jobUpdateBehaviour, final Writers writers) {
     this.jobUpdateBehaviour = jobUpdateBehaviour;
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
   }
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    jobUpdateBehaviour.completeJobUpdateRetries(command);
+    final long jobKey = command.getKey();
+    jobUpdateBehaviour
+        .getJob(jobKey, command)
+        .ifRightOrLeft(
+            job ->
+                jobUpdateBehaviour
+                    .updateJobRetries(jobKey, job, command)
+                    .ifPresentOrElse(
+                        errorMessage -> {
+                          rejectionWriter.appendRejection(
+                              command, RejectionType.INVALID_STATE, errorMessage);
+                          responseWriter.writeRejectionOnCommand(
+                              command, RejectionType.INVALID_STATE, errorMessage);
+                        },
+                        () ->
+                            responseWriter.writeEventOnCommand(
+                                jobKey, JobIntent.RETRIES_UPDATED, job, command)),
+            errorMessage -> {
+              responseWriter.writeRejectionOnCommand(
+                  command, RejectionType.NOT_FOUND, errorMessage);
+            });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -7,60 +7,28 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<JobRecord> {
 
-  private static final String NO_JOB_FOUND_MESSAGE =
-      "Expected to update retries for job with key '%d', but no such job was found";
-  private static final String NEGATIVE_RETRIES_MESSAGE =
-      "Expected to update retries for job with key '%d' with a positive amount of retries, "
-          + "but the amount given was '%d'";
+  private final JobUpdateBehaviour jobUpdateBehaviour;
 
-  private final JobState jobState;
-  private final StateWriter stateWriter;
-  private final TypedRejectionWriter rejectionWriter;
-  private final TypedResponseWriter responseWriter;
-
-  public JobUpdateRetriesProcessor(final ProcessingState state, final Writers writers) {
-    jobState = state.getJobState();
-    stateWriter = writers.state();
-    rejectionWriter = writers.rejection();
-    responseWriter = writers.response();
+  public JobUpdateRetriesProcessor(final JobUpdateBehaviour jobUpdateBehaviour) {
+    this.jobUpdateBehaviour = jobUpdateBehaviour;
   }
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    final long key = command.getKey();
-    final int retries = command.getValue().getRetries();
+    final long jobKey = command.getKey();
 
-    if (retries > 0) {
-      final JobRecord job = jobState.getJob(key, command.getAuthorizations());
-
-      if (job != null) {
-        // update retries for response sent to client
-        job.setRetries(retries);
-
-        stateWriter.appendFollowUpEvent(key, JobIntent.RETRIES_UPDATED, job);
-        responseWriter.writeEventOnCommand(key, JobIntent.RETRIES_UPDATED, job, command);
-      } else {
-        rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
-        responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
-      }
-    } else {
-      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
-      responseWriter.writeRejectionOnCommand(
-          command, RejectionType.INVALID_ARGUMENT, String.format(NEGATIVE_RETRIES_MESSAGE, key, retries));
+    final var jobRecord = jobUpdateBehaviour.getJobOrAppendRejection(jobKey, command);
+    if (jobRecord == null) {
+      return;
     }
+    jobUpdateBehaviour.updateJobRetries(jobKey, jobRecord, command);
+    jobUpdateBehaviour.writeUpdateJobRetriesResponse(jobKey, jobRecord, command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -7,7 +7,11 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
-import io.camunda.zeebe.engine.processing.streamprocessor.CommandProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
@@ -15,7 +19,7 @@ import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
-public final class JobUpdateRetriesProcessor implements CommandProcessor<JobRecord> {
+public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<JobRecord> {
 
   private static final String NO_JOB_FOUND_MESSAGE =
       "Expected to update retries for job with key '%d', but no such job was found";
@@ -24,14 +28,19 @@ public final class JobUpdateRetriesProcessor implements CommandProcessor<JobReco
           + "but the amount given was '%d'";
 
   private final JobState jobState;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
 
-  public JobUpdateRetriesProcessor(final ProcessingState state) {
+  public JobUpdateRetriesProcessor(final ProcessingState state, final Writers writers) {
     jobState = state.getJobState();
+    stateWriter = writers.state();
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
   }
 
   @Override
-  public boolean onCommand(
-      final TypedRecord<JobRecord> command, final CommandControl<JobRecord> commandControl) {
+  public void processRecord(final TypedRecord<JobRecord> command) {
     final long key = command.getKey();
     final int retries = command.getValue().getRetries();
 
@@ -42,14 +51,16 @@ public final class JobUpdateRetriesProcessor implements CommandProcessor<JobReco
         // update retries for response sent to client
         job.setRetries(retries);
 
-        commandControl.accept(JobIntent.RETRIES_UPDATED, job);
+        stateWriter.appendFollowUpEvent(key, JobIntent.RETRIES_UPDATED, job);
+        responseWriter.writeEventOnCommand(key, JobIntent.RETRIES_UPDATED, job, command);
       } else {
-        commandControl.reject(RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
+        rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
+        responseWriter.writeRejectionOnCommand(command, RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
       }
     } else {
-      commandControl.reject(
-          RejectionType.INVALID_ARGUMENT, String.format(NEGATIVE_RETRIES_MESSAGE, key, retries));
+      rejectionWriter.appendRejection(command, RejectionType.NOT_FOUND, String.format(NO_JOB_FOUND_MESSAGE, key));
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.INVALID_ARGUMENT, String.format(NEGATIVE_RETRIES_MESSAGE, key, retries));
     }
-    return true;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateRetriesProcessor.java
@@ -42,9 +42,9 @@ public final class JobUpdateRetriesProcessor implements TypedRecordProcessor<Job
                     .ifPresentOrElse(
                         errorMessage -> {
                           rejectionWriter.appendRejection(
-                              command, RejectionType.INVALID_STATE, errorMessage);
+                              command, RejectionType.INVALID_ARGUMENT, errorMessage);
                           responseWriter.writeRejectionOnCommand(
-                              command, RejectionType.INVALID_STATE, errorMessage);
+                              command, RejectionType.INVALID_ARGUMENT, errorMessage);
                         },
                         () ->
                             responseWriter.writeEventOnCommand(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
@@ -9,19 +9,49 @@ package io.camunda.zeebe.engine.processing.job;
 
 import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord> {
 
   private final JobUpdateBehaviour jobUpdateBehaviour;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
 
-  public JobUpdateTimeoutProcessor(final JobUpdateBehaviour jobUpdateBehaviour) {
+  public JobUpdateTimeoutProcessor(
+      final JobUpdateBehaviour jobUpdateBehaviour, final Writers writers) {
     this.jobUpdateBehaviour = jobUpdateBehaviour;
+    rejectionWriter = writers.rejection();
+    responseWriter = writers.response();
   }
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    jobUpdateBehaviour.completeJobUpdateTimeout(command);
+    final long jobKey = command.getKey();
+    jobUpdateBehaviour
+        .getJob(jobKey, command)
+        .ifRightOrLeft(
+            job ->
+                jobUpdateBehaviour
+                    .updateJobTimeout(jobKey, job, command)
+                    .ifPresentOrElse(
+                        errorMessage -> {
+                          rejectionWriter.appendRejection(
+                              command, RejectionType.INVALID_STATE, errorMessage);
+                          responseWriter.writeRejectionOnCommand(
+                              command, RejectionType.INVALID_STATE, errorMessage);
+                        },
+                        () ->
+                            responseWriter.writeEventOnCommand(
+                                jobKey, JobIntent.TIMEOUT_UPDATED, job, command)),
+            errorMessage -> {
+              responseWriter.writeRejectionOnCommand(
+                  command, RejectionType.NOT_FOUND, errorMessage);
+            });
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
@@ -22,13 +22,6 @@ public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    final long jobKey = command.getKey();
-
-    final var jobRecord = jobUpdateBehaviour.getJobOrAppendRejection(jobKey, command);
-    if (jobRecord == null) {
-      return;
-    }
-    jobUpdateBehaviour.updateJobTimeout(jobKey, jobRecord, command);
-    jobUpdateBehaviour.writeUpdateJobTimeoutResponse(jobKey, jobRecord, command);
+    jobUpdateBehaviour.completeJobUpdateTimeout(command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutProcessor.java
@@ -7,67 +7,28 @@
  */
 package io.camunda.zeebe.engine.processing.job;
 
+import io.camunda.zeebe.engine.processing.job.behaviour.JobUpdateBehaviour;
 import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessor;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
-import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
-import io.camunda.zeebe.engine.state.immutable.JobState;
-import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
-import io.camunda.zeebe.protocol.record.RejectionType;
-import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 
 public class JobUpdateTimeoutProcessor implements TypedRecordProcessor<JobRecord> {
 
-  public static final String NO_JOB_FOUND_MESSAGE =
-      "Expected to update job deadline with key '%d', but no such job was found";
+  private final JobUpdateBehaviour jobUpdateBehaviour;
 
-  public static final String NO_DEADLINE_FOUND_MESSAGE =
-      "Expected to update the timeout of job with key '%d', but it is not active";
-
-  private final JobState jobState;
-  private final StateWriter stateWriter;
-  private final TypedRejectionWriter rejectionWriter;
-  private final TypedResponseWriter responseWriter;
-
-  public JobUpdateTimeoutProcessor(final ProcessingState state, final Writers writers) {
-    jobState = state.getJobState();
-    stateWriter = writers.state();
-    rejectionWriter = writers.rejection();
-    responseWriter = writers.response();
+  public JobUpdateTimeoutProcessor(final JobUpdateBehaviour jobUpdateBehaviour) {
+    this.jobUpdateBehaviour = jobUpdateBehaviour;
   }
 
   @Override
   public void processRecord(final TypedRecord<JobRecord> command) {
-    final var value = command.getValue();
     final long jobKey = command.getKey();
-    final var job = jobState.getJob(jobKey, command.getAuthorizations());
 
-    if (job == null) {
-      rejectionWriter.appendRejection(
-          command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(jobKey));
-      responseWriter.writeRejectionOnCommand(
-          command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(jobKey));
+    final var jobRecord = jobUpdateBehaviour.getJobOrAppendRejection(jobKey, command);
+    if (jobRecord == null) {
       return;
     }
-
-    final long oldDeadline = job.getDeadline();
-
-    if (!jobState.jobDeadlineExists(jobKey, oldDeadline)) {
-      rejectionWriter.appendRejection(
-          command, RejectionType.INVALID_STATE, NO_DEADLINE_FOUND_MESSAGE.formatted(jobKey));
-      responseWriter.writeRejectionOnCommand(
-          command, RejectionType.INVALID_STATE, NO_DEADLINE_FOUND_MESSAGE.formatted(jobKey));
-      return;
-    }
-
-    final long newDeadline = ActorClock.currentTimeMillis() + value.getTimeout();
-    job.setDeadline(newDeadline);
-
-    stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMEOUT_UPDATED, job);
-    responseWriter.writeEventOnCommand(jobKey, JobIntent.TIMEOUT_UPDATED, job, command);
+    jobUpdateBehaviour.updateJobTimeout(jobKey, jobRecord, command);
+    jobUpdateBehaviour.writeUpdateJobTimeoutResponse(jobKey, jobRecord, command);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/behaviour/JobUpdateBehaviour.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.job.behaviour;
+
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedRejectionWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.engine.state.immutable.JobState;
+import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+
+public class JobUpdateBehaviour {
+
+  public static final String NO_JOB_FOUND_MESSAGE =
+      "Expected to update retries for job with key '%d', but no such job was found";
+  public static final String NO_JOB_FOUND_MESSAGE_DEADLINE =
+      "Expected to update job deadline with key '%d', but no such job was found";
+  public static final String NO_DEADLINE_FOUND_MESSAGE =
+      "Expected to update the timeout of job with key '%d', but it is not active";
+  private static final String NEGATIVE_RETRIES_MESSAGE =
+      "Expected to update retries for job with key '%d' with a positive amount of retries, "
+          + "but the amount given was '%d'";
+  private static final String ERROR_MESSAGE_AT_LEAST_ONE_FIELD =
+      "At least one field between retries or timeout is required";
+
+  private final JobState jobState;
+  private final StateWriter stateWriter;
+  private final TypedRejectionWriter rejectionWriter;
+  private final TypedResponseWriter responseWriter;
+
+  public JobUpdateBehaviour(final JobState jobState, final Writers writers) {
+    this.jobState = jobState;
+    stateWriter = writers.state();
+    responseWriter = writers.response();
+    rejectionWriter = writers.rejection();
+  }
+
+  public JobRecord getJobOrAppendRejection(
+      final long jobKey, final TypedRecord<JobRecord> command) {
+    final var job = jobState.getJob(jobKey, command.getAuthorizations());
+
+    if (job != null) {
+      return job;
+    }
+    rejectionWriter.appendRejection(
+        command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(jobKey));
+    responseWriter.writeRejectionOnCommand(
+        command, RejectionType.NOT_FOUND, NO_JOB_FOUND_MESSAGE.formatted(jobKey));
+    return null;
+  }
+
+  public boolean updateJobRetries(
+      final long jobKey, final JobRecord jobRecord, final TypedRecord<JobRecord> command) {
+    final int retries = command.getValue().getRetries();
+    if (retries < 1) {
+      rejectionWriter.appendRejection(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          String.format(NEGATIVE_RETRIES_MESSAGE, jobKey, retries));
+      responseWriter.writeRejectionOnCommand(
+          command,
+          RejectionType.INVALID_ARGUMENT,
+          String.format(NEGATIVE_RETRIES_MESSAGE, jobKey, retries));
+      return false;
+    }
+    // update retries for response sent to client
+    jobRecord.setRetries(retries);
+    stateWriter.appendFollowUpEvent(jobKey, JobIntent.RETRIES_UPDATED, jobRecord);
+    return true;
+  }
+
+  public void writeUpdateJobRetriesResponse(
+      final long jobKey, final JobRecord jobRecord, final TypedRecord<JobRecord> command) {
+    responseWriter.writeEventOnCommand(jobKey, JobIntent.RETRIES_UPDATED, jobRecord, command);
+  }
+
+  public boolean updateJobTimeout(
+      final long jobKey, final JobRecord jobRecord, final TypedRecord<JobRecord> command) {
+    final long oldDeadline = jobRecord.getDeadline();
+
+    if (!jobState.jobDeadlineExists(jobKey, oldDeadline)) {
+      rejectionWriter.appendRejection(
+          command, RejectionType.INVALID_STATE, NO_DEADLINE_FOUND_MESSAGE.formatted(jobKey));
+      responseWriter.writeRejectionOnCommand(
+          command, RejectionType.INVALID_STATE, NO_DEADLINE_FOUND_MESSAGE.formatted(jobKey));
+      return false;
+    }
+    final long timeout = command.getValue().getTimeout();
+    final long newDeadline = ActorClock.currentTimeMillis() + timeout;
+    jobRecord.setDeadline(newDeadline);
+    stateWriter.appendFollowUpEvent(jobKey, JobIntent.TIMEOUT_UPDATED, jobRecord);
+    return true;
+  }
+
+  public void writeUpdateJobTimeoutResponse(
+      final long jobKey, final JobRecord jobRecord, final TypedRecord<JobRecord> command) {
+    responseWriter.writeEventOnCommand(jobKey, JobIntent.TIMEOUT_UPDATED, jobRecord, command);
+  }
+
+  public void completeJobUpdate(
+      final long jobKey, final JobRecord jobRecord, final TypedRecord<JobRecord> command) {
+    stateWriter.appendFollowUpEvent(jobKey, JobIntent.UPDATED, jobRecord);
+    responseWriter.writeEventOnCommand(jobKey, JobIntent.UPDATED, jobRecord, command);
+  }
+
+  public void rejectJobUpdate(final TypedRecord<JobRecord> command) {
+    rejectionWriter.appendRejection(
+        command, RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_AT_LEAST_ONE_FIELD);
+    responseWriter.writeRejectionOnCommand(
+        command, RejectionType.INVALID_ARGUMENT, ERROR_MESSAGE_AT_LEAST_ONE_FIELD);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobUpdateTimeoutTest.java
@@ -91,8 +91,7 @@ public class JobUpdateTimeoutTest {
     Assertions.assertThat(jobRecord)
         .hasRejectionType(RejectionType.NOT_FOUND)
         .hasRejectionReason(
-            "Expected to update job deadline with key '%d', but no such job was found"
-                .formatted(jobKey));
+            "Expected to update job with key '%d', but no such job was found".formatted(jobKey));
   }
 
   @Test

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/multitenancy/MultiTenancyOverIdentityIT.java
@@ -921,7 +921,7 @@ public class MultiTenancyOverIdentityIT {
           .withThrowableThat()
           .withMessageContaining("NOT_FOUND")
           .withMessageContaining(
-              "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job deadline with key '%d', but no such job was found"
+              "Command 'UPDATE_TIMEOUT' rejected with code 'NOT_FOUND': Expected to update job with key '%d', but no such job was found"
                   .formatted(activatedJob.getKey()));
     }
   }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- Introduced a `JobUpdateBehaviour` to handle all the common operation between the Job Update processors to align the behaviour of the 3 different processors
- Add rejection if no updates are made in `JobUpdateProcessor`

## Related issues

follow up PR of https://github.com/camunda/camunda/pull/20679
