### PR TITLE
ci: create workflow to push preview images to harbor

### DIFF
--- a/.github/workflows/operate-ci-build-reusable.yml
+++ b/.github/workflows/operate-ci-build-reusable.yml
@@ -20,9 +20,13 @@ on:
         required: true
         type: string
       pushDocker:
-        description: "whether the built docker images are pushed to camunda registry"
+        description: "Whether the built docker images are pushed to camunda registry"
         type: boolean
         default: true
+      previewEnv:
+        description: "Defines whether this is a preview environment build or not. If true, the image will be pushed to the Harbor Docker registry."
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -110,7 +114,7 @@ jobs:
       - name: Build Docker image
         uses: ./.github/actions/build-platform-docker
         with:
-          repository: registry.camunda.cloud/team-operate/camunda-operate
+          repository: ${{ inputs.previewEnv && 'registry.camunda.cloud/team-camunda/operate' || 'registry.camunda.cloud/team-operate/camunda-operate' }}
           version: |
             ${{ env.IMAGE_TAG }}
             ${{ env.CI_IMAGE_TAG }}

--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -22,10 +22,6 @@ on:
       pushDocker:
         description: "Whether the built docker images are pushed to camunda registry"
         type: boolean
-        default: true
-      previewEnv:
-        description: "Defines whether this is a preview environment build or not. If true, the image will be pushed to the Harbor Docker registry."
-        type: boolean
         default: false
 
 defaults:
@@ -54,11 +50,7 @@ jobs:
           GIT_COMMIT_HASH=$(git rev-parse ${{ inputs.branch }})
           echo "GIT_COMMIT_HASH=$GIT_COMMIT_HASH" >> $GITHUB_ENV
           echo "IMAGE_TAG=registry.camunda.cloud/team-camunda/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
-          if [ "${{ inputs.previewEnv }}" = "true" ]; then
-            echo "IMAGE_TAG=registry.camunda.cloud/team-camunda/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
-          else
-            echo "IMAGE_TAG=registry.camunda.cloud/team-optimize/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
-          fi
+          echo "IMAGE_TAG=registry.camunda.cloud/team-camunda/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
 
       #########################################################################
       # Setup: read java version from pom
@@ -99,4 +91,4 @@ jobs:
             VERSION=${{ steps.pom-info.outputs.project_version }}
             REVISION=${{ env.GIT_COMMIT_HASH }}
           tags: ${{ env.IMAGE_TAG }}
-          push: true
+          push: ${{ inputs.pushDocker }}

--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -50,7 +50,6 @@ jobs:
           GIT_COMMIT_HASH=$(git rev-parse ${{ inputs.branch }})
           echo "GIT_COMMIT_HASH=$GIT_COMMIT_HASH" >> $GITHUB_ENV
           echo "IMAGE_TAG=registry.camunda.cloud/team-camunda/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
-          echo "IMAGE_TAG=registry.camunda.cloud/team-camunda/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
 
       #########################################################################
       # Setup: read java version from pom

--- a/.github/workflows/optimize-ci-build-reusable.yml
+++ b/.github/workflows/optimize-ci-build-reusable.yml
@@ -1,0 +1,102 @@
+# This GitHub Actions workflow automates the CI build process for the 'optimize' service.
+# It triggers on a `workflow_call` event and accepts inputs for branch name[required], Java version[optional]
+#
+# It consists of a several steps:
+# 1. Setup: Checks out the branch, defines environment variables, fetches the main branch, reads Java/Maven project info, logs into the Harbor registry, and sets up Maven.
+# 2. Build: Generates a production .tar.gz file using Maven and builds a Docker image with appropriate tags.
+# 3. Upload: Pushes the Docker image to the Harbor registry tagged for the pull request.
+#
+# Environment variables are used to define the image tags used for Docker builds.
+# This workflow is designed to provide a comprehensive, automated CI process that ensures code quality, handles secrets securely,
+# and enables detailed reporting of test results.
+
+name: Optimize CI Reusable
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: "The branch name to be used for the workflow"
+        required: true
+        type: string
+      pushDocker:
+        description: "Whether the built docker images are pushed to camunda registry"
+        type: boolean
+        default: true
+      previewEnv:
+        description: "Defines whether this is a preview environment build or not. If true, the image will be pushed to the Harbor Docker registry."
+        type: boolean
+        default: false
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      # Setup: checkout branch
+      - name: Checkout '${{ inputs.branch }}' branch
+        uses: actions/checkout@v4
+        with:
+          ref: refs/heads/${{ inputs.branch }}
+          fetch-depth: 0 # fetches all history for all branches and tags
+
+      #########################################################################
+      # Setup: define env variables
+      - name: Set GitHub environment variables
+        run: |
+          GIT_COMMIT_HASH=$(git rev-parse ${{ inputs.branch }})
+          echo "GIT_COMMIT_HASH=$GIT_COMMIT_HASH" >> $GITHUB_ENV
+          echo "IMAGE_TAG=registry.camunda.cloud/team-camunda/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
+          if [ "${{ inputs.previewEnv }}" = "true" ]; then
+            echo "IMAGE_TAG=registry.camunda.cloud/team-camunda/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
+          else
+            echo "IMAGE_TAG=registry.camunda.cloud/team-optimize/optimize:pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
+          fi
+
+      #########################################################################
+      # Setup: read java version from pom
+      - name: "Read Java / Version Info"
+        id: pom-info
+        uses: YunaBraska/java-info-action@72dd3fb638d774fb4353d99d2bb3fddddd084789 # 2.1.0
+
+      #########################################################################
+      # Docker login and image tagging
+      - name: Login to Harbor registry
+        uses: ./.github/actions/login-registry
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
+      #########################################################################
+      # Setup and configure Maven
+      - name: Setup Maven
+        uses: ./.github/actions/setup-maven
+        with:
+          secrets: ${{ toJSON(secrets) }}
+
+      #########################################################################
+      # Build Optimize
+      - name: Generate production .tar.gz
+        uses: ./.github/actions/run-maven
+        with:
+          parameters: -f optimize/pom.xml install -DskipTests -Dskip.docker -PrunAssembly
+
+      #########################################################################
+      # Build Docker image
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          file: optimize.Dockerfile
+          provenance: false
+          build-args: |
+            VERSION=${{ steps.pom-info.outputs.project_version }}
+            REVISION=${{ env.GIT_COMMIT_HASH }}
+          tags: ${{ env.IMAGE_TAG }}
+          push: true

--- a/.github/workflows/optimize-ci.yml
+++ b/.github/workflows/optimize-ci.yml
@@ -56,47 +56,12 @@ jobs:
     secrets: inherit
 
   docker:
+    name: Optimize Build
     if: github.event_name == 'pull_request'
-    name: Docker
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-
-    - name: Fetch main branch
-      run: git fetch origin main:refs/remote/origin/main
-
-    - name: "Read Java / Version Info"
-      id: pom-info
-      uses: YunaBraska/java-info-action@191c7fcb671125f85486b6fee92b17b180d8e0ab # 2.1.2
-
-    - name: Login to Harbor registry
-      uses: ./.github/actions/login-registry
-      with:
-        secrets: ${{ toJSON(secrets) }}
-
-    - name: Setup Maven
-      uses: ./.github/actions/setup-maven
-      with:
-        secrets: ${{ toJSON(secrets) }}
-
-    - name: Generate production .tar.gz
-      uses: ./.github/actions/run-maven
-      with:
-        parameters: -f optimize/pom.xml install -DskipTests -Dskip.docker -PrunAssembly
-
-    - name: Build and push Docker image
-      uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
-      with:
-        context: .
-        file: optimize.Dockerfile
-        provenance: false
-        build-args: |
-          VERSION=${{ steps.pom-info.outputs.project_version }}
-          REVISION=${{ github.event.pull_request.head.sha }}
-        tags: "registry.camunda.cloud/team-optimize/optimize:pr-${{ github.event.pull_request.head.sha }}"
-        push: true
+    uses: ./.github/workflows/optimize-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref }}
 
   integration-tests:
     name: Integration Tests

--- a/.github/workflows/preview-env-build.yml
+++ b/.github/workflows/preview-env-build.yml
@@ -1,0 +1,102 @@
+---
+name: Preview Environment Build
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+# Limit workflow to 1 concurrent run per ref (branch): new commit -> old runs are canceled to save costs
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name }}
+
+defaults:
+  run:
+    # use bash shell by default to ensure pipefail behavior is the default
+    # see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
+    shell: bash
+
+jobs:
+  build-optimize:
+    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    name: Optimize Build
+    uses: ./.github/workflows/optimize-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref }}
+      previewEnv: true
+
+  build-operare:
+    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    name: Operate Build
+    uses: ./.github/workflows/operate-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref }}
+      previewEnv: true
+
+  build-tasklist:
+    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    name: Tasklist Build
+    uses: ./.github/workflows/tasklist-ci-build-reusable.yml
+    secrets: inherit
+    with:
+      branch: ${{ github.head_ref }}
+      previewEnv: true
+
+  build-zeebe:
+    if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))
+    name: Build Zeebe
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout ${{ github.head_ref }} branch
+        uses: actions/checkout@v4
+        with:
+          ref: refs/heads/${{ github.head_ref }}
+          fetch-depth: 0 # fetches all history for all branches and tags
+
+      - uses: ./.github/actions/setup-zeebe
+        with:
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
+        with:
+          maven-extra-args: -T1C -PskipFrontendBuild
+
+      - name: Import Secrets
+        id: secrets
+        uses: hashicorp/vault-action@v3.0.0
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          method: approle
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secrets: |
+            secret/data/github.com/organizations/camunda NEXUS_USR;
+            secret/data/github.com/organizations/camunda NEXUS_PSW;
+
+      - name: Set environment variables
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          GIT_COMMIT_HASH=$(git rev-parse $HEAD_REF)
+          echo "VERSION=pr-$GIT_COMMIT_HASH" >> $GITHUB_ENV
+
+      - name: Login to Harbor docker registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.camunda.cloud
+          username: ${{ steps.secrets.outputs.NEXUS_USR }}
+          password: ${{ steps.secrets.outputs.NEXUS_PSW }}
+
+      - uses: ./.github/actions/build-platform-docker
+        with:
+          repository: registry.camunda.cloud/team-camunda/zeebe
+          version: ${{ env.VERSION }}
+          platforms: ${{ env.DOCKER_PLATFORMS }}
+          push: true
+          distball: ${{ steps.build-zeebe.outputs.distball }}

--- a/.github/workflows/preview-env-build.yml
+++ b/.github/workflows/preview-env-build.yml
@@ -24,7 +24,7 @@ jobs:
     secrets: inherit
     with:
       branch: ${{ github.head_ref }}
-      previewEnv: true
+      pushDocker: true
 
   build-operare:
     if: github.event.pull_request.state != 'closed' && (contains( github.event.label.name, 'deploy-preview') || contains( github.event.pull_request.labels.*.name, 'deploy-preview'))

--- a/.github/workflows/tasklist-ci-build-reusable.yml
+++ b/.github/workflows/tasklist-ci-build-reusable.yml
@@ -23,6 +23,10 @@ on:
         description: "whether the built docker images are pushed to camunda registry"
         type: boolean
         default: true
+      previewEnv:
+        description: "Defines whether this is a preview environment build or not. If true, the image will be pushed to the Harbor Docker registry."
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -108,7 +112,7 @@ jobs:
       - name: Build Docker image
         uses: ./.github/actions/build-platform-docker
         with:
-          repository: registry.camunda.cloud/team-hto/tasklist
+          repository: ${{ inputs.previewEnv && 'registry.camunda.cloud/team-camunda/tasklist' || 'registry.camunda.cloud/team-hto/tasklist' }}
           version: |
             ${{ env.IMAGE_TAG }}
             ${{ env.CI_IMAGE_TAG }}


### PR DESCRIPTION
## Description
 
This pr aims to:
- Add a new workflow called `preview-env-build.yml ` which is going to responsible for building the docker images for `optimize`, `operate`, `tasklist` & `zeebe` and pushing team to the harbor project `team-camunda`
- To achieve this the reusable workflows for tasklist & operate have been modified as well so that they can push to harbor based on an input variable called `previewenv`.  
- A new reusable workflow has been introduced for `optimize`
- Similarly the reusable workflow to build and push the zeebe docker image has been modified to log in to harbor in case of a preview environment build.

To be merged after:
- [x] https://github.com/camunda/infra-core/pull/8186

## Tests

### Test1: Ensure the workflow pushes the images to dev harbor 
- [commit](https://github.com/camunda/camunda/pull/20885/commits/edc159d44351d4ae31111e0afb69058cb462d43b)
- Link to dev harbor project https://dev.registry.camunda.cloud/harbor/projects/91/repositories/operate/artifacts-tab 
- image tag is `pr-60433bcf6cbeff1984183668cb1a28eaa9860a77`

### Test2: Ensure nothing gets pushed to dockerhub
- https://hub.docker.com/r/camunda/tasklist/tags
- https://hub.docker.com/r/camunda/zeebe/tags
- https://hub.docker.com/r/camunda/operate/tags
## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/team-infrastructure/issues/655
