### PR TITLE
ci: exclude Optimize from renovate temporarely

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,22 +1,14 @@
 {
   "enabled": true,
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "commitMessagePrefix": "deps:",
-  "baseBranches": [
-    "/^stable\\/8\\..*/",
-    "stable/operate-8.5",
-    "main"
-  ],
+  "baseBranches": ["/^stable\\/8\\..*/", "stable/operate-8.5", "main"],
   "dependencyDashboard": true,
   "prConcurrentLimit": 30,
   "prHourlyLimit": 2,
   "updateNotScheduled": false,
-  "schedule": [
-    "at any time"
-  ],
+  "schedule": ["at any time"],
   "helmv3": {
     "registryAliases": {
       "helm-camunda-io": "https://helm.camunda.io"
@@ -34,16 +26,17 @@
   "packageRules": [
     {
       "description": "Only patch updates for our maintenance branches to avoid breaking changes.",
-      "matchBaseBranches": [
-        "/^stable\\/8\\..*/",
-        "stable/operate-8.5"
-      ],
+      "matchBaseBranches": ["/^stable\\/8\\..*/", "stable/operate-8.5"],
       "matchUpdateTypes": ["minor", "major"],
       "enabled": false
     },
     {
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["org.opensearch.client", "org.elasticsearch", "co.elastic"],
+      "matchPackagePrefixes": [
+        "org.opensearch.client",
+        "org.elasticsearch",
+        "co.elastic"
+      ],
       "matchUpdateTypes": ["minor", "major"],
       "enabled": false
     },
@@ -95,17 +88,19 @@
       "description": "Exclude frontend deps until migration is done in Operate (see issues #17736, #17844, #18851)",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["operate/**"],
-      "matchPackagePrefixes": [
-        "react-router-dom",
-        "msw",
-        "@carbon/react"
-      ],
+      "matchPackagePrefixes": ["react-router-dom", "msw", "@carbon/react"],
       "enabled": false
     },
     {
       "description": "This additional prefix is used to skip Operate backend tests.",
       "matchManagers": ["npm", "nvm"],
       "additionalBranchPrefix": "fe-"
+    },
+    {
+      "description": "Disable optimize until our checks are compliant with unified CI requirements and added to required checks",
+      "matchFileNames": ["optimize/**"],
+      "matchPackagePatterns": ["*"],
+      "enabled": false
     },
     {
       "description": "Exclude frontend deps until Optimize migrates to react-router v6 and react v18",
@@ -175,17 +170,16 @@
     },
     {
       "description": "For known GitHub repositories that use GitHub tags/releases of format 'v1.2.3' and where we ignore the 'v' prefix, we also tell Renovate to ignore it via extractVersion when updating .tool-version file",
-      "matchFileNames": [
-        ".github/workflows/*.yml"
-      ],
-      "matchPackagePrefixes": [
-        "rhysd/actionlint"
-      ],
+      "matchFileNames": [".github/workflows/*.yml"],
+      "matchPackagePrefixes": ["rhysd/actionlint"],
       "extractVersion": "^v(?<version>.*)$"
     },
     {
       "description": "Both dependencies need to be updated at once for green CI.",
-      "matchPackagePrefixes": ["@playwright/test", "mcr.microsoft.com/playwright"],
+      "matchPackagePrefixes": [
+        "@playwright/test",
+        "mcr.microsoft.com/playwright"
+      ],
       "groupName": "playwright"
     },
     {
@@ -197,10 +191,7 @@
   ],
   "dockerfile": {
     "fileMatch": ["(^|\\/)([\\w-]+\\.)?[Dd]ockerfile$"],
-    "ignorePaths": [
-      "zeebe/benchmarks/**",
-      "clients/go/vendor/**"
-    ]
+    "ignorePaths": ["zeebe/benchmarks/**", "clients/go/vendor/**"]
   },
   "customManagers": [
     {
@@ -215,7 +206,7 @@
       "customType": "regex",
       "fileMatch": ["package\\.json"],
       "matchStrings": [
-        "mcr\\.microsoft\\.com\\\/playwright:(?<currentValue>.*?)\\s"
+        "mcr\\.microsoft\\.com\\/playwright:(?<currentValue>.*?)\\s"
       ],
       "depNameTemplate": "mcr.microsoft.com/playwright",
       "datasourceTemplate": "docker"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Due to the lack of checks in the list of required check for renovate automerge, Optimize is vulnerable to braking changes comming from dependenciy updates. To mitigate that, we need to disable dependency checks until our CI pipelines meet the unified CI requirements and are added to the required checks. 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
