### PR TITLE
refactor: support newer helm chart version

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -250,8 +250,12 @@ jobs:
         --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}
         --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
         --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+        # To support old versions
         --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
         --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+        # To support new versions
+        --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
+        --set camunda-platform.zeebeGateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
         ${{ inputs.benchmark-load }}
   deploy-benchmark-cluster:
     name: Deploy
@@ -293,8 +297,12 @@ jobs:
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}
           --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+          # To support old versions
           --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
+          # To support new versions
+          --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
+          --set camunda-platform.zeebeGateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}
           ${{ inputs.stable-vms && '-f zeebe/benchmarks/setup/default/values-stable.yaml' || '' }}
           ${{ inputs.benchmark-load }}

--- a/zeebe/benchmarks/setup/default/values-stable.yaml
+++ b/zeebe/benchmarks/setup/default/values-stable.yaml
@@ -12,6 +12,7 @@ camunda-platform:
         effect: NoSchedule
         value: 'false'
 
+  # Support of -9.x camunda platform
   zeebe-gateway:
     # Prefer scheduling on any non-spot VM
     # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is
@@ -24,6 +25,27 @@ camunda-platform:
             - matchExpressions:
               - key: cloud.google.com/gke-spot
                 operator: DoesNotExist
+
+    # Ignore the stable VM node taints
+    tolerations:
+      - key: cloud.google.com/gke-spot
+        operator: Equal
+        effect: NoSchedule
+        value: 'false'
+
+  # Support of 10.x camunda platform
+  zeebeGateway:
+    # Prefer scheduling on any non-spot VM
+    # GKE does not let us add the cloud.google.com/gke-spot label manually, so when an instance is
+    # not a spot VM, that node label simply is not present. When it is a spot VM, then the value is
+    # set to true.
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: cloud.google.com/gke-spot
+                  operator: DoesNotExist
 
     # Ignore the stable VM node taints
     tolerations:


### PR DESCRIPTION
## Description
Adjust values for helm installation to support 9x, and 10x camunda platform helm chart.

<!-- Describe the goal and purpose of this PR. -->

## Related issues

See https://docs.camunda.io/docs/next/self-managed/setup/upgrade/#deprecation-notes 
See https://github.com/zeebe-io/benchmark-helm/pull/171
