### PR TITLE
[Backport stable/8.4] refactor: Change order of `fold` method arguments in `Either` interface

### DIFF
--- a/util/src/main/java/io/camunda/zeebe/util/Either.java
+++ b/util/src/main/java/io/camunda/zeebe/util/Either.java
@@ -350,22 +350,22 @@ public sealed interface Either<L, R> {
    * <p>A common use case is to map to a new common value in success and error cases. Example:
    *
    * <pre>{@code
-   * * Either<String, Integer> success = Either.right(42); // => Right(42)
-   * * Either<String, Integer> failure = Either.left("Error occurred"); // => Left("Error occurred")
-   * *
-   * * var rightFn = result -> "Success: " + result;
-   * * var leftFn = error -> "Failure: " + error;
-   * *
-   * * success.fold(rightFn, leftFn); // => "Success: 42"
-   * * failure.fold(rightFn, leftFn); // => "Failure: Error occurred"
+   * Either<String, Integer> success = Either.right(42); // => Right(42)
+   * Either<String, Integer> failure = Either.left("Error occurred"); // => Left("Error occurred")
+   *
+   * var rightFn = result -> "Success: " + result;
+   * var leftFn = error -> "Failure: " + error;
+   *
+   * success.fold(leftFn, rightFn); // => "Success: 42"
+   * failure.fold(leftFn, rightFn); // => "Failure: Error occurred"
    * }</pre>
    *
-   * @param rightFn the mapping function for the right value
    * @param leftFn the mapping function for the left value
+   * @param rightFn the mapping function for the right value
    * @return either a mapped {@link Left} or {@link Right}, folded to the new type
    * @param <T> the type of the resulting value
    */
-  <T> T fold(Function<? super R, ? extends T> rightFn, Function<? super L, ? extends T> leftFn);
+  <T> T fold(Function<? super L, ? extends T> leftFn, Function<? super R, ? extends T> rightFn);
 
   /**
    * A right for either a left or right. By convention, right is used for success and left for
@@ -440,8 +440,8 @@ public sealed interface Either<L, R> {
 
     @Override
     public <T> T fold(
-        final Function<? super R, ? extends T> rightFn,
-        final Function<? super L, ? extends T> leftFn) {
+        final Function<? super L, ? extends T> leftFn,
+        final Function<? super R, ? extends T> rightFn) {
       return rightFn.apply(value);
     }
   }
@@ -519,8 +519,8 @@ public sealed interface Either<L, R> {
 
     @Override
     public <T> T fold(
-        final Function<? super R, ? extends T> rightFn,
-        final Function<? super L, ? extends T> leftFn) {
+        final Function<? super L, ? extends T> leftFn,
+        final Function<? super R, ? extends T> rightFn) {
       return leftFn.apply(value);
     }
   }

--- a/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
+++ b/util/src/test/java/io/camunda/zeebe/util/EitherTest.java
@@ -306,9 +306,9 @@ class EitherTest {
     }
   }
 
-  @DisplayName("Folding method tests")
+  @DisplayName("`fold` method tests")
   @Nested
-  class FoldingMethodTests {
+  class FoldMethodTests {
 
     @DisplayName("Folds `Left`s into target types using the left function.")
     @ParameterizedTest
@@ -318,7 +318,7 @@ class EitherTest {
       final Function<Object, String> rightMapper = o -> "Unexpected-" + o.toString();
       final String mappedValue = leftMapper.apply(value);
       assertThat(mappedValue).isNotEqualTo(value);
-      assertThat(Either.left(value).fold(rightMapper, leftMapper)).isEqualTo(mappedValue);
+      assertThat(Either.left(value).fold(leftMapper, rightMapper)).isEqualTo(mappedValue);
     }
 
     @DisplayName("Folds `Right`s into target types using the right function.")
@@ -329,7 +329,7 @@ class EitherTest {
       final Function<Object, String> rightMapper = o -> "Expected-" + o.toString();
       final String mappedValue = rightMapper.apply(value);
       assertThat(mappedValue).isNotEqualTo(value);
-      assertThat(Either.right(value).fold(rightMapper, leftMapper)).isEqualTo(mappedValue);
+      assertThat(Either.right(value).fold(leftMapper, rightMapper)).isEqualTo(mappedValue);
     }
   }
 }


### PR DESCRIPTION
# Description
Backport of #20889 to `stable/8.4`.

relates to #20588
original author: @ce-dmelnych