### PR TITLE
feat: Get decision definition xml - service implementation

### DIFF
--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/source/SourceFilterTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/source/SourceFilterTransformer.java
@@ -11,6 +11,7 @@ import co.elastic.clients.elasticsearch.core.search.SourceFilter;
 import io.camunda.search.clients.source.SearchSourceFilter;
 import io.camunda.search.es.transformers.ElasticsearchTransformer;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import java.util.List;
 
 public final class SourceFilterTransformer
     extends ElasticsearchTransformer<SearchSourceFilter, SourceFilter> {
@@ -22,11 +23,15 @@ public final class SourceFilterTransformer
   @Override
   public SourceFilter apply(final SearchSourceFilter value) {
     final var builder = new SourceFilter.Builder();
-    if (value.includes() != null) {
-      builder.includes(value.includes());
+
+    final List<String> includes = value.includes();
+    if (includes != null && !includes.isEmpty()) {
+      builder.includes(includes);
     }
-    if (value.excludes() != null) {
-      builder.excludes(value.excludes());
+
+    final List<String> excludes = value.excludes();
+    if (excludes != null && !excludes.isEmpty()) {
+      builder.excludes(excludes);
     }
     return builder.build();
   }

--- a/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/source/SourceFilterTransformer.java
+++ b/search/search-client-opensearch/src/main/java/io/camunda/search/os/transformers/source/SourceFilterTransformer.java
@@ -10,6 +10,7 @@ package io.camunda.search.os.transformers.source;
 import io.camunda.search.clients.source.SearchSourceFilter;
 import io.camunda.search.os.transformers.OpensearchTransformer;
 import io.camunda.search.os.transformers.OpensearchTransformers;
+import java.util.List;
 import org.opensearch.client.opensearch.core.search.SourceFilter;
 
 public final class SourceFilterTransformer
@@ -22,12 +23,17 @@ public final class SourceFilterTransformer
   @Override
   public SourceFilter apply(final SearchSourceFilter value) {
     final var builder = new SourceFilter.Builder();
-    if (value.includes() != null) {
-      builder.includes(value.includes());
+
+    final List<String> includes = value.includes();
+    if (includes != null && !includes.isEmpty()) {
+      builder.includes(includes);
     }
-    if (value.excludes() != null) {
-      builder.excludes(value.excludes());
+
+    final List<String> excludes = value.excludes();
+    if (excludes != null && !excludes.isEmpty()) {
+      builder.excludes(excludes);
     }
+
     return builder.build();
   }
 }

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -87,6 +87,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-scheduler</artifactId>
       <scope>test</scope>

--- a/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
+++ b/service/src/main/java/io/camunda/service/DecisionDefinitionServices.java
@@ -7,11 +7,15 @@
  */
 package io.camunda.service;
 
+import static io.camunda.service.search.query.SearchQueryBuilders.decisionDefinitionSearchQuery;
+import static io.camunda.service.search.query.SearchQueryBuilders.decisionRequirementsSearchQuery;
+
 import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.entities.DecisionDefinitionEntity;
+import io.camunda.service.entities.DecisionRequirementsEntity;
+import io.camunda.service.exception.NotFoundException;
 import io.camunda.service.search.core.SearchQueryService;
 import io.camunda.service.search.query.DecisionDefinitionQuery;
-import io.camunda.service.search.query.SearchQueryBuilders;
 import io.camunda.service.search.query.SearchQueryResult;
 import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
@@ -48,6 +52,37 @@ public final class DecisionDefinitionServices
 
   public SearchQueryResult<DecisionDefinitionEntity> search(
       final Function<DecisionDefinitionQuery.Builder, ObjectBuilder<DecisionDefinitionQuery>> fn) {
-    return search(SearchQueryBuilders.decisionDefinitionSearchQuery(fn));
+    return search(decisionDefinitionSearchQuery(fn));
+  }
+
+  public String getDecisionDefinitionXml(final Long decisionKey) {
+    final var decisionDefinitionQuery =
+        decisionDefinitionSearchQuery(q -> q.filter(f -> f.decisionKeys(decisionKey)));
+    final var decisionDefinition =
+        search(decisionDefinitionQuery).items().stream()
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new NotFoundException(
+                        "DecisionDefinition with decisionKey=%d cannot be found"
+                            .formatted(decisionKey)));
+
+    final Long decisionRequirementsKey = decisionDefinition.decisionRequirementsKey();
+    final var decisionRequirementsQuery =
+        decisionRequirementsSearchQuery(
+            q ->
+                q.filter(f -> f.decisionRequirementsKeys(decisionRequirementsKey))
+                    .resultConfig(r -> r.xml().include()));
+    return executor
+        .search(decisionRequirementsQuery, DecisionRequirementsEntity.class)
+        .items()
+        .stream()
+        .findFirst()
+        .map(DecisionRequirementsEntity::xml)
+        .orElseThrow(
+            () ->
+                new NotFoundException(
+                    "DecisionRequirements with decisionRequirementsKey=%d cannot be found"
+                        .formatted(decisionRequirementsKey)));
   }
 }

--- a/service/src/main/java/io/camunda/service/exception/NotFoundException.java
+++ b/service/src/main/java/io/camunda/service/exception/NotFoundException.java
@@ -5,16 +5,11 @@
  * Licensed under the Camunda License 1.0. You may not use this file
  * except in compliance with the Camunda License 1.0.
  */
-package io.camunda.service.entities;
+package io.camunda.service.exception;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+public class NotFoundException extends RuntimeException {
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-public record DecisionRequirementsEntity(
-    String tenantId,
-    Long key,
-    String decisionRequirementsId,
-    String name,
-    Integer version,
-    String resourceName,
-    String xml) {}
+  public NotFoundException(String message) {
+    super(message);
+  }
+}

--- a/service/src/test/java/io/camunda/service/DecisionDefinitionServicesTest.java
+++ b/service/src/test/java/io/camunda/service/DecisionDefinitionServicesTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import static java.util.Collections.emptyList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import io.camunda.search.clients.core.SearchQueryRequest;
+import io.camunda.service.entities.DecisionDefinitionEntity;
+import io.camunda.service.entities.DecisionRequirementsEntity;
+import io.camunda.service.exception.NotFoundException;
+import io.camunda.service.query.filter.DecisionDefinitionSearchQueryStub;
+import io.camunda.service.query.filter.DecisionRequirementsSearchQueryStub;
+import io.camunda.service.util.StubbedCamundaSearchClient;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class DecisionDefinitionServicesTest {
+
+  private DecisionDefinitionServices services;
+  private StubbedCamundaSearchClient client;
+  private DecisionDefinitionSearchQueryStub decisionDefinitionSearchQueryStub;
+  private DecisionRequirementsSearchQueryStub decisionRequirementsSearchQueryStub;
+
+  @BeforeEach
+  public void before() {
+    client = spy(new StubbedCamundaSearchClient());
+    decisionDefinitionSearchQueryStub = new DecisionDefinitionSearchQueryStub();
+    decisionDefinitionSearchQueryStub.registerWith(client);
+    decisionRequirementsSearchQueryStub = new DecisionRequirementsSearchQueryStub();
+    decisionRequirementsSearchQueryStub.registerWith(client);
+    services = new DecisionDefinitionServices(null, client);
+  }
+
+  @Test
+  public void shouldReturnDecisionDefinitionXml() {
+    // given
+    final Long decisionKey = 123L;
+    final Long decisionRequirementsKey = 124L;
+
+    // when
+    final String decisionDefinitionXml = services.getDecisionDefinitionXml(decisionKey);
+
+    // then
+    assertThat(decisionDefinitionXml).isEqualTo("<xml/>");
+    verify(client)
+        .search(
+            SearchQueryRequest.of(
+                b ->
+                    b.index("operate-decision-8.3.0_alias")
+                        .query(q -> q.term(t -> t.field("key").value(decisionKey)))
+                        .sort(s -> s.field(f -> f.field("key").asc()))),
+            DecisionDefinitionEntity.class);
+    verify(client)
+        .search(
+            SearchQueryRequest.of(
+                b ->
+                    b.index("operate-decision-requirements-8.3.0_alias")
+                        .source(
+                            s -> s.filter(f -> f.includes(List.of("xml")).excludes(emptyList())))
+                        .query(q -> q.term(t -> t.field("key").value(decisionRequirementsKey)))
+                        .sort(s -> s.field(f -> f.field("key").asc()))),
+            DecisionRequirementsEntity.class);
+  }
+
+  @Test
+  public void shouldThorwNotFoundExceptionOnUnmatchedDecisionKey() {
+    // given
+    final Long decisionKey = 1L;
+    decisionDefinitionSearchQueryStub.setReturnEmptyResults(true);
+
+    // then
+    final var exception =
+        assertThrows(NotFoundException.class, () -> services.getDecisionDefinitionXml(decisionKey));
+    assertThat(exception.getMessage())
+        .isEqualTo("DecisionDefinition with decisionKey=1 cannot be found");
+    verify(client).search(any(SearchQueryRequest.class), eq(DecisionDefinitionEntity.class));
+    verify(client, never())
+        .search(any(SearchQueryRequest.class), eq(DecisionRequirementsEntity.class));
+  }
+
+  @Test
+  public void shouldThorwNotFoundExceptionOnUnmatchedDecisionRequirementsKey() {
+    // given
+    final Long decisionKey = 1L;
+    decisionRequirementsSearchQueryStub.setReturnEmptyResults(true);
+
+    // then
+    final var exception =
+        assertThrows(NotFoundException.class, () -> services.getDecisionDefinitionXml(decisionKey));
+    assertThat(exception.getMessage())
+        .isEqualTo("DecisionRequirements with decisionRequirementsKey=124 cannot be found");
+  }
+}

--- a/service/src/test/java/io/camunda/service/query/filter/DecisionDefinitionSearchQueryStub.java
+++ b/service/src/test/java/io/camunda/service/query/filter/DecisionDefinitionSearchQueryStub.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.service.query.filter;
 
+import static java.util.Collections.emptyList;
+
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
@@ -17,12 +19,18 @@ import java.util.List;
 
 public class DecisionDefinitionSearchQueryStub implements RequestStub<DecisionDefinitionEntity> {
 
+  private boolean returnEmptyResults = false;
+
   @Override
   public SearchQueryResponse<DecisionDefinitionEntity> handle(final SearchQueryRequest request)
       throws Exception {
 
+    if (returnEmptyResults) {
+      return SearchQueryResponse.of(f -> f.totalHits(0).hits(emptyList()));
+    }
+
     final var decisionDefinition =
-        new DecisionDefinitionEntity("t", 123L, "dId", "name", 1, "drId", 2L);
+        new DecisionDefinitionEntity("t", 123L, "dId", "name", 1, "drId", 124L);
 
     final SearchQueryHit<DecisionDefinitionEntity> hit =
         new SearchQueryHit.Builder<DecisionDefinitionEntity>()
@@ -40,8 +48,12 @@ public class DecisionDefinitionSearchQueryStub implements RequestStub<DecisionDe
     return response;
   }
 
+  public void setReturnEmptyResults(final boolean returnEmptyResults) {
+    this.returnEmptyResults = returnEmptyResults;
+  }
+
   @Override
   public void registerWith(final StubbedCamundaSearchClient client) {
-    client.registerHandler(this);
+    client.registerHandler(this, DecisionDefinitionEntity.class);
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/DecisionRequirementsFilterTest.java
+++ b/service/src/test/java/io/camunda/service/query/filter/DecisionRequirementsFilterTest.java
@@ -37,7 +37,7 @@ public final class DecisionRequirementsFilterTest {
   public void shouldQueryByDecisionRequirementsKey() {
     // given
     final var decisionRequirementFilter =
-        FilterBuilders.decisionRequirements(f -> f.decisionRequirementsKeys(123L));
+        FilterBuilders.decisionRequirements(f -> f.decisionRequirementsKeys(124L));
     final var searchQuery =
         SearchQueryBuilders.decisionRequirementsSearchQuery(
             q -> q.filter(decisionRequirementFilter));
@@ -54,7 +54,7 @@ public final class DecisionRequirementsFilterTest {
             SearchTermQuery.class,
             t -> {
               assertThat(t.field()).isEqualTo("key");
-              assertThat(t.value().longValue()).isEqualTo(123L);
+              assertThat(t.value().longValue()).isEqualTo(124L);
             });
   }
 
@@ -207,6 +207,6 @@ public final class DecisionRequirementsFilterTest {
     assertThat(searchQueryResult.total()).isEqualTo(1);
     assertThat(searchQueryResult.items()).hasSize(1);
     final DecisionRequirementsEntity item = searchQueryResult.items().get(0);
-    assertThat(item.key()).isEqualTo(123L);
+    assertThat(item.key()).isEqualTo(124L);
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/DecisionRequirementsSearchQueryStub.java
+++ b/service/src/test/java/io/camunda/service/query/filter/DecisionRequirementsSearchQueryStub.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.service.query.filter;
 
+import static java.util.Collections.emptyList;
+
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
@@ -18,12 +20,18 @@ import java.util.List;
 public class DecisionRequirementsSearchQueryStub
     implements RequestStub<DecisionRequirementsEntity> {
 
+  private boolean returnEmptyResults = false;
+
   @Override
   public SearchQueryResponse<DecisionRequirementsEntity> handle(final SearchQueryRequest request)
       throws Exception {
 
+    if (returnEmptyResults) {
+      return SearchQueryResponse.of(f -> f.totalHits(0).hits(emptyList()));
+    }
+
     final var decisionRequirement =
-        new DecisionRequirementsEntity("t", 123L, "id", "dId", 1, "name");
+        new DecisionRequirementsEntity("t", 124L, "id", "dId", 1, "name", "<xml/>");
 
     final SearchQueryHit<DecisionRequirementsEntity> hit =
         new SearchQueryHit.Builder<DecisionRequirementsEntity>()
@@ -41,8 +49,12 @@ public class DecisionRequirementsSearchQueryStub
     return response;
   }
 
+  public void setReturnEmptyResults(final boolean returnEmptyResults) {
+    this.returnEmptyResults = returnEmptyResults;
+  }
+
   @Override
   public void registerWith(final StubbedCamundaSearchClient client) {
-    client.registerHandler(this);
+    client.registerHandler(this, DecisionRequirementsEntity.class);
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceSearchQueryStub.java
+++ b/service/src/test/java/io/camunda/service/query/filter/ProcessInstanceSearchQueryStub.java
@@ -42,6 +42,6 @@ public class ProcessInstanceSearchQueryStub implements RequestStub<ProcessInstan
 
   @Override
   public void registerWith(final StubbedCamundaSearchClient client) {
-    client.registerHandler(this);
+    client.registerHandler(this, ProcessInstanceEntity.class);
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/UserTaskSearchQueryStub.java
+++ b/service/src/test/java/io/camunda/service/query/filter/UserTaskSearchQueryStub.java
@@ -59,6 +59,6 @@ public class UserTaskSearchQueryStub implements RequestStub<UserTaskEntity> {
 
   @Override
   public void registerWith(final StubbedCamundaSearchClient client) {
-    client.registerHandler(this);
+    client.registerHandler(this, UserTaskEntity.class);
   }
 }

--- a/service/src/test/java/io/camunda/service/query/filter/VariableSearchQueryStub.java
+++ b/service/src/test/java/io/camunda/service/query/filter/VariableSearchQueryStub.java
@@ -39,6 +39,6 @@ public class VariableSearchQueryStub implements RequestStub<VariableEntity> {
 
   @Override
   public void registerWith(final StubbedCamundaSearchClient client) {
-    client.registerHandler(this);
+    client.registerHandler(this, VariableEntity.class);
   }
 }

--- a/service/src/test/java/io/camunda/service/util/StubbedCamundaSearchClient.java
+++ b/service/src/test/java/io/camunda/service/util/StubbedCamundaSearchClient.java
@@ -14,11 +14,13 @@ import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.zeebe.util.Either;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class StubbedCamundaSearchClient implements CamundaSearchClient {
 
-  private SearchRequestHandler<?> searchRequestHandler;
+  private final Map<Class<?>, SearchRequestHandler<?>> searchRequestHandlerMap = new HashMap<>();
   private final List<SearchQueryRequest> searchRequests = new ArrayList<>();
 
   public StubbedCamundaSearchClient() {}
@@ -29,7 +31,8 @@ public class StubbedCamundaSearchClient implements CamundaSearchClient {
     searchRequests.add(searchRequest);
 
     try {
-      final SearchQueryResponse response = searchRequestHandler.handle(searchRequest);
+      final SearchQueryResponse response =
+          searchRequestHandlerMap.get(documentClass).handle(searchRequest);
       return Either.right(response);
     } catch (final Exception e) {
       return Either.left(e);
@@ -46,8 +49,8 @@ public class StubbedCamundaSearchClient implements CamundaSearchClient {
   }
 
   public <DocumentT> void registerHandler(
-      final SearchRequestHandler<DocumentT> searchRequestHandler) {
-    this.searchRequestHandler = searchRequestHandler;
+      final SearchRequestHandler<DocumentT> searchRequestHandler, Class<DocumentT> documentClass) {
+    this.searchRequestHandlerMap.put(documentClass, searchRequestHandler);
   }
 
   @Override

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -58,7 +58,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
   static final SearchQueryResult<DecisionRequirementsEntity> SEARCH_QUERY_RESULT =
       new Builder<DecisionRequirementsEntity>()
           .total(1L)
-          .items(List.of(new DecisionRequirementsEntity("t", 0L, "id", "name", 1, "rN")))
+          .items(List.of(new DecisionRequirementsEntity("t", 0L, "id", "name", 1, "rN", null)))
           .sortValues(new Object[] {"v"})
           .build();
 


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Creates a new service `getDecisionDefinitionXml(key)` in `DecisionDefinitionServices`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

relates to https://github.com/camunda/camunda/issues/20654
