### PR TITLE
feat: render subchart notes

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -292,6 +292,7 @@ jobs:
           --namespace ${{ inputs.name }}
           --create-namespace
           --reuse-values
+          --render-subchart-notes
           --set global.image.tag=${{ needs.build-benchmark-images.outputs.image-tag }}
           --set camunda-platform.zeebe.image.repository=gcr.io/zeebe-io/zeebe
           --set camunda-platform.zeebe.image.tag=${{ needs.build-zeebe-image.outputs.image-tag }}


### PR DESCRIPTION
## Description

### Problem 

It is often unclear what exactly is set, during installation. Whether Operate is enabled, what tag it has, etc. We miss information from the dependency subchart.

### Solution - PR

To detect what values have been set, and how the camunda-platform chart is configured print the sub-chart notes during installation