### PR TITLE
Retry of exporter open during transition step

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirector.java
@@ -259,26 +259,53 @@ public final class ExporterDirector extends Actor implements HealthMonitorable, 
       return CompletableActorFuture.completed(null);
     }
 
-    return actor.call(
-        () -> {
-          containers.stream()
-              .map(ExporterContainer::getId)
-              .filter(exporterId::equals)
-              .findFirst()
-              .ifPresentOrElse(
-                  container -> {
-                    LOG.debug(
-                        "Exporter '{}' is already enabled. Skipping the enabling operation.",
-                        exporterId);
-                  },
-                  () -> addExporter(exporterId, initializationInfo, descriptor));
-        });
+    return actor.call(() -> addExporter(exporterId, initializationInfo, descriptor));
+  }
+
+  /**
+   * Enables an exporter with the given id and descriptor. The exporter will start exporting records
+   * after this operation completes. This operation will be retried until successful or the exporter
+   * director closes.
+   *
+   * <p>It is expected that the exporter to initialize from the metadata is of same type as the
+   * exporter to enable. The caller of this method must verify that.
+   *
+   * @param exporterId id of the exporter to enable
+   * @param initializationInfo the info required to initialize the exporter state
+   * @param descriptor the descriptor of the exporter to enable
+   * @return future which will be completed after the exporter is enabled.
+   */
+  public ActorFuture<Boolean> enableExporterWithRetry(
+      final String exporterId,
+      final ExporterInitializationInfo initializationInfo,
+      final ExporterDescriptor descriptor) {
+    return new BackOffRetryStrategy(actor, Duration.ofSeconds(10))
+        .runWithRetry(
+            () -> {
+              try {
+                addExporter(exporterId, initializationInfo, descriptor);
+                return true;
+              } catch (final Exception e) {
+                LOG.error("Failed to add exporter '{}'. Retrying...", exporterId, e);
+                return false;
+              }
+            },
+            this::isClosed);
   }
 
   private void addExporter(
       final String exporterId,
       final ExporterInitializationInfo initializationInfo,
       final ExporterDescriptor descriptor) {
+
+    final var exporterEnabled =
+        containers.stream().map(ExporterContainer::getId).anyMatch(exporterId::equals);
+
+    if (exporterEnabled) {
+      LOG.debug("Exporter '{}' is already enabled. Skipping the enabling operation.", exporterId);
+      return;
+    }
+
     final ExporterContainer container =
         new ExporterContainer(descriptor, partitionId, initializationInfo, meterRegistry);
     container.initContainer(actor, metrics, state, exporterPhase);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -171,7 +171,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
       if (!startedExporters.containsKey(exporter)) {
         context
             .getExporterDirector()
-            .enableExporter(exporter.getId(), exporterEntry.getValue(), exporter);
+            .enableExporterWithRetry(exporter.getId(), exporterEntry.getValue(), exporter);
       }
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStepTest.java
@@ -212,7 +212,7 @@ class ExporterDirectorPartitionTransitionStepTest {
 
     // then
     verify(mockedExporterDirector, timeout(1000))
-        .enableExporter(eq(reEnabledExporterId), any(), any());
+        .enableExporterWithRetry(eq(reEnabledExporterId), any(), any());
   }
 
   private void setExportersInContext(


### PR DESCRIPTION
## Description

This PR will only handle code path (3) referenced here https://github.com/camunda/camunda/issues/20728#issuecomment-2271370664 and make sure that the openExporter call is retried if it fails when initialising exporters due to the context changing between the time an asynchronous exporter director creation call is made and when the future completes.

## Related issues

closes #20728 
