### PR TITLE
Replace BCryptPasswordEncoder for Operate & Tasklist auth profile

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/auth/OperateUserDetailsService.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -56,7 +56,7 @@ public class OperateUserDetailsService implements UserDetailsService {
   @Bean
   @Primary
   public PasswordEncoder getPasswordEncoder() {
-    return new BCryptPasswordEncoder();
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 
   public void initializeUsers() {

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/se/SearchEngineUserDetailsService.java
@@ -26,7 +26,7 @@ import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
@@ -50,7 +50,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
   @Bean
   @Primary
   public PasswordEncoder getPasswordEncoder() {
-    return new BCryptPasswordEncoder();
+    return PasswordEncoderFactories.createDelegatingPasswordEncoder();
   }
 
   public void initializeUsers() {
@@ -86,10 +86,10 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
     }
   }
 
-  private boolean userExists(String userId) {
+  private boolean userExists(final String userId) {
     try {
       return userStore.getByUserId(userId) != null;
-    } catch (Exception t) {
+    } catch (final Exception t) {
       return false;
     }
   }
@@ -113,7 +113,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
   }
 
   @Override
-  public User loadUserByUsername(String username) throws UsernameNotFoundException {
+  public User loadUserByUsername(final String username) throws UsernameNotFoundException {
     try {
       final UserEntity userEntity = userStore.getByUserId(username);
       return new User(
@@ -122,7 +122,7 @@ public class SearchEngineUserDetailsService implements UserDetailsService {
               map(userEntity.getRoles(), Role::fromString))
           .setDisplayName(userEntity.getDisplayName())
           .setRoles(map(userEntity.getRoles(), Role::fromString));
-    } catch (NotFoundApiException e) {
+    } catch (final NotFoundApiException e) {
       throw new UsernameNotFoundException(
           String.format("User with user id '%s' not found.", username), e);
     }


### PR DESCRIPTION
## Description

Use the Spring recommended DelegatingPasswordEncoder for Encoding stored passwords. Fix issue with _/login_ URL returning status 500 instead of 401, with the thrown error: 
```
ERROR org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/].[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception
java.lang.IllegalArgumentException: You have entered a password with no PasswordEncoder. If that is your intent, it should be prefixed with `{noop}`.
	at org.springframework.security.crypto.password.DelegatingPasswordEncoder$UnmappedIdPasswordEncoder.matches(DelegatingPasswordEncoder.java:296) ~[spring-security-crypto-6.3.1.jar:6.3.1]
	at org.springframework.security.crypto.password.DelegatingPasswordEncoder.matches(DelegatingPasswordEncoder.java:241) ~[spring-security-crypto-6.3.1.jar:6.3.1]
	at org.springframework.security.authentication.dao.DaoAuthenticationProvider.additionalAuthenticationChecks(DaoAuthenticationProvider.java:90) ~[spring-security-core-6.3.1.jar:6.3.1]
	at org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider.authenticate(AbstractUserDetailsAuthenticationProvider.java:147) ~[spring-security-core-6.3.1.jar:6.3.1]
	at org.springframework.security.authentication.ProviderManager.authenticate(ProviderManager.java:182) ~[spring-security-core-6.3.1.jar:6.3.1]
	at org.springframework.security.authentication.ProviderManager.authenticate(ProviderManager.java:201) ~[spring-security-core-6.3.1.jar:6.3.1]
	at org.springframework.security.authentication.ObservationAuthenticationManager.lambda$authenticate$1(ObservationAuthenticationManager.java:54) ~[spring-security-core-6.3.1.jar:6.3.1]
	at io.micrometer.observation.Observation.observe(Observation.java:565) ~[micrometer-observation-1.13.2.jar:1.13.2]
``` 

BCryptPasswordEncoder did not add the {bcryt} prefix on password records. 
