### PR TITLE
fix: use treePathCache per partition

### DIFF
--- a/operate/importer-8_4/pom.xml
+++ b/operate/importer-8_4/pom.xml
@@ -61,11 +61,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -29,6 +29,7 @@ import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
+import io.camunda.operate.util.SoftHashMap;
 import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -73,7 +74,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
             partitionId ->
                 partitionToTreePathCache.put(
                     partitionId,
-                    new HashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize())));
+                    new SoftHashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize())));
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -35,7 +35,6 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
-import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -44,7 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -56,16 +54,19 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   private static final Set<String> AI_FINISH_STATES =
       Set.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
   private static final Set<String> AI_START_STATES = Set.of(ELEMENT_ACTIVATING.name());
-  @Autowired protected FlowNodeStore flowNodeStore;
-  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
-  @Autowired private OperateProperties operateProperties;
-  @Autowired private PartitionHolder partitionHolder;
+  private final FlowNodeStore flowNodeStore;
+  private final FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   // treePath by flowNodeInstanceKey per partition cache
   private final Map<Integer, Map<String, String>> partitionToTreePathCache = new HashMap<>();
 
-  @PostConstruct
-  private void init() {
+  public FlowNodeInstanceZeebeRecordProcessor(
+      final FlowNodeStore flowNodeStore,
+      final FlowNodeInstanceTemplate flowNodeInstanceTemplate,
+      final OperateProperties operateProperties,
+      final PartitionHolder partitionHolder) {
+    this.flowNodeStore = flowNodeStore;
+    this.flowNodeInstanceTemplate = flowNodeInstanceTemplate;
     partitionHolder
         .getPartitionIds()
         .forEach(
@@ -218,7 +219,8 @@ public class FlowNodeInstanceZeebeRecordProcessor {
       final Record record, final ProcessInstanceRecordValue recordValue) {
     String parentTreePath;
     final var partitionTreePathCache = partitionToTreePathCache.get(record.getPartitionId());
-    // if scopeKey differs from processInstanceKey, then it's inner tree level and we need to search
+    // if scopeKey differs from processInstanceKey, then it's inner tree level, and we need to
+    // search
     // for parent 1st
     if (recordValue.getFlowScopeKey() == recordValue.getProcessInstanceKey()) {
       parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());

--- a/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_4/src/main/java/io/camunda/operate/zeebeimport/v8_4/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -29,7 +29,7 @@ import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
-import io.camunda.operate.util.SoftHashMap;
+import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
@@ -59,13 +59,20 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   @Autowired protected FlowNodeStore flowNodeStore;
   @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
   @Autowired private OperateProperties operateProperties;
+  @Autowired private PartitionHolder partitionHolder;
 
-  // treePath by flowNodeInstanceKey cache
-  private Map<String, String> treePathCache;
+  // treePath by flowNodeInstanceKey per partition cache
+  private final Map<Integer, Map<String, String>> partitionToTreePathCache = new HashMap<>();
 
   @PostConstruct
   private void init() {
-    treePathCache = new SoftHashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize());
+    partitionHolder
+        .getPartitionIds()
+        .forEach(
+            partitionId ->
+                partitionToTreePathCache.put(
+                    partitionId,
+                    new HashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize())));
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)
@@ -210,19 +217,15 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   private String getParentTreePath(
       final Record record, final ProcessInstanceRecordValue recordValue) {
     String parentTreePath;
+    final var partitionTreePathCache = partitionToTreePathCache.get(record.getPartitionId());
     // if scopeKey differs from processInstanceKey, then it's inner tree level and we need to search
     // for parent 1st
     if (recordValue.getFlowScopeKey() == recordValue.getProcessInstanceKey()) {
       parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());
     } else {
       // find parent flow node instance
-      parentTreePath = null;
-      // search in cache
-      if (treePathCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()))
-          != null) {
-        parentTreePath =
-            treePathCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()));
-      }
+      parentTreePath =
+          partitionTreePathCache.get(ConversionUtils.toStringOrNull(recordValue.getFlowScopeKey()));
       // query from ELS
       if (parentTreePath == null) {
         parentTreePath = flowNodeStore.findParentTreePathFor(recordValue.getFlowScopeKey());
@@ -230,15 +233,13 @@ public class FlowNodeInstanceZeebeRecordProcessor {
 
       if (parentTreePath == null) {
         LOGGER.warn(
-            "Unable to find parent tree path for flow node instance id ["
-                + record.getKey()
-                + "], parent flow node instance id ["
-                + recordValue.getFlowScopeKey()
-                + "]");
+            "Unable to find parent tree path for flow node instance id [{}], parent flow node instance id [{}]",
+            record.getKey(),
+            recordValue.getFlowScopeKey());
         parentTreePath = ConversionUtils.toStringOrNull(recordValue.getProcessInstanceKey());
       }
     }
-    treePathCache.put(
+    partitionTreePathCache.put(
         ConversionUtils.toStringOrNull(record.getKey()),
         String.join("/", parentTreePath, ConversionUtils.toStringOrNull(record.getKey())));
     return parentTreePath;

--- a/operate/importer-8_5/pom.xml
+++ b/operate/importer-8_5/pom.xml
@@ -62,11 +62,6 @@
     </dependency>
 
     <dependency>
-      <groupId>jakarta.annotation</groupId>
-      <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>io.micrometer</groupId>
       <artifactId>micrometer-core</artifactId>
     </dependency>

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -35,7 +35,6 @@ import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
 import io.camunda.zeebe.protocol.record.value.BpmnElementType;
 import io.camunda.zeebe.protocol.record.value.IncidentRecordValue;
 import io.camunda.zeebe.protocol.record.value.ProcessInstanceRecordValue;
-import jakarta.annotation.PostConstruct;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashMap;
@@ -44,7 +43,6 @@ import java.util.Map;
 import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -56,16 +54,20 @@ public class FlowNodeInstanceZeebeRecordProcessor {
   private static final Set<String> AI_FINISH_STATES =
       Set.of(ELEMENT_COMPLETED.name(), ELEMENT_TERMINATED.name());
   private static final Set<String> AI_START_STATES = Set.of(ELEMENT_ACTIVATING.name());
-  @Autowired protected FlowNodeStore flowNodeStore;
-  @Autowired private FlowNodeInstanceTemplate flowNodeInstanceTemplate;
-  @Autowired private OperateProperties operateProperties;
-  @Autowired private PartitionHolder partitionHolder;
+
+  private final FlowNodeStore flowNodeStore;
+  private final FlowNodeInstanceTemplate flowNodeInstanceTemplate;
 
   // treePath by flowNodeInstanceKey per partition cache
   private final Map<Integer, Map<String, String>> partitionToTreePathCache = new HashMap<>();
 
-  @PostConstruct
-  private void init() {
+  public FlowNodeInstanceZeebeRecordProcessor(
+      final FlowNodeStore flowNodeStore,
+      final FlowNodeInstanceTemplate flowNodeInstanceTemplate,
+      final OperateProperties operateProperties,
+      final PartitionHolder partitionHolder) {
+    this.flowNodeStore = flowNodeStore;
+    this.flowNodeInstanceTemplate = flowNodeInstanceTemplate;
     partitionHolder
         .getPartitionIds()
         .forEach(

--- a/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
+++ b/operate/importer-8_5/src/main/java/io/camunda/operate/zeebeimport/processors/FlowNodeInstanceZeebeRecordProcessor.java
@@ -29,6 +29,7 @@ import io.camunda.operate.store.BatchRequest;
 import io.camunda.operate.store.FlowNodeStore;
 import io.camunda.operate.util.ConversionUtils;
 import io.camunda.operate.util.DateUtil;
+import io.camunda.operate.util.SoftHashMap;
 import io.camunda.operate.zeebe.PartitionHolder;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
@@ -74,7 +75,7 @@ public class FlowNodeInstanceZeebeRecordProcessor {
             partitionId ->
                 partitionToTreePathCache.put(
                     partitionId,
-                    new HashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize())));
+                    new SoftHashMap<>(operateProperties.getImporter().getFlowNodeTreeCacheSize())));
   }
 
   public void processIncidentRecord(final Record record, final BatchRequest batchRequest)


### PR DESCRIPTION
## Description

* Use `treePathCache` per partition with help of `PartitionHolder`

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Closes #20076