### PR TITLE
ci: split operate frontend build from maven

### DIFF
--- a/.github/actions/build-operate-fe/action.yml
+++ b/.github/actions/build-operate-fe/action.yml
@@ -1,0 +1,27 @@
+name: Build Operate FE
+description: Builds the Operate frontend
+
+runs:
+  using: composite
+  steps:
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+    - name: Setup yarn
+      run: npm install -g yarn
+      shell: bash
+    - name: Setup yarn cache
+      uses: actions/setup-node@v4
+      with:
+        node-version: "20"
+        cache: "yarn"
+        cache-dependency-path: operate/client/yarn.lock
+    - name: Install node dependencies
+      working-directory: ./operate/client
+      shell: bash
+      run: yarn
+    - name: Build frontend
+      working-directory: ./operate/client
+      run: yarn build
+      shell: bash

--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -62,7 +62,7 @@ jobs:
       #########################################################################
       # Setup: import secrets from vault
       - name: Import Secrets
-        id: secrets  # important to refer to it in later steps
+        id: secrets # important to refer to it in later steps
         uses: hashicorp/vault-action@v3
         with:
           url: ${{ secrets.VAULT_ADDR }}
@@ -86,10 +86,15 @@ jobs:
           nexusPassword: ${{ steps.secrets.outputs.NEXUS_PSW }}
 
       #########################################################################
+      # Build Operate frontend
+      - name: Build frontend
+        uses: ./.github/actions/build-operate-fe
+
+      #########################################################################
       # Build: maven artifacts and Docker images
       - name: Build Maven
         run: |
-          mvn clean deploy -B -T1C -P -docker -DskipTests -D skipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          mvn clean deploy -B -T1C -P -docker,skipFrontendBuild -DskipTests -D skipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Docker login and image tagging

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -73,15 +73,8 @@ jobs:
           secrets: |
             secret/data/github.com/organizations/camunda NEXUS_USR;
             secret/data/github.com/organizations/camunda NEXUS_PSW;
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: "20"
-      - name: Setup yarn
-        run: npm install -g yarn
-      - name: Install node dependencies
-        working-directory: ./operate/client
-        run: yarn install
+      - name: Build frontend
+        uses: ./.github/actions/build-operate-fe
       - name: Add Yarn binaries to Path
         working-directory: ./operate/client
         run: |
@@ -90,9 +83,6 @@ jobs:
       - name: Install Playwright
         run: yarn exec playwright install -- --with-deps chromium
         working-directory: ./operate/client
-      - name: Build frontend
-        working-directory: ./operate/client
-        run: yarn build
       - name: Setup Java
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/operate-release-reusable.yml
+++ b/.github/workflows/operate-release-reusable.yml
@@ -136,12 +136,17 @@ jobs:
           mirrors: '[{"url": "https://repository.nexus.camunda.cloud/content/groups/internal/", "id": "camunda-nexus", "mirrorOf": "*", "name": "camunda Nexus"}]'
 
       #########################################################################
+      # Build frontend
+      - name: Build frontend
+        uses: ./.github/actions/build-operate-fe
+
+      #########################################################################
       # Release: run Maven release
       - name: Prepare Maven release
         env:
           NEXT_DEVELOPMENT_VERSION: ${{ inputs.nextDevelopmentVersion }}
         run: |
-          mvn -f operate release:prepare -P -docker \
+          mvn -f operate release:prepare -P -docker,skipFrontendBuild \
           -DpushChanges=false \
           -DskipTests=true -B -T$LIMITS_CPU --fail-at-end \
           -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \


### PR DESCRIPTION
## Description

- create action to build Operate frontend 
- Operate CI and release workflow: remove frontend build from maven container, use action instead
- reuse action in E2E tests

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #17926 
closes #19085
