### PR TITLE
ci: exclude some Optimzie dependencies from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -108,6 +108,39 @@
       "additionalBranchPrefix": "fe-"
     },
     {
+      "description": "Exclude frontend deps until Optimize migrates to react-router v6 and react v18",
+      "matchManagers": ["npm", "nvm"],
+      "matchFileNames": ["optimize/**"],
+      "matchPackagePatterns": [
+        "@carbon/react",
+        "old-bpmn-js",
+        "react",
+        "react-dom",
+        "react-router",
+        "react-router-dom",
+        "@types/react",
+        "@types/react-dom",
+        "@types/react-router-dom"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Exclude Optimize backend dependencies",
+      "matchManagers": ["maven"],
+      "matchFileNames": ["optimize/**"],
+      "matchPackagePatterns": [
+        "io.camunda.optimize:optimize-data-generator",
+        "io.camunda.optimize:camunda-optimize",
+        "io.camunda.optimize:util",
+        "io.camunda:identity-sdk",
+        "io.camunda:identity-spring-boot-starter",
+        "io.camunda:zeebe-client-java",
+        "io.camunda:zeebe-protocol",
+        "ant-contrib:ant-contrib"
+      ],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["mcr.microsoft.com/playwright"],
       "additionalBranchPrefix": "fe-"
     },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -43,20 +43,20 @@
     },
     {
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["org.opensearch.client", "org.elasticsearch", "co.elastic"],
+      "matchPackageNames": ["/^org.opensearch.client/", "/^org.elasticsearch/", "/^co.elastic/"],
       "matchUpdateTypes": ["minor", "major"],
       "enabled": false
     },
     {
       "description": "Skip lucene major updates to avoid breaking changes.",
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["org.apache.lucene"],
+      "matchPackageNames": ["/^org.apache.lucene/"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
     {
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["com.graphql-java"],
+      "matchPackageNames": ["/^com.graphql-java/"],
       "matchUpdateTypes": ["major"],
       "enabled": false
     },
@@ -69,19 +69,19 @@
     },
     {
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": ["org.jacoco"],
+      "matchPackageNames": ["/^org.jacoco/"],
       "allowedVersions": "!/0.8.9/"
     },
     {
-      "description" : "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
+      "description": "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
       "matchManagers": ["maven"],
-      "matchPackagePatterns": [".*"],
+      "matchPackageNames": ["/.*/"],
       "allowedVersions": "!/-SNAPSHOT$/"
     },
     {
-      "description" : "Exclude internal Maven modules and Maven dependencies lacking metadata.",
+      "description": "Exclude internal Maven modules and Maven dependencies lacking metadata.",
       "matchManagers": ["maven"],
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "io.camunda:operate-parent",
         "io.camunda:operate-qa",
         "io.camunda:operate-qa-migration-tests-parent",
@@ -95,7 +95,7 @@
       "description": "Exclude frontend deps until migration is done in Operate (see issues #17736, #17844, #18851)",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["operate/**"],
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "react-router-dom",
         "msw",
         "@carbon/react"
@@ -111,7 +111,7 @@
       "description": "Exclude frontend deps until Optimize migrates to react-router v6 and react v18",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["optimize/**"],
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "@carbon/react",
         "old-bpmn-js",
         "react",
@@ -128,7 +128,7 @@
       "description": "Exclude Optimize backend dependencies",
       "matchManagers": ["maven"],
       "matchFileNames": ["optimize/**"],
-      "matchPackagePatterns": [
+      "matchPackageNames": [
         "io.camunda.optimize:optimize-data-generator",
         "io.camunda.optimize:camunda-optimize",
         "io.camunda.optimize:util",
@@ -145,7 +145,7 @@
       "additionalBranchPrefix": "fe-"
     },
     {
-      "matchPackagePrefixes": ["@types/"],
+      "matchPackageNames": ["/^@types/"],
       "groupName": "definitelyTyped"
     },
     {
@@ -158,7 +158,7 @@
     },
     {
       "matchManagers": ["npm", "nvm"],
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "matchUpdateTypes": ["patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
@@ -180,7 +180,7 @@
     },
     {
       "description": "Automerge all updates with green CI.",
-      "matchPackagePatterns": ["*"],
+      "matchPackageNames": ["*"],
       "automerge": true,
       "addLabels": ["automerge"]
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

After migrating Optimize to monorepo, we need to update the renovate config to exclude some dependencies we were excluding in `camunda-optimize` repository

Additionally, due to the renovate validation failures, I updated the config to follow the new schema

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
