### PR TITLE
test: ensure that controlled actor scheduler starts idle

### DIFF
--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
@@ -64,6 +64,7 @@ public class ControlledActorSchedulerExtension implements BeforeEachCallback, Af
     actorScheduler = builder.build();
     controlledActorTaskRunner = actorTaskRunnerFactory.controlledThread;
     actorScheduler.start();
+    controlledActorTaskRunner.waitUntilDone();
   }
 
   public ActorFuture<Void> submitActor(final Actor actor) {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
@@ -50,6 +50,7 @@ public final class ControlledActorSchedulerRule extends ExternalResource {
   @Override
   protected void before() {
     actorScheduler.start();
+    controlledActorTaskRunner.waitUntilDone();
   }
 
   @Override


### PR DESCRIPTION
When starting the `ControlledActorScheduler`, we also need to ensure that it runs long enough to become idle initially. Without waiting, the thread might start a bit late, after initial actor tasks were submitted already. In that case the thread _should_ be idle and wait for an explicit `workUntilDone` call and not execute the task. We now ensure this by waiting for idle state after starting the thread.

This hopefully closes #13493 because the mocked/spied objects are no longer accessed concurrently.