### PR TITLE
ci: skip optimize from operate maven build

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -89,7 +89,7 @@ jobs:
       # Build: maven artifacts and Docker images
       - name: Build Maven
         run: |
-          mvn clean deploy -B -T1C -P -docker -DskipTests -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
+          mvn clean deploy -B -T1C -P -docker -DskipTests -D skipOptimize -DskipChecks -DaltStagingDirectory=${{ github.workspace }}/staging-${{ env.BRANCH_NAME }} -DskipRemoteStaging=true -Dmaven.deploy.skip=true
 
       #########################################################################
       # Docker login and image tagging


### PR DESCRIPTION
## Description

This PR removes the Optimize module from the Operate workflows, as its presence cause consistent failures in their runs. This is a workaround until the root cause of the failure is resolved (see the related issues section).

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

* https://github.com/camunda/camunda/pull/20880