### PR TITLE
Only activate/complete child process instance while call activity is active

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -103,6 +103,20 @@ public final class ProcessInstanceStateTransitionGuard {
     }
   }
 
+  private Either<String, ElementInstance> getCallActivityInstance(
+      final BpmnElementContext context) {
+    final var callActivityInstanceKey = context.getParentElementInstanceKey();
+    final var callActivityInstance = stateBehavior.getElementInstance(callActivityInstanceKey);
+    if (callActivityInstance != null) {
+      return Either.right(callActivityInstance);
+    } else {
+      return Either.left(
+          String.format(
+              "Expected call activity instance with key '%d' to be present in state but not found.",
+              callActivityInstanceKey));
+    }
+  }
+
   private Either<String, ElementInstance> hasElementInstanceInState(
       final ElementInstance elementInstance,
       final ProcessInstanceIntent expectedState,
@@ -168,8 +182,18 @@ public final class ProcessInstanceStateTransitionGuard {
                       flowScopeInstance, ProcessInstanceIntent.ELEMENT_ACTIVATED))
           .flatMap(flowScopeInstance -> hasNonInterruptedFlowScope(flowScopeInstance, context));
 
+    } else if (context.getParentProcessInstanceKey() > 0) {
+      // a child process has a call activity instance (parentElementInstance) as special flow scope
+      return getCallActivityInstance(context)
+          .flatMap(
+              callActivityInstance ->
+                  hasElementInstanceInState(
+                      callActivityInstance, ProcessInstanceIntent.ELEMENT_ACTIVATED))
+          .flatMap(
+              callActivityInstance -> hasNonInterruptedFlowScope(callActivityInstance, context));
+
     } else {
-      // a process has no flow scope instance
+      // a root process has no flow scope instance
       return Either.right(null);
     }
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -173,7 +173,6 @@ public final class ProcessInstanceStateTransitionGuard {
   }
 
   private Either<String, ?> hasActiveFlowScopeInstance(final BpmnElementContext context) {
-    // a shortcut to improve readability
     if (context.getBpmnElementType() != BpmnElementType.PROCESS) {
       return getFlowScopeInstance(context)
           .flatMap(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/ProcessInstanceStateTransitionGuard.java
@@ -160,17 +160,17 @@ public final class ProcessInstanceStateTransitionGuard {
 
   private Either<String, ?> hasActiveFlowScopeInstance(final BpmnElementContext context) {
     // a shortcut to improve readability
-    if (context.getBpmnElementType() == BpmnElementType.PROCESS) {
-      // a process has no flow scope instance
-      return Either.right(null);
-
-    } else {
+    if (context.getBpmnElementType() != BpmnElementType.PROCESS) {
       return getFlowScopeInstance(context)
           .flatMap(
               flowScopeInstance ->
                   hasFlowScopeInstanceInState(
                       flowScopeInstance, ProcessInstanceIntent.ELEMENT_ACTIVATED))
           .flatMap(flowScopeInstance -> hasNonInterruptedFlowScope(flowScopeInstance, context));
+
+    } else {
+      // a process has no flow scope instance
+      return Either.right(null);
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.engine.processing.bpmn.activity;
 
 import static io.camunda.zeebe.protocol.record.RecordType.COMMAND;
+import static io.camunda.zeebe.protocol.record.RecordType.COMMAND_REJECTION;
 import static io.camunda.zeebe.protocol.record.RecordType.EVENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
@@ -110,6 +111,8 @@ public class CallActivityInterruptionTest {
         .containsSubsequence(
             tuple(COMMAND, BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(EVENT, BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(
+                COMMAND_REJECTION, BpmnElementType.PROCESS, ProcessInstanceIntent.COMPLETE_ELEMENT),
             tuple(EVENT, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
             tuple(EVENT, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(EVENT, BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
@@ -108,7 +108,8 @@ public class CallActivityInterruptionTest {
         .containsSubsequence(
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.TERMINATE_ELEMENT),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),
             tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
             tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/CallActivityInterruptionTest.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.activity;
 
+import static io.camunda.zeebe.protocol.record.RecordType.COMMAND;
+import static io.camunda.zeebe.protocol.record.RecordType.EVENT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
 
@@ -104,16 +106,16 @@ public class CallActivityInterruptionTest {
             RecordingExporter.records()
                 .betweenProcessInstance(processInstanceKey)
                 .processInstanceRecords())
-        .extracting(r -> tuple(r.getValue().getBpmnElementType(), r.getIntent()))
+        .extracting(r -> tuple(r.getRecordType(), r.getValue().getBpmnElementType(), r.getIntent()))
         .containsSubsequence(
-            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.TERMINATE_ELEMENT),
-            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),
-            tuple(BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
-            tuple(BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
-            tuple(BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
+            tuple(COMMAND, BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.TERMINATE_ELEMENT),
+            tuple(EVENT, BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(EVENT, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATING),
+            tuple(EVENT, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(EVENT, BpmnElementType.CALL_ACTIVITY, ProcessInstanceIntent.ELEMENT_TERMINATED),
+            tuple(EVENT, BpmnElementType.BOUNDARY_EVENT, ProcessInstanceIntent.ELEMENT_ACTIVATED),
+            tuple(EVENT, BpmnElementType.SEQUENCE_FLOW, ProcessInstanceIntent.SEQUENCE_FLOW_TAKEN),
+            tuple(EVENT, BpmnElementType.PROCESS, ProcessInstanceIntent.ELEMENT_COMPLETED));
   }
 
   private static BpmnModelInstance parentProcess(final Consumer<CallActivityBuilder> consumer) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This rejects `ACTIVATE_ELEMENT` and `COMPLETE_ELEMENT` commands for child process instances if the associated Call Activity is interrupted, terminating, or terminated.

This behavior was already present for all other element types than `PROCESS` regarding their flow scope instance. For a child process instance, the call activity instance is not specified by `flowScopeInstanceKey` but by `parentElementInstanceKey` which meant that this behavior was missing for child process instances. This PR rectifies that.

PS: no test case is added for a child instance's `ACTIVATE_ELEMENT` command. We currently don't support a way to write this test.

## Related issues

closes #20762
