### PR TITLE
fix: do not complete multi-instance before all child element batches has been activated

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -82,6 +82,11 @@ public final class BpmnStateBehavior {
       return false;
     }
 
+    final boolean multiInstanceStillActivating = flowScopeInstance.isMultiInstanceBatchActivating();
+    if (multiInstanceStillActivating) {
+      return false;
+    }
+
     final long activePaths =
         flowScopeInstance.getNumberOfActiveElementInstances()
             + flowScopeInstance.getActiveSequenceFlows();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateTransitionBehavior.java
@@ -314,14 +314,17 @@ public final class BpmnStateTransitionBehavior {
    * @param amount the amount of children for which we will write an activate command
    */
   public void activateChildInstancesInBatches(final BpmnElementContext context, final int amount) {
+    final long elementInstanceKey = context.getElementInstanceKey();
     final var record =
         new ProcessInstanceBatchRecord()
             .setProcessInstanceKey(context.getProcessInstanceKey())
-            .setBatchElementInstanceKey(context.getElementInstanceKey())
+            .setBatchElementInstanceKey(elementInstanceKey)
             .setIndex(amount);
 
     final var key = keyGenerator.nextKey();
     commandWriter.appendFollowUpCommand(key, ProcessInstanceBatchIntent.ACTIVATE, record);
+    stateWriter.appendFollowUpEvent(
+        elementInstanceKey, ProcessInstanceBatchIntent.ACTIVATING, record);
   }
 
   public void activateElementInstanceInFlowScope(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageStartEventSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessEventIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceCreationIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
@@ -71,6 +72,7 @@ public final class EventAppliers implements EventApplier {
     registerProcessInstanceModificationAppliers(state);
     registerProcessInstanceMigrationAppliers();
     register(ProcessInstanceResultIntent.COMPLETED, NOOP_EVENT_APPLIER);
+    registerProcessInstanceBatchEventAppliers(state);
 
     registerProcessAppliers(state);
     register(ErrorIntent.CREATED, new ErrorCreatedApplier(state.getBannedInstanceState()));
@@ -202,6 +204,12 @@ public final class EventAppliers implements EventApplier {
 
   private void registerProcessInstanceMigrationAppliers() {
     register(ProcessInstanceMigrationIntent.MIGRATED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerProcessInstanceBatchEventAppliers(final MutableProcessingState state) {
+    register(
+        ProcessInstanceBatchIntent.ACTIVATING, new ProcessInstanceBatchActivatingApplier(state));
+    register(ProcessInstanceBatchIntent.ACTIVATED, new ProcessInstanceBatchActivatedApplier(state));
   }
 
   private void registerJobIntentEventAppliers(final MutableProcessingState state) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceBatchActivatedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceBatchActivatedApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+
+public class ProcessInstanceBatchActivatedApplier
+    implements TypedEventApplier<ProcessInstanceBatchIntent, ProcessInstanceBatchRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceBatchActivatedApplier(final MutableProcessingState state) {
+    elementInstanceState = state.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceBatchRecord value) {
+    elementInstanceState.updateInstance(key, mi -> mi.setMultiInstanceBatchActivating(false));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceBatchActivatingApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ProcessInstanceBatchActivatingApplier.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableElementInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceBatchRecord;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceBatchIntent;
+
+public class ProcessInstanceBatchActivatingApplier
+    implements TypedEventApplier<ProcessInstanceBatchIntent, ProcessInstanceBatchRecord> {
+
+  private final MutableElementInstanceState elementInstanceState;
+
+  public ProcessInstanceBatchActivatingApplier(final MutableProcessingState state) {
+    elementInstanceState = state.getElementInstanceState();
+  }
+
+  @Override
+  public void applyState(final long key, final ProcessInstanceBatchRecord value) {
+    elementInstanceState.updateInstance(key, mi -> mi.setMultiInstanceBatchActivating(true));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/instance/ElementInstance.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.engine.processing.bpmn.ProcessInstanceLifecycle;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.ArrayProperty;
+import io.camunda.zeebe.msgpack.property.BooleanProperty;
 import io.camunda.zeebe.msgpack.property.IntegerProperty;
 import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.msgpack.property.ObjectProperty;
@@ -49,8 +50,11 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
   private final IntegerProperty executionListenerIndexProp =
       new IntegerProperty("executionListenerIndex", 0);
 
+  private final BooleanProperty multiInstanceBatchActivating =
+      new BooleanProperty("multiInstanceBatchActivating", false);
+
   public ElementInstance() {
-    super(14);
+    super(15);
     declareProperty(parentKeyProp)
         .declareProperty(childCountProp)
         .declareProperty(childActivatedCountProp)
@@ -64,7 +68,8 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
         .declareProperty(activeSequenceFlowsProp)
         .declareProperty(activeSequenceFlowIdsProp)
         .declareProperty(userTaskKeyProp)
-        .declareProperty(executionListenerIndexProp);
+        .declareProperty(executionListenerIndexProp)
+        .declareProperty(multiInstanceBatchActivating);
   }
 
   public ElementInstance(
@@ -280,5 +285,13 @@ public final class ElementInstance extends UnpackedObject implements DbValue {
    */
   public List<DirectBuffer> getActiveSequenceFlowIds() {
     return activeSequenceFlowIdsProp.stream().map(StringValue::getValue).toList();
+  }
+
+  public boolean isMultiInstanceBatchActivating() {
+    return multiInstanceBatchActivating.getValue();
+  }
+
+  public void setMultiInstanceBatchActivating(final boolean activating) {
+    multiInstanceBatchActivating.setValue(activating);
   }
 }

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ProcessInstanceBatchIntent.java
@@ -17,7 +17,9 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
   TERMINATE(0),
-  ACTIVATE(1);
+  ACTIVATE(1),
+  ACTIVATING(2),
+  ACTIVATED(3);
 
   private final short value;
   private final boolean shouldBanInstance;
@@ -37,6 +39,10 @@ public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
         return TERMINATE;
       case 1:
         return ACTIVATE;
+      case 2:
+        return ACTIVATING;
+      case 3:
+        return ACTIVATED;
       default:
         return UNKNOWN;
     }
@@ -49,7 +55,13 @@ public enum ProcessInstanceBatchIntent implements ProcessInstanceRelatedIntent {
 
   @Override
   public boolean isEvent() {
-    return false;
+    switch (this) {
+      case ACTIVATING:
+      case ACTIVATED:
+        return true;
+      default:
+        return false;
+    }
   }
 
   @Override


### PR DESCRIPTION
## Description
Right now, a multi-instance with a big input collection could be marked as completed mistakenly if a portion of it's child elements has been completed before one or some of the next batches has been activated. 
This results in `NullPointerException` when activated the `delayed` batches, because it can't find the parent anymore (as it has been prematurely completed)

In this fix, I'm introducing two new intents for the `ProcessInstanceBatch`: `ACTIVATING` and `ACTIVATED`

Once we start processing the multi-instance child elements, I write to the state that the `ProcessInstanceBatch` is `ACTIVATING`, and I only transition it to `ACTIVATED` once there are no more children to activate. I'm using these events then to signal this fact in the multi-instance body element instance state.

In the BpmnStateBehavior, I'm then changing the logic to reject completing a multi-instance body if its state indicates it's still `ACTIVATING`.

## Related issues

closes #12918