### PR TITLE
Retry of Exporter open

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -7,7 +7,6 @@
  */
 package io.camunda.zeebe.broker.exporter.stream;
 
-import com.esotericsoftware.minlog.Log;
 import io.camunda.zeebe.broker.Loggers;
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
 import io.camunda.zeebe.broker.exporter.stream.ExporterDirectorContext.ExporterMode;
@@ -509,13 +508,10 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       containerOpenFutures.add(openFuture);
     }
 
+    // Don't need to handle error as any are caught within the runWithRetry try catch
     actor.runOnCompletion(
         containerOpenFutures,
         (error) -> {
-          if (error != null) {
-            Log.error("Failed to open exporters", error);
-            return;
-          }
           if (state.hasExporters()) {
             final long snapshotPosition = state.getLowestPosition();
             // start reading and exporting

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorTest.java
@@ -12,8 +12,10 @@ import static io.camunda.zeebe.test.util.TestUtil.waitUntil;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import io.camunda.zeebe.broker.exporter.repo.ExporterDescriptor;
@@ -178,6 +180,43 @@ public final class ExporterDirectorTest {
         .untilAsserted(() -> assertThat(tailingExporter.getExportedRecords()).hasSize(2));
     assertThat(state.getPosition(EXPORTER_ID_1)).isEqualTo(skippedRecordPosition);
     assertThat(state.getPosition(EXPORTER_ID_2)).isEqualTo(-1L);
+  }
+
+  @Test
+  public void shouldRetryOpenCallIfFails() throws Exception {
+    // given, when
+    final var exporter = startExporterWithFaultyOpenCall();
+
+    // then
+    Awaitility.await("exporter open has been retried")
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> verify(exporter, times(2)).open(any()));
+
+    rule.closeExporterDirector();
+  }
+
+  @Test
+  public void shouldExportAfterOpenRetried() throws Exception {
+    // given
+    final var exporter = startExporterWithFaultyOpenCall();
+
+    Awaitility.await("exporter open has been retried")
+        .atMost(Duration.ofSeconds(10))
+        .untilAsserted(() -> verify(exporter, times(2)).open(any()));
+
+    // when
+    final var eventPosition1 = writeEvent();
+    final var eventPosition2 = writeEvent();
+
+    // then
+    Awaitility.await("Exporter has exported all records")
+        .untilAsserted(
+            () ->
+                assertThat(exporter.getExportedRecords())
+                    .extracting(Record::getPosition)
+                    .containsExactly(eventPosition1, eventPosition2));
+
+    rule.closeExporterDirector();
   }
 
   @Test
@@ -708,5 +747,23 @@ public final class ExporterDirectorTest {
                 return valueTypes.contains(valueType);
               }
             });
+  }
+
+  private ControlledTestExporter startExporterWithFaultyOpenCall() {
+    // given
+    final ControlledTestExporter exporter = spy(new ControlledTestExporter());
+
+    doThrow(new RuntimeException("open failed")).doCallRealMethod().when(exporter).open(any());
+
+    final ExporterDescriptor descriptor =
+        spy(
+            new ExporterDescriptor(
+                "exporter-failing", exporter.getClass(), Collections.singletonMap("x", 1)));
+    doAnswer(c -> exporter).when(descriptor).newInstance();
+
+    // when
+    startExporterDirector(List.of(descriptor));
+
+    return exporter;
   }
 }


### PR DESCRIPTION
## Description

This PR will only handle code path (1) referenced here https://github.com/camunda/camunda/issues/20728#issuecomment-2271370664 and make sure that the `openExporter` call is retried if it fails when initialising exporters through configuration.

## Related issues

relates to #20728 
