### PR TITLE
refactor: Change order of `fold` method arguments in `Either` interface

### DIFF
--- a/service/src/main/java/io/camunda/service/search/core/SearchClientBasedQueryExecutor.java
+++ b/service/src/main/java/io/camunda/service/search/core/SearchClientBasedQueryExecutor.java
@@ -45,10 +45,10 @@ public final class SearchClientBasedQueryExecutor {
     return searchClient
         .search(searchRequest, documentClass)
         .fold(
-            responseTransformer::apply,
             (e) -> {
               throw rethrowRuntimeException(e);
-            });
+            },
+            responseTransformer::apply);
   }
 
   private SearchQuery getAuthenticationCheckIfPresent() {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryController.java
@@ -36,7 +36,7 @@ public class DecisionDefinitionQueryController {
   public ResponseEntity<DecisionDefinitionSearchQueryResponse> searchDecisionDefinitions(
       @RequestBody(required = false) final DecisionDefinitionSearchQueryRequest query) {
     return SearchQueryRequestMapper.toDecisionDefinitionQuery(query)
-        .fold(this::search, RestErrorMapper::mapProblemToResponse);
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
   private ResponseEntity<DecisionDefinitionSearchQueryResponse> search(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryController.java
@@ -36,7 +36,7 @@ public class DecisionRequirementsQueryController {
   public ResponseEntity<Object> searchUserTasks(
       @RequestBody(required = false) final DecisionRequirementsSearchQueryRequest query) {
     return SearchQueryRequestMapper.toDecisionRequirementsQuery(query)
-        .fold(this::search, RestErrorMapper::mapProblemToResponse);
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
   private ResponseEntity<Object> search(final DecisionRequirementsQuery query) {

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/JobController.java
@@ -53,7 +53,7 @@ public class JobController {
   public CompletableFuture<ResponseEntity<Object>> activateJobs(
       @RequestBody final JobActivationRequest activationRequest) {
     return RequestMapper.toJobsActivationRequest(activationRequest)
-        .fold(this::activateJobs, RestErrorMapper::mapProblemToCompletedResponse);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::activateJobs);
   }
 
   @PostMapping(
@@ -73,7 +73,7 @@ public class JobController {
   public CompletableFuture<ResponseEntity<Object>> errorJob(
       @PathVariable final long jobKey, @RequestBody final JobErrorRequest errorRequest) {
     return RequestMapper.toJobErrorRequest(errorRequest, jobKey)
-        .fold(this::errorJob, RestErrorMapper::mapProblemToCompletedResponse);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::errorJob);
   }
 
   @PostMapping(
@@ -93,7 +93,7 @@ public class JobController {
   public CompletableFuture<ResponseEntity<Object>> updateJob(
       @PathVariable final long jobKey, @RequestBody final JobUpdateRequest jobUpdateRequest) {
     return RequestMapper.toJobUpdateRequest(jobUpdateRequest, jobKey)
-        .fold(this::updateJob, RestErrorMapper::mapProblemToCompletedResponse);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateJob);
   }
 
   private CompletableFuture<ResponseEntity<Object>> activateJobs(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryController.java
@@ -36,7 +36,7 @@ public class ProcessInstanceQueryController {
   public ResponseEntity<ProcessInstanceSearchQueryResponse> searchProcessInstances(
       @RequestBody(required = false) final ProcessInstanceSearchQueryRequest query) {
     return SearchQueryRequestMapper.toProcessInstanceQuery(query)
-        .fold(this::search, RestErrorMapper::mapProblemToResponse);
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
   private ResponseEntity<ProcessInstanceSearchQueryResponse> search(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskController.java
@@ -59,7 +59,7 @@ public class UserTaskController {
       @RequestBody final UserTaskAssignmentRequest assignmentRequest) {
 
     return RequestMapper.toUserTaskAssignmentRequest(assignmentRequest, userTaskKey)
-        .fold(this::assignUserTask, RestErrorMapper::mapProblemToCompletedResponse);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::assignUserTask);
   }
 
   @DeleteMapping(path = "/{userTaskKey}/assignee")
@@ -78,7 +78,7 @@ public class UserTaskController {
       @RequestBody(required = false) final UserTaskUpdateRequest updateRequest) {
 
     return RequestMapper.toUserTaskUpdateRequest(updateRequest, userTaskKey)
-        .fold(this::updateUserTask, RestErrorMapper::mapProblemToCompletedResponse);
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::updateUserTask);
   }
 
   private CompletableFuture<ResponseEntity<Object>> assignUserTask(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
@@ -36,7 +36,7 @@ public class UserTaskQueryController {
   public ResponseEntity<Object> searchUserTasks(
       @RequestBody(required = false) final UserTaskSearchQueryRequest query) {
     return SearchQueryRequestMapper.toUserTaskQuery(query)
-        .fold(this::search, RestErrorMapper::mapProblemToResponse);
+        .fold(RestErrorMapper::mapProblemToResponse, this::search);
   }
 
   private ResponseEntity<Object> search(final UserTaskQuery query) {

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -350,22 +350,22 @@ public sealed interface Either<L, R> {
    * <p>A common use case is to map to a new common value in success and error cases. Example:
    *
    * <pre>{@code
-   * * Either<String, Integer> success = Either.right(42); // => Right(42)
-   * * Either<String, Integer> failure = Either.left("Error occurred"); // => Left("Error occurred")
-   * *
-   * * var rightFn = result -> "Success: " + result;
-   * * var leftFn = error -> "Failure: " + error;
-   * *
-   * * success.fold(rightFn, leftFn); // => "Success: 42"
-   * * failure.fold(rightFn, leftFn); // => "Failure: Error occurred"
+   * Either<String, Integer> success = Either.right(42); // => Right(42)
+   * Either<String, Integer> failure = Either.left("Error occurred"); // => Left("Error occurred")
+   *
+   * var rightFn = result -> "Success: " + result;
+   * var leftFn = error -> "Failure: " + error;
+   *
+   * success.fold(leftFn, rightFn); // => "Success: 42"
+   * failure.fold(leftFn, rightFn); // => "Failure: Error occurred"
    * }</pre>
    *
-   * @param rightFn the mapping function for the right value
    * @param leftFn the mapping function for the left value
+   * @param rightFn the mapping function for the right value
    * @return either a mapped {@link Left} or {@link Right}, folded to the new type
    * @param <T> the type of the resulting value
    */
-  <T> T fold(Function<? super R, ? extends T> rightFn, Function<? super L, ? extends T> leftFn);
+  <T> T fold(Function<? super L, ? extends T> leftFn, Function<? super R, ? extends T> rightFn);
 
   /**
    * A right for either a left or right. By convention, right is used for success and left for
@@ -440,8 +440,8 @@ public sealed interface Either<L, R> {
 
     @Override
     public <T> T fold(
-        final Function<? super R, ? extends T> rightFn,
-        final Function<? super L, ? extends T> leftFn) {
+        final Function<? super L, ? extends T> leftFn,
+        final Function<? super R, ? extends T> rightFn) {
       return rightFn.apply(value);
     }
   }
@@ -519,8 +519,8 @@ public sealed interface Either<L, R> {
 
     @Override
     public <T> T fold(
-        final Function<? super R, ? extends T> rightFn,
-        final Function<? super L, ? extends T> leftFn) {
+        final Function<? super L, ? extends T> leftFn,
+        final Function<? super R, ? extends T> rightFn) {
       return leftFn.apply(value);
     }
   }

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
@@ -306,9 +306,9 @@ class EitherTest {
     }
   }
 
-  @DisplayName("Folding method tests")
+  @DisplayName("`fold` method tests")
   @Nested
-  class FoldingMethodTests {
+  class FoldMethodTests {
 
     @DisplayName("Folds `Left`s into target types using the left function.")
     @ParameterizedTest
@@ -318,7 +318,7 @@ class EitherTest {
       final Function<Object, String> rightMapper = o -> "Unexpected-" + o.toString();
       final String mappedValue = leftMapper.apply(value);
       assertThat(mappedValue).isNotEqualTo(value);
-      assertThat(Either.left(value).fold(rightMapper, leftMapper)).isEqualTo(mappedValue);
+      assertThat(Either.left(value).fold(leftMapper, rightMapper)).isEqualTo(mappedValue);
     }
 
     @DisplayName("Folds `Right`s into target types using the right function.")
@@ -329,7 +329,7 @@ class EitherTest {
       final Function<Object, String> rightMapper = o -> "Expected-" + o.toString();
       final String mappedValue = rightMapper.apply(value);
       assertThat(mappedValue).isNotEqualTo(value);
-      assertThat(Either.right(value).fold(rightMapper, leftMapper)).isEqualTo(mappedValue);
+      assertThat(Either.right(value).fold(leftMapper, rightMapper)).isEqualTo(mappedValue);
     }
   }
 }


### PR DESCRIPTION
## Description
This PR refactors the `fold` method in the `Either` interface to align with the convention used in Scala, making it more intuitive. The `left` parameter now transforms Left, and the `right` parameter transforms Right. 
The implementation, JavaDoc, `fold` method usage and unit tests have been updated accordingly. 
This change addresses feedback on potential confusion caused by the previous parameter order. 

## Checklist
<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #20588 
