### PR TITLE
build: fix compilation issues in optimize

### DIFF
--- a/optimize/backend/src/main/java/io/camunda/optimize/IgnoreDuringScan.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/IgnoreDuringScan.java
@@ -13,7 +13,8 @@ import java.lang.annotation.RetentionPolicy;
 /**
  * This annotation is used to ignore annotated classes during component-scan.
  *
- * Sample usage:
+ * <p>Sample usage:
+ *
  * <pre>{@code
  * @ComponentScan(excludeFilters = @ComponentScan.Filter(IgnoreDuringScan.class))
  * @Configuration

--- a/optimize/backend/src/main/java/io/camunda/optimize/IgnoreDuringScan.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/IgnoreDuringScan.java
@@ -18,6 +18,7 @@ import java.lang.annotation.RetentionPolicy;
  * @ComponentScan(excludeFilters = @ComponentScan.Filter(IgnoreDuringScan.class))
  * @Configuration
  * public class Main {
+ * }
  * }</pre>
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/DecisionInstanceDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/DecisionInstanceDto.java
@@ -17,13 +17,11 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @Accessors(chain = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants
 public class DecisionInstanceDto implements OptimizeDto {
 
   private String decisionInstanceId;
@@ -43,4 +41,25 @@ public class DecisionInstanceDto implements OptimizeDto {
   private Set<String> matchedRules = new HashSet<>();
   private String engine;
   private String tenantId;
+
+  public static final class Fields {
+
+    public static final String decisionInstanceId = "decisionInstanceId";
+    public static final String processDefinitionId = "processDefinitionId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String decisionDefinitionId = "decisionDefinitionId";
+    public static final String decisionDefinitionKey = "decisionDefinitionKey";
+    public static final String decisionDefinitionVersion = "decisionDefinitionVersion";
+    public static final String evaluationDateTime = "evaluationDateTime";
+    public static final String processInstanceId = "processInstanceId";
+    public static final String rootProcessInstanceId = "rootProcessInstanceId";
+    public static final String activityId = "activityId";
+    public static final String collectResultValue = "collectResultValue";
+    public static final String rootDecisionInstanceId = "rootDecisionInstanceId";
+    public static final String inputs = "inputs";
+    public static final String outputs = "outputs";
+    public static final String matchedRules = "matchedRules";
+    public static final String engine = "engine";
+    public static final String tenantId = "tenantId";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/IdentityLinkLogEntryDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/IdentityLinkLogEntryDto.java
@@ -13,12 +13,10 @@ import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @Accessors(chain = true)
 @AllArgsConstructor
 @Data
-@FieldNameConstants(asEnum = true)
 public class IdentityLinkLogEntryDto implements OptimizeDto {
 
   private String id;
@@ -34,4 +32,18 @@ public class IdentityLinkLogEntryDto implements OptimizeDto {
   private String operationType;
   private String assignerId;
   private OffsetDateTime timestamp;
+
+  public enum Fields {
+    id,
+    processInstanceId,
+    processDefinitionKey,
+    engine,
+    type,
+    userId,
+    groupId,
+    taskId,
+    operationType,
+    assignerId,
+    timestamp
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/UserOperationLogEntryDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/importing/UserOperationLogEntryDto.java
@@ -13,13 +13,12 @@ import java.time.OffsetDateTime;
 import lombok.Builder;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @Accessors(chain = true)
 @Builder
 @Data
-@FieldNameConstants(asEnum = true)
 public class UserOperationLogEntryDto implements OptimizeDto {
+
   private String id;
 
   @JsonIgnore private String processDefinitionId;
@@ -28,4 +27,13 @@ public class UserOperationLogEntryDto implements OptimizeDto {
 
   private UserOperationType operationType;
   private OffsetDateTime timestamp;
+
+  public enum Fields {
+    id,
+    processDefinitionId,
+    processDefinitionKey,
+    processInstanceId,
+    operationType,
+    timestamp
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ReportShareRestDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/query/sharing/ReportShareRestDto.java
@@ -9,11 +9,16 @@ package io.camunda.optimize.dto.optimize.query.sharing;
 
 import java.io.Serializable;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 public class ReportShareRestDto implements Serializable {
+
   private String id;
   private String reportId;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String reportId = "reportId";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/AlertEmailValidationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/AlertEmailValidationResponseDto.java
@@ -10,12 +10,11 @@ package io.camunda.optimize.dto.optimize.rest;
 import io.camunda.optimize.service.exceptions.OptimizeAlertEmailValidationException;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public class AlertEmailValidationResponseDto extends ErrorResponseDto {
+
   private final String invalidAlertEmails;
 
   public AlertEmailValidationResponseDto(
@@ -24,7 +23,11 @@ public class AlertEmailValidationResponseDto extends ErrorResponseDto {
         optimizeAlertEmailValidationException.getErrorCode(),
         optimizeAlertEmailValidationException.getMessage(),
         optimizeAlertEmailValidationException.getMessage());
-    this.invalidAlertEmails =
-        String.join(", ", optimizeAlertEmailValidationException.getAlertEmails());
+    invalidAlertEmails = String.join(", ", optimizeAlertEmailValidationException.getAlertEmails());
+  }
+
+  public static final class Fields {
+
+    public static final String invalidAlertEmails = "invalidAlertEmails";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ConflictedItemDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ConflictedItemDto.java
@@ -8,20 +8,26 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import lombok.Getter;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
-@FieldNameConstants
 public class ConflictedItemDto {
+
   private String id;
   private ConflictedItemType type;
   private String name;
 
   public ConflictedItemDto() {}
 
-  public ConflictedItemDto(String id, ConflictedItemType type, String name) {
+  public ConflictedItemDto(final String id, final ConflictedItemType type, final String name) {
     this.id = id;
     this.type = type;
     this.name = name;
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String type = "type";
+    public static final String name = "name";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ErrorResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/ErrorResponseDto.java
@@ -8,11 +8,10 @@
 package io.camunda.optimize.dto.optimize.rest;
 
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 public class ErrorResponseDto {
+
   private String errorCode;
   private String errorMessage;
   private String detailedMessage;
@@ -21,28 +20,37 @@ public class ErrorResponseDto {
   public ErrorResponseDto() {}
 
   public ErrorResponseDto(
-      String errorCode,
-      String errorMessage,
-      String detailedMessage,
-      AuthorizedReportDefinitionResponseDto reportDefinition) {
+      final String errorCode,
+      final String errorMessage,
+      final String detailedMessage,
+      final AuthorizedReportDefinitionResponseDto reportDefinition) {
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
     this.detailedMessage = detailedMessage;
     this.reportDefinition = reportDefinition;
   }
 
-  public ErrorResponseDto(String errorMessage) {
+  public ErrorResponseDto(final String errorMessage) {
     this.errorMessage = errorMessage;
   }
 
-  public ErrorResponseDto(String errorCode, String errorMessage) {
+  public ErrorResponseDto(final String errorCode, final String errorMessage) {
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
   }
 
-  public ErrorResponseDto(String errorCode, String errorMessage, String detailedMessage) {
+  public ErrorResponseDto(
+      final String errorCode, final String errorMessage, final String detailedMessage) {
     this.errorCode = errorCode;
     this.errorMessage = errorMessage;
     this.detailedMessage = detailedMessage;
+  }
+
+  public static final class Fields {
+
+    public static final String errorCode = "errorCode";
+    public static final String errorMessage = "errorMessage";
+    public static final String detailedMessage = "detailedMessage";
+    public static final String reportDefinition = "reportDefinition";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/event/EventProcessMappingResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/event/EventProcessMappingResponseDto.java
@@ -23,15 +23,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
-@FieldNameConstants
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class EventProcessMappingResponseDto {
+
   @EqualsAndHashCode.Include private String id;
   @NotBlank private String name;
 
@@ -54,8 +53,8 @@ public class EventProcessMappingResponseDto {
 
   public static EventProcessMappingResponseDto from(
       final EventProcessMappingDto dto,
-      String lastModifierName,
-      List<EventSourceEntryDto<?>> eventSourcesDtos) {
+      final String lastModifierName,
+      final List<EventSourceEntryDto<?>> eventSourcesDtos) {
     return EventProcessMappingResponseDto.builder()
         .id(dto.getId())
         .lastModified(dto.getLastModified())
@@ -67,5 +66,18 @@ public class EventProcessMappingResponseDto {
         .xml(dto.getXml())
         .eventSources(eventSourcesDtos)
         .build();
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String lastModifier = "lastModifier";
+    public static final String lastModified = "lastModified";
+    public static final String xml = "xml";
+    public static final String mappings = "mappings";
+    public static final String state = "state";
+    public static final String publishingProgress = "publishingProgress";
+    public static final String eventSources = "eventSources";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/OptimizeEntityExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/OptimizeEntityExportDto.java
@@ -22,11 +22,9 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 @Data
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -46,9 +44,19 @@ import lombok.experimental.FieldNameConstants;
   @JsonSubTypes.Type(value = DashboardDefinitionExportDto.class, name = DASHBOARD),
 })
 public abstract class OptimizeEntityExportDto {
+
   @NotNull private String id;
   @NotNull private ExportEntityType exportEntityType;
   @NotNull private String name;
   private String description;
   private int sourceIndexVersion;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String exportEntityType = "exportEntityType";
+    public static final String name = "name";
+    public static final String description = "description";
+    public static final String sourceIndexVersion = "sourceIndexVersion";
+  }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/dashboard/DashboardDefinitionExportDto.java
@@ -24,13 +24,12 @@ import java.util.Set;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
-@FieldNameConstants
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
+
   @NotNull private List<DashboardReportTileDto> tiles = new ArrayList<>();
   @NotNull private List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
   private String collectionId;
@@ -43,9 +42,9 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
         dashboardDefinition.getName(),
         dashboardDefinition.getDescription(),
         DashboardIndex.VERSION);
-    this.tiles = dashboardDefinition.getTiles();
-    this.availableFilters = dashboardDefinition.getAvailableFilters();
-    this.collectionId = dashboardDefinition.getCollectionId();
+    tiles = dashboardDefinition.getTiles();
+    availableFilters = dashboardDefinition.getAvailableFilters();
+    collectionId = dashboardDefinition.getCollectionId();
   }
 
   @JsonIgnore
@@ -62,5 +61,13 @@ public class DashboardDefinitionExportDto extends OptimizeEntityExportDto {
         .map(DashboardReportTileDto::getId)
         .filter(id -> !IdGenerator.isValidId(id))
         .collect(toSet());
+  }
+
+  public static final class Fields {
+
+    public static final String tiles = "tiles";
+    public static final String availableFilters = "availableFilters";
+    public static final String collectionId = "collectionId";
+    public static final String isInstantPreviewDashboard = "isInstantPreviewDashboard";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/ReportDefinitionExportDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/export/report/ReportDefinitionExportDto.java
@@ -17,13 +17,12 @@ import io.camunda.optimize.dto.optimize.rest.export.OptimizeEntityExportDto;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
-@FieldNameConstants
 @Data
 @EqualsAndHashCode(callSuper = true)
 public abstract class ReportDefinitionExportDto extends OptimizeEntityExportDto {
+
   private String collectionId;
 
   protected ReportDefinitionExportDto(
@@ -50,5 +49,10 @@ public abstract class ReportDefinitionExportDto extends OptimizeEntityExportDto 
       return new SingleDecisionReportDefinitionExportDto(
           (SingleDecisionReportDefinitionRequestDto) reportDef);
     }
+  }
+
+  public static final class Fields {
+
+    public static final String collectionId = "collectionId";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedSingleReportEvaluationResponseDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/optimize/rest/report/AuthorizedSingleReportEvaluationResponseDto.java
@@ -13,11 +13,9 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants(asEnum = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuthorizedSingleReportEvaluationResponseDto<T, D extends ReportDefinitionDto<?>>
     extends AuthorizedReportEvaluationResponseDto<D> {
@@ -30,5 +28,9 @@ public class AuthorizedSingleReportEvaluationResponseDto<T, D extends ReportDefi
       final D reportDefinition) {
     super(currentUserRole, reportDefinition);
     this.result = result;
+  }
+
+  public enum Fields {
+    result
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/ZeebeRecordDto.java
@@ -22,12 +22,10 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @EqualsAndHashCode
 @Getter
 @Setter
-@FieldNameConstants
 @NoArgsConstructor
 @ToString(callSuper = true)
 public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends Intent>
@@ -67,5 +65,24 @@ public abstract class ZeebeRecordDto<VALUE extends RecordValue, INTENT extends I
 
   public OffsetDateTime getDateForTimestamp() {
     return OffsetDateTime.ofInstant(Instant.ofEpochMilli(timestamp), ZoneId.systemDefault());
+  }
+
+  public static final class Fields {
+
+    public static final String position = "position";
+    public static final String sequence = "sequence";
+    public static final String sourceRecordPosition = "sourceRecordPosition";
+    public static final String key = "key";
+    public static final String timestamp = "timestamp";
+    public static final String partitionId = "partitionId";
+    public static final String recordType = "recordType";
+    public static final String rejectionType = "rejectionType";
+    public static final String rejectionReason = "rejectionReason";
+    public static final String brokerVersion = "brokerVersion";
+    public static final String valueType = "valueType";
+    public static final String value = "value";
+    public static final String intent = "intent";
+    public static final String authorizations = "authorizations";
+    public static final String operationReference = "operationReference";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/incident/ZeebeIncidentDataDto.java
@@ -13,12 +13,10 @@ import io.camunda.zeebe.protocol.record.value.ErrorType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.StringUtils;
 
 @EqualsAndHashCode
 @Data
-@FieldNameConstants
 public class ZeebeIncidentDataDto implements IncidentRecordValue {
 
   private String errorMessage;
@@ -40,5 +38,19 @@ public class ZeebeIncidentDataDto implements IncidentRecordValue {
   @Override
   public String getTenantId() {
     return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
+  }
+
+  public static final class Fields {
+
+    public static final String errorMessage = "errorMessage";
+    public static final String bpmnProcessId = "bpmnProcessId";
+    public static final String elementId = "elementId";
+    public static final String elementInstanceKey = "elementInstanceKey";
+    public static final String processInstanceKey = "processInstanceKey";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String jobKey = "jobKey";
+    public static final String errorType = "errorType";
+    public static final String variableScopeKey = "variableScopeKey";
+    public static final String tenantId = "tenantId";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/process/ZeebeProcessInstanceDataDto.java
@@ -14,10 +14,8 @@ import io.camunda.zeebe.protocol.record.value.BpmnEventType;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.StringUtils;
 
-@FieldNameConstants
 @EqualsAndHashCode
 @Data
 public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
@@ -46,5 +44,19 @@ public class ZeebeProcessInstanceDataDto implements ProcessInstanceRecordValue {
   @Override
   public String getTenantId() {
     return StringUtils.isEmpty(tenantId) ? ZEEBE_DEFAULT_TENANT_ID : tenantId;
+  }
+
+  public static final class Fields {
+
+    public static final String version = "version";
+    public static final String bpmnProcessId = "bpmnProcessId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String flowScopeKey = "flowScopeKey";
+    public static final String bpmnElementType = "bpmnElementType";
+    public static final String parentProcessInstanceKey = "parentProcessInstanceKey";
+    public static final String parentElementInstanceKey = "parentElementInstanceKey";
+    public static final String elementId = "elementId";
+    public static final String processInstanceKey = "processInstanceKey";
+    public static final String tenantId = "tenantId";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/dto/zeebe/usertask/ZeebeUserTaskDataDto.java
@@ -13,12 +13,10 @@ import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Map;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.annotate.JsonIgnore;
 
 @Data
-@FieldNameConstants
 @Slf4j
 public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
 
@@ -53,5 +51,29 @@ public class ZeebeUserTaskDataDto implements UserTaskRecordValue {
                   dueDate);
               return null;
             });
+  }
+
+  public static final class Fields {
+
+    public static final String userTaskKey = "userTaskKey";
+    public static final String assignee = "assignee";
+    public static final String candidateGroupsList = "candidateGroupsList";
+    public static final String candidateUsersList = "candidateUsersList";
+    public static final String dueDate = "dueDate";
+    public static final String elementId = "elementId";
+    public static final String elementInstanceKey = "elementInstanceKey";
+    public static final String bpmnProcessId = "bpmnProcessId";
+    public static final String processDefinitionVersion = "processDefinitionVersion";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String processInstanceKey = "processInstanceKey";
+    public static final String tenantId = "tenantId";
+    public static final String changedAttributes = "changedAttributes";
+    public static final String variables = "variables";
+    public static final String followUpDate = "followUpDate";
+    public static final String formKey = "formKey";
+    public static final String action = "action";
+    public static final String externalFormReference = "externalFormReference";
+    public static final String customHeaders = "customHeaders";
+    public static final String creationTimestamp = "creationTimestamp";
   }
 }

--- a/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/command/modules/result/CompositeCommandResult.java
+++ b/optimize/backend/src/main/java/io/camunda/optimize/service/db/es/report/command/modules/result/CompositeCommandResult.java
@@ -37,6 +37,7 @@ import io.camunda.optimize.service.db.es.report.result.NumberCommandResult;
 import io.camunda.optimize.service.db.es.report.result.RawDataCommandResult;
 import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -49,12 +50,10 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import lombok.Singular;
 import lombok.experimental.Accessors;
 import org.apache.commons.lang3.StringUtils;
 
@@ -462,22 +461,144 @@ public class CompositeCommandResult {
     }
   }
 
-  @Builder
   @Data
   public static class ViewResult {
-    @Singular private List<ViewMeasure> viewMeasures;
+
+    private List<ViewMeasure> viewMeasures;
     private List<? extends RawDataInstanceDto> rawData;
+
+    ViewResult(List<ViewMeasure> viewMeasures, List<? extends RawDataInstanceDto> rawData) {
+      this.viewMeasures = viewMeasures;
+      this.rawData = rawData;
+    }
+
+    public static ViewResultBuilder builder() {
+      return new ViewResultBuilder();
+    }
+
+    public static class ViewResultBuilder {
+
+      private ArrayList<ViewMeasure> viewMeasures;
+      private List<? extends RawDataInstanceDto> rawData;
+
+      ViewResultBuilder() {}
+
+      public ViewResultBuilder viewMeasure(ViewMeasure viewMeasure) {
+        if (this.viewMeasures == null) {
+          this.viewMeasures = new ArrayList<ViewMeasure>();
+        }
+        this.viewMeasures.add(viewMeasure);
+        return this;
+      }
+
+      public ViewResultBuilder viewMeasures(Collection<? extends ViewMeasure> viewMeasures) {
+        if (viewMeasures == null) {
+          throw new NullPointerException("viewMeasures cannot be null");
+        }
+        if (this.viewMeasures == null) {
+          this.viewMeasures = new ArrayList<ViewMeasure>();
+        }
+        this.viewMeasures.addAll(viewMeasures);
+        return this;
+      }
+
+      public ViewResultBuilder clearViewMeasures() {
+        if (this.viewMeasures != null) {
+          this.viewMeasures.clear();
+        }
+        return this;
+      }
+
+      public ViewResultBuilder rawData(List<? extends RawDataInstanceDto> rawData) {
+        this.rawData = rawData;
+        return this;
+      }
+
+      public ViewResult build() {
+        List<ViewMeasure> viewMeasures;
+        switch (this.viewMeasures == null ? 0 : this.viewMeasures.size()) {
+          case 0:
+            viewMeasures = Collections.emptyList();
+            break;
+          case 1:
+            viewMeasures = Collections.singletonList(this.viewMeasures.get(0));
+            break;
+          default:
+            viewMeasures =
+                Collections.unmodifiableList(new ArrayList<ViewMeasure>(this.viewMeasures));
+        }
+
+        return new ViewResult(viewMeasures, this.rawData);
+      }
+
+      public String toString() {
+        return "CompositeCommandResult.ViewResult.ViewResultBuilder(viewMeasures="
+            + this.viewMeasures
+            + ", rawData="
+            + this.rawData
+            + ")";
+      }
+    }
   }
 
-  @Builder
   @Data
   public static class ViewMeasure {
+
     private AggregationDto aggregationType;
     private UserTaskDurationTime userTaskDurationTime;
     private Double value;
 
+    ViewMeasure(
+        AggregationDto aggregationType, UserTaskDurationTime userTaskDurationTime, Double value) {
+      this.aggregationType = aggregationType;
+      this.userTaskDurationTime = userTaskDurationTime;
+      this.value = value;
+    }
+
     public ViewMeasureIdentifier getViewMeasureIdentifier() {
       return new ViewMeasureIdentifier(aggregationType, userTaskDurationTime);
+    }
+
+    public static ViewMeasureBuilder builder() {
+      return new ViewMeasureBuilder();
+    }
+
+    public static class ViewMeasureBuilder {
+
+      private AggregationDto aggregationType;
+      private UserTaskDurationTime userTaskDurationTime;
+      private Double value;
+
+      ViewMeasureBuilder() {}
+
+      public ViewMeasureBuilder aggregationType(AggregationDto aggregationType) {
+        this.aggregationType = aggregationType;
+        return this;
+      }
+
+      public ViewMeasureBuilder userTaskDurationTime(UserTaskDurationTime userTaskDurationTime) {
+        this.userTaskDurationTime = userTaskDurationTime;
+        return this;
+      }
+
+      public ViewMeasureBuilder value(Double value) {
+        this.value = value;
+        return this;
+      }
+
+      public ViewMeasure build() {
+        return new ViewMeasure(this.aggregationType, this.userTaskDurationTime, this.value);
+      }
+
+      public String toString() {
+        return "CompositeCommandResult.ViewMeasure.ViewMeasureBuilder(aggregationType="
+            + this.aggregationType
+            + ", userTaskDurationTime="
+            + this.userTaskDurationTime
+            + ", value="
+            + this.value
+            + ")";
+      }
     }
   }
 

--- a/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogEntryDto.java
+++ b/optimize/upgrade/src/main/java/io/camunda/optimize/upgrade/service/UpgradeStepLogEntryDto.java
@@ -16,14 +16,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @Builder
-@FieldNameConstants
 public class UpgradeStepLogEntryDto {
+
   @NonNull private String indexName;
   @NonNull private String optimizeVersion;
   @NonNull private UpgradeStepType stepType;
@@ -33,5 +32,14 @@ public class UpgradeStepLogEntryDto {
   @JsonIgnore
   public String getId() {
     return String.join("_", optimizeVersion, stepType.toString(), indexName);
+  }
+
+  public static final class Fields {
+
+    public static final String indexName = "indexName";
+    public static final String optimizeVersion = "optimizeVersion";
+    public static final String stepType = "stepType";
+    public static final String stepNumber = "stepNumber";
+    public static final String appliedDate = "appliedDate";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DecisionDefinitionOptimizeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DecisionDefinitionOptimizeDto.java
@@ -16,13 +16,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants(asEnum = true)
 public class DecisionDefinitionOptimizeDto extends DefinitionOptimizeResponseDto {
+
   private String dmn10Xml;
   private List<DecisionVariableNameResponseDto> inputVariableNames = new ArrayList<>();
   private List<DecisionVariableNameResponseDto> outputVariableNames = new ArrayList<>();
@@ -61,5 +60,11 @@ public class DecisionDefinitionOptimizeDto extends DefinitionOptimizeResponseDto
     this.dmn10Xml = dmn10Xml;
     this.inputVariableNames = inputVariableNames;
     this.outputVariableNames = outputVariableNames;
+  }
+
+  public enum Fields {
+    dmn10Xml,
+    inputVariableNames,
+    outputVariableNames
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/DefinitionOptimizeResponseDto.java
@@ -14,13 +14,12 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
-@FieldNameConstants
 public abstract class DefinitionOptimizeResponseDto implements Serializable, OptimizeDto {
+
   private String id;
   private String key;
   private String version;
@@ -34,5 +33,18 @@ public abstract class DefinitionOptimizeResponseDto implements Serializable, Opt
   protected DefinitionOptimizeResponseDto(final String id, final DataSourceDto dataSource) {
     this.id = id;
     this.dataSource = dataSource;
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String key = "key";
+    public static final String version = "version";
+    public static final String versionTag = "versionTag";
+    public static final String name = "name";
+    public static final String dataSource = "dataSource";
+    public static final String tenantId = "tenantId";
+    public static final String deleted = "deleted";
+    public static final String type = "type";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/GroupDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/GroupDto.java
@@ -17,14 +17,13 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants
 @ToString(callSuper = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 public class GroupDto extends IdentityWithMetadataResponseDto {
+
   private Long memberCount;
 
   public GroupDto(final String id) {
@@ -44,5 +43,10 @@ public class GroupDto extends IdentityWithMetadataResponseDto {
   @JsonIgnore
   public List<Supplier<String>> getSearchableDtoFields() {
     return List.of(this::getId, this::getName);
+  }
+
+  public static final class Fields {
+
+    public static final String memberCount = "memberCount";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityDto.java
@@ -12,13 +12,18 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@FieldNameConstants
 public class IdentityDto {
+
   @NonNull private String id;
   private IdentityType type;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String type = "type";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityWithMetadataResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/IdentityWithMetadataResponseDto.java
@@ -17,7 +17,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.StringUtils;
 
 @JsonTypeInfo(
@@ -31,10 +30,10 @@ import org.apache.commons.lang3.StringUtils;
 })
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 public abstract class IdentityWithMetadataResponseDto extends IdentityDto {
+
   private String name;
 
   public IdentityWithMetadataResponseDto(final String id, final IdentityType type) {
@@ -62,5 +61,10 @@ public abstract class IdentityWithMetadataResponseDto extends IdentityDto {
                 searchableField ->
                     StringUtils.isNotBlank(searchableField.get())
                         && StringUtils.containsAnyIgnoreCase(searchableField.get(), searchTerm));
+  }
+
+  public static final class Fields {
+
+    public static final String name = "name";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ImportRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ImportRequestDto.java
@@ -10,11 +10,9 @@ package io.camunda.optimize.dto.optimize;
 import io.camunda.optimize.service.db.schema.ScriptData;
 import lombok.Builder;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @Builder
-@FieldNameConstants(asEnum = true)
 public class ImportRequestDto {
 
   private String importName;
@@ -24,4 +22,14 @@ public class ImportRequestDto {
   private Object source;
   private RequestType type;
   private int retryNumberOnConflict;
+
+  public enum Fields {
+    importName,
+    indexName,
+    scriptData,
+    id,
+    source,
+    type,
+    retryNumberOnConflict
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessDefinitionOptimizeDto.java
@@ -19,13 +19,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto {
+
   private String bpmn20Xml;
   private List<FlowNodeDataDto> flowNodeData = new ArrayList<>();
   private Map<String, String> userTaskNames = new HashMap<>();
@@ -33,7 +32,7 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
   @JsonIgnore private boolean eventBased;
 
   public ProcessDefinitionOptimizeDto() {
-    this.setType(DefinitionType.PROCESS);
+    setType(DefinitionType.PROCESS);
   }
 
   public ProcessDefinitionOptimizeDto(
@@ -98,5 +97,14 @@ public class ProcessDefinitionOptimizeDto extends DefinitionOptimizeResponseDto 
 
   public Map<String, String> getUserTaskNames() {
     return userTaskNames == null ? new HashMap<>() : new HashMap<>(userTaskNames);
+  }
+
+  public static final class Fields {
+
+    public static final String bpmn20Xml = "bpmn20Xml";
+    public static final String flowNodeData = "flowNodeData";
+    public static final String userTaskNames = "userTaskNames";
+    public static final String onboarded = "onboarded";
+    public static final String eventBased = "eventBased";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/ProcessInstanceDto.java
@@ -22,14 +22,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
-@FieldNameConstants
 public class ProcessInstanceDto implements OptimizeDto {
 
   private String processDefinitionKey;
@@ -52,5 +50,23 @@ public class ProcessInstanceDto implements OptimizeDto {
     return flowNodeInstances.stream()
         .filter(flowNode -> FLOW_NODE_TYPE_USER_TASK.equalsIgnoreCase(flowNode.getFlowNodeType()))
         .toList();
+  }
+
+  public static final class Fields {
+
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String processDefinitionVersion = "processDefinitionVersion";
+    public static final String processDefinitionId = "processDefinitionId";
+    public static final String processInstanceId = "processInstanceId";
+    public static final String businessKey = "businessKey";
+    public static final String startDate = "startDate";
+    public static final String endDate = "endDate";
+    public static final String duration = "duration";
+    public static final String state = "state";
+    public static final String flowNodeInstances = "flowNodeInstances";
+    public static final String variables = "variables";
+    public static final String incidents = "incidents";
+    public static final String dataSource = "dataSource";
+    public static final String tenantId = "tenantId";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SettingsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/SettingsDto.java
@@ -14,13 +14,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Builder
 @Data
-@FieldNameConstants(asEnum = true)
 public class SettingsDto {
 
   private Boolean sharingEnabled;
@@ -29,5 +27,10 @@ public class SettingsDto {
 
   public Optional<Boolean> getSharingEnabled() {
     return Optional.ofNullable(sharingEnabled);
+  }
+
+  public enum Fields {
+    sharingEnabled,
+    lastModified
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/TenantDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/TenantDto.java
@@ -13,17 +13,21 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Data
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@FieldNameConstants(asEnum = true)
 public class TenantDto implements OptimizeDto {
 
   @EqualsAndHashCode.Include private String id;
   @EqualsAndHashCode.Include private String name;
   private String engine;
+
+  public enum Fields {
+    id,
+    name,
+    engine
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/UserDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/UserDto.java
@@ -23,15 +23,14 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants
 @ToString(callSuper = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true, callSuper = true)
 public class UserDto extends IdentityWithMetadataResponseDto {
+
   private String firstName;
   private String lastName;
   private String email;
@@ -85,5 +84,13 @@ public class UserDto extends IdentityWithMetadataResponseDto {
   public List<Supplier<String>> getSearchableDtoFields() {
     return List.of(
         this::getId, this::getEmail, this::getName, this::getFirstName, this::getLastName);
+  }
+
+  public static final class Fields {
+
+    public static final String firstName = "firstName";
+    public static final String lastName = "lastName";
+    public static final String email = "email";
+    public static final String roles = "roles";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/alert/AlertNotificationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/alert/AlertNotificationDto.java
@@ -14,6 +14,7 @@ import lombok.Data;
 @AllArgsConstructor
 @Data
 public class AlertNotificationDto {
+
   private final AlertDefinitionDto alert;
   private final Double currentValue;
   private final AlertNotificationType type;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/DataSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/datasource/DataSourceDto.java
@@ -15,12 +15,10 @@ import java.io.Serializable;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
     include = JsonTypeInfo.As.EXISTING_PROPERTY,
@@ -35,4 +33,10 @@ public abstract class DataSourceDto implements OptimizeDto, Serializable {
 
   private DataImportSourceType type;
   private String name;
+
+  public static final class Fields {
+
+    public static final String type = "type";
+    public static final String name = "name";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/ImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/ImportIndexDto.java
@@ -15,16 +15,22 @@ import java.time.ZoneId;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
-@FieldNameConstants
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
 public abstract class ImportIndexDto<T extends DataSourceDto> implements OptimizeDto {
+
   protected OffsetDateTime lastImportExecutionTimestamp =
       OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
   protected OffsetDateTime timestampOfLastEntity =
       OffsetDateTime.ofInstant(Instant.EPOCH, ZoneId.systemDefault());
   protected T dataSource;
+
+  public static final class Fields {
+
+    public static final String lastImportExecutionTimestamp = "lastImportExecutionTimestamp";
+    public static final String timestampOfLastEntity = "timestampOfLastEntity";
+    public static final String dataSource = "dataSource";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/PositionBasedImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/PositionBasedImportIndexDto.java
@@ -11,12 +11,10 @@ import io.camunda.optimize.dto.optimize.datasource.ZeebeDataSourceDto;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public class PositionBasedImportIndexDto extends ImportIndexDto<ZeebeDataSourceDto> {
 
   protected long positionOfLastEntity = 0;
@@ -24,4 +22,12 @@ public class PositionBasedImportIndexDto extends ImportIndexDto<ZeebeDataSourceD
   protected String esTypeIndexRefersTo;
   protected boolean hasSeenSequenceField =
       false; // flag to indicate whether at least one record with a sequence field has been imported
+
+  public static final class Fields {
+
+    public static final String positionOfLastEntity = "positionOfLastEntity";
+    public static final String sequenceOfLastEntity = "sequenceOfLastEntity";
+    public static final String esTypeIndexRefersTo = "esTypeIndexRefersTo";
+    public static final String hasSeenSequenceField = "hasSeenSequenceField";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/TimestampBasedImportIndexDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/index/TimestampBasedImportIndexDto.java
@@ -13,20 +13,18 @@ import java.time.OffsetDateTime;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public class TimestampBasedImportIndexDto extends ImportIndexDto<DataSourceDto>
     implements EngineImportIndexDto {
 
   protected String esTypeIndexRefersTo;
 
   public TimestampBasedImportIndexDto(
-      OffsetDateTime lastImportExecutionTimestamp,
-      OffsetDateTime timestampOfLastEntity,
+      final OffsetDateTime lastImportExecutionTimestamp,
+      final OffsetDateTime timestampOfLastEntity,
       final String esTypeIndexRefersTo,
       final DataSourceDto dataSourceDto) {
     super(lastImportExecutionTimestamp, timestampOfLastEntity, dataSourceDto);
@@ -37,5 +35,10 @@ public class TimestampBasedImportIndexDto extends ImportIndexDto<DataSourceDto>
   @JsonIgnore
   public String getEngine() {
     return dataSource.getName();
+  }
+
+  public static final class Fields {
+
+    public static final String esTypeIndexRefersTo = "esTypeIndexRefersTo";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/AssigneeOperationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/AssigneeOperationDto.java
@@ -15,13 +15,11 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@FieldNameConstants
 @Accessors(chain = true)
 public class AssigneeOperationDto implements OptimizeDto, Serializable {
 
@@ -30,4 +28,12 @@ public class AssigneeOperationDto implements OptimizeDto, Serializable {
   private String userId;
   private String operationType;
   private OffsetDateTime timestamp;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String userId = "userId";
+    public static final String operationType = "operationType";
+    public static final String timestamp = "timestamp";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/BusinessKeyDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/BusinessKeyDto.java
@@ -13,11 +13,9 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
 @ToString
-@FieldNameConstants
 @AllArgsConstructor
 @NoArgsConstructor
 @EqualsAndHashCode
@@ -25,4 +23,10 @@ public class BusinessKeyDto implements OptimizeDto {
 
   private String processInstanceId;
   private String businessKey;
+
+  public static final class Fields {
+
+    public static final String processInstanceId = "processInstanceId";
+    public static final String businessKey = "businessKey";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/CandidateGroupOperationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/CandidateGroupOperationDto.java
@@ -14,13 +14,11 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@FieldNameConstants
 public class CandidateGroupOperationDto implements OptimizeDto, Serializable {
 
   @EqualsAndHashCode.Include private String id;
@@ -28,4 +26,12 @@ public class CandidateGroupOperationDto implements OptimizeDto, Serializable {
   private String groupId;
   private String operationType;
   private OffsetDateTime timestamp;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String groupId = "groupId";
+    public static final String operationType = "operationType";
+    public static final String timestamp = "timestamp";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/persistence/incident/IncidentDto.java
@@ -16,13 +16,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @Accessors(chain = true)
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants
 @Builder
 public class IncidentDto implements Serializable, OptimizeDto {
 
@@ -41,4 +39,22 @@ public class IncidentDto implements Serializable, OptimizeDto {
   protected String failedActivityId;
   protected String incidentMessage;
   protected IncidentStatus incidentStatus;
+
+  public static final class Fields {
+
+    public static final String processInstanceId = "processInstanceId";
+    public static final String definitionKey = "definitionKey";
+    public static final String definitionVersion = "definitionVersion";
+    public static final String tenantId = "tenantId";
+    public static final String engineAlias = "engineAlias";
+    public static final String id = "id";
+    public static final String createTime = "createTime";
+    public static final String endTime = "endTime";
+    public static final String durationInMs = "durationInMs";
+    public static final String incidentType = "incidentType";
+    public static final String activityId = "activityId";
+    public static final String failedActivityId = "failedActivityId";
+    public static final String incidentMessage = "incidentMessage";
+    public static final String incidentStatus = "incidentStatus";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/MetadataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/MetadataDto.java
@@ -13,13 +13,17 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
-@FieldNameConstants(asEnum = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Data
 public class MetadataDto implements OptimizeDto, Serializable {
+
   private String schemaVersion;
   private String installationId;
+
+  public enum Fields {
+    schemaVersion,
+    installationId
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertCreationRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertCreationRequestDto.java
@@ -12,15 +12,9 @@ import java.util.List;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 public class AlertCreationRequestDto {
-
-  // needed to allow inheritance of field name constants
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  public static class Fields {}
 
   private String name;
   private AlertInterval checkInterval;
@@ -31,4 +25,19 @@ public class AlertCreationRequestDto {
   private AlertInterval reminder;
   private List<String> emails = new ArrayList<>();
   private String webhook;
+
+  // needed to allow inheritance of field name constants
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class Fields {
+
+    public static final String name = "name";
+    public static final String checkInterval = "checkInterval";
+    public static final String reportId = "reportId";
+    public static final String threshold = "threshold";
+    public static final String thresholdOperator = "thresholdOperator";
+    public static final String fixNotification = "fixNotification";
+    public static final String reminder = "reminder";
+    public static final String emails = "emails";
+    public static final String webhook = "webhook";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertDefinitionDto.java
@@ -10,15 +10,10 @@ package io.camunda.optimize.dto.optimize.query.alert;
 import java.time.OffsetDateTime;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public class AlertDefinitionDto extends AlertCreationRequestDto {
-
-  /** Needed to inherit field name constants from {@link AlertCreationRequestDto} */
-  public static class Fields extends AlertCreationRequestDto.Fields {}
 
   protected String id;
   protected OffsetDateTime lastModified;
@@ -26,4 +21,15 @@ public class AlertDefinitionDto extends AlertCreationRequestDto {
   protected String owner;
   protected String lastModifier;
   protected boolean triggered;
+
+  /** Needed to inherit field name constants from {@link AlertCreationRequestDto} */
+  public static class Fields extends AlertCreationRequestDto.Fields {
+
+    public static final String id = "id";
+    public static final String lastModified = "lastModified";
+    public static final String created = "created";
+    public static final String owner = "owner";
+    public static final String lastModifier = "lastModifier";
+    public static final String triggered = "triggered";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertInterval.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/alert/AlertInterval.java
@@ -10,13 +10,18 @@ package io.camunda.optimize.dto.optimize.query.alert;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 @AllArgsConstructor
 @NoArgsConstructor
 public class AlertInterval {
+
   private int value;
   private AlertIntervalUnit unit;
+
+  public static final class Fields {
+
+    public static final String value = "value";
+    public static final String unit = "unit";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/BaseCollectionDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/BaseCollectionDefinitionDto.java
@@ -9,10 +9,8 @@ package io.camunda.optimize.dto.optimize.query.collection;
 
 import java.time.OffsetDateTime;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants(asEnum = true)
 public class BaseCollectionDefinitionDto<DATA_TYPE> {
 
   protected String id;
@@ -23,4 +21,15 @@ public class BaseCollectionDefinitionDto<DATA_TYPE> {
   protected String lastModifier;
   protected DATA_TYPE data;
   protected boolean automaticallyCreated = false;
+
+  public enum Fields {
+    id,
+    name,
+    lastModified,
+    created,
+    owner,
+    lastModifier,
+    data,
+    automaticallyCreated
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionDataDto.java
@@ -12,13 +12,18 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Data
-@FieldNameConstants(asEnum = true)
 public class CollectionDataDto {
+
   protected Object configuration = new HashMap<>();
   private List<CollectionRoleRequestDto> roles = new ArrayList<>();
   private List<CollectionScopeEntryDto> scope = new ArrayList<>();
+
+  public enum Fields {
+    configuration,
+    roles,
+    scope
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleRequestDto.java
@@ -14,12 +14,11 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants(asEnum = true)
 public class CollectionRoleRequestDto {
+
   private static final String ID_SEGMENT_SEPARATOR = ":";
 
   @Setter(value = AccessLevel.PROTECTED)
@@ -38,7 +37,7 @@ public class CollectionRoleRequestDto {
   }
 
   public void setIdentity(final IdentityDto identity) {
-    this.id = convertIdentityToRoleId(identity);
+    id = convertIdentityToRoleId(identity);
     this.identity = identity;
   }
 
@@ -46,5 +45,11 @@ public class CollectionRoleRequestDto {
     return identity.getType() == null
         ? "UNKNOWN" + ID_SEGMENT_SEPARATOR + identity.getId()
         : identity.getType().name() + ID_SEGMENT_SEPARATOR + identity.getId();
+  }
+
+  public enum Fields {
+    id,
+    identity,
+    role
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleResponseDto.java
@@ -16,12 +16,10 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants(asEnum = true)
 public class CollectionRoleResponseDto implements Comparable<CollectionRoleResponseDto> {
 
   private static final String ID_SEGMENT_SEPARATOR = ":";
@@ -32,39 +30,40 @@ public class CollectionRoleResponseDto implements Comparable<CollectionRoleRespo
   private IdentityWithMetadataResponseDto identity;
   private RoleType role;
 
-  public CollectionRoleResponseDto(CollectionRoleResponseDto oldRole) {
+  public CollectionRoleResponseDto(final CollectionRoleResponseDto oldRole) {
     if (oldRole.getIdentity().getType().equals(IdentityType.USER)) {
-      UserDto oldUserDto = (UserDto) oldRole.getIdentity();
-      this.identity =
+      final UserDto oldUserDto = (UserDto) oldRole.getIdentity();
+      identity =
           new UserDto(
               oldUserDto.getId(),
               oldUserDto.getFirstName(),
               oldUserDto.getLastName(),
               oldUserDto.getEmail());
     } else {
-      GroupDto oldGroupDto = (GroupDto) oldRole.getIdentity();
-      this.identity =
+      final GroupDto oldGroupDto = (GroupDto) oldRole.getIdentity();
+      identity =
           new GroupDto(oldGroupDto.getId(), oldGroupDto.getName(), oldGroupDto.getMemberCount());
     }
 
-    this.role = oldRole.role;
-    this.id = convertIdentityToRoleId(this.identity);
+    role = oldRole.role;
+    id = convertIdentityToRoleId(identity);
   }
 
-  public CollectionRoleResponseDto(IdentityWithMetadataResponseDto identity, RoleType role) {
+  public CollectionRoleResponseDto(
+      final IdentityWithMetadataResponseDto identity, final RoleType role) {
     this.identity = identity;
-    this.id = convertIdentityToRoleId(this.identity);
+    id = convertIdentityToRoleId(this.identity);
     this.role = role;
   }
 
   @Override
   public int compareTo(final CollectionRoleResponseDto other) {
-    if (this.identity instanceof UserDto && other.getIdentity() instanceof GroupDto) {
+    if (identity instanceof UserDto && other.getIdentity() instanceof GroupDto) {
       return 1;
-    } else if (this.identity instanceof GroupDto && other.getIdentity() instanceof UserDto) {
+    } else if (identity instanceof GroupDto && other.getIdentity() instanceof UserDto) {
       return -1;
     } else {
-      return StringUtils.compareIgnoreCase(this.identity.getName(), other.getIdentity().getName());
+      return StringUtils.compareIgnoreCase(identity.getName(), other.getIdentity().getName());
     }
   }
 
@@ -73,7 +72,13 @@ public class CollectionRoleResponseDto implements Comparable<CollectionRoleRespo
   }
 
   public static <T extends IdentityWithMetadataResponseDto> CollectionRoleResponseDto from(
-      final CollectionRoleRequestDto roleDto, T identityWithMetaData) {
+      final CollectionRoleRequestDto roleDto, final T identityWithMetaData) {
     return new CollectionRoleResponseDto(identityWithMetaData, roleDto.getRole());
+  }
+
+  public enum Fields {
+    id,
+    identity,
+    role
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleUpdateRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionRoleUpdateRequestDto.java
@@ -12,12 +12,15 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@FieldNameConstants(asEnum = true)
 public class CollectionRoleUpdateRequestDto {
+
   private RoleType role;
+
+  public enum Fields {
+    role
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/collection/CollectionScopeEntryDto.java
@@ -20,13 +20,12 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants(asEnum = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class CollectionScopeEntryDto {
+
   private static final String ID_SEGMENT_SEPARATOR = ":";
 
   @EqualsAndHashCode.Include
@@ -43,11 +42,11 @@ public class CollectionScopeEntryDto {
         id.split(ID_SEGMENT_SEPARATOR)[1]);
   }
 
-  public CollectionScopeEntryDto(CollectionScopeEntryDto oldEntry) {
-    this.definitionKey = oldEntry.definitionKey;
-    this.definitionType = oldEntry.definitionType;
-    this.tenants = oldEntry.tenants;
-    this.id = convertTypeAndKeyToScopeEntryId(this.definitionType, this.definitionKey);
+  public CollectionScopeEntryDto(final CollectionScopeEntryDto oldEntry) {
+    definitionKey = oldEntry.definitionKey;
+    definitionType = oldEntry.definitionType;
+    tenants = oldEntry.tenants;
+    id = convertTypeAndKeyToScopeEntryId(definitionType, definitionKey);
   }
 
   public CollectionScopeEntryDto(final DefinitionType definitionType, final String definitionKey) {
@@ -56,7 +55,7 @@ public class CollectionScopeEntryDto {
 
   public CollectionScopeEntryDto(
       final DefinitionType definitionType, final String definitionKey, final List<String> tenants) {
-    this.id = convertTypeAndKeyToScopeEntryId(definitionType, definitionKey);
+    id = convertTypeAndKeyToScopeEntryId(definitionType, definitionKey);
     this.definitionType = definitionType;
     this.definitionKey = definitionKey;
     this.tenants = tenants;
@@ -83,11 +82,18 @@ public class CollectionScopeEntryDto {
   }
 
   private boolean isInTenantScope(final List<String> givenTenants) {
-    return givenTenants != null && this.tenants.containsAll(givenTenants);
+    return givenTenants != null && tenants.containsAll(givenTenants);
   }
 
   public static String convertTypeAndKeyToScopeEntryId(
       final DefinitionType definitionType, final String definitionKey) {
     return definitionType.getId() + ID_SEGMENT_SEPARATOR + definitionKey;
+  }
+
+  public enum Fields {
+    id,
+    definitionType,
+    definitionKey,
+    tenants
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/BaseDashboardDefinitionDto.java
@@ -12,11 +12,10 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 public class BaseDashboardDefinitionDto {
+
   protected String id;
   protected String name;
   protected String description;
@@ -29,4 +28,20 @@ public class BaseDashboardDefinitionDto {
   protected boolean instantPreviewDashboard = false;
   protected List<DashboardFilterDto<?>> availableFilters = new ArrayList<>();
   protected Long refreshRateSeconds;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String description = "description";
+    public static final String lastModified = "lastModified";
+    public static final String created = "created";
+    public static final String owner = "owner";
+    public static final String lastModifier = "lastModifier";
+    public static final String collectionId = "collectionId";
+    public static final String managementDashboard = "managementDashboard";
+    public static final String instantPreviewDashboard = "instantPreviewDashboard";
+    public static final String availableFilters = "availableFilters";
+    public static final String refreshRateSeconds = "refreshRateSeconds";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionRestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/DashboardDefinitionRestDto.java
@@ -26,13 +26,11 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 public class DashboardDefinitionRestDto extends BaseDashboardDefinitionDto
     implements CollectionEntity {
 
@@ -59,5 +57,10 @@ public class DashboardDefinitionRestDto extends BaseDashboardDefinitionDto
         EntityType.DASHBOARD,
         new EntityData(Map.of(EntityType.REPORT, (long) getTiles().size())),
         roleType);
+  }
+
+  public static final class Fields {
+
+    public static final String tiles = "tiles";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/InstantDashboardDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/InstantDashboardDataDto.java
@@ -9,27 +9,34 @@ package io.camunda.optimize.dto.optimize.query.dashboard;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.StringUtils;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Data
-@FieldNameConstants
 public class InstantDashboardDataDto {
+
+  public static final String INSTANT_DASHBOARD_DEFAULT_TEMPLATE = "template1.json";
   private String instantDashboardId;
   private String processDefinitionKey;
   private String templateName = INSTANT_DASHBOARD_DEFAULT_TEMPLATE;
   private long templateHash;
   private String dashboardId;
 
-  public static final String INSTANT_DASHBOARD_DEFAULT_TEMPLATE = "template1.json";
-
   public String getInstantDashboardId() {
     return processDefinitionKey + "_" + templateName.replace(".", "");
   }
 
-  public void setTemplateName(String templateName) {
+  public void setTemplateName(final String templateName) {
     this.templateName =
         StringUtils.isEmpty(templateName) ? INSTANT_DASHBOARD_DEFAULT_TEMPLATE : templateName;
+  }
+
+  public static final class Fields {
+
+    public static final String instantDashboardId = "instantDashboardId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String templateName = "templateName";
+    public static final String templateHash = "templateHash";
+    public static final String dashboardId = "dashboardId";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/DashboardFilterDto.java
@@ -12,11 +12,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.camunda.optimize.dto.optimize.query.report.single.filter.data.FilterDataDto;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor
-@FieldNameConstants
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSubTypes({
   @JsonSubTypes.Type(value = DashboardInstanceStartDateFilterDto.class, name = "instanceStartDate"),
@@ -27,9 +25,15 @@ import lombok.experimental.FieldNameConstants;
   @JsonSubTypes.Type(value = DashboardCandidateGroupFilterDto.class, name = "candidateGroup")
 })
 public abstract class DashboardFilterDto<DATA extends FilterDataDto> {
+
   protected DATA data;
 
   protected DashboardFilterDto(final DATA data) {
     this.data = data;
+  }
+
+  public static final class Fields {
+
+    public static final String data = "data";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardDateFilterDataDto.java
@@ -13,12 +13,16 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants
 public class DashboardDateFilterDataDto implements FilterDataDto {
+
   private DateFilterDataDto<?> defaultValues;
+
+  public static final class Fields {
+
+    public static final String defaultValues = "defaultValues";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIdentityFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardIdentityFilterDataDto.java
@@ -14,12 +14,10 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public class DashboardIdentityFilterDataDto extends IdentityLinkFilterDataDto {
 
   protected boolean allowCustomValues;
@@ -41,5 +39,11 @@ public class DashboardIdentityFilterDataDto extends IdentityLinkFilterDataDto {
     super(operator, values);
     this.allowCustomValues = allowCustomValues;
     this.defaultValues = defaultValues;
+  }
+
+  public static final class Fields {
+
+    public static final String allowCustomValues = "allowCustomValues";
+    public static final String defaultValues = "defaultValues";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/filter/data/DashboardStateFilterDataDto.java
@@ -13,12 +13,16 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants
 public class DashboardStateFilterDataDto implements FilterDataDto {
+
   private List<String> defaultValues;
+
+  public static final class Fields {
+
+    public static final String defaultValues = "defaultValues";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DashboardReportTileDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DashboardReportTileDto.java
@@ -12,13 +12,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @Builder(toBuilder = true)
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 public class DashboardReportTileDto {
 
   protected String id;
@@ -26,4 +24,13 @@ public class DashboardReportTileDto {
   protected DimensionDto dimensions;
   @NotNull protected DashboardTileType type;
   protected Object configuration;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String position = "position";
+    public static final String dimensions = "dimensions";
+    public static final String type = "type";
+    public static final String configuration = "configuration";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DimensionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/DimensionDto.java
@@ -10,14 +10,18 @@ package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 public class DimensionDto {
 
   protected int width;
   protected int height;
+
+  public static final class Fields {
+
+    public static final String width = "width";
+    public static final String height = "height";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/PositionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/dashboard/tile/PositionDto.java
@@ -10,14 +10,18 @@ package io.camunda.optimize.dto.optimize.query.dashboard.tile;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 public class PositionDto {
 
   protected int x;
   protected int y;
+
+  public static final class Fields {
+
+    public static final String x = "x";
+    public static final String y = "y";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityNameRequestDto.java
@@ -11,12 +11,10 @@ import jakarta.ws.rs.QueryParam;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants(asEnum = true)
 public class EntityNameRequestDto {
 
   @QueryParam("collectionId")
@@ -30,4 +28,11 @@ public class EntityNameRequestDto {
 
   @QueryParam("eventBasedProcessId")
   private String eventBasedProcessId;
+
+  public enum Fields {
+    collectionId,
+    dashboardId,
+    reportId,
+    eventBasedProcessId
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/entity/EntityResponseDto.java
@@ -14,13 +14,12 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
-@FieldNameConstants
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Data
 public class EntityResponseDto {
+
   private String id;
   private String name;
   private String description;
@@ -85,5 +84,21 @@ public class EntityResponseDto {
         combined,
         reportType,
         currentUserRole);
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String description = "description";
+    public static final String lastModified = "lastModified";
+    public static final String created = "created";
+    public static final String owner = "owner";
+    public static final String lastModifier = "lastModifier";
+    public static final String entityType = "entityType";
+    public static final String data = "data";
+    public static final String combined = "combined";
+    public static final String reportType = "reportType";
+    public static final String currentUserRole = "currentUserRole";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/DeletableEventDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/DeletableEventDto.java
@@ -12,12 +12,10 @@ import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 public class DeletableEventDto {
 
   private String id;
@@ -35,5 +33,15 @@ public class DeletableEventDto {
         eventDto.getSource(),
         eventDto.getEventName(),
         Instant.ofEpochMilli(eventDto.getTimestamp()));
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String traceId = "traceId";
+    public static final String group = "group";
+    public static final String source = "source";
+    public static final String eventName = "eventName";
+    public static final String timestamp = "timestamp";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/CamundaActivityEventDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/CamundaActivityEventDto.java
@@ -14,11 +14,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 @Builder(toBuilder = true)
 @Getter
 @ToString
@@ -37,4 +35,21 @@ public class CamundaActivityEventDto implements OptimizeDto, EventProcessEventDt
   private OffsetDateTime timestamp;
   private Long orderCounter;
   private boolean canceled;
+
+  public static final class Fields {
+
+    public static final String activityId = "activityId";
+    public static final String activityName = "activityName";
+    public static final String activityType = "activityType";
+    public static final String activityInstanceId = "activityInstanceId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String processInstanceId = "processInstanceId";
+    public static final String processDefinitionVersion = "processDefinitionVersion";
+    public static final String processDefinitionName = "processDefinitionName";
+    public static final String engine = "engine";
+    public static final String tenantId = "tenantId";
+    public static final String timestamp = "timestamp";
+    public static final String orderCounter = "orderCounter";
+    public static final String canceled = "canceled";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventCorrelationStateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventCorrelationStateDto.java
@@ -13,13 +13,18 @@ import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants
 public class EventCorrelationStateDto {
+
   private Map<MappedEventType, Set<String>> correlatedAsToFlowNodeInstanceIds =
       new EnumMap<>(MappedEventType.class);
+
+  public static final class Fields {
+
+    public static final String correlatedAsToFlowNodeInstanceIds =
+        "correlatedAsToFlowNodeInstanceIds";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventDto.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @NoArgsConstructor
@@ -27,8 +26,8 @@ import lombok.experimental.SuperBuilder;
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString(onlyExplicitlyIncluded = true)
-@FieldNameConstants()
 public class EventDto implements OptimizeDto, EventProcessEventDto {
+
   @NotBlank @EqualsAndHashCode.Include @ToString.Include private String id;
   @NotBlank @ToString.Include private String eventName;
 
@@ -42,4 +41,16 @@ public class EventDto implements OptimizeDto, EventProcessEventDto {
   @ToString.Include private String group;
   @ToString.Include private String source;
   private Object data;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String eventName = "eventName";
+    public static final String timestamp = "timestamp";
+    public static final String ingestionTimestamp = "ingestionTimestamp";
+    public static final String traceId = "traceId";
+    public static final String group = "group";
+    public static final String source = "source";
+    public static final String data = "data";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventImportSourceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventImportSourceDto.java
@@ -16,9 +16,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
-@FieldNameConstants
 @Builder
 @Data
 @NoArgsConstructor
@@ -36,4 +34,16 @@ public class EventImportSourceDto {
   // If the source type is 'Camunda', there should be a single config in this list. If 'External',
   // there can be multiple
   private List<EventSourceConfigDto> eventSourceConfigurations;
+
+  public static final class Fields {
+
+    public static final String firstEventForSourceAtTimeOfPublishTimestamp =
+        "firstEventForSourceAtTimeOfPublishTimestamp";
+    public static final String lastEventForSourceAtTimeOfPublishTimestamp =
+        "lastEventForSourceAtTimeOfPublishTimestamp";
+    public static final String lastImportedEventTimestamp = "lastImportedEventTimestamp";
+    public static final String lastImportExecutionTimestamp = "lastImportExecutionTimestamp";
+    public static final String eventImportSourceType = "eventImportSourceType";
+    public static final String eventSourceConfigurations = "eventSourceConfigurations";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventMappingDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventMappingDto.java
@@ -13,15 +13,19 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Builder
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 public class EventMappingDto implements OptimizeDto {
 
   @Valid EventTypeDto start;
   @Valid EventTypeDto end;
+
+  public static final class Fields {
+
+    public static final String start = "start";
+    public static final String end = "end";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessInstanceDto.java
@@ -17,18 +17,23 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(callSuper = true)
 @SuperBuilder(builderMethodName = "eventProcessInstanceBuilder")
-@FieldNameConstants
 public class EventProcessInstanceDto extends ProcessInstanceDto {
+
   @Builder.Default
   private List<FlowNodeInstanceUpdateDto> pendingFlowNodeInstanceUpdates = new ArrayList<>();
 
   @Builder.Default
   private Map<String, EventCorrelationStateDto> correlatedEventsById = new HashMap<>();
+
+  public static final class Fields {
+
+    public static final String pendingFlowNodeInstanceUpdates = "pendingFlowNodeInstanceUpdates";
+    public static final String correlatedEventsById = "correlatedEventsById";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessMappingDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessMappingDto.java
@@ -22,15 +22,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@FieldNameConstants
 public class EventProcessMappingDto implements OptimizeDto {
+
   @EqualsAndHashCode.Include private String id;
   @NotBlank private String name;
 
@@ -52,4 +51,18 @@ public class EventProcessMappingDto implements OptimizeDto {
   private Double publishingProgress;
 
   @Builder.Default private List<EventSourceEntryDto<?>> eventSources = new ArrayList<>();
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String lastModifier = "lastModifier";
+    public static final String lastModified = "lastModified";
+    public static final String xml = "xml";
+    public static final String mappings = "mappings";
+    public static final String roles = "roles";
+    public static final String state = "state";
+    public static final String publishingProgress = "publishingProgress";
+    public static final String eventSources = "eventSources";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessPublishStateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessPublishStateDto.java
@@ -18,15 +18,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Data
 @Builder
-@FieldNameConstants
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class EventProcessPublishStateDto {
+
   @EqualsAndHashCode.Include private String id;
   private String processMappingId;
   private String name;
@@ -41,5 +40,19 @@ public class EventProcessPublishStateDto {
   @JsonIgnore
   public String getProcessKey() {
     return processMappingId;
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String processMappingId = "processMappingId";
+    public static final String name = "name";
+    public static final String publishDateTime = "publishDateTime";
+    public static final String state = "state";
+    public static final String publishProgress = "publishProgress";
+    public static final String deleted = "deleted";
+    public static final String xml = "xml";
+    public static final String mappings = "mappings";
+    public static final String eventImportSources = "eventImportSources";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessRoleRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventProcessRoleRequestDto.java
@@ -13,12 +13,11 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@FieldNameConstants
 public class EventProcessRoleRequestDto<T extends IdentityDto> {
+
   private static final String ID_SEGMENT_SEPARATOR = ":";
 
   @Setter(value = AccessLevel.PROTECTED)
@@ -27,7 +26,7 @@ public class EventProcessRoleRequestDto<T extends IdentityDto> {
   private T identity;
 
   public EventProcessRoleRequestDto(final T identity) {
-    this.id = convertIdentityToRoleId(identity);
+    id = convertIdentityToRoleId(identity);
     this.identity = identity;
   }
 
@@ -39,5 +38,11 @@ public class EventProcessRoleRequestDto<T extends IdentityDto> {
     return identity.getType() == null
         ? "UNKNOWN" + ID_SEGMENT_SEPARATOR + identity.getId()
         : identity.getType().name() + ID_SEGMENT_SEPARATOR + identity.getId();
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String identity = "identity";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventToFlowNodeMapping.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventToFlowNodeMapping.java
@@ -14,19 +14,28 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@FieldNameConstants
 public class EventToFlowNodeMapping {
+
   @EqualsAndHashCode.Include private String eventIdentifier;
   private MappedEventType mappedAs;
   private String flowNodeId;
   private String flowNodeType;
   private List<String> previousMappedFlowNodeIds;
   private List<String> nextMappedFlowNodeIds;
+
+  public static final class Fields {
+
+    public static final String eventIdentifier = "eventIdentifier";
+    public static final String mappedAs = "mappedAs";
+    public static final String flowNodeId = "flowNodeId";
+    public static final String flowNodeType = "flowNodeType";
+    public static final String previousMappedFlowNodeIds = "previousMappedFlowNodeIds";
+    public static final String nextMappedFlowNodeIds = "nextMappedFlowNodeIds";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventTypeDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/EventTypeDto.java
@@ -17,7 +17,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
 @Setter
@@ -26,10 +25,18 @@ import lombok.experimental.FieldNameConstants;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder(toBuilder = true)
-@FieldNameConstants
 public class EventTypeDto implements OptimizeDto {
+
   private String group;
   private String source;
   @NotBlank private String eventName;
   @EqualsAndHashCode.Exclude private String eventLabel;
+
+  public static final class Fields {
+
+    public static final String group = "group";
+    public static final String source = "source";
+    public static final String eventName = "eventName";
+    public static final String eventLabel = "eventLabel";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/FlowNodeInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/FlowNodeInstanceDto.java
@@ -22,12 +22,10 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants
 @Accessors(chain = true)
 public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
 
@@ -115,7 +113,7 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
     this.engine = engine;
     this.flowNodeId = flowNodeId;
     this.flowNodeInstanceId = flowNodeInstanceId;
-    this.flowNodeType = FLOW_NODE_TYPE_USER_TASK;
+    flowNodeType = FLOW_NODE_TYPE_USER_TASK;
     this.userTaskInstanceId = userTaskInstanceId;
   }
 
@@ -128,7 +126,32 @@ public class FlowNodeInstanceDto implements Serializable, OptimizeDto {
     this.processInstanceId = processInstanceId;
     this.definitionKey = definitionKey;
     this.engine = engine;
-    this.flowNodeType = FLOW_NODE_TYPE_USER_TASK;
+    flowNodeType = FLOW_NODE_TYPE_USER_TASK;
     this.userTaskInstanceId = userTaskInstanceId;
+  }
+
+  public static final class Fields {
+
+    public static final String flowNodeInstanceId = "flowNodeInstanceId";
+    public static final String flowNodeId = "flowNodeId";
+    public static final String flowNodeType = "flowNodeType";
+    public static final String processInstanceId = "processInstanceId";
+    public static final String totalDurationInMs = "totalDurationInMs";
+    public static final String startDate = "startDate";
+    public static final String endDate = "endDate";
+    public static final String canceled = "canceled";
+    public static final String definitionKey = "definitionKey";
+    public static final String definitionVersion = "definitionVersion";
+    public static final String tenantId = "tenantId";
+    public static final String engine = "engine";
+    public static final String userTaskInstanceId = "userTaskInstanceId";
+    public static final String dueDate = "dueDate";
+    public static final String deleteReason = "deleteReason";
+    public static final String assignee = "assignee";
+    public static final String candidateGroups = "candidateGroups";
+    public static final String assigneeOperations = "assigneeOperations";
+    public static final String candidateGroupOperations = "candidateGroupOperations";
+    public static final String idleDurationInMs = "idleDurationInMs";
+    public static final String workDurationInMs = "workDurationInMs";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/FlowNodeInstanceUpdateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/FlowNodeInstanceUpdateDto.java
@@ -14,14 +14,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Data
-@FieldNameConstants
 public class FlowNodeInstanceUpdateDto implements OptimizeDto {
+
   protected String sourceEventId;
   protected String flowNodeId;
   protected String flowNodeType;
@@ -30,5 +29,14 @@ public class FlowNodeInstanceUpdateDto implements OptimizeDto {
 
   public String getId() {
     return sourceEventId + ":" + flowNodeId;
+  }
+
+  public static final class Fields {
+
+    public static final String sourceEventId = "sourceEventId";
+    public static final String flowNodeId = "flowNodeId";
+    public static final String flowNodeType = "flowNodeType";
+    public static final String mappedAs = "mappedAs";
+    public static final String date = "date";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/db/DbEventMappingDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/db/DbEventMappingDto.java
@@ -16,14 +16,12 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @Builder
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 @EqualsAndHashCode
 public class DbEventMappingDto implements OptimizeDto {
 
@@ -38,5 +36,12 @@ public class DbEventMappingDto implements OptimizeDto {
         .start(eventMappingDto.getStart())
         .end(eventMappingDto.getEnd())
         .build();
+  }
+
+  public static final class Fields {
+
+    public static final String flowNodeId = "flowNodeId";
+    public static final String start = "start";
+    public static final String end = "end";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/db/DbEventProcessMappingDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/db/DbEventProcessMappingDto.java
@@ -22,15 +22,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
-@FieldNameConstants
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class DbEventProcessMappingDto implements OptimizeDto {
+
   @EqualsAndHashCode.Include private String id;
   private String name;
   private String xml;
@@ -88,5 +87,17 @@ public class DbEventProcessMappingDto implements OptimizeDto {
         .eventSources(eventSources)
         .roles(roles)
         .build();
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String xml = "xml";
+    public static final String lastModified = "lastModified";
+    public static final String lastModifier = "lastModifier";
+    public static final String mappings = "mappings";
+    public static final String eventSources = "eventSources";
+    public static final String roles = "roles";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/db/DbEventProcessPublishStateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/db/DbEventProcessPublishStateDto.java
@@ -21,15 +21,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Data
 @Builder
-@FieldNameConstants
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class DbEventProcessPublishStateDto {
+
   @EqualsAndHashCode.Include private String id;
   private String processMappingId;
   private String name;
@@ -93,5 +92,19 @@ public class DbEventProcessPublishStateDto {
                 .orElse(null))
         .eventImportSources(getEventImportSources())
         .build();
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String processMappingId = "processMappingId";
+    public static final String name = "name";
+    public static final String publishDateTime = "publishDateTime";
+    public static final String state = "state";
+    public static final String publishProgress = "publishProgress";
+    public static final String deleted = "deleted";
+    public static final String xml = "xml";
+    public static final String mappings = "mappings";
+    public static final String eventImportSources = "eventImportSources";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/CamundaEventSourceConfigDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/CamundaEventSourceConfigDto.java
@@ -14,14 +14,12 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @NoArgsConstructor
 @SuperBuilder
 @Getter
 @Setter
-@FieldNameConstants
 @EqualsAndHashCode(callSuper = true)
 public class CamundaEventSourceConfigDto extends EventSourceConfigDto {
 
@@ -31,4 +29,14 @@ public class CamundaEventSourceConfigDto extends EventSourceConfigDto {
   @Builder.Default private List<String> tenants = new ArrayList<>();
   private boolean tracedByBusinessKey;
   private String traceVariable;
+
+  public static final class Fields {
+
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String processDefinitionName = "processDefinitionName";
+    public static final String versions = "versions";
+    public static final String tenants = "tenants";
+    public static final String tracedByBusinessKey = "tracedByBusinessKey";
+    public static final String traceVariable = "traceVariable";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/EventSourceConfigDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/EventSourceConfigDto.java
@@ -15,14 +15,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @SuperBuilder
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants
 @JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = CamundaEventSourceConfigDto.class),
@@ -31,4 +29,9 @@ import lombok.experimental.SuperBuilder;
 public abstract class EventSourceConfigDto {
 
   @Builder.Default protected List<EventScopeType> eventScope = Arrays.asList(EventScopeType.ALL);
+
+  public static final class Fields {
+
+    public static final String eventScope = "eventScope";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/EventSourceEntryDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/EventSourceEntryDto.java
@@ -18,7 +18,6 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
@@ -28,7 +27,6 @@ import lombok.experimental.SuperBuilder;
 })
 @Data
 @NoArgsConstructor
-@FieldNameConstants
 @SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public abstract class EventSourceEntryDto<CONFIG extends EventSourceConfigDto> {
@@ -38,10 +36,10 @@ public abstract class EventSourceEntryDto<CONFIG extends EventSourceConfigDto> {
   @EqualsAndHashCode.Include @NonNull @Builder.Default
   protected String id = IdGenerator.getNextId();
 
+  @NotNull protected CONFIG configuration;
+
   @JsonIgnore
   public abstract EventSourceType getSourceType();
-
-  @NotNull protected CONFIG configuration;
 
   // This source identifier is only used internally by Optimize for logic such as autogeneration
   @JsonIgnore
@@ -62,5 +60,11 @@ public abstract class EventSourceEntryDto<CONFIG extends EventSourceConfigDto> {
                 .orElse("optimize_noGroupSpecified");
       }
     }
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String configuration = "configuration";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/ExternalEventSourceConfigDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/process/source/ExternalEventSourceConfigDto.java
@@ -10,16 +10,20 @@ package io.camunda.optimize.dto.optimize.query.event.process.source;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @NoArgsConstructor
 @SuperBuilder
 @Getter
-@FieldNameConstants
 @EqualsAndHashCode(callSuper = true)
 public class ExternalEventSourceConfigDto extends EventSourceConfigDto {
 
   private String group;
   private boolean includeAllGroups;
+
+  public static final class Fields {
+
+    public static final String group = "group";
+    public static final String includeAllGroups = "includeAllGroups";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/EventCountResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/EventCountResponseDto.java
@@ -12,18 +12,27 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @Builder(toBuilder = true)
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 public class EventCountResponseDto {
+
   private String group;
   @NonNull private String source;
   @NonNull private String eventName;
   private String eventLabel;
   private Long count;
   @Builder.Default private boolean suggested = false;
+
+  public static final class Fields {
+
+    public static final String group = "group";
+    public static final String source = "source";
+    public static final String eventName = "eventName";
+    public static final String eventLabel = "eventLabel";
+    public static final String count = "count";
+    public static final String suggested = "suggested";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/EventSequenceCountDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/EventSequenceCountDto.java
@@ -14,13 +14,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Builder
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 public class EventSequenceCountDto implements OptimizeDto {
 
   public static final String ID_FIELD_SEPARATOR = ":";
@@ -47,12 +45,20 @@ public class EventSequenceCountDto implements OptimizeDto {
     }
   }
 
-  private String generateIdForEventType(EventTypeDto eventTypeDto) {
+  private String generateIdForEventType(final EventTypeDto eventTypeDto) {
     final Optional<EventTypeDto> eventType = Optional.ofNullable(eventTypeDto);
     return String.join(
         ID_FIELD_SEPARATOR,
         eventType.map(EventTypeDto::getGroup).orElse(null),
         eventType.map(EventTypeDto::getSource).orElse(null),
         eventType.map(EventTypeDto::getEventName).orElse(null));
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String sourceEvent = "sourceEvent";
+    public static final String targetEvent = "targetEvent";
+    public static final String count = "count";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/EventTraceStateDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/EventTraceStateDto.java
@@ -13,15 +13,19 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Builder
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 public class EventTraceStateDto implements OptimizeDto {
 
   private String traceId;
   private List<TracedEventDto> eventTrace;
+
+  public static final class Fields {
+
+    public static final String traceId = "traceId";
+    public static final String eventTrace = "eventTrace";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/TracedEventDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/event/sequence/TracedEventDto.java
@@ -13,13 +13,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Builder
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 public class TracedEventDto implements OptimizeDto {
 
   private String eventId;
@@ -29,7 +27,7 @@ public class TracedEventDto implements OptimizeDto {
   private Long timestamp;
   private Long orderCounter;
 
-  public static TracedEventDto fromEventDto(EventDto eventDto) {
+  public static TracedEventDto fromEventDto(final EventDto eventDto) {
     return TracedEventDto.builder()
         .eventId(eventDto.getId())
         .timestamp(eventDto.getTimestamp())
@@ -41,5 +39,15 @@ public class TracedEventDto implements OptimizeDto {
                 ? ((OrderedEventDto) eventDto).getOrderCounter()
                 : null)
         .build();
+  }
+
+  public static final class Fields {
+
+    public static final String eventId = "eventId";
+    public static final String group = "group";
+    public static final String source = "source";
+    public static final String eventName = "eventName";
+    public static final String timestamp = "timestamp";
+    public static final String orderCounter = "orderCounter";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/KpiResultDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/KpiResultDto.java
@@ -18,11 +18,9 @@ import io.camunda.optimize.service.exceptions.OptimizeRuntimeException;
 import java.time.Duration;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import org.apache.commons.lang3.StringUtils;
 
 @Data
-@FieldNameConstants
 @NoArgsConstructor
 public class KpiResultDto {
 
@@ -66,5 +64,18 @@ public class KpiResultDto {
               >= 0
           : doubleValue >= doubleTarget;
     }
+  }
+
+  public static final class Fields {
+
+    public static final String reportId = "reportId";
+    public static final String collectionId = "collectionId";
+    public static final String reportName = "reportName";
+    public static final String value = "value";
+    public static final String target = "target";
+    public static final String isBelow = "isBelow";
+    public static final String type = "type";
+    public static final String measure = "measure";
+    public static final String unit = "unit";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestDto.java
@@ -12,17 +12,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProcessDigestDto extends ProcessDigestResponseDto {
-
-  /** Needed to inherit field name constants from {@link ProcessDigestResponseDto} */
-  public static class Fields extends ProcessDigestResponseDto.Fields {}
 
   // This is the baseline results, or in other words the results that were included in the
   // previously sent digest
@@ -31,5 +26,11 @@ public class ProcessDigestDto extends ProcessDigestResponseDto {
   public ProcessDigestDto(final Boolean enabled, final Map<String, String> kpiReportResults) {
     super(enabled);
     this.kpiReportResults = kpiReportResults;
+  }
+
+  /** Needed to inherit field name constants from {@link ProcessDigestResponseDto} */
+  public static class Fields extends ProcessDigestResponseDto.Fields {
+
+    public static final String kpiReportResults = "kpiReportResults";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessDigestResponseDto.java
@@ -13,18 +13,19 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProcessDigestResponseDto implements OptimizeDto {
 
-  // needed to allow inheritance of field name constants
-  @NoArgsConstructor(access = AccessLevel.PROTECTED)
-  public static class Fields {}
-
   @JsonProperty("enabled")
   protected boolean enabled;
+
+  // needed to allow inheritance of field name constants
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class Fields {
+
+    public static final String enabled = "enabled";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewDto.java
@@ -12,15 +12,22 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProcessOverviewDto implements OptimizeDto {
+
   private String owner;
   private String processDefinitionKey;
   private ProcessDigestDto digest;
   private Map<String, String> lastKpiEvaluationResults;
+
+  public static final class Fields {
+
+    public static final String owner = "owner";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String digest = "digest";
+    public static final String lastKpiEvaluationResults = "lastKpiEvaluationResults";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/processoverview/ProcessOverviewResponseDto.java
@@ -11,16 +11,24 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 @AllArgsConstructor
 @NoArgsConstructor
 public class ProcessOverviewResponseDto {
+
   private String processDefinitionName;
   private String processDefinitionKey;
   private ProcessOwnerResponseDto owner;
   private ProcessDigestResponseDto digest;
   private List<KpiResultDto> kpis;
+
+  public static final class Fields {
+
+    public static final String processDefinitionName = "processDefinitionName";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String owner = "owner";
+    public static final String digest = "digest";
+    public static final String kpis = "kpis";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/ReportDefinitionDto.java
@@ -18,13 +18,11 @@ import jakarta.validation.Valid;
 import java.time.OffsetDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @Data
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
-@FieldNameConstants
 public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionEntity {
 
   protected String id;
@@ -42,7 +40,7 @@ public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionE
 
   private final ReportType reportType;
 
-  protected ReportDefinitionDto(D data, Boolean combined, ReportType reportType) {
+  protected ReportDefinitionDto(final D data, final Boolean combined, final ReportType reportType) {
     this.data = data;
     this.combined = combined;
     this.reportType = reportType;
@@ -59,13 +57,28 @@ public class ReportDefinitionDto<D extends ReportDataDto> implements CollectionE
         getOwner(),
         getLastModifier(),
         EntityType.REPORT,
-        this.combined,
-        this.reportType,
+        combined,
+        reportType,
         roleType);
   }
 
   @JsonIgnore
   public DefinitionType getDefinitionType() {
-    return this.reportType.toDefinitionType();
+    return reportType.toDefinitionType();
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String description = "description";
+    public static final String lastModified = "lastModified";
+    public static final String created = "created";
+    public static final String owner = "owner";
+    public static final String lastModifier = "lastModifier";
+    public static final String collectionId = "collectionId";
+    public static final String data = "data";
+    public static final String combined = "combined";
+    public static final String reportType = "reportType";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportDataDto.java
@@ -20,12 +20,10 @@ import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 public class CombinedReportDataDto implements ReportDataDto {
 
   protected CombinedReportConfigurationDto configuration = new CombinedReportConfigurationDto();
@@ -50,5 +48,12 @@ public class CombinedReportDataDto implements ReportDataDto {
   @Override
   public List<String> createCommandKeys() {
     return Collections.singletonList(createCommandKey());
+  }
+
+  public static final class Fields {
+
+    public static final String configuration = "configuration";
+    public static final String visualization = "visualization";
+    public static final String reports = "reports";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportItemDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/combined/CombinedReportItemDto.java
@@ -14,19 +14,23 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @Builder(toBuilder = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@FieldNameConstants
 public class CombinedReportItemDto {
 
   private String id;
   @Builder.Default private String color = DEFAULT_CONFIGURATION_COLOR;
 
-  public CombinedReportItemDto(String id) {
+  public CombinedReportItemDto(final String id) {
     this.id = id;
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String color = "color";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ReportDataDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/ReportDataDefinitionDto.java
@@ -17,13 +17,12 @@ import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Data
-@FieldNameConstants
 @NoArgsConstructor
 public class ReportDataDefinitionDto {
+
   @NotEmpty private String identifier = UUID.randomUUID().toString();
   private String key;
   private String name;
@@ -92,6 +91,16 @@ public class ReportDataDefinitionDto {
 
   @JsonIgnore
   public void setVersion(final String version) {
-    this.versions = List.of(version);
+    versions = List.of(version);
+  }
+
+  public static final class Fields {
+
+    public static final String identifier = "identifier";
+    public static final String key = "key";
+    public static final String name = "name";
+    public static final String displayName = "displayName";
+    public static final String versions = "versions";
+    public static final String tenantIds = "tenantIds";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/SingleReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/SingleReportDataDto.java
@@ -22,11 +22,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @AllArgsConstructor
-@FieldNameConstants
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SuperBuilder
 public abstract class SingleReportDataDto implements ReportDataDto {
@@ -74,12 +72,18 @@ public abstract class SingleReportDataDto implements ReportDataDto {
 
   @JsonIgnore
   public void setTenantIds(final List<String> tenantIds) {
-    if (this.definitions.isEmpty()) {
-      this.definitions.add(new ReportDataDefinitionDto());
+    if (definitions.isEmpty()) {
+      definitions.add(new ReportDataDefinitionDto());
     }
-    this.definitions.get(0).setTenantIds(tenantIds);
+    definitions.get(0).setTenantIds(tenantIds);
   }
 
   @JsonIgnore
   public abstract List<ViewProperty> getViewProperties();
+
+  public static final class Fields {
+
+    public static final String configuration = "configuration";
+    public static final String definitions = "definitions";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/MeasureVisualizationsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/MeasureVisualizationsDto.java
@@ -9,11 +9,16 @@ package io.camunda.optimize.dto.optimize.query.report.single.configuration;
 
 import io.camunda.optimize.dto.optimize.ReportConstants;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 public class MeasureVisualizationsDto {
+
   private String frequency = ReportConstants.BAR_VISUALIZATION;
   private String duration = ReportConstants.LINE_VISUALIZATION;
+
+  public static final class Fields {
+
+    public static final String frequency = "frequency";
+    public static final String duration = "duration";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/SingleReportConfigurationDto.java
@@ -27,14 +27,13 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @Builder
 @Data
-@FieldNameConstants
 @NoArgsConstructor
 public class SingleReportConfigurationDto implements Combinable {
+
   @Builder.Default private String color = ReportConstants.DEFAULT_CONFIGURATION_COLOR;
 
   @Builder.Default
@@ -128,5 +127,36 @@ public class SingleReportConfigurationDto implements Combinable {
 
   public Optional<ProcessPartDto> getProcessPart() {
     return Optional.ofNullable(processPart);
+  }
+
+  public static final class Fields {
+
+    public static final String color = "color";
+    public static final String aggregationTypes = "aggregationTypes";
+    public static final String userTaskDurationTimes = "userTaskDurationTimes";
+    public static final String showInstanceCount = "showInstanceCount";
+    public static final String pointMarkers = "pointMarkers";
+    public static final String precision = "precision";
+    public static final String hideRelativeValue = "hideRelativeValue";
+    public static final String hideAbsoluteValue = "hideAbsoluteValue";
+    public static final String yLabel = "yLabel";
+    public static final String xLabel = "xLabel";
+    public static final String alwaysShowRelative = "alwaysShowRelative";
+    public static final String alwaysShowAbsolute = "alwaysShowAbsolute";
+    public static final String showGradientBars = "showGradientBars";
+    public static final String xml = "xml";
+    public static final String tableColumns = "tableColumns";
+    public static final String targetValue = "targetValue";
+    public static final String heatmapTargetValue = "heatmapTargetValue";
+    public static final String groupByDateVariableUnit = "groupByDateVariableUnit";
+    public static final String distributeByDateVariableUnit = "distributeByDateVariableUnit";
+    public static final String customBucket = "customBucket";
+    public static final String distributeByCustomBucket = "distributeByCustomBucket";
+    public static final String sorting = "sorting";
+    public static final String processPart = "processPart";
+    public static final String measureVisualizations = "measureVisualizations";
+    public static final String stackedBar = "stackedBar";
+    public static final String horizontalBar = "horizontalBar";
+    public static final String logScale = "logScale";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/TableColumnDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/TableColumnDto.java
@@ -18,16 +18,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import lombok.extern.slf4j.Slf4j;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 @Builder
 @Data
 @Slf4j
 public class TableColumnDto {
+
   public static final String VARIABLE_PREFIX = "variable:";
   public static final String INPUT_PREFIX = "input:";
   public static final String OUTPUT_PREFIX = "output:";
@@ -122,7 +121,7 @@ public class TableColumnDto {
     return 0;
   }
 
-  private String getColumnNameWithoutPrefixAndNumbers(String columnName) {
+  private String getColumnNameWithoutPrefixAndNumbers(final String columnName) {
     if (getPrefixOrder(columnName) == 0) {
       // do not sort dto fields to keep them in original order
       return "";
@@ -148,15 +147,23 @@ public class TableColumnDto {
     removeColumns(columnsToRemove);
   }
 
-  private double getNumbersInColumnName(String columnName) {
-    String digitsInString = columnName.replaceAll("\\D+", "");
+  private double getNumbersInColumnName(final String columnName) {
+    final String digitsInString = columnName.replaceAll("\\D+", "");
     try {
       return digitsInString.isEmpty() ? 0 : Double.parseDouble(digitsInString);
-    } catch (NumberFormatException e) {
+    } catch (final NumberFormatException e) {
       log.debug(
           "Cannot parse numbers in variable column names to double, ignoring and sorting by string.",
           e);
       return Double.MAX_VALUE;
     }
+  }
+
+  public static final class Fields {
+
+    public static final String includeNewVariables = "includeNewVariables";
+    public static final String excludedColumns = "excludedColumns";
+    public static final String includedColumns = "includedColumns";
+    public static final String columnOrder = "columnOrder";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/custom_buckets/CustomBucketDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/custom_buckets/CustomBucketDto.java
@@ -16,14 +16,13 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @Builder
-@FieldNameConstants(asEnum = true)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class CustomBucketDto {
+
   @Builder.Default private boolean active = false;
 
   @Builder.Default
@@ -41,11 +40,11 @@ public class CustomBucketDto {
   @Builder.Default private BucketUnit baselineUnit = null;
 
   public Optional<Double> getBucketSizeInUnit(final BucketUnit requestedBucketUnit) {
-    return convertValueToRequestedUnit(requestedBucketUnit, this.bucketSize, this.bucketSizeUnit);
+    return convertValueToRequestedUnit(requestedBucketUnit, bucketSize, bucketSizeUnit);
   }
 
   public Optional<Double> getBaselineInUnit(final BucketUnit requestedBucketUnit) {
-    return convertValueToRequestedUnit(requestedBucketUnit, this.baseline, this.baselineUnit);
+    return convertValueToRequestedUnit(requestedBucketUnit, baseline, baselineUnit);
   }
 
   private Optional<Double> convertValueToRequestedUnit(
@@ -92,5 +91,13 @@ public class CustomBucketDto {
         throw new OptimizeRuntimeException("Unsupported bucket unit: " + bucketUnit);
     }
     return chronoUnit.getDuration().toMillis();
+  }
+
+  public enum Fields {
+    active,
+    bucketSize,
+    bucketSizeUnit,
+    baseline,
+    baselineUnit
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/CountProgressDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/CountProgressDto.java
@@ -11,17 +11,20 @@ import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
 @Setter
-@FieldNameConstants
 @ToString
 public class CountProgressDto {
 
   private String baseline = "0";
   private String target = "100";
   private Boolean isBelow = false;
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(baseline, target);
+  }
 
   @Override
   public boolean equals(final Object o) {
@@ -36,8 +39,10 @@ public class CountProgressDto {
         && Objects.equals(target, that.target);
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(baseline, target);
+  public static final class Fields {
+
+    public static final String baseline = "baseline";
+    public static final String target = "target";
+    public static final String isBelow = "isBelow";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/DurationProgressDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/DurationProgressDto.java
@@ -11,16 +11,19 @@ import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
 @Setter
-@FieldNameConstants
 @ToString
 public class DurationProgressDto {
 
   private BaseLineDto baseline = new BaseLineDto();
   private TargetDto target = new TargetDto();
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(baseline, target);
+  }
 
   @Override
   public boolean equals(final Object o) {
@@ -33,8 +36,9 @@ public class DurationProgressDto {
     return Objects.equals(baseline, that.baseline) && Objects.equals(target, that.target);
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(baseline, target);
+  public static final class Fields {
+
+    public static final String baseline = "baseline";
+    public static final String target = "target";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportTargetValueDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/SingleReportTargetValueDto.java
@@ -8,10 +8,8 @@
 package io.camunda.optimize.dto.optimize.query.report.single.configuration.target_value;
 
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 public class SingleReportTargetValueDto {
 
   private SingleReportCountChartDto countChart = new SingleReportCountChartDto();
@@ -20,4 +18,14 @@ public class SingleReportTargetValueDto {
   private CountProgressDto countProgress = new CountProgressDto();
   private SingleReportDurationChartDto durationChart = new SingleReportDurationChartDto();
   private Boolean isKpi;
+
+  public static final class Fields {
+
+    public static final String countChart = "countChart";
+    public static final String durationProgress = "durationProgress";
+    public static final String active = "active";
+    public static final String countProgress = "countProgress";
+    public static final String durationChart = "durationChart";
+    public static final String isKpi = "isKpi";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/TargetDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/configuration/target_value/TargetDto.java
@@ -11,17 +11,20 @@ import java.util.Objects;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
 @Setter
-@FieldNameConstants
 @ToString
 public class TargetDto {
 
   private TargetValueUnit unit = TargetValueUnit.HOURS;
   private String value = "2";
   private Boolean isBelow = false;
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(unit, value);
+  }
 
   @Override
   public boolean equals(final Object o) {
@@ -36,8 +39,10 @@ public class TargetDto {
         && Objects.equals(value, targetDto.value);
   }
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(unit, value);
+  public static final class Fields {
+
+    public static final String unit = "unit";
+    public static final String value = "value";
+    public static final String isBelow = "isBelow";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/DecisionReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/DecisionReportDataDto.java
@@ -26,13 +26,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(callSuper = false)
-@FieldNameConstants
 @NoArgsConstructor
 @SuperBuilder
 @DecisionFiltersMustReferenceExistingDefinitionsConstraint
@@ -61,7 +59,7 @@ public class DecisionReportDataDto extends SingleReportDataDto {
   }
 
   @JsonIgnore
-  public void setDecisionDefinitionName(String name) {
+  public void setDecisionDefinitionName(final String name) {
     final List<ReportDataDefinitionDto> definitions = getDefinitions();
     if (definitions.isEmpty()) {
       definitions.add(new ReportDataDefinitionDto());
@@ -96,16 +94,25 @@ public class DecisionReportDataDto extends SingleReportDataDto {
     return getView().getProperties();
   }
 
+  @JsonIgnore
+  @Override
+  public String createCommandKey() {
+    final String viewCommandKey = view == null ? "null" : view.createCommandKey();
+    final String groupByCommandKey = groupBy == null ? "null" : groupBy.createCommandKey();
+    return viewCommandKey + "_" + groupByCommandKey;
+  }
+
   @Override
   public List<String> createCommandKeys() {
     return Collections.singletonList(createCommandKey());
   }
 
-  @JsonIgnore
-  @Override
-  public String createCommandKey() {
-    String viewCommandKey = view == null ? "null" : view.createCommandKey();
-    String groupByCommandKey = groupBy == null ? "null" : groupBy.createCommandKey();
-    return viewCommandKey + "_" + groupByCommandKey;
+  public static final class Fields {
+
+    public static final String filter = "filter";
+    public static final String view = "view";
+    public static final String groupBy = "groupBy";
+    public static final String distributedBy = "distributedBy";
+    public static final String visualization = "visualization";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/RawDataDecisionInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/result/raw/RawDataDecisionInstanceDto.java
@@ -13,13 +13,12 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@FieldNameConstants(asEnum = true)
 public class RawDataDecisionInstanceDto implements RawDataInstanceDto {
+
   protected String decisionDefinitionKey;
   protected String decisionDefinitionId;
   protected String decisionInstanceId;
@@ -27,6 +26,16 @@ public class RawDataDecisionInstanceDto implements RawDataInstanceDto {
   protected OffsetDateTime evaluationDateTime;
   protected String engineName;
   protected String tenantId;
-  @FieldNameConstants.Exclude protected Map<String, InputVariableEntry> inputVariables;
-  @FieldNameConstants.Exclude protected Map<String, OutputVariableEntry> outputVariables;
+  protected Map<String, InputVariableEntry> inputVariables;
+  protected Map<String, OutputVariableEntry> outputVariables;
+
+  public enum Fields {
+    decisionDefinitionKey,
+    decisionDefinitionId,
+    decisionInstanceId,
+    processInstanceId,
+    evaluationDateTime,
+    engineName,
+    tenantId
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/view/DecisionViewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/decision/view/DecisionViewDto.java
@@ -16,18 +16,16 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants
 public class DecisionViewDto {
 
   protected List<ViewProperty> properties = new ArrayList<>();
 
   public DecisionViewDto(final ViewProperty property) {
-    this.getProperties().add(property);
+    getProperties().add(property);
   }
 
   @JsonIgnore
@@ -42,5 +40,10 @@ public class DecisionViewDto {
 
   public void setProperties(final ViewProperty... properties) {
     this.properties = Arrays.asList(properties);
+  }
+
+  public static final class Fields {
+
+    public static final String properties = "properties";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/DateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/DateFilterDataDto.java
@@ -22,7 +22,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish which filter type the jackson
@@ -41,7 +40,6 @@ import lombok.experimental.FieldNameConstants;
 @Setter
 @EqualsAndHashCode
 @Accessors(chain = true)
-@FieldNameConstants
 public abstract class DateFilterDataDto<START> implements FilterDataDto {
 
   protected DateFilterType type;
@@ -57,5 +55,14 @@ public abstract class DateFilterDataDto<START> implements FilterDataDto {
     this.type = type;
     this.start = start;
     this.end = end;
+  }
+
+  public static final class Fields {
+
+    public static final String type = "type";
+    public static final String start = "start";
+    public static final String end = "end";
+    public static final String includeUndefined = "includeUndefined";
+    public static final String excludeUndefined = "excludeUndefined";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RelativeDateFilterStartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RelativeDateFilterStartDto.java
@@ -12,16 +12,20 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 @EqualsAndHashCode
 public class RelativeDateFilterStartDto {
 
   protected Long value;
   protected DateUnit unit;
+
+  public static final class Fields {
+
+    public static final String value = "value";
+    public static final String unit = "unit";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RollingDateFilterStartDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/RollingDateFilterStartDto.java
@@ -12,16 +12,20 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 @EqualsAndHashCode
 public class RollingDateFilterStartDto {
 
   protected Long value;
   protected DateUnit unit;
+
+  public static final class Fields {
+
+    public static final String value = "value";
+    public static final String unit = "unit";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FlowNodeDateFilterDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/date/flownode/FlowNodeDateFilterDataDto.java
@@ -20,7 +20,6 @@ import java.util.List;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @JsonTypeInfo(
     use = JsonTypeInfo.Id.NAME,
@@ -34,7 +33,6 @@ import lombok.experimental.FieldNameConstants;
 @Getter
 @Setter
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public abstract class FlowNodeDateFilterDataDto<START> extends DateFilterDataDto<START> {
 
   protected List<String> flowNodeIds;
@@ -46,5 +44,10 @@ public abstract class FlowNodeDateFilterDataDto<START> extends DateFilterDataDto
       final OffsetDateTime end) {
     super(type, start, end);
     this.flowNodeIds = flowNodeIds;
+  }
+
+  public static final class Fields {
+
+    public static final String flowNodeIds = "flowNodeIds";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/DashboardVariableFilterSubDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/filter/data/variable/data/DashboardVariableFilterSubDataDto.java
@@ -15,13 +15,11 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
-@FieldNameConstants
 public class DashboardVariableFilterSubDataDto extends OperatorMultipleValuesFilterDataDto {
 
   protected boolean allowCustomValues;
@@ -30,5 +28,10 @@ public class DashboardVariableFilterSubDataDto extends OperatorMultipleValuesFil
       final FilterOperator operator, final List<String> values, final boolean allowCustomValues) {
     super(operator, values);
     this.allowCustomValues = allowCustomValues;
+  }
+
+  public static final class Fields {
+
+    public static final String allowCustomValues = "allowCustomValues";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/ProcessReportDataDto.java
@@ -39,13 +39,11 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(callSuper = false)
-@FieldNameConstants
 @NoArgsConstructor
 @SuperBuilder
 @ProcessFiltersMustReferenceExistingDefinitionsConstraint
@@ -114,12 +112,18 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     return view.getProperties();
   }
 
+  @JsonIgnore
+  @Override
+  public String createCommandKey() {
+    return createCommandKeys().get(0);
+  }
+
   @Override
   public List<String> createCommandKeys() {
     final String groupByCommandKey =
         groupBy == null ? MISSING_COMMAND_PART_PLACEHOLDER : groupBy.createCommandKey();
-    String distributedByCommandKey = createDistributedByCommandKey();
-    String configurationCommandKey =
+    final String distributedByCommandKey = createDistributedByCommandKey();
+    final String configurationCommandKey =
         Optional.ofNullable(getConfiguration())
             .map(SingleReportConfigurationDto::createCommandKey)
             .orElse(MISSING_COMMAND_PART_PLACEHOLDER);
@@ -138,12 +142,6 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
         .collect(Collectors.toList());
   }
 
-  @JsonIgnore
-  @Override
-  public String createCommandKey() {
-    return createCommandKeys().get(0);
-  }
-
   public String createDistributedByCommandKey() {
     if (distributedBy != null && (isModelElementCommand() || isInstanceCommand())) {
       return distributedBy.createCommandKey();
@@ -152,14 +150,14 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
   }
 
   @Override
-  public boolean isCombinable(Object o) {
+  public boolean isCombinable(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof ProcessReportDataDto)) {
       return false;
     }
-    ProcessReportDataDto that = (ProcessReportDataDto) o;
+    final ProcessReportDataDto that = (ProcessReportDataDto) o;
     return Combinable.isCombinable(getView(), that.getView())
         && isGroupByCombinable(that)
         && Combinable.isCombinable(getDistributedBy(), that.getDistributedBy())
@@ -198,9 +196,9 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
   }
 
   private boolean isGroupByCombinable(final ProcessReportDataDto that) {
-    if (Combinable.isCombinable(this.groupBy, that.groupBy)) {
+    if (Combinable.isCombinable(groupBy, that.groupBy)) {
       if (isGroupByDateVariableReport()) {
-        return this.getConfiguration()
+        return getConfiguration()
             .getGroupByDateVariableUnit()
             .equals(that.getConfiguration().getGroupByDateVariableUnit());
       } else if (isGroupByNumberReport()) {
@@ -212,10 +210,10 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
   }
 
   private boolean isBucketSizeCombinable(final ProcessReportDataDto that) {
-    return this.getConfiguration().getCustomBucket().isActive()
+    return getConfiguration().getCustomBucket().isActive()
             && that.getConfiguration().getCustomBucket().isActive()
             && Objects.equals(
-                this.getConfiguration().getCustomBucket().getBucketSize(),
+                getConfiguration().getCustomBucket().getBucketSize(),
                 that.getConfiguration().getCustomBucket().getBucketSize())
         || isBucketSizeIrrelevant(this) && isBucketSizeIrrelevant(that);
   }
@@ -260,5 +258,16 @@ public class ProcessReportDataDto extends SingleReportDataDto implements Combina
     return nonNull(view)
         && nonNull(view.getEntity())
         && ProcessViewEntity.PROCESS_INSTANCE.equals(view.getEntity());
+  }
+
+  public static final class Fields {
+
+    public static final String filter = "filter";
+    public static final String view = "view";
+    public static final String groupBy = "groupBy";
+    public static final String distributedBy = "distributedBy";
+    public static final String visualization = "visualization";
+    public static final String managementReport = "managementReport";
+    public static final String instantPreviewReport = "instantPreviewReport";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/ProcessReportDistributedByDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/distributed/ProcessReportDistributedByDto.java
@@ -25,7 +25,6 @@ import io.camunda.optimize.dto.optimize.query.report.Combinable;
 import io.camunda.optimize.dto.optimize.query.report.single.configuration.DistributedByType;
 import io.camunda.optimize.dto.optimize.query.report.single.process.distributed.value.ProcessReportDistributedByValueDto;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish which distributed by type the
@@ -49,7 +48,6 @@ import lombok.experimental.FieldNameConstants;
   @JsonSubTypes.Type(value = ProcessDistributedByDto.class, name = DISTRIBUTED_BY_PROCESS)
 })
 @Data
-@FieldNameConstants
 public class ProcessReportDistributedByDto<VALUE extends ProcessReportDistributedByValueDto>
     implements Combinable {
 
@@ -70,5 +68,11 @@ public class ProcessReportDistributedByDto<VALUE extends ProcessReportDistribute
   public boolean isCombinable(final Object o) {
     return DistributedByType.NONE.equals(type)
         && DistributedByType.NONE.equals(((ProcessReportDistributedByDto<?>) o).getType());
+  }
+
+  public static final class Fields {
+
+    public static final String type = "type";
+    public static final String value = "value";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/filter/ProcessFilterDto.java
@@ -16,7 +16,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 /**
  * Abstract class that contains a hidden "type" field to distinguish, which filter type the jackson
@@ -66,7 +65,6 @@ import lombok.experimental.FieldNameConstants;
 })
 @Data
 @NoArgsConstructor
-@FieldNameConstants
 public abstract class ProcessFilterDto<DATA extends FilterDataDto> {
 
   protected DATA data;
@@ -74,7 +72,7 @@ public abstract class ProcessFilterDto<DATA extends FilterDataDto> {
 
   @NotEmpty protected List<String> appliedTo = List.of(ReportConstants.APPLIED_TO_ALL_DEFINITIONS);
 
-  protected ProcessFilterDto(final DATA data, FilterApplicationLevel filterLevel) {
+  protected ProcessFilterDto(final DATA data, final FilterApplicationLevel filterLevel) {
     this.data = data;
     setFilterLevel(filterLevel);
   }
@@ -84,5 +82,12 @@ public abstract class ProcessFilterDto<DATA extends FilterDataDto> {
   @Override
   public String toString() {
     return "ProcessFilter=" + getClass().getSimpleName();
+  }
+
+  public static final class Fields {
+
+    public static final String data = "data";
+    public static final String filterLevel = "filterLevel";
+    public static final String appliedTo = "appliedTo";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataCountDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataCountDto.java
@@ -11,14 +11,19 @@ import io.camunda.optimize.dto.optimize.query.report.single.RawDataInstanceDto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
-@FieldNameConstants(asEnum = true)
 public class RawDataCountDto implements RawDataInstanceDto {
+
   protected long incidents;
   protected long openIncidents;
   protected long userTasks;
+
+  public enum Fields {
+    incidents,
+    openIncidents,
+    userTasks
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataProcessInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/result/raw/RawDataProcessInstanceDto.java
@@ -15,18 +15,17 @@ import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Data
-@FieldNameConstants(asEnum = true)
 public class RawDataProcessInstanceDto implements RawDataInstanceDto {
+
   protected String processDefinitionKey;
   protected String processDefinitionId;
   protected String processInstanceId;
-  @FieldNameConstants.Exclude protected RawDataCountDto counts;
-  @FieldNameConstants.Exclude protected Map<String, FlowNodeTotalDurationDataDto> flowNodeDurations;
+  protected RawDataCountDto counts;
+  protected Map<String, FlowNodeTotalDurationDataDto> flowNodeDurations;
   protected String businessKey;
   protected OffsetDateTime startDate;
   protected OffsetDateTime endDate;
@@ -35,12 +34,23 @@ public class RawDataProcessInstanceDto implements RawDataInstanceDto {
   protected String engineName;
   protected String tenantId;
 
-  @FieldNameConstants.Exclude
   // Note that for more convenient display in raw data reports, each list of variable values is
   // joined to form one
   // comma separated string
   protected Map<String, Object> variables;
 
   // Note that the flow node data field can only be included on the Json export response
-  @FieldNameConstants.Exclude protected List<RawDataFlowNodeDataDto> flowNodeInstances;
+  protected List<RawDataFlowNodeDataDto> flowNodeInstances;
+
+  public enum Fields {
+    processDefinitionKey,
+    processDefinitionId,
+    processInstanceId,
+    businessKey,
+    startDate,
+    endDate,
+    duration,
+    engineName,
+    tenantId
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/report/single/process/view/ProcessViewDto.java
@@ -20,12 +20,11 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @Data
-@FieldNameConstants
 public class ProcessViewDto implements Combinable {
+
   private static final Set<ProcessViewEntity> FLOW_NODE_ENTITIES =
       ImmutableSet.of(ProcessViewEntity.FLOW_NODE, ProcessViewEntity.USER_TASK);
   private static final String COMMAND_KEY_SEPARATOR = "-";
@@ -33,13 +32,13 @@ public class ProcessViewDto implements Combinable {
   protected ProcessViewEntity entity;
   protected List<ViewProperty> properties = new ArrayList<>();
 
-  public ProcessViewDto(ViewProperty property) {
+  public ProcessViewDto(final ViewProperty property) {
     this(null, property);
   }
 
   public ProcessViewDto(final ProcessViewEntity entity, final ViewProperty property) {
     this.entity = entity;
-    this.properties.add(property);
+    properties.add(property);
   }
 
   public ProcessViewDto(final ProcessViewEntity entity, final List<ViewProperty> properties) {
@@ -48,14 +47,14 @@ public class ProcessViewDto implements Combinable {
   }
 
   @Override
-  public boolean isCombinable(Object o) {
+  public boolean isCombinable(final Object o) {
     if (this == o) {
       return true;
     }
     if (!(o instanceof ProcessViewDto)) {
       return false;
     }
-    ProcessViewDto viewDto = (ProcessViewDto) o;
+    final ProcessViewDto viewDto = (ProcessViewDto) o;
     if (getProperties().size() != 1 || viewDto.getProperties().size() != 1) {
       // multiple properties are not supported for combined reports
       return false;
@@ -77,7 +76,7 @@ public class ProcessViewDto implements Combinable {
 
   @JsonIgnore
   public ViewProperty getFirstProperty() {
-    return this.properties != null && !this.properties.isEmpty() ? properties.get(0) : null;
+    return properties != null && !properties.isEmpty() ? properties.get(0) : null;
   }
 
   @JsonSetter
@@ -97,5 +96,11 @@ public class ProcessViewDto implements Combinable {
 
   private boolean isPropertyCombinable(final ProcessViewDto viewDto) {
     return Combinable.isCombinable(getFirstProperty(), viewDto.getFirstProperty());
+  }
+
+  public static final class Fields {
+
+    public static final String entity = "entity";
+    public static final String properties = "properties";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DefinitionVariableLabelsDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/DefinitionVariableLabelsDto.java
@@ -14,14 +14,19 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 public class DefinitionVariableLabelsDto implements OptimizeDto {
+
   @NotBlank private String definitionKey;
 
   @Valid private List<LabelDto> labels;
+
+  public static final class Fields {
+
+    public static final String definitionKey = "definitionKey";
+    public static final String labels = "labels";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableDto.java
@@ -19,12 +19,11 @@ import java.util.List;
 import java.util.Map;
 import lombok.Data;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @Accessors(chain = true)
-@FieldNameConstants
 public class ExternalProcessVariableDto implements OptimizeDto {
+
   private String variableId;
   private String variableName;
   private String variableValue;
@@ -55,5 +54,17 @@ public class ExternalProcessVariableDto implements OptimizeDto {
                   .setProcessDefinitionKey(varDto.getProcessDefinitionKey());
             })
         .toList();
+  }
+
+  public static final class Fields {
+
+    public static final String variableId = "variableId";
+    public static final String variableName = "variableName";
+    public static final String variableValue = "variableValue";
+    public static final String variableType = "variableType";
+    public static final String ingestionTimestamp = "ingestionTimestamp";
+    public static final String processInstanceId = "processInstanceId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String serializationDataFormat = "serializationDataFormat";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/ExternalProcessVariableRequestDto.java
@@ -14,13 +14,12 @@ import java.util.List;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @Data
 @Accessors(chain = true)
-@FieldNameConstants
 public class ExternalProcessVariableRequestDto implements OptimizeDto {
+
   @NotBlank private String id;
   @NotBlank private String name;
   private String value;
@@ -44,5 +43,16 @@ public class ExternalProcessVariableRequestDto implements OptimizeDto {
                     .setProcessDefinitionKey(varDto.getProcessDefinitionKey())
                     .setSerializationDataFormat(varDto.getSerializationDataFormat()))
         .toList();
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String value = "value";
+    public static final String type = "type";
+    public static final String processInstanceId = "processInstanceId";
+    public static final String processDefinitionKey = "processDefinitionKey";
+    public static final String serializationDataFormat = "serializationDataFormat";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/LabelDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/LabelDto.java
@@ -13,14 +13,20 @@ import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@FieldNameConstants
 public class LabelDto implements OptimizeDto {
+
   private String variableLabel;
   @NotBlank private String variableName;
   @NotNull private VariableType variableType;
+
+  public static final class Fields {
+
+    public static final String variableLabel = "variableLabel";
+    public static final String variableName = "variableName";
+    public static final String variableType = "variableType";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/SimpleProcessVariableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/SimpleProcessVariableDto.java
@@ -13,18 +13,26 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-@FieldNameConstants
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 public class SimpleProcessVariableDto {
+
   @EqualsAndHashCode.Include private String id;
   private String name;
   private String type;
   private List<String> value;
   @EqualsAndHashCode.Include private long version;
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String name = "name";
+    public static final String type = "type";
+    public static final String value = "value";
+    public static final String version = "version";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/VariableUpdateInstanceDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/query/variable/VariableUpdateInstanceDto.java
@@ -15,11 +15,9 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
-@FieldNameConstants
 @Builder
 @Getter
 @Setter
@@ -32,4 +30,15 @@ public class VariableUpdateInstanceDto implements OptimizeDto {
   private String processInstanceId;
   private String tenantId;
   private OffsetDateTime timestamp;
+
+  public static final class Fields {
+
+    public static final String instanceId = "instanceId";
+    public static final String name = "name";
+    public static final String type = "type";
+    public static final String value = "value";
+    public static final String processInstanceId = "processInstanceId";
+    public static final String tenantId = "tenantId";
+    public static final String timestamp = "timestamp";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedCollectionDefinitionDto.java
@@ -24,6 +24,7 @@ import lombok.NoArgsConstructor;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class AuthorizedCollectionDefinitionDto extends AuthorizedEntityDto {
+
   @JsonUnwrapped private CollectionDefinitionDto definitionDto;
 
   public AuthorizedCollectionDefinitionDto(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedDashboardDefinitionResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedDashboardDefinitionResponseDto.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class AuthorizedDashboardDefinitionResponseDto extends AuthorizedEntityDto {
+
   @JsonUnwrapped private DashboardDefinitionRestDto definitionDto;
 
   public AuthorizedDashboardDefinitionResponseDto(

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedReportDefinitionResponseDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/AuthorizedReportDefinitionResponseDto.java
@@ -15,18 +15,22 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 @EqualsAndHashCode(callSuper = true)
-@FieldNameConstants
 public class AuthorizedReportDefinitionResponseDto extends AuthorizedEntityDto {
+
   @JsonUnwrapped private ReportDefinitionDto definitionDto;
 
   public AuthorizedReportDefinitionResponseDto(
       final ReportDefinitionDto definitionDto, final RoleType currentUserRole) {
     super(currentUserRole);
     this.definitionDto = definitionDto;
+  }
+
+  public static final class Fields {
+
+    public static final String definitionDto = "definitionDto";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupInfoDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupInfoDto.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class BackupInfoDto {
+
   private long backupId;
   private String failureReason;
   private BackupState state;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/BackupRequestDto.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Data
 public class BackupRequestDto {
+
   @NotNull
   @Min(0)
   private Long backupId;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/CloudEventRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/CloudEventRequestDto.java
@@ -21,7 +21,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -30,8 +29,8 @@ import lombok.experimental.FieldNameConstants;
 @Setter
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString(onlyExplicitlyIncluded = true)
-@FieldNameConstants
 public class CloudEventRequestDto {
+
   // required properties
   @NotBlank @EqualsAndHashCode.Include @ToString.Include private String id;
 
@@ -81,5 +80,17 @@ public class CloudEventRequestDto {
 
   public Optional<Object> getData() {
     return Optional.ofNullable(data);
+  }
+
+  public static final class Fields {
+
+    public static final String id = "id";
+    public static final String source = "source";
+    public static final String specversion = "specversion";
+    public static final String type = "type";
+    public static final String time = "time";
+    public static final String data = "data";
+    public static final String traceid = "traceid";
+    public static final String group = "group";
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/EventMappingCleanupRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/EventMappingCleanupRequestDto.java
@@ -25,6 +25,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class EventMappingCleanupRequestDto {
+
   @NotNull private String xml;
 
   @NotNull @Builder.Default private Map<String, EventMappingDto> mappings = new HashMap<>();

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/EventProcessMappingRequestDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/EventProcessMappingRequestDto.java
@@ -19,15 +19,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
-@FieldNameConstants
 @Builder
 public class EventProcessMappingRequestDto {
+
   private String name;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -38,4 +37,12 @@ public class EventProcessMappingRequestDto {
   private Map<String, EventMappingDto> mappings;
 
   @Builder.Default @Valid private List<EventSourceEntryDto<?>> eventSources = new ArrayList<>();
+
+  public static final class Fields {
+
+    public static final String name = "name";
+    public static final String xml = "xml";
+    public static final String mappings = "mappings";
+    public static final String eventSources = "eventSources";
+  }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/Page.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/Page.java
@@ -17,6 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Data
 public class Page<T> {
+
   private Integer offset;
   private Integer limit;
   private Long total;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/SnapshotInfoDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/SnapshotInfoDto.java
@@ -18,6 +18,7 @@ import org.elasticsearch.snapshots.SnapshotState;
 @AllArgsConstructor
 @Data
 public class SnapshotInfoDto {
+
   private String snapshotName;
   private SnapshotState state;
   private OffsetDateTime startTime;

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginatedDataExportDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginatedDataExportDto.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Data
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class PaginatedDataExportDto {
+
   private String searchRequestId;
   private String message;
   private Integer numberOfRecordsInResponse;
@@ -25,14 +26,14 @@ public class PaginatedDataExportDto {
   private String reportId;
   private Object data;
 
-  public void setData(Object data) {
+  public void setData(final Object data) {
     this.data = data;
     if (data == null) {
-      this.numberOfRecordsInResponse = 0;
+      numberOfRecordsInResponse = 0;
     } else if (data instanceof Collection) {
-      this.numberOfRecordsInResponse = ((Collection<?>) data).size();
+      numberOfRecordsInResponse = ((Collection<?>) data).size();
     } else {
-      this.numberOfRecordsInResponse = 1;
+      numberOfRecordsInResponse = 1;
     }
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationDto.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PaginationDto {
+
   protected Integer limit;
   protected Integer offset;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/pagination/PaginationScrollableDto.java
@@ -18,6 +18,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class PaginationScrollableDto extends PaginationDto {
+
   protected String scrollId;
   protected Integer scrollTimeout;
 

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/sorting/EntitySorter.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/dto/optimize/rest/sorting/EntitySorter.java
@@ -33,14 +33,14 @@ public class EntitySorter extends Sorter<EntityResponseDto> {
   private static final ImmutableMap<String, Comparator<EntityResponseDto>> sortComparators =
       ImmutableMap.of(
           name.toLowerCase(Locale.ENGLISH),
-              Comparator.comparing(
-                  EntityResponseDto::getName, nullsFirst(String.CASE_INSENSITIVE_ORDER)),
+          Comparator.comparing(
+              EntityResponseDto::getName, nullsFirst(String.CASE_INSENSITIVE_ORDER)),
           entityType.toLowerCase(Locale.ENGLISH),
-              Comparator.comparing(EntityResponseDto::getEntityType),
+          Comparator.comparing(EntityResponseDto::getEntityType),
           lastModified.toLowerCase(Locale.ENGLISH),
-              Comparator.comparing(EntityResponseDto::getLastModified),
+          Comparator.comparing(EntityResponseDto::getLastModified),
           lastModifier.toLowerCase(Locale.ENGLISH),
-              Comparator.comparing(EntityResponseDto::getLastModifier));
+          Comparator.comparing(EntityResponseDto::getLastModifier));
 
   public EntitySorter(final String sortBy, final SortOrder sortOrder) {
     this.sortRequestDto = new SortRequestDto(sortBy, sortOrder);

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/TelemetryConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/TelemetryConfiguration.java
@@ -14,13 +14,12 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import lombok.experimental.FieldNameConstants;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@FieldNameConstants(asEnum = true)
 @Data
 public class TelemetryConfiguration {
+
   private boolean initializeTelemetry;
   private long reportingIntervalInHours;
 
@@ -31,5 +30,10 @@ public class TelemetryConfiguration {
               "%s.%s must be set to a positive number",
               TELEMETRY_CONFIGURATION, Fields.reportingIntervalInHours.name()));
     }
+  }
+
+  public enum Fields {
+    initializeTelemetry,
+    reportingIntervalInHours
   }
 }

--- a/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/IdentityCacheConfiguration.java
+++ b/optimize/util/optimize-commons/src/main/java/io/camunda/optimize/service/util/configuration/engine/IdentityCacheConfiguration.java
@@ -12,11 +12,10 @@ import io.camunda.optimize.service.exceptions.OptimizeConfigurationException;
 import io.camunda.optimize.service.util.CronNormalizerUtil;
 import java.util.Optional;
 import lombok.Data;
-import lombok.experimental.FieldNameConstants;
 
 @Data
-@FieldNameConstants
 public abstract class IdentityCacheConfiguration {
+
   private boolean includeUserMetaData;
   private boolean collectionRoleCleanupEnabled;
   private String cronTrigger;
@@ -30,11 +29,20 @@ public abstract class IdentityCacheConfiguration {
     }
   }
 
-  public final void setCronTrigger(String cronTrigger) {
+  public final void setCronTrigger(final String cronTrigger) {
     this.cronTrigger =
         Optional.ofNullable(cronTrigger).map(CronNormalizerUtil::normalizeToSixParts).orElse(null);
   }
 
   @JsonIgnore
   public abstract String getConfigName();
+
+  public static final class Fields {
+
+    public static final String includeUserMetaData = "includeUserMetaData";
+    public static final String collectionRoleCleanupEnabled = "collectionRoleCleanupEnabled";
+    public static final String cronTrigger = "cronTrigger";
+    public static final String maxPageSize = "maxPageSize";
+    public static final String maxEntryLimit = "maxEntryLimit";
+  }
 }


### PR DESCRIPTION
## Description

This PR fixes compilation issues detected in Optimize after the merge. In particular:
* the experimental Lombok annotation `@FieldNameConstants` was not being compiled correctly, so it is being removed in favor of its corresponding vanilla Java
* the `@Builder` annotation in one class was not being compiled, so it is being removed in favor of its corresponding vanilla Java
* the docstrings in `IgnoreDuringScan.java` had syntax issues that are being corrected

The command that I used to do the compilation is the following:
```bash
$ mvn -B -D skipTests -D skipChecks compile generate-sources source:jar javadoc:jar -P skipFrontendBuild
```

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

* https://github.com/camunda/camunda-optimize/issues/13962