### PR TITLE
fix: flaky e2e datetime regex include single digit hours

### DIFF
--- a/tasklist/client/e2e/tests/task-details.spec.ts
+++ b/tasklist/client/e2e/tests/task-details.spec.ts
@@ -91,7 +91,7 @@ test.describe('task details page', () => {
     await expect(tasksPage.detailsPanel).toContainText('Creation date');
     await expect(
       tasksPage.detailsPanel.getByText(
-        /^\d{2}\s\w{3}\s\d{4}\s-\s\d{2}:\d{2}\s(AM|PM)$/,
+        /^\d{2}\s\w{3}\s\d{4}\s-\s\d{1,2}:\d{2}\s(AM|PM)$/,
       ),
     ).toBeVisible();
     await expect(tasksPage.detailsPanel).toContainText('Candidates');


### PR DESCRIPTION
## Description

Change datetime regex in E2E test to accommodate hours with single digit, since this fails the CI regularly
