### PR TITLE
Set helm install arguments correctly

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -292,6 +292,7 @@ jobs:
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values
+          --render-subchart-notes
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}
           --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -250,10 +250,8 @@ jobs:
         --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}
         --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
         --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
-        # To support old versions
         --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
         --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
-        # To support new versions
         --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
         --set camunda-platform.zeebeGateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
         ${{ inputs.benchmark-load }}
@@ -297,10 +295,8 @@ jobs:
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}
           --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
-          # To support old versions
           --set camunda-platform.zeebe-gateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe-gateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
-          # To support new versions
           --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebeGateway.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}
           ${{ steps.find-chart-release.outputs.chart-release != '' && format('--version {0}', steps.find-chart-release.outputs.chart-release) || '' }}


### PR DESCRIPTION
## Description

### Problem
Arguments for the benchmark are merged into one line, where comments, are cutting the rest.

Resulting values for an installation missing half of the args
```sh
$ helm get values ck-operate-benchmark
USER-SUPPLIED VALUES:
camunda-platform:
  zeebe:
    image:
      repository: gcr.io/zeebe-io/zeebe
      tag: ck-operate-benchmark-1ad8f375
global:
  image:
    tag: ck-operate-benchmark-1ad8f375
```
<!-- Describe the goal and purpose of this PR. -->

See recent run https://github.com/camunda/camunda/actions/runs/10318610814/job/28565648616#step:7:1

### PR description

This PR removes the comments, so values are correctly set.