### PR TITLE
refactor: inject engine clock

### DIFF
--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -35,6 +35,7 @@ import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.impl.RecordProcessorContextImpl;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import java.nio.file.Path;
+import java.time.InstantSource;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,7 +81,7 @@ final class CheckpointRecordsProcessorTest {
         context,
         null,
         new DbKeyGenerator(1, zeebeDb, context),
-        StreamClock.system());
+        StreamClock.controllable(InstantSource.system()));
   }
 
   @AfterEach

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -34,6 +34,7 @@ import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.impl.RecordProcessorContextImpl;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import java.nio.file.Path;
+import java.time.InstantSource;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +74,13 @@ final class CheckpointRecordsProcessorTest {
       final ProcessingScheduleService executor, final ZeebeDb zeebeDb) {
     final var context = zeebeDb.createContext();
     return new RecordProcessorContextImpl(
-        1, executor, zeebeDb, context, null, new DbKeyGenerator(1, zeebeDb, context));
+        1,
+        executor,
+        zeebeDb,
+        context,
+        null,
+        new DbKeyGenerator(1, zeebeDb, context),
+        InstantSource.system());
   }
 
   @AfterEach

--- a/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
+++ b/zeebe/backup/src/test/java/io/camunda/zeebe/backup/processing/CheckpointRecordsProcessorTest.java
@@ -30,11 +30,11 @@ import io.camunda.zeebe.protocol.impl.record.value.management.CheckpointRecord;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.impl.RecordProcessorContextImpl;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
 import java.nio.file.Path;
-import java.time.InstantSource;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -80,7 +80,7 @@ final class CheckpointRecordsProcessorTest {
         context,
         null,
         new DbKeyGenerator(1, zeebeDb, context),
-        InstantSource.system());
+        StreamClock.system());
   }
 
   @AfterEach

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/MigrationTransitionStep.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.migration.DbMigratorImpl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import java.time.InstantSource;
 
 public class MigrationTransitionStep implements PartitionTransitionStep {
 
@@ -45,7 +46,8 @@ public class MigrationTransitionStep implements PartitionTransitionStep {
             new DbKeyGenerator(context.getPartitionId(), zeebeDb, zeebeDbContext),
             transientMessageSubscriptionState,
             transientProcessMessageSubscriptionState,
-            context.getBrokerCfg().getExperimental().getEngine().createEngineConfiguration());
+            context.getBrokerCfg().getExperimental().getEngine().createEngineConfiguration(),
+            InstantSource.system());
 
     final var dbMigrator = new DbMigratorImpl(processingState);
     try {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServicePartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/QueryServicePartitionTransitionStep.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.engine.state.QueryService;
 import io.camunda.zeebe.engine.state.query.StateQueryService;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.time.InstantSource;
 import org.agrona.CloseHelper;
 
 public final class QueryServicePartitionTransitionStep implements PartitionTransitionStep {
@@ -44,7 +45,7 @@ public final class QueryServicePartitionTransitionStep implements PartitionTrans
     if (targetRole != Role.INACTIVE
         && (currentRole == Role.LEADER || context.getQueryService() == null)) {
       try {
-        final var service = new StateQueryService(context.getZeebeDb());
+        final var service = new StateQueryService(context.getZeebeDb(), InstantSource.system());
         context.setQueryService(service);
         return CompletableActorFuture.completed(null);
       } catch (final Exception e) {

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -25,10 +25,6 @@
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-stream-platform</artifactId>
     </dependency>
-    <dependency>
-      <groupId>io.camunda</groupId>
-      <artifactId>zeebe-scheduler</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>org.agrona</groupId>
@@ -116,6 +112,12 @@
     </dependency>
 
     <!-- TEST DEPENDENCIES -->
+    <dependency>
+      <groupId>io.camunda</groupId>
+      <artifactId>zeebe-scheduler</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>io.camunda</groupId>
       <artifactId>zeebe-logstreams</artifactId>

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/BpmnProcessors.java
@@ -47,6 +47,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.InstantSource;
 import java.util.Arrays;
 import java.util.function.Supplier;
 
@@ -62,7 +63,8 @@ public final class BpmnProcessors {
       final Writers writers,
       final CommandDistributionBehavior commandDistributionBehavior,
       final int partitionId,
-      final int partitionsCount) {
+      final int partitionsCount,
+      final InstantSource clock) {
     final MutableProcessMessageSubscriptionState subscriptionState =
         processingState.getProcessMessageSubscriptionState();
     final var keyGenerator = processingState.getKeyGenerator();
@@ -82,7 +84,8 @@ public final class BpmnProcessors {
         bpmnBehaviors,
         processingState,
         scheduledTaskState,
-        writers);
+        writers,
+        clock);
     addTimerStreamProcessors(
         typedRecordProcessors, timerChecker, processingState, bpmnBehaviors, writers);
     addVariableDocumentStreamProcessors(
@@ -137,7 +140,8 @@ public final class BpmnProcessors {
       final BpmnBehaviors bpmnBehaviors,
       final MutableProcessingState processingState,
       final Supplier<ScheduledTaskState> scheduledTaskState,
-      final Writers writers) {
+      final Writers writers,
+      final InstantSource clock) {
     typedRecordProcessors
         .onCommand(
             ValueType.PROCESS_MESSAGE_SUBSCRIPTION,
@@ -160,7 +164,8 @@ public final class BpmnProcessors {
         .withListener(
             new PendingProcessMessageSubscriptionChecker(
                 subscriptionCommandSender,
-                scheduledTaskState.get().getPendingProcessMessageSubscriptionState()));
+                scheduledTaskState.get().getPendingProcessMessageSubscriptionState(),
+                clock));
   }
 
   private static void addTimerStreamProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnBufferedMessageStartEventBehavior.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.ProcessState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageStartEventSubscriptionRecord;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.InstantSource;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
@@ -29,16 +29,19 @@ public final class BpmnBufferedMessageStartEventBehavior {
   private final MessageStartEventSubscriptionState messageStartEventSubscriptionState;
 
   private final EventHandle eventHandle;
+  private final InstantSource clock;
 
   public BpmnBufferedMessageStartEventBehavior(
       final ProcessingState processingState,
       final KeyGenerator keyGenerator,
       final EventTriggerBehavior eventTriggerBehavior,
       final BpmnStateBehavior stateBehavior,
-      final Writers writers) {
+      final Writers writers,
+      final InstantSource clock) {
     messageState = processingState.getMessageState();
     processState = processingState.getProcessState();
     messageStartEventSubscriptionState = processingState.getMessageStartEventSubscriptionState();
+    this.clock = clock;
 
     eventHandle =
         new EventHandle(
@@ -106,7 +109,7 @@ public final class BpmnBufferedMessageStartEventBehavior {
               correlationKey,
               storedMessage -> {
                 // correlate the first message with same correlation key that was not correlated yet
-                if (storedMessage.getMessage().getDeadline() > ActorClock.currentTimeMillis()
+                if (storedMessage.getMessage().getDeadline() > clock.millis()
                     && !messageState.existMessageCorrelation(
                         storedMessage.getMessageKey(), process.getBpmnProcessId())) {
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -27,9 +27,9 @@ import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.value.ErrorType;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
+import java.time.InstantSource;
 import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -54,6 +54,7 @@ public final class BpmnUserTaskBehavior {
   private final BpmnStateBehavior stateBehavior;
   private final FormState formState;
   private final MutableUserTaskState userTaskState;
+  private final InstantSource clock;
 
   public BpmnUserTaskBehavior(
       final KeyGenerator keyGenerator,
@@ -61,13 +62,15 @@ public final class BpmnUserTaskBehavior {
       final ExpressionProcessor expressionBehavior,
       final BpmnStateBehavior stateBehavior,
       final FormState formState,
-      final MutableUserTaskState userTaskState) {
+      final MutableUserTaskState userTaskState,
+      final InstantSource clock) {
     this.keyGenerator = keyGenerator;
     stateWriter = writers.state();
     this.expressionBehavior = expressionBehavior;
     this.stateBehavior = stateBehavior;
     this.formState = formState;
     this.userTaskState = userTaskState;
+    this.clock = clock;
   }
 
   public Either<Failure, UserTaskProperties> evaluateUserTaskExpressions(
@@ -135,7 +138,7 @@ public final class BpmnUserTaskBehavior {
         .setElementInstanceKey(context.getElementInstanceKey())
         .setTenantId(context.getTenantId())
         .setPriority(userTaskProperties.getPriority())
-        .setCreationTimestamp(ActorClock.currentTimeMillis());
+        .setCreationTimestamp(clock.millis());
 
     stateWriter.appendFollowUpEvent(userTaskKey, UserTaskIntent.CREATING, userTaskRecord);
     return userTaskRecord;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/clock/ZeebeFeelEngineClock.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/clock/ZeebeFeelEngineClock.java
@@ -7,27 +7,22 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.clock;
 
-import io.camunda.zeebe.scheduler.clock.ActorClock;
-import java.time.Instant;
+import java.time.InstantSource;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Objects;
 import org.camunda.feel.FeelEngineClock;
 
 public final class ZeebeFeelEngineClock implements FeelEngineClock {
 
-  private final ActorClock clock;
+  private final InstantSource clock;
 
-  public ZeebeFeelEngineClock(final ActorClock clock) {
-    this.clock = clock;
+  public ZeebeFeelEngineClock(final InstantSource clock) {
+    this.clock = Objects.requireNonNull(clock);
   }
 
   @Override
   public ZonedDateTime getCurrentTime() {
-
-    final long currentMillis = clock.getTimeMillis();
-    final var instant = Instant.ofEpochMilli(currentMillis);
-    final var zone = ZoneId.systemDefault();
-
-    return instant.atZone(zone);
+    return clock.instant().atZone(ZoneId.systemDefault());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/CatchEventBehavior.java
@@ -36,10 +36,10 @@ import io.camunda.zeebe.protocol.record.intent.ProcessMessageSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.SignalSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.function.Predicate;
 import org.agrona.DirectBuffer;
@@ -63,6 +63,7 @@ public final class CatchEventBehavior {
   private final DueDateTimerChecker timerChecker;
   private final KeyGenerator keyGenerator;
   private final SignalSubscriptionRecord signalSubscription = new SignalSubscriptionRecord();
+  private final InstantSource clock;
 
   public CatchEventBehavior(
       final ProcessingState processingState,
@@ -72,7 +73,8 @@ public final class CatchEventBehavior {
       final StateWriter stateWriter,
       final SideEffectWriter sideEffectWriter,
       final DueDateTimerChecker timerChecker,
-      final int partitionsCount) {
+      final int partitionsCount,
+      final InstantSource clock) {
     this.expressionProcessor = expressionProcessor;
     this.subscriptionCommandSender = subscriptionCommandSender;
     this.stateWriter = stateWriter;
@@ -86,6 +88,7 @@ public final class CatchEventBehavior {
 
     this.keyGenerator = keyGenerator;
     this.timerChecker = timerChecker;
+    this.clock = clock;
   }
 
   /**
@@ -344,7 +347,7 @@ public final class CatchEventBehavior {
       final DirectBuffer handlerNodeId,
       final String tenantId,
       final Timer timer) {
-    final long dueDate = timer.getDueDate(ActorClock.currentTimeMillis());
+    final long dueDate = timer.getDueDate(clock.millis());
     timerRecord.reset();
     timerRecord
         .setRepetitions(timer.getRepetitions())

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/DeploymentCreateProcessor.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.List;
 import org.agrona.DirectBuffer;
 
@@ -83,7 +84,8 @@ public final class DeploymentCreateProcessor
       final KeyGenerator keyGenerator,
       final FeatureFlags featureFlags,
       final CommandDistributionBehavior distributionBehavior,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final InstantSource clock) {
     processState = processingState.getProcessState();
     decisionState = processingState.getDecisionState();
     formState = processingState.getFormState();
@@ -97,7 +99,13 @@ public final class DeploymentCreateProcessor
     this.distributionBehavior = distributionBehavior;
     deploymentTransformer =
         new DeploymentTransformer(
-            stateWriter, processingState, expressionProcessor, keyGenerator, featureFlags, config);
+            stateWriter,
+            processingState,
+            expressionProcessor,
+            keyGenerator,
+            featureFlags,
+            config,
+            clock);
     startEventSubscriptionManager =
         new StartEventSubscriptionManager(processingState, keyGenerator, stateWriter);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/BpmnFactory.java
@@ -13,19 +13,20 @@ import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor;
 import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTransformer;
 import io.camunda.zeebe.engine.processing.deployment.transform.BpmnValidator;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 
 public final class BpmnFactory {
 
-  public static BpmnTransformer createTransformer() {
-    return new BpmnTransformer(
-        createExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())));
+  public static BpmnTransformer createTransformer(final InstantSource clock) {
+    return new BpmnTransformer(createExpressionLanguage(new ZeebeFeelEngineClock(clock)));
   }
 
   public static BpmnValidator createValidator(
-      final ExpressionProcessor expressionProcessor, final int validatorResultsOutputMaxSize) {
+      final InstantSource clock,
+      final ExpressionProcessor expressionProcessor,
+      final int validatorResultsOutputMaxSize) {
     return new BpmnValidator(
-        createExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())),
+        createExpressionLanguage(new ZeebeFeelEngineClock(clock)),
         expressionProcessor,
         validatorResultsOutputMaxSize);
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/BpmnResourceTransformer.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.function.Function;
 import org.agrona.DirectBuffer;
@@ -38,7 +39,7 @@ import org.camunda.bpm.model.xml.ModelParseException;
 
 public final class BpmnResourceTransformer implements DeploymentResourceTransformer {
 
-  private final BpmnTransformer bpmnTransformer = BpmnFactory.createTransformer();
+  private final BpmnTransformer bpmnTransformer;
 
   private final KeyGenerator keyGenerator;
   private final StateWriter stateWriter;
@@ -55,14 +56,16 @@ public final class BpmnResourceTransformer implements DeploymentResourceTransfor
       final ProcessState processState,
       final ExpressionProcessor expressionProcessor,
       final boolean enableStraightThroughProcessingLoopDetector,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final InstantSource clock) {
+    bpmnTransformer = BpmnFactory.createTransformer(clock);
     this.keyGenerator = keyGenerator;
     this.stateWriter = stateWriter;
     this.checksumGenerator = checksumGenerator;
     this.processState = processState;
     validator =
         BpmnFactory.createValidator(
-            expressionProcessor, config.getValidatorsResultsOutputMaxSize());
+            clock, expressionProcessor, config.getValidatorsResultsOutputMaxSize());
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/transform/DeploymentTransformer.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.time.InstantSource;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -52,7 +53,8 @@ public final class DeploymentTransformer {
       final ExpressionProcessor expressionProcessor,
       final KeyGenerator keyGenerator,
       final FeatureFlags featureFlags,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final InstantSource clock) {
 
     try {
       // We get an alert by LGTM, since MD5 is a weak cryptographic hash function,
@@ -73,7 +75,8 @@ public final class DeploymentTransformer {
             processingState.getProcessState(),
             expressionProcessor,
             featureFlags.enableStraightThroughProcessingLoopDetector(),
-            config);
+            config,
+            clock);
     final var dmnResourceTransformer =
         new DmnResourceTransformer(
             keyGenerator, stateWriter, this::getChecksum, processingState.getDecisionState());

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobBackoffChecker.java
@@ -10,10 +10,10 @@ package io.camunda.zeebe.engine.processing.job;
 import io.camunda.zeebe.engine.processing.scheduled.DueDateChecker;
 import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.time.Duration;
+import java.time.InstantSource;
 
 public final class JobBackoffChecker implements StreamProcessorLifecycleAware {
 
@@ -21,17 +21,18 @@ public final class JobBackoffChecker implements StreamProcessorLifecycleAware {
 
   private final DueDateChecker backOffDueDateChecker;
 
-  public JobBackoffChecker(final JobState jobState) {
+  public JobBackoffChecker(final InstantSource clock, final JobState jobState) {
     backOffDueDateChecker =
         new DueDateChecker(
             BACKOFF_RESOLUTION,
             false,
             taskResultBuilder ->
                 jobState.findBackedOffJobs(
-                    ActorClock.currentTimeMillis(),
+                    clock.millis(),
                     (key, record) ->
                         taskResultBuilder.appendCommandRecord(
-                            key, JobIntent.RECUR_AFTER_BACKOFF, record)));
+                            key, JobIntent.RECUR_AFTER_BACKOFF, record)),
+            clock);
   }
 
   public void scheduleBackOff(final long dueDate) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobRecurProcessor.java
@@ -18,8 +18,8 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.time.InstantSource;
 
 public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
 
@@ -29,15 +29,18 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
   private final StateWriter stateWriter;
   private final TypedRejectionWriter rejectionWriter;
   private final BpmnJobActivationBehavior jobActivationBehavior;
+  private final InstantSource clock;
 
   public JobRecurProcessor(
       final ProcessingState processingState,
       final Writers writers,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final InstantSource clock) {
     jobState = processingState.getJobState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     this.jobActivationBehavior = jobActivationBehavior;
+    this.clock = clock;
   }
 
   @Override
@@ -76,6 +79,6 @@ public class JobRecurProcessor implements TypedRecordProcessor<JobRecord> {
   }
 
   private boolean hasRecurred(final JobRecord job) {
-    return job.getRecurringTime() < ActorClock.currentTimeMillis();
+    return job.getRecurringTime() < clock.millis();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeOutProcessor.java
@@ -19,8 +19,8 @@ import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.record.RejectionType;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
+import java.time.InstantSource;
 
 public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord> {
   public static final String NOT_ACTIVATED_JOB_MESSAGE =
@@ -30,17 +30,20 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
   private final TypedRejectionWriter rejectionWriter;
   private final JobMetrics jobMetrics;
   private final BpmnJobActivationBehavior jobActivationBehavior;
+  private final InstantSource clock;
 
   public JobTimeOutProcessor(
       final ProcessingState state,
       final Writers writers,
       final JobMetrics jobMetrics,
-      final BpmnJobActivationBehavior jobActivationBehavior) {
+      final BpmnJobActivationBehavior jobActivationBehavior,
+      final InstantSource clock) {
     jobState = state.getJobState();
     stateWriter = writers.state();
     rejectionWriter = writers.rejection();
     this.jobMetrics = jobMetrics;
     this.jobActivationBehavior = jobActivationBehavior;
+    this.clock = clock;
   }
 
   @Override
@@ -69,6 +72,6 @@ public final class JobTimeOutProcessor implements TypedRecordProcessor<JobRecord
   }
 
   private boolean hasTimedOut(final JobRecord job) {
-    return job.getDeadline() < ActorClock.currentTimeMillis();
+    return job.getDeadline() < clock.millis();
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerScheduler.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.engine.state.immutable.JobState;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import java.time.Duration;
+import java.time.InstantSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,9 +21,12 @@ public final class JobTimeoutCheckerScheduler implements StreamProcessorLifecycl
   private final JobTimeoutChecker jobTimeoutChecker;
 
   public JobTimeoutCheckerScheduler(
-      final JobState state, final Duration pollingInterval, final int batchLimit) {
+      final JobState state,
+      final Duration pollingInterval,
+      final int batchLimit,
+      final InstantSource clock) {
     this.pollingInterval = pollingInterval;
-    jobTimeoutChecker = new JobTimeoutChecker(state, pollingInterval, batchLimit);
+    jobTimeoutChecker = new JobTimeoutChecker(state, pollingInterval, batchLimit, clock);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageCorrelator.java
@@ -14,7 +14,7 @@ import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.message.StoredMessage;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 import org.agrona.collections.MutableBoolean;
 
 public final class MessageCorrelator {
@@ -24,18 +24,21 @@ public final class MessageCorrelator {
   private final StateWriter stateWriter;
   private final SideEffectWriter sideEffectWriter;
   private final int currentPartitionId;
+  private final InstantSource clock;
 
   public MessageCorrelator(
       final int currentPartitionId,
       final MessageState messageState,
       final SubscriptionCommandSender commandSender,
       final StateWriter stateWriter,
-      final SideEffectWriter sideEffectWriter) {
+      final SideEffectWriter sideEffectWriter,
+      final InstantSource clock) {
     this.currentPartitionId = currentPartitionId;
     this.messageState = messageState;
     this.commandSender = commandSender;
     this.stateWriter = stateWriter;
     this.sideEffectWriter = sideEffectWriter;
+    this.clock = clock;
   }
 
   public boolean correlateNextMessage(
@@ -66,7 +69,7 @@ public final class MessageCorrelator {
     final var message = storedMessage.getMessage();
 
     final boolean correlateMessage =
-        message.getDeadline() > ActorClock.currentTimeMillis()
+        message.getDeadline() > clock.millis()
             && !messageState.existMessageCorrelation(
                 messageKey, subscriptionRecord.getBpmnProcessIdBuffer());
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageEventProcessors.java
@@ -27,6 +27,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.FeatureFlags;
+import java.time.InstantSource;
 import java.util.function.Supplier;
 
 public final class MessageEventProcessors {
@@ -40,7 +41,8 @@ public final class MessageEventProcessors {
       final Writers writers,
       final EngineConfiguration config,
       final FeatureFlags featureFlags,
-      final CommandDistributionBehavior commandDistributionBehavior) {
+      final CommandDistributionBehavior commandDistributionBehavior,
+      final InstantSource clock) {
 
     final MutableMessageState messageState = processingState.getMessageState();
     final MutableMessageCorrelationState messageCorrelationState =
@@ -84,7 +86,8 @@ public final class MessageEventProcessors {
                 subscriptionState,
                 subscriptionCommandSender,
                 writers,
-                keyGenerator))
+                keyGenerator,
+                clock))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.CORRELATE,
@@ -94,7 +97,8 @@ public final class MessageEventProcessors {
                 messageCorrelationState,
                 subscriptionState,
                 subscriptionCommandSender,
-                writers))
+                writers,
+                clock))
         .onCommand(
             ValueType.MESSAGE_SUBSCRIPTION,
             MessageSubscriptionIntent.DELETE,
@@ -129,6 +133,7 @@ public final class MessageEventProcessors {
                 subscriptionCommandSender,
                 config.getMessagesTtlCheckerInterval(),
                 config.getMessagesTtlCheckerBatchLimit(),
-                featureFlags.enableMessageTTLCheckerAsync()));
+                featureFlags.enableMessageTTLCheckerAsync(),
+                clock));
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCorrelateProcessor.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageCorrelationIntent;
 import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 
 public final class MessageSubscriptionCorrelateProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
@@ -46,7 +47,8 @@ public final class MessageSubscriptionCorrelateProcessor
       final MessageCorrelationState messageCorrelationState,
       final MessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender commandSender,
-      final Writers writers) {
+      final Writers writers,
+      final InstantSource clock) {
     this.subscriptionState = subscriptionState;
     this.messageCorrelationState = messageCorrelationState;
     stateWriter = writers.state();
@@ -54,7 +56,7 @@ public final class MessageSubscriptionCorrelateProcessor
     responseWriter = writers.response();
     messageCorrelator =
         new MessageCorrelator(
-            partitionId, messageState, commandSender, stateWriter, writers.sideEffect());
+            partitionId, messageState, commandSender, stateWriter, writers.sideEffect(), clock);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageSubscriptionCreateProcessor.java
@@ -21,6 +21,7 @@ import io.camunda.zeebe.protocol.record.intent.MessageSubscriptionIntent;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 
 public final class MessageSubscriptionCreateProcessor
     implements TypedRecordProcessor<MessageSubscriptionRecord> {
@@ -46,7 +47,8 @@ public final class MessageSubscriptionCreateProcessor
       final MessageSubscriptionState subscriptionState,
       final SubscriptionCommandSender commandSender,
       final Writers writers,
-      final KeyGenerator keyGenerator) {
+      final KeyGenerator keyGenerator,
+      final InstantSource clock) {
     this.subscriptionState = subscriptionState;
     this.commandSender = commandSender;
     stateWriter = writers.state();
@@ -55,7 +57,7 @@ public final class MessageSubscriptionCreateProcessor
     this.keyGenerator = keyGenerator;
     messageCorrelator =
         new MessageCorrelator(
-            partitionId, messageState, commandSender, stateWriter, sideEffectWriter);
+            partitionId, messageState, commandSender, stateWriter, sideEffectWriter, clock);
     currentPartitionId = partitionId;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/MessageTimeToLiveChecker.java
@@ -11,12 +11,12 @@ import io.camunda.zeebe.engine.state.immutable.MessageState;
 import io.camunda.zeebe.engine.state.immutable.MessageState.Index;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageBatchRecord;
 import io.camunda.zeebe.protocol.record.intent.MessageBatchIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
+import java.time.InstantSource;
 import org.agrona.collections.MutableInteger;
 
 /**
@@ -51,24 +51,28 @@ public final class MessageTimeToLiveChecker implements Task {
   /** Keeps track of where to continue between iterations. */
   private MessageState.Index lastIndex;
 
+  private final InstantSource clock;
+
   public MessageTimeToLiveChecker(
       final Duration executionInterval,
       final int batchLimit,
       final boolean enableMessageTtlCheckerAsync,
       final ProcessingScheduleService scheduleService,
-      final MessageState messageState) {
+      final MessageState messageState,
+      final InstantSource clock) {
     this.executionInterval = executionInterval;
     this.batchLimit = batchLimit;
     this.enableMessageTtlCheckerAsync = enableMessageTtlCheckerAsync;
     this.messageState = messageState;
     this.scheduleService = scheduleService;
+    this.clock = clock;
     lastIndex = null;
   }
 
   @Override
   public TaskResult execute(final TaskResultBuilder taskResultBuilder) {
     if (currentTimestamp == -1) {
-      currentTimestamp = ActorClock.currentTimeMillis();
+      currentTimestamp = clock.millis();
     }
 
     final var counter = new MutableInteger(0);
@@ -107,7 +111,7 @@ public final class MessageTimeToLiveChecker implements Task {
   }
 
   private void reschedule(final Duration idleInterval) {
-    final var timestamp = ActorClock.currentTimeMillis() + idleInterval.toMillis();
+    final var timestamp = clock.millis() + idleInterval.toMillis();
     if (enableMessageTtlCheckerAsync) {
       scheduleService.runAtAsync(timestamp, this);
     } else {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/message/PendingMessageSubscriptionChecker.java
@@ -10,26 +10,29 @@ package io.camunda.zeebe.engine.processing.message;
 import io.camunda.zeebe.engine.processing.message.command.SubscriptionCommandSender;
 import io.camunda.zeebe.engine.state.immutable.PendingMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.MessageSubscription;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 
 public final class PendingMessageSubscriptionChecker implements Runnable {
   private final SubscriptionCommandSender commandSender;
   private final PendingMessageSubscriptionState state;
 
   private final long subscriptionTimeout;
+  private final InstantSource clock;
 
   public PendingMessageSubscriptionChecker(
       final SubscriptionCommandSender commandSender,
       final PendingMessageSubscriptionState state,
-      final long subscriptionTimeout) {
+      final long subscriptionTimeout,
+      final InstantSource clock) {
     this.commandSender = commandSender;
     this.state = state;
     this.subscriptionTimeout = subscriptionTimeout;
+    this.clock = clock;
   }
 
   @Override
   public void run() {
-    state.visitPending(ActorClock.currentTimeMillis() - subscriptionTimeout, this::sendCommand);
+    state.visitPending(clock.millis() - subscriptionTimeout, this::sendCommand);
   }
 
   private boolean sendCommand(final MessageSubscription subscription) {
@@ -46,7 +49,7 @@ public final class PendingMessageSubscriptionChecker implements Runnable {
         record.getTenantId());
 
     // TODO (saig0): the state change of the sent time should be reflected by a record (#6364)
-    final var sentTime = ActorClock.currentTimeMillis();
+    final var sentTime = clock.millis();
     state.onSent(record, sentTime);
 
     return true; // to continue visiting

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import java.time.InstantSource;
 import java.util.function.Supplier;
 
 public interface TypedRecordProcessorContext {
@@ -31,4 +32,6 @@ public interface TypedRecordProcessorContext {
   Supplier<ScheduledTaskState> getScheduledTaskStateFactory();
 
   EngineConfiguration getConfig();
+
+  InstantSource getClock();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -44,6 +44,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
     zeebeDb = context.getZeebeDb();
     transientMessageSubscriptionState = new TransientPendingSubscriptionState();
     transientProcessMessageSubscriptionState = new TransientPendingSubscriptionState();
+    clock = Objects.requireNonNull(context.getClock());
     processingState =
         new ProcessingDbState(
             partitionId,
@@ -52,11 +53,11 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
             context.getKeyGenerator(),
             transientMessageSubscriptionState,
             transientProcessMessageSubscriptionState,
-            config);
+            config,
+            clock);
     this.writers = writers;
     partitionCommandSender = context.getPartitionCommandSender();
     this.config = config;
-    clock = Objects.requireNonNull(context.getClock());
   }
 
   @Override
@@ -92,7 +93,8 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
             zeebeDb.createContext(),
             partitionId,
             transientMessageSubscriptionState,
-            transientProcessMessageSubscriptionState);
+            transientProcessMessageSubscriptionState,
+            clock);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -18,6 +18,8 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import java.time.InstantSource;
+import java.util.Objects;
 import java.util.function.Supplier;
 
 public class TypedRecordProcessorContextImpl implements TypedRecordProcessorContext {
@@ -31,6 +33,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final EngineConfiguration config;
   private final TransientPendingSubscriptionState transientMessageSubscriptionState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
+  private final InstantSource clock;
 
   public TypedRecordProcessorContextImpl(
       final RecordProcessorContext context,
@@ -53,6 +56,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
     this.writers = writers;
     partitionCommandSender = context.getPartitionCommandSender();
     this.config = config;
+    clock = Objects.requireNonNull(context.getClock());
   }
 
   @Override
@@ -94,5 +98,10 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   @Override
   public EngineConfiguration getConfig() {
     return config;
+  }
+
+  @Override
+  public InstantSource getClock() {
+    return clock;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerChecker.java
@@ -13,12 +13,12 @@ import io.camunda.zeebe.engine.state.immutable.TimerInstanceState.TimerVisitor;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.protocol.impl.record.value.timer.TimerRecord;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.function.Function;
 
 public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
@@ -28,13 +28,16 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   private final DueDateChecker dueDateChecker;
 
   public DueDateTimerChecker(
-      final TimerInstanceState timerInstanceState, final FeatureFlags featureFlags) {
+      final TimerInstanceState timerInstanceState,
+      final FeatureFlags featureFlags,
+      final InstantSource clock) {
     dueDateChecker =
         new DueDateChecker(
             TIMER_RESOLUTION,
             featureFlags.enableTimerDueDateCheckerAsync(),
             new TriggerTimersSideEffect(
-                timerInstanceState, ActorClock.current(), featureFlags.yieldingDueDateChecker()));
+                timerInstanceState, clock, featureFlags.yieldingDueDateChecker()),
+            clock);
   }
 
   public void scheduleTimer(final long dueDate) {
@@ -69,23 +72,23 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   protected static final class TriggerTimersSideEffect
       implements Function<TaskResultBuilder, Long> {
 
-    private final ActorClock actorClock;
+    private final InstantSource clock;
 
     private final TimerInstanceState timerInstanceState;
     private final boolean yieldControl;
 
     public TriggerTimersSideEffect(
         final TimerInstanceState timerInstanceState,
-        final ActorClock actorClock,
+        final InstantSource clock,
         final boolean yieldControl) {
       this.timerInstanceState = timerInstanceState;
-      this.actorClock = actorClock;
+      this.clock = clock;
       this.yieldControl = yieldControl;
     }
 
     @Override
     public Long apply(final TaskResultBuilder taskResultBuilder) {
-      final var now = actorClock.getTimeMillis();
+      final var now = clock.millis();
 
       final var yieldAfter = now + Math.round(TIMER_RESOLUTION * GIVE_YIELD_FACTOR);
 
@@ -93,7 +96,7 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
       if (yieldControl) {
         timerVisitor =
             new YieldingDecorator(
-                actorClock, yieldAfter, new WriteTriggerTimerCommandVisitor(taskResultBuilder));
+                clock, yieldAfter, new WriteTriggerTimerCommandVisitor(taskResultBuilder));
       } else {
         timerVisitor = new WriteTriggerTimerCommandVisitor(taskResultBuilder);
       }
@@ -132,19 +135,19 @@ public class DueDateTimerChecker implements StreamProcessorLifecycleAware {
   protected static final class YieldingDecorator implements TimerVisitor {
 
     private final TimerVisitor delegate;
-    private final ActorClock actorClock;
+    private final InstantSource clock;
     private final long giveYieldAfter;
 
     public YieldingDecorator(
-        final ActorClock actorClock, final long giveYieldAfter, final TimerVisitor delegate) {
+        final InstantSource clock, final long giveYieldAfter, final TimerVisitor delegate) {
       this.delegate = delegate;
-      this.actorClock = actorClock;
+      this.clock = clock;
       this.giveYieldAfter = giveYieldAfter;
     }
 
     @Override
     public boolean visit(final TimerInstance timer) {
-      if (actorClock.getTimeMillis() >= giveYieldAfter) {
+      if (clock.millis() >= giveYieldAfter) {
         return false;
       }
       return delegate.visit(timer);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -63,6 +63,7 @@ import io.camunda.zeebe.engine.state.variable.DbVariableState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.InstantSource;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
@@ -103,13 +104,14 @@ public class ProcessingDbState implements MutableProcessingState {
       final KeyGenerator keyGenerator,
       final TransientPendingSubscriptionState transientMessageSubscriptionState,
       final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final InstantSource clock) {
     this.partitionId = partitionId;
     this.zeebeDb = zeebeDb;
     this.keyGenerator = Objects.requireNonNull(keyGenerator);
 
     variableState = new DbVariableState(zeebeDb, transactionContext);
-    processState = new DbProcessState(zeebeDb, transactionContext, config);
+    processState = new DbProcessState(zeebeDb, transactionContext, config, clock);
     timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
     elementInstanceState = new DbElementInstanceState(zeebeDb, transactionContext, variableState);
     eventScopeInstanceState = new DbEventScopeInstanceState(zeebeDb, transactionContext);
@@ -119,12 +121,12 @@ public class ProcessingDbState implements MutableProcessingState {
     messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
     messageSubscriptionState =
         new DbMessageSubscriptionState(
-            zeebeDb, transactionContext, transientMessageSubscriptionState);
+            zeebeDb, transactionContext, transientMessageSubscriptionState, clock);
     messageStartEventSubscriptionState =
         new DbMessageStartEventSubscriptionState(zeebeDb, transactionContext);
     processMessageSubscriptionState =
         new DbProcessMessageSubscriptionState(
-            zeebeDb, transactionContext, transientProcessMessageSubscriptionState);
+            zeebeDb, transactionContext, transientProcessMessageSubscriptionState, clock);
     messageCorrelationState = new DbMessageCorrelationState(zeebeDb, transactionContext);
     incidentState = new DbIncidentState(zeebeDb, transactionContext, partitionId);
     bannedInstanceState = new DbBannedInstanceState(zeebeDb, transactionContext, partitionId);

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ScheduledTaskDbState.java
@@ -28,6 +28,7 @@ import io.camunda.zeebe.engine.state.message.DbMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import java.time.InstantSource;
 
 /** Contains read-only state that can be accessed safely by scheduled tasks. */
 public final class ScheduledTaskDbState implements ScheduledTaskState {
@@ -46,7 +47,8 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
       final TransactionContext transactionContext,
       final int partitionId,
       final TransientPendingSubscriptionState transientMessageSubscriptionState,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final InstantSource clock) {
     distributionState = new DbDistributionState(zeebeDb, transactionContext);
     messageState = new DbMessageState(zeebeDb, transactionContext, partitionId);
     timerInstanceState = new DbTimerInstanceState(zeebeDb, transactionContext);
@@ -54,10 +56,10 @@ public final class ScheduledTaskDbState implements ScheduledTaskState {
     deploymentState = new DbDeploymentState(zeebeDb, transactionContext);
     pendingMessageSubscriptionState =
         new DbMessageSubscriptionState(
-            zeebeDb, transactionContext, transientMessageSubscriptionState);
+            zeebeDb, transactionContext, transientMessageSubscriptionState, clock);
     pendingProcessMessageSubscriptionState =
         new DbProcessMessageSubscriptionState(
-            zeebeDb, transactionContext, transientProcessMessageSubscriptionState);
+            zeebeDb, transactionContext, transientProcessMessageSubscriptionState, clock);
     userTaskState = new DbUserTaskState(zeebeDb, transactionContext);
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/deployment/DbProcessState.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessMetadata;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
@@ -48,7 +49,7 @@ public final class DbProcessState implements MutableProcessState {
 
   private static final int DEFAULT_VERSION_VALUE = 0;
 
-  private final BpmnTransformer transformer = BpmnFactory.createTransformer();
+  private final BpmnTransformer transformer;
   private final ProcessRecord processRecordForDeployments = new ProcessRecord();
   private final Cache<TenantIdAndProcessIdAndVersion, DeployedProcess>
       processesByTenantAndProcessIdAndVersionCache;
@@ -98,7 +99,9 @@ public final class DbProcessState implements MutableProcessState {
   public DbProcessState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final EngineConfiguration config) {
+      final EngineConfiguration config,
+      final InstantSource clock) {
+    transformer = BpmnFactory.createTransformer(clock);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     tenantIdKey = new DbString();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbMessageSubscriptionState.java
@@ -22,10 +22,10 @@ import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.P
 import io.camunda.zeebe.engine.state.mutable.MutableMessageSubscriptionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
 
@@ -55,11 +55,14 @@ public final class DbMessageSubscriptionState
       messageNameAndCorrelationKeyColumnFamily;
 
   private final TransientPendingSubscriptionState transientState;
+  private final InstantSource clock;
 
   public DbMessageSubscriptionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final TransientPendingSubscriptionState transientState) {
+      final TransientPendingSubscriptionState transientState,
+      final InstantSource clock) {
+    this.clock = clock;
 
     elementInstanceKey = new DbLong();
     messageName = new DbString();
@@ -96,7 +99,7 @@ public final class DbMessageSubscriptionState
             transientState.add(
                 new PendingSubscription(
                     elementInstanceKey.getValue(), messageName.toString(), tenantIdKey.toString()),
-                ActorClock.currentTimeMillis());
+                clock.millis());
           }
         });
   }
@@ -176,7 +179,7 @@ public final class DbMessageSubscriptionState
             subscription.getRecord().getElementInstanceKey(),
             subscription.getRecord().getMessageName(),
             subscription.getRecord().getTenantId()),
-        ActorClock.currentTimeMillis());
+        clock.millis());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/message/DbProcessMessageSubscriptionState.java
@@ -21,10 +21,10 @@ import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState.P
 import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionState;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscriptionRecord;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.function.Consumer;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
@@ -48,11 +48,14 @@ public final class DbProcessMessageSubscriptionState
       subscriptionColumnFamily;
 
   private final TransientPendingSubscriptionState transientState;
+  private final InstantSource clock;
 
   public DbProcessMessageSubscriptionState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb,
       final TransactionContext transactionContext,
-      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState) {
+      final TransientPendingSubscriptionState transientProcessMessageSubscriptionState,
+      final InstantSource clock) {
+    this.clock = clock;
     elementInstanceKey = new DbLong();
     tenantIdKey = new DbString();
     messageName = new DbString();
@@ -78,7 +81,7 @@ public final class DbProcessMessageSubscriptionState
             transientState.add(
                 new PendingSubscription(
                     record.getElementInstanceKey(), record.getMessageName(), record.getTenantId()),
-                ActorClock.currentTimeMillis());
+                clock.millis());
           }
         });
   }
@@ -96,7 +99,7 @@ public final class DbProcessMessageSubscriptionState
     transientState.add(
         new PendingSubscription(
             record.getElementInstanceKey(), record.getMessageName(), record.getTenantId()),
-        ActorClock.currentTimeMillis());
+        clock.millis());
   }
 
   @Override
@@ -105,7 +108,7 @@ public final class DbProcessMessageSubscriptionState
     transientState.update(
         new PendingSubscription(
             record.getElementInstanceKey(), record.getMessageName(), record.getTenantId()),
-        ActorClock.currentTimeMillis());
+        clock.millis());
   }
 
   @Override
@@ -122,7 +125,7 @@ public final class DbProcessMessageSubscriptionState
     transientState.update(
         new PendingSubscription(
             record.getElementInstanceKey(), record.getMessageName(), record.getTenantId()),
-        ActorClock.currentTimeMillis());
+        clock.millis());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/query/StateQueryService.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.impl.record.value.job.JobRecord;
 import io.camunda.zeebe.protocol.impl.record.value.processinstance.ProcessInstanceRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import java.time.InstantSource;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 
@@ -28,9 +29,11 @@ public final class StateQueryService implements QueryService {
   private volatile boolean isClosed;
   private ProcessingState state;
   private final ZeebeDb<ZbColumnFamilies> zeebeDb;
+  private final InstantSource clock;
 
-  public StateQueryService(final ZeebeDb<ZbColumnFamilies> zeebeDb) {
+  public StateQueryService(final ZeebeDb<ZbColumnFamilies> zeebeDb, final InstantSource clock) {
     this.zeebeDb = zeebeDb;
+    this.clock = clock;
   }
 
   @Override
@@ -83,7 +86,8 @@ public final class StateQueryService implements QueryService {
               },
               new TransientPendingSubscriptionState(),
               new TransientPendingSubscriptionState(),
-              new EngineConfiguration());
+              new EngineConfiguration(),
+              clock);
     }
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/ArchitectureTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/ArchitectureTest.java
@@ -33,5 +33,5 @@ public class ArchitectureTest {
           .resideInAPackage("io.camunda.zeebe.engine..")
           .should()
           .dependOnClassesThat()
-          .resideInAPackage("io.camunda.zeebe.scheduler");
+          .resideInAPackage("io.camunda.zeebe.scheduler..");
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/UserTaskTransformerTest.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.engine.processing.deployment.model.transformation.BpmnTr
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.builder.UserTaskBuilder;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -36,7 +36,7 @@ class UserTaskTransformerTest {
 
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
-          new ZeebeFeelEngineClock(ActorClock.current()));
+          new ZeebeFeelEngineClock(InstantSource.system()));
   private final BpmnTransformer transformer = new BpmnTransformer(expressionLanguage);
 
   private BpmnModelInstance processWithUserTask(final Consumer<UserTaskBuilder> userTaskModifier) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessorTest.java
@@ -14,8 +14,8 @@ import io.camunda.zeebe.el.ExpressionLanguage;
 import io.camunda.zeebe.el.ExpressionLanguageFactory;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.common.ExpressionProcessor.EvaluationContextLookup;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.util.Either;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Nested;
@@ -30,7 +30,7 @@ class ExpressionProcessorTest {
 
   private static final ExpressionLanguage EXPRESSION_LANGUAGE =
       ExpressionLanguageFactory.createExpressionLanguage(
-          new ZeebeFeelEngineClock(ActorClock.current()));
+          new ZeebeFeelEngineClock(InstantSource.system()));
   private static final EvaluationContext EMPTY_LOOKUP = x -> null;
   private static final EvaluationContextLookup DEFAULT_CONTEXT_LOOKUP = scope -> EMPTY_LOOKUP;
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessMessageStartEventMessageNameValidatorTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -46,7 +46,7 @@ public class ProcessMessageStartEventMessageNameValidatorTest {
 
     final var sutValidator =
         new ProcessMessageStartEventMessageNameValidator(
-            new FeelExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())));
+            new FeelExpressionLanguage(new ZeebeFeelEngineClock(InstantSource.system())));
 
     // when
     assertThatNoException()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessSignalStartEventSignalNameValidatorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessSignalStartEventSignalNameValidatorTest.java
@@ -22,7 +22,7 @@ import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.instance.StartEvent;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -46,7 +46,7 @@ public class ProcessSignalStartEventSignalNameValidatorTest {
 
     final var sutValidator =
         new ProcessSignalStartEventSignalNameValidator(
-            new FeelExpressionLanguage(new ZeebeFeelEngineClock(ActorClock.current())));
+            new FeelExpressionLanguage(new ZeebeFeelEngineClock(InstantSource.system())));
 
     // when
     assertThatNoException()

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ProcessValidationUtil.java
@@ -19,7 +19,7 @@ import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
 import io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebeDesignTimeValidators;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 import java.util.Collection;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -72,7 +72,7 @@ public class ProcessValidationUtil {
     final ModelWalker walker = new ModelWalker(model);
     final ExpressionLanguage expressionLanguage =
         ExpressionLanguageFactory.createExpressionLanguage(
-            new ZeebeFeelEngineClock(ActorClock.current()));
+            new ZeebeFeelEngineClock(InstantSource.system()));
     final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
     final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
     final ValidationVisitor visitor =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -33,8 +33,8 @@ import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeTaskSchedule;
 import io.camunda.zeebe.model.bpmn.traversal.ModelWalker;
 import io.camunda.zeebe.model.bpmn.validation.ValidationVisitor;
 import io.camunda.zeebe.protocol.Protocol;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import java.io.InputStream;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -504,7 +504,7 @@ public final class ZeebeRuntimeValidationTest {
     final ModelWalker walker = new ModelWalker(model);
     final ExpressionLanguage expressionLanguage =
         ExpressionLanguageFactory.createExpressionLanguage(
-            new ZeebeFeelEngineClock(ActorClock.current()));
+            new ZeebeFeelEngineClock(InstantSource.system()));
     final EvaluationContextLookup emptyLookup = scopeKey -> name -> null;
     final var expressionProcessor = new ExpressionProcessor(expressionLanguage, emptyLookup);
     final ValidationVisitor visitor =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/job/JobTimeoutCheckerTest.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import java.time.Duration;
+import java.time.InstantSource;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -87,7 +88,8 @@ public class JobTimeoutCheckerTest {
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = Integer.MAX_VALUE;
 
-    final var task = new JobTimeoutChecker(jobState, pollingInterval, batchLimit);
+    final var task =
+        new JobTimeoutChecker(jobState, pollingInterval, batchLimit, InstantSource.system());
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 
@@ -117,7 +119,8 @@ public class JobTimeoutCheckerTest {
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = 3;
 
-    final var task = new JobTimeoutChecker(jobState, pollingInterval, batchLimit);
+    final var task =
+        new JobTimeoutChecker(jobState, pollingInterval, batchLimit, InstantSource.system());
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 
@@ -160,7 +163,8 @@ public class JobTimeoutCheckerTest {
     final Duration pollingInterval = EngineConfiguration.DEFAULT_JOBS_TIMEOUT_POLLING_INTERVAL;
     final int batchLimit = Integer.MAX_VALUE;
 
-    final var task = new JobTimeoutChecker(jobState, pollingInterval, batchLimit);
+    final var task =
+        new JobTimeoutChecker(jobState, pollingInterval, batchLimit, InstantSource.system());
     task.setProcessingContext(mockContext);
     task.setShouldReschedule(true);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/message/MessageStreamProcessorTest.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ProcessingResultBuilder;
 import io.camunda.zeebe.util.FeatureFlags;
 import java.time.Duration;
+import java.time.InstantSource;
 import org.agrona.DirectBuffer;
 import org.awaitility.Awaitility;
 import org.junit.Before;
@@ -81,7 +82,8 @@ public final class MessageStreamProcessorTest {
               processingContext.getWriters(),
               DEFAULT_ENGINE_CONFIGURATION,
               FeatureFlags.createDefault(),
-              spyCommandDistributionBehavior);
+              spyCommandDistributionBehavior,
+              InstantSource.system());
           return typedRecordProcessors;
         });
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/scheduled/DueDateCheckerTest.java
@@ -14,12 +14,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService.ScheduledTask;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
+import java.time.InstantSource;
 import java.util.function.Function;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -30,7 +30,8 @@ public class DueDateCheckerTest {
   public void shouldNotScheduleTwoTasks() {
     // given
     final var timerResolution = 100;
-    final var dueDateChecker = new DueDateChecker(timerResolution, false, (builder) -> 0L);
+    final var dueDateChecker =
+        new DueDateChecker(timerResolution, false, (builder) -> 0L, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     when(mockContext.getScheduleService()).thenReturn(mockScheduleService);
@@ -52,7 +53,8 @@ public class DueDateCheckerTest {
   public void shouldScheduleForAnEarlierTasks() {
     // given
     final var timerResolution = 100;
-    final var dueDateChecker = new DueDateChecker(timerResolution, false, (builder) -> 0L);
+    final var dueDateChecker =
+        new DueDateChecker(timerResolution, false, (builder) -> 0L, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -78,10 +80,11 @@ public class DueDateCheckerTest {
   public void shouldRescheduleAutomatically() {
     // given
     final Function<TaskResultBuilder, Long> visitor =
-        (builder) -> ActorClock.currentTimeMillis() + 1000L;
+        (builder) -> InstantSource.system().millis() + 1000L;
 
     final var timerResolution = 100;
-    final var dueDateChecker = new DueDateChecker(timerResolution, false, visitor);
+    final var dueDateChecker =
+        new DueDateChecker(timerResolution, false, visitor, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -103,10 +106,11 @@ public class DueDateCheckerTest {
   public void shouldScheduleEarlierIfRescheduledAutomatically() {
     // given
     final Function<TaskResultBuilder, Long> visitor =
-        (builder) -> ActorClock.currentTimeMillis() + 1000L;
+        (builder) -> InstantSource.system().millis() + 1000L;
 
     final var timerResolution = 100;
-    final var dueDateChecker = new DueDateChecker(timerResolution, false, visitor);
+    final var dueDateChecker =
+        new DueDateChecker(timerResolution, false, visitor, InstantSource.system());
     final var mockContext = mock(ReadonlyStreamProcessorContext.class);
     final var mockScheduleService = mock(ProcessingScheduleService.class);
     final var mockScheduledTask = mock(ScheduledTask.class);
@@ -123,7 +127,7 @@ public class DueDateCheckerTest {
     Mockito.clearInvocations(mockScheduleService);
 
     // when
-    dueDateChecker.schedule(ActorClock.currentTimeMillis() + 100); // in one second
+    dueDateChecker.schedule(InstantSource.system().millis() + 100); // in one second
 
     // then
     verify(mockScheduleService).runAt(anyLong(), any(Task.class));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/timer/DueDateTimerCheckerTest.java
@@ -24,9 +24,9 @@ import io.camunda.zeebe.engine.state.immutable.TimerInstanceState.TimerVisitor;
 import io.camunda.zeebe.engine.state.instance.TimerInstance;
 import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
-import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -178,7 +178,7 @@ class DueDateTimerCheckerTest {
     }
   }
 
-  private final class TestActorClock implements ActorClock {
+  private final class TestActorClock implements InstantSource {
 
     private long time = 0;
 
@@ -186,25 +186,19 @@ class DueDateTimerCheckerTest {
       this.time = time;
     }
 
-    @Override
     public boolean update() {
       time = time + 10;
       return true;
     }
 
     @Override
-    public long getTimeMillis() {
+    public Instant instant() {
+      return Instant.ofEpochMilli(time);
+    }
+
+    @Override
+    public long millis() {
       return time;
-    }
-
-    @Override
-    public long getNanosSinceLastMillisecond() {
-      return 0;
-    }
-
-    @Override
-    public long getNanoTime() {
-      return Duration.ofMillis(getTimeMillis()).toNanos();
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableInputMappingTransformerTest.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -42,7 +42,7 @@ public final class VariableInputMappingTransformerTest {
   private final VariableMappingTransformer transformer = new VariableMappingTransformer();
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
-          new ZeebeFeelEngineClock(ActorClock.current()));
+          new ZeebeFeelEngineClock(InstantSource.system()));
 
   @Parameters(name = "with {0} to {2}")
   public static Object[][] parameters() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableMappingTransformerTest.java
@@ -17,7 +17,7 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
+import java.time.InstantSource;
 import java.util.List;
 import org.junit.Test;
 
@@ -26,7 +26,7 @@ public final class VariableMappingTransformerTest {
   private final VariableMappingTransformer transformer = new VariableMappingTransformer();
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
-          new ZeebeFeelEngineClock(ActorClock.current()));
+          new ZeebeFeelEngineClock(InstantSource.system()));
 
   @Test
   public void shouldCreateValidExpression() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/variable/mapping/VariableOutputMappingTransformerTest.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.el.ResultType;
 import io.camunda.zeebe.engine.processing.bpmn.clock.ZeebeFeelEngineClock;
 import io.camunda.zeebe.engine.processing.deployment.model.transformer.VariableMappingTransformer;
 import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeMapping;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.Map;
 import org.agrona.DirectBuffer;
@@ -30,7 +30,7 @@ public final class VariableOutputMappingTransformerTest {
   private final VariableMappingTransformer transformer = new VariableMappingTransformer();
   private final ExpressionLanguage expressionLanguage =
       ExpressionLanguageFactory.createExpressionLanguage(
-          new ZeebeFeelEngineClock(ActorClock.current()));
+          new ZeebeFeelEngineClock(InstantSource.system()));
 
   public static Object[][] parametersSuccessfulEvaluationToObject() {
     return new Object[][] {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/UserTaskStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/instance/UserTaskStateTest.java
@@ -18,9 +18,9 @@ import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.msgpack.value.DocumentValue;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.BufferAssert;
 import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.time.InstantSource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
@@ -170,7 +170,7 @@ public class UserTaskStateTest {
         .setFollowUpDate("2023-11-12T11:11:00+01:00")
         .setFormKey(5678)
         .setUserTaskKey(userTaskKey)
-        .setCreationTimestamp(ActorClock.currentTimeMillis());
+        .setCreationTimestamp(InstantSource.system().millis());
   }
 
   private void assertUserTask(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/message/MessageStateTest.java
@@ -16,8 +16,8 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.engine.util.ProcessingStateRule;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageRecord;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
-import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.test.util.MsgPackUtil;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.mutable.MutableObject;
@@ -305,7 +305,7 @@ public final class MessageStateTest {
   @Test
   public void shouldVisitMessagesBeforeTimeInOrder() {
     // given
-    final long now = ActorClock.currentTimeMillis();
+    final long now = InstantSource.system().millis();
 
     final var message = createMessage("name", "correlationKey", "{}", "nr1", 1234);
     final var message2 = createMessage("name", "correlationKey", "{}", "nr1", 2000);
@@ -483,7 +483,7 @@ public final class MessageStateTest {
     messageState.remove(2L);
 
     // then
-    final long deadline = ActorClock.currentTimeMillis() + 2_000L;
+    final long deadline = InstantSource.system().millis() + 2_000L;
     final List<Long> readMessages = new ArrayList<>();
     messageState.visitMessagesWithDeadlineBeforeTimestamp(
         deadline, null, (d, e) -> readMessages.add(e));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigrationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/MultiTenancyMigrationTest.java
@@ -60,6 +60,7 @@ import io.camunda.zeebe.protocol.impl.record.value.message.ProcessMessageSubscri
 import io.camunda.zeebe.protocol.record.Assertions;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -87,8 +88,10 @@ public class MultiTenancyMigrationTest {
 
     @BeforeEach
     void setup() {
-      legacyState = new LegacyProcessState(zeebeDb, transactionContext);
-      processState = new DbProcessState(zeebeDb, transactionContext, new EngineConfiguration());
+      legacyState = new LegacyProcessState(zeebeDb, transactionContext, InstantSource.system());
+      processState =
+          new DbProcessState(
+              zeebeDb, transactionContext, new EngineConfiguration(), InstantSource.system());
     }
 
     @Test
@@ -711,7 +714,8 @@ public class MultiTenancyMigrationTest {
     @BeforeEach
     void setup() {
       legacyState = new LegacyMessageSubscriptionState(zeebeDb, transactionContext);
-      state = new DbMessageSubscriptionState(zeebeDb, transactionContext, null);
+      state =
+          new DbMessageSubscriptionState(zeebeDb, transactionContext, null, InstantSource.system());
     }
 
     @Test
@@ -787,7 +791,9 @@ public class MultiTenancyMigrationTest {
     @BeforeEach
     void setup() {
       legacyState = new LegacyProcessMessageSubscriptionState(zeebeDb, transactionContext);
-      state = new DbProcessMessageSubscriptionState(zeebeDb, transactionContext, null);
+      state =
+          new DbProcessMessageSubscriptionState(
+              zeebeDb, transactionContext, null, InstantSource.system());
     }
 
     @Test

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/migration/to_8_3/legacy/LegacyProcessState.java
@@ -33,6 +33,7 @@ import io.camunda.zeebe.protocol.impl.record.value.deployment.ProcessRecord;
 import io.camunda.zeebe.protocol.record.value.deployment.DeploymentResource;
 import io.camunda.zeebe.stream.impl.state.NextValue;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,7 +54,7 @@ import org.agrona.io.DirectBufferInputStream;
 public final class LegacyProcessState {
   private static final int DEFAULT_VERSION_VALUE = 0;
 
-  private final BpmnTransformer transformer = BpmnFactory.createTransformer();
+  private final BpmnTransformer transformer;
   private final ProcessRecord processRecordForDeployments = new ProcessRecord();
 
   private final Map<DirectBuffer, Long2ObjectHashMap<DeployedProcess>>
@@ -79,7 +80,10 @@ public final class LegacyProcessState {
   private final LegacyProcessVersionManager versionManager;
 
   public LegacyProcessState(
-      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+      final ZeebeDb<ZbColumnFamilies> zeebeDb,
+      final TransactionContext transactionContext,
+      final InstantSource clock) {
+    transformer = BpmnFactory.createTransformer(clock);
     processDefinitionKey = new DbLong();
     persistedProcess = new PersistedProcess();
     processColumnFamily =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/query/StateQueryServiceTest.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
@@ -40,7 +41,7 @@ final class StateQueryServiceTest {
 
   @BeforeEach
   void setup() {
-    sut = new StateQueryService(db);
+    sut = new StateQueryService(db, InstantSource.system());
   }
 
   @ParameterizedTest(name = "[{index}] should throw ClosedServiceException when closed")

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateExtension.java
@@ -28,6 +28,7 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.time.InstantSource;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.junit.jupiter.api.extension.BeforeEachCallback;
@@ -166,7 +167,8 @@ public class ProcessingStateExtension implements BeforeEachCallback {
                 keyGenerator,
                 new TransientPendingSubscriptionState(),
                 new TransientPendingSubscriptionState(),
-                new EngineConfiguration());
+                new EngineConfiguration(),
+                InstantSource.system());
       } catch (final Exception e) {
         ExceptionUtils.throwAsUncheckedException(e);
       }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/ProcessingStateRule.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.Protocol;
 import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
+import java.time.InstantSource;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TemporaryFolder;
 
@@ -49,7 +50,8 @@ public final class ProcessingStateRule extends ExternalResource {
             keyGenerator,
             new TransientPendingSubscriptionState(),
             new TransientPendingSubscriptionState(),
-            new EngineConfiguration());
+            new EngineConfiguration(),
+            InstantSource.system());
   }
 
   @Override

--- a/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ActorClock.java
+++ b/zeebe/scheduler/src/main/java/io/camunda/zeebe/scheduler/clock/ActorClock.java
@@ -8,8 +8,10 @@
 package io.camunda.zeebe.scheduler.clock;
 
 import io.camunda.zeebe.scheduler.ActorThread;
+import java.time.Instant;
+import java.time.InstantSource;
 
-public interface ActorClock {
+public interface ActorClock extends InstantSource {
   boolean update();
 
   long getTimeMillis();
@@ -26,5 +28,15 @@ public interface ActorClock {
   static long currentTimeMillis() {
     final ActorClock clock = current();
     return clock != null ? clock.getTimeMillis() : System.currentTimeMillis();
+  }
+
+  @Override
+  default Instant instant() {
+    return Instant.ofEpochMilli(getTimeMillis());
+  }
+
+  @Override
+  default long millis() {
+    return getTimeMillis();
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.stream.api;
 
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
-import java.time.InstantSource;
 
 public interface ReadonlyStreamProcessorContext {
 
@@ -26,5 +25,5 @@ public interface ReadonlyStreamProcessorContext {
    */
   boolean enableAsyncScheduledTasks();
 
-  InstantSource getClock();
+  StreamClock getClock();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/ReadonlyStreamProcessorContext.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.api;
 
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
+import java.time.InstantSource;
 
 public interface ReadonlyStreamProcessorContext {
 
@@ -24,4 +25,6 @@ public interface ReadonlyStreamProcessorContext {
    * @return true when scheduled tasks should run async, concurrently to the processing actor.
    */
   boolean enableAsyncScheduledTasks();
+
+  InstantSource getClock();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.InstantSource;
 import java.util.List;
 
 public interface RecordProcessorContext {
@@ -30,4 +31,6 @@ public interface RecordProcessorContext {
   InterPartitionCommandSender getPartitionCommandSender();
 
   KeyGenerator getKeyGenerator();
+
+  InstantSource getClock();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
@@ -11,7 +11,6 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
-import java.time.InstantSource;
 import java.util.List;
 
 public interface RecordProcessorContext {
@@ -32,5 +31,5 @@ public interface RecordProcessorContext {
 
   KeyGenerator getKeyGenerator();
 
-  InstantSource getClock();
+  StreamClock getClock();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/RecordProcessorContext.java
@@ -9,6 +9,7 @@ package io.camunda.zeebe.stream.api;
 
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import java.util.List;
@@ -31,5 +32,5 @@ public interface RecordProcessorContext {
 
   KeyGenerator getKeyGenerator();
 
-  StreamClock getClock();
+  ControllableStreamClock getClock();
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
@@ -71,6 +71,18 @@ public interface StreamClock extends InstantSource {
     }
 
     /**
+     * If the clock is already offset, stacks the additional offset on top of the current offset.
+     * Otherwise, offsets the clock by the given duration, overwriting any previous modification.
+     */
+    default void stackOffset(final Duration additionalOffset) {
+      if (currentModification() instanceof Modification.Offset(final var initialOffset)) {
+        applyModification(Modification.offsetBy(initialOffset.plus(additionalOffset)));
+      } else {
+        offsetBy(additionalOffset);
+      }
+    }
+
+    /**
      * Shortcut to reset the clock to the current system time.
      *
      * @implSpec Equivalent to {@code applyModification(Modification.none())}.

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.api;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
+
+/**
+ * A clock that provides the current time. Used as a marker interface instead of using {@link
+ * InstantSource} directly to indicate that the clock is used for stream processing.
+ */
+public interface StreamClock extends InstantSource {
+
+  /**
+   * A controllable {@link StreamClock} that allows to pin the time to a specific instant or to
+   * offset the current system time by some duration.
+   */
+  interface ControllableStreamClock extends StreamClock {
+
+    /**
+     * Modifies the clock by applying the given modification. Previous modifications are overridden
+     * and do not stack up.
+     *
+     * @param modification the modification to apply. Use {@link Modification#none()} to reset the
+     *     clock to current system time.
+     */
+    void applyModification(Modification modification);
+
+    /**
+     * Returns the current modification applied to the clock. If no modification is applied, {@link
+     * Modification.None} is returned.
+     */
+    Modification currentModification();
+
+    /**
+     * Shortcut to reset the clock to the current system time. Equivalent to {@code
+     * applyModification(Modification.none())}.
+     */
+    default void reset() {
+      applyModification(Modification.none());
+    }
+
+    /**
+     * Shortcut to check if the clock is modified. Equivalent to {@code !(currentModification()
+     * instanceof Modification.None)}
+     */
+    default boolean isModified() {
+      return !(currentModification() instanceof Modification.None);
+    }
+
+    sealed interface Modification {
+      static None none() {
+        return new None();
+      }
+
+      static Pin pinAt(final Instant at) {
+        return new Pin(at);
+      }
+
+      static Offset offsetBy(final Duration by) {
+        return new Offset(by);
+      }
+
+      record None() implements Modification {}
+
+      record Pin(Instant at) implements Modification {}
+
+      record Offset(Duration by) implements Modification {
+        public Offset {
+          if (by.isZero()) {
+            throw new IllegalArgumentException("Offset must not be zero");
+          }
+        }
+      }
+    }
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
@@ -53,8 +53,27 @@ public interface StreamClock extends InstantSource {
     Modification currentModification();
 
     /**
-     * Shortcut to reset the clock to the current system time. Equivalent to {@code
-     * applyModification(Modification.none())}.
+     * Shortcut to pin the clock to a specific instant.
+     *
+     * @implSpec Equivalent to {@code applyModification(Modification.pinAt(at))}.
+     */
+    default void pinAt(final Instant at) {
+      applyModification(Modification.pinAt(at));
+    }
+
+    /**
+     * Shortcut to offset the clock by a specific duration.
+     *
+     * @implSpec Equivalent to {@code applyModification(Modification.offsetBy(by))}.
+     */
+    default void offsetBy(final Duration by) {
+      applyModification(Modification.offsetBy(by));
+    }
+
+    /**
+     * Shortcut to reset the clock to the current system time.
+     *
+     * @implSpec Equivalent to {@code applyModification(Modification.none())}.
      */
     default void reset() {
       applyModification(Modification.none());

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import io.camunda.zeebe.stream.impl.UncontrolledStreamClock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.InstantSource;
@@ -16,6 +17,14 @@ import java.time.InstantSource;
  * InstantSource} directly to indicate that the clock is used for stream processing.
  */
 public interface StreamClock extends InstantSource {
+
+  static StreamClock uncontrolled(final InstantSource source) {
+    return new UncontrolledStreamClock(source);
+  }
+
+  static StreamClock system() {
+    return new UncontrolledStreamClock(InstantSource.system());
+  }
 
   /**
    * A controllable {@link StreamClock} that allows to pin the time to a specific instant or to

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import io.camunda.zeebe.stream.impl.ControllableStreamClockImpl;
 import io.camunda.zeebe.stream.impl.UncontrolledStreamClock;
 import java.time.Duration;
 import java.time.Instant;
@@ -24,6 +25,10 @@ public interface StreamClock extends InstantSource {
 
   static StreamClock system() {
     return new UncontrolledStreamClock(InstantSource.system());
+  }
+
+  static ControllableStreamClock controllable(final InstantSource source) {
+    return new ControllableStreamClockImpl(source);
   }
 
   /**

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
@@ -116,13 +116,7 @@ public interface StreamClock extends InstantSource {
 
       record Pin(Instant at) implements Modification {}
 
-      record Offset(Duration by) implements Modification {
-        public Offset {
-          if (by.isZero()) {
-            throw new IllegalArgumentException("Offset must not be zero");
-          }
-        }
-      }
+      record Offset(Duration by) implements Modification {}
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ControllableStreamClockImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ControllableStreamClockImpl.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.stream.api.StreamClock;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification.None;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification.Offset;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification.Pin;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.util.Objects;
+
+public final class ControllableStreamClockImpl implements StreamClock.ControllableStreamClock {
+
+  private final InstantSource source;
+  private Modification modification;
+
+  /**
+   * Internal field to optimize {@link #millis()} calls. For {@link Pin}, it stores the pinned time
+   * in millis. For {@link Offset}, it stores the offset in millis. For {@link None}, it stores 0.
+   */
+  private long millis;
+
+  public ControllableStreamClockImpl(final InstantSource source) {
+    this.source = Objects.requireNonNull(source);
+    reset();
+  }
+
+  @Override
+  public void applyModification(final Modification modification) {
+    this.modification = modification;
+    millis =
+        switch (modification) {
+          case None() -> 0;
+          case Offset(final var offset) -> offset.toMillis();
+          case Pin(final var pinnedAt) -> pinnedAt.toEpochMilli();
+        };
+  }
+
+  @Override
+  public Modification currentModification() {
+    return modification;
+  }
+
+  @Override
+  public Instant instant() {
+    return switch (modification) {
+      case None() -> source.instant();
+      case Offset(final var offset) -> source.instant().plus(offset);
+      case Pin(final var pinnedAt) -> pinnedAt;
+    };
+  }
+
+  @Override
+  public long millis() {
+    return switch (modification) {
+      case final None ignored -> source.millis();
+      case final Pin ignored -> millis;
+      case final Offset ignored -> source.millis() + millis;
+    };
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(source, modification);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof final ControllableStreamClockImpl that)) {
+      return false;
+    }
+    return Objects.equals(source, that.source) && Objects.equals(modification, that.modification);
+  }
+
+  @Override
+  public String toString() {
+    return "ControllableStreamClock{" + "source=" + source + ", modification=" + modification + '}';
+  }
+}

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -11,7 +11,7 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
-import io.camunda.zeebe.stream.api.StreamClock;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
@@ -29,7 +29,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private final InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
-  private final StreamClock clock;
+  private final ControllableStreamClock clock;
 
   public RecordProcessorContextImpl(
       final int partitionId,
@@ -38,7 +38,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final TransactionContext transactionContext,
       final InterPartitionCommandSender partitionCommandSender,
       final KeyGeneratorControls keyGeneratorControls,
-      final StreamClock clock) {
+      final ControllableStreamClock clock) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.zeebeDb = zeebeDb;
@@ -89,7 +89,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   }
 
   @Override
-  public StreamClock getClock() {
+  public ControllableStreamClock getClock() {
     return clock;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -11,11 +11,11 @@ import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
-import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -29,7 +29,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private final InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
-  private final InstantSource clock;
+  private final StreamClock clock;
 
   public RecordProcessorContextImpl(
       final int partitionId,
@@ -38,7 +38,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final TransactionContext transactionContext,
       final InterPartitionCommandSender partitionCommandSender,
       final KeyGeneratorControls keyGeneratorControls,
-      final InstantSource clock) {
+      final StreamClock clock) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.zeebeDb = zeebeDb;
@@ -89,7 +89,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   }
 
   @Override
-  public InstantSource getClock() {
+  public StreamClock getClock() {
     return clock;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/RecordProcessorContextImpl.java
@@ -15,8 +15,10 @@ import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public final class RecordProcessorContextImpl implements RecordProcessorContext {
 
@@ -27,6 +29,7 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   private final List<StreamProcessorLifecycleAware> lifecycleListeners = new ArrayList<>();
   private final InterPartitionCommandSender partitionCommandSender;
   private final KeyGenerator keyGenerator;
+  private final InstantSource clock;
 
   public RecordProcessorContextImpl(
       final int partitionId,
@@ -34,13 +37,15 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
       final ZeebeDb zeebeDb,
       final TransactionContext transactionContext,
       final InterPartitionCommandSender partitionCommandSender,
-      final KeyGeneratorControls keyGeneratorControls) {
+      final KeyGeneratorControls keyGeneratorControls,
+      final InstantSource clock) {
     this.partitionId = partitionId;
     this.scheduleService = scheduleService;
     this.zeebeDb = zeebeDb;
     this.transactionContext = transactionContext;
     this.partitionCommandSender = partitionCommandSender;
     keyGenerator = keyGeneratorControls;
+    this.clock = Objects.requireNonNull(clock);
   }
 
   @Override
@@ -81,5 +86,10 @@ public final class RecordProcessorContextImpl implements RecordProcessorContext 
   @Override
   public KeyGenerator getKeyGenerator() {
     return keyGenerator;
+  }
+
+  @Override
+  public InstantSource getClock() {
+    return clock;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -153,7 +153,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     final var reader = logStream.newLogStreamReader();
     logStreamReader = reader;
     streamProcessorContext.logStreamReader(reader);
-    streamProcessorContext.clock(StreamClock.uncontrolled(ActorClock.current()));
+    streamProcessorContext.clock(StreamClock.controllable(ActorClock.current()));
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -152,6 +152,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     final var reader = logStream.newLogStreamReader();
     logStreamReader = reader;
     streamProcessorContext.logStreamReader(reader);
+    streamProcessorContext.clock(ActorClock.current());
   }
 
   @Override
@@ -341,7 +342,8 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
             zeebeDb,
             streamProcessorContext.getTransactionContext(),
             streamProcessorContext.getPartitionCommandSender(),
-            streamProcessorContext.getKeyGeneratorControls());
+            streamProcessorContext.getKeyGeneratorControls(),
+            streamProcessorContext.getClock());
 
     recordProcessors.forEach(processor -> processor.init(processorContext));
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.api.RecordProcessor;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
@@ -152,7 +153,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     final var reader = logStream.newLogStreamReader();
     logStreamReader = reader;
     streamProcessorContext.logStreamReader(reader);
-    streamProcessorContext.clock(ActorClock.current());
+    streamProcessorContext.clock(StreamClock.uncontrolled(ActorClock.current()));
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -21,6 +21,8 @@ import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
+import java.time.InstantSource;
+import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
 public final class StreamProcessorContext implements ReadonlyStreamProcessorContext {
@@ -50,6 +52,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
   private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
+  private InstantSource clock;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -74,6 +77,16 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   @Override
   public boolean enableAsyncScheduledTasks() {
     return enableAsyncScheduledTasks;
+  }
+
+  @Override
+  public InstantSource getClock() {
+    return clock;
+  }
+
+  public StreamProcessorContext clock(final InstantSource clock) {
+    this.clock = Objects.requireNonNull(clock);
+    return this;
   }
 
   public LogStream getLogStream() {

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -16,7 +16,7 @@ import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
-import io.camunda.zeebe.stream.api.StreamClock;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
@@ -52,7 +52,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
   private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
-  private StreamClock clock;
+  private ControllableStreamClock clock;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -80,11 +80,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   }
 
   @Override
-  public StreamClock getClock() {
+  public ControllableStreamClock getClock() {
     return clock;
   }
 
-  public StreamProcessorContext clock(final StreamClock clock) {
+  public StreamProcessorContext clock(final ControllableStreamClock clock) {
     this.clock = Objects.requireNonNull(clock);
     return this;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -16,12 +16,12 @@ import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
 import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
-import java.time.InstantSource;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
@@ -52,7 +52,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private int maxCommandsInBatch = DEFAULT_MAX_COMMANDS_IN_BATCH;
   private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
-  private InstantSource clock;
+  private StreamClock clock;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -80,11 +80,11 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   }
 
   @Override
-  public InstantSource getClock() {
+  public StreamClock getClock() {
     return clock;
   }
 
-  public StreamProcessorContext clock(final InstantSource clock) {
+  public StreamProcessorContext clock(final StreamClock clock) {
     this.clock = Objects.requireNonNull(clock);
     return this;
   }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncontrolledStreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncontrolledStreamClock.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import io.camunda.zeebe.stream.api.StreamClock;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.InstantSource;
+import java.time.ZoneId;
+import java.util.Objects;
+
+public final class UncontrolledStreamClock implements StreamClock {
+  private final InstantSource source;
+
+  public UncontrolledStreamClock(final InstantSource source) {
+    this.source = Objects.requireNonNull(source);
+  }
+
+  @Override
+  public Instant instant() {
+    return source.instant();
+  }
+
+  @Override
+  public long millis() {
+    return source.millis();
+  }
+
+  @Override
+  public Clock withZone(final ZoneId zone) {
+    return source.withZone(zone);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(source);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof final UncontrolledStreamClock that)) {
+      return false;
+    }
+    return Objects.equals(source, that.source);
+  }
+
+  @Override
+  public String toString() {
+    return "UncontrolledStreamClock{" + "source=" + source + '}';
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ControllableStreamClockTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ControllableStreamClockTest.java
@@ -150,4 +150,23 @@ final class ControllableStreamClockTest {
     assertThat(clock.instant()).isEqualTo(sourceTime);
     assertThat(clock.millis()).isEqualTo(sourceTime.toEpochMilli());
   }
+
+  @Test
+  void shouldStackOffset() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controllable(source);
+
+    // when
+    final var firstOffset = Duration.ofSeconds(5);
+    final var secondOffset = Duration.ofSeconds(10);
+    clock.offsetBy(firstOffset);
+    clock.stackOffset(secondOffset);
+
+    // then
+    assertThat(clock.instant()).isEqualTo(sourceTime.plus(firstOffset).plus(secondOffset));
+    assertThat(clock.millis())
+        .isEqualTo(sourceTime.toEpochMilli() + firstOffset.toMillis() + secondOffset.toMillis());
+  }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ControllableStreamClockTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ControllableStreamClockTest.java
@@ -8,7 +8,6 @@
 package io.camunda.zeebe.stream.impl;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
@@ -26,7 +25,7 @@ final class ControllableStreamClockTest {
     // given
     final var now = Instant.now();
     final var source = InstantSource.fixed(now);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
 
     // then
     assertThat(clock.isModified()).isFalse();
@@ -38,7 +37,7 @@ final class ControllableStreamClockTest {
     // given
     final var sourceTime = Instant.now();
     final var source = InstantSource.fixed(sourceTime);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
 
     // then
     assertThat(clock.instant()).isEqualTo(sourceTime);
@@ -50,7 +49,7 @@ final class ControllableStreamClockTest {
     // given
     final var sourceTime = Instant.now();
     final var source = InstantSource.fixed(sourceTime);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
     final var pinnedTime = Instant.now().plusSeconds(10);
 
     // when
@@ -65,7 +64,7 @@ final class ControllableStreamClockTest {
     // given
     final var sourceTime = Instant.now();
     final var source = InstantSource.fixed(sourceTime);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
     final var firstPin = Instant.now().plusSeconds(5);
     final var secondPin = Instant.now().plusSeconds(10);
 
@@ -82,7 +81,7 @@ final class ControllableStreamClockTest {
     // given
     final var sourceTime = Instant.now();
     final var source = InstantSource.fixed(sourceTime);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
     final var offset = Duration.ofSeconds(10);
 
     // when
@@ -98,7 +97,7 @@ final class ControllableStreamClockTest {
     // given
     final var sourceTime = Instant.now();
     final var source = InstantSource.fixed(sourceTime);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
     final var offset = Duration.ofSeconds(-10);
 
     // when
@@ -114,7 +113,7 @@ final class ControllableStreamClockTest {
     // given
     final var sourceTime = Instant.now();
     final var source = InstantSource.fixed(sourceTime);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
     final var firstOffset = Duration.ofSeconds(5);
     final var secondOffset = Duration.ofSeconds(10);
 
@@ -131,7 +130,7 @@ final class ControllableStreamClockTest {
     // given
     final var sourceTime = Instant.now();
     final var source = InstantSource.fixed(sourceTime);
-    final var clock = StreamClock.controlled(source);
+    final var clock = StreamClock.controllable(source);
 
     // when -- offset and then reset
     final var offset = Duration.ofSeconds(10);

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ControllableStreamClockTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ControllableStreamClockTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.zeebe.stream.api.StreamClock;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.InstantSource;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
+
+@Execution(ExecutionMode.CONCURRENT)
+final class ControllableStreamClockTest {
+  @Test
+  void shouldStartWithoutModification() {
+    // given
+    final var now = Instant.now();
+    final var source = InstantSource.fixed(now);
+    final var clock = StreamClock.controlled(source);
+
+    // then
+    assertThat(clock.isModified()).isFalse();
+    assertThat(clock.currentModification()).isInstanceOf(Modification.None.class);
+  }
+
+  @Test
+  void shouldReturnSourceTimeWhenNotModified() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controlled(source);
+
+    // then
+    assertThat(clock.instant()).isEqualTo(sourceTime);
+    assertThat(clock.millis()).isEqualTo(sourceTime.toEpochMilli());
+  }
+
+  @Test
+  void shouldReturnPinnedTime() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controlled(source);
+    final var pinnedTime = Instant.now().plusSeconds(10);
+
+    // when
+    clock.applyModification(Modification.pinAt(pinnedTime));
+
+    // then
+    assertThat(clock.instant()).isEqualTo(pinnedTime);
+  }
+
+  @Test
+  void shouldReturnLastPinned() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controlled(source);
+    final var firstPin = Instant.now().plusSeconds(5);
+    final var secondPin = Instant.now().plusSeconds(10);
+
+    // when
+    clock.applyModification(Modification.pinAt(firstPin));
+    clock.applyModification(Modification.pinAt(secondPin));
+
+    // then
+    assertThat(clock.instant()).isEqualTo(secondPin);
+  }
+
+  @Test
+  void shouldReturnOffsetTime() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controlled(source);
+    final var offset = Duration.ofSeconds(10);
+
+    // when
+    clock.applyModification(Modification.offsetBy(offset));
+
+    // then
+    assertThat(clock.instant()).isEqualTo(sourceTime.plus(offset));
+    assertThat(clock.millis()).isEqualTo(sourceTime.toEpochMilli() + offset.toMillis());
+  }
+
+  @Test
+  void shouldReturnNegativeOffsetTime() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controlled(source);
+    final var offset = Duration.ofSeconds(-10);
+
+    // when
+    clock.applyModification(Modification.offsetBy(offset));
+
+    // then
+    assertThat(clock.instant()).isEqualTo(sourceTime.plus(offset));
+    assertThat(clock.millis()).isEqualTo(sourceTime.toEpochMilli() + offset.toMillis());
+  }
+
+  @Test
+  void shouldReturnLastOffset() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controlled(source);
+    final var firstOffset = Duration.ofSeconds(5);
+    final var secondOffset = Duration.ofSeconds(10);
+
+    // when
+    clock.applyModification(Modification.offsetBy(firstOffset));
+    clock.applyModification(Modification.offsetBy(secondOffset));
+
+    // then
+    assertThat(clock.instant()).isEqualTo(sourceTime.plus(secondOffset));
+  }
+
+  @Test
+  void shouldResetToSourceTime() {
+    // given
+    final var sourceTime = Instant.now();
+    final var source = InstantSource.fixed(sourceTime);
+    final var clock = StreamClock.controlled(source);
+
+    // when -- offset and then reset
+    final var offset = Duration.ofSeconds(10);
+    clock.applyModification(Modification.offsetBy(offset));
+    clock.reset();
+
+    // then -- should return source time without offset
+    assertThat(clock.instant()).isEqualTo(sourceTime);
+    assertThat(clock.millis()).isEqualTo(sourceTime.toEpochMilli());
+
+    // when -- pin and then reset
+    final var pinnedTime = Instant.now().plusSeconds(10);
+    clock.applyModification(Modification.pinAt(pinnedTime));
+    clock.reset();
+
+    // then -- should return source time without pin
+    assertThat(clock.instant()).isEqualTo(sourceTime);
+    assertThat(clock.millis()).isEqualTo(sourceTime.toEpochMilli());
+  }
+}


### PR DESCRIPTION
Before this PR, the engine was directly using `ActorClock` in various places to get the current time. The implicit assumption was that the engine would always run in an actor thread where such an `ActorClock` is available.

This PR refactors (mostly the engine) such that a `ControllableStreamClock` is injected as clock. It is injected by the `StreamProcessor` which takes the current `ActorClock` as source. Because we still use the same clock, no behavior changes are expected.

This is useful for two reasons:
1. Being able to run the engine outside of an actor thread.
2.  Injecting the clock gives us more control over the clock (e.g. for testing)

Having the engine not rely on the actor scheduler was a long-standing goal. An architecture test that was supposed to verify this goal is fixed now, proving that engine production code no longer depends on the actor scheduler.

relates to #21051