### PR TITLE
feat: document API draft

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/CamundaServicesConfiguration.java
@@ -11,6 +11,7 @@ import io.camunda.search.clients.CamundaSearchClient;
 import io.camunda.service.CamundaServices;
 import io.camunda.service.DecisionDefinitionServices;
 import io.camunda.service.DecisionRequirementsServices;
+import io.camunda.service.DocumentServices;
 import io.camunda.service.IncidentServices;
 import io.camunda.service.JobServices;
 import io.camunda.service.MessageServices;
@@ -86,5 +87,10 @@ public class CamundaServicesConfiguration {
   @Bean
   public MessageServices messageServices(final CamundaServices camundaServices) {
     return camundaServices.messageServices();
+  }
+
+  @Bean
+  public DocumentServices documentServices(final CamundaServices camundaServices) {
+    return camundaServices.documentServices();
   }
 }

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -12,6 +12,7 @@ import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
+import java.util.HashMap;
 
 public final class CamundaServices extends ApiServices<CamundaServices> {
 
@@ -63,6 +64,11 @@ public final class CamundaServices extends ApiServices<CamundaServices> {
 
   public MessageServices messageServices() {
     return new MessageServices(brokerClient, searchClient, transformers, authentication);
+  }
+
+  public DocumentServices documentServices() {
+    return new DocumentServices(
+        brokerClient, searchClient, transformers, authentication, new HashMap<>());
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/CamundaServices.java
+++ b/service/src/main/java/io/camunda/service/CamundaServices.java
@@ -12,7 +12,6 @@ import io.camunda.service.security.auth.Authentication;
 import io.camunda.service.transformers.ServiceTransformers;
 import io.camunda.zeebe.broker.client.api.BrokerClient;
 import io.camunda.zeebe.gateway.impl.job.ActivateJobsHandler;
-import java.util.HashMap;
 
 public final class CamundaServices extends ApiServices<CamundaServices> {
 
@@ -67,8 +66,7 @@ public final class CamundaServices extends ApiServices<CamundaServices> {
   }
 
   public DocumentServices documentServices() {
-    return new DocumentServices(
-        brokerClient, searchClient, transformers, authentication, new HashMap<>());
+    return new DocumentServices(brokerClient, searchClient, transformers, authentication);
   }
 
   @Override

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -40,6 +40,14 @@ public class DocumentServices extends ApiServices<DocumentServices> {
     this.documents = documents;
   }
 
+  public DocumentServices(
+      final BrokerClient brokerClient,
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication) {
+    this(brokerClient, searchClient, transformers, authentication, new HashMap<>());
+  }
+
   @Override
   public DocumentServices withAuthentication(final Authentication authentication) {
     return new DocumentServices(

--- a/service/src/main/java/io/camunda/service/DocumentServices.java
+++ b/service/src/main/java/io/camunda/service/DocumentServices.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.service;
+
+import io.camunda.search.clients.CamundaSearchClient;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.service.transformers.ServiceTransformers;
+import io.camunda.zeebe.broker.client.api.BrokerClient;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+public class DocumentServices extends ApiServices<DocumentServices> {
+
+  // TODO: This is an in-memory implementation, replace it with a real document store
+  private static final String STORE_ID = "default";
+  private final Map<String, byte[]> documents;
+
+  public DocumentServices(final BrokerClient brokerClient, final CamundaSearchClient searchClient) {
+    this(brokerClient, searchClient, null, null, new HashMap<>());
+  }
+
+  public DocumentServices(
+      final BrokerClient brokerClient,
+      final CamundaSearchClient searchClient,
+      final ServiceTransformers transformers,
+      final Authentication authentication,
+      final Map<String, byte[]> documents) {
+    super(brokerClient, searchClient, transformers, authentication);
+    this.documents = documents;
+  }
+
+  @Override
+  public DocumentServices withAuthentication(final Authentication authentication) {
+    return new DocumentServices(
+        brokerClient, searchClient, transformers, authentication, documents);
+  }
+
+  public CompletableFuture<DocumentReferenceResponse> createDocument(
+      DocumentCreateRequest request) {
+    validateStoreId(request.storeId);
+    final String id =
+        request.documentId != null ? request.documentId : UUID.randomUUID().toString();
+    if (documents.containsKey(id)) {
+      throw new CamundaServiceException("Document already exists: " + id);
+    }
+    final var contentInputStream = request.contentInputStream;
+    final byte[] content;
+    try {
+      content = contentInputStream.readAllBytes();
+      contentInputStream.close();
+    } catch (IOException e) {
+      throw new CamundaServiceException("Failed to read document content", e);
+    }
+    documents.put(id, content);
+    return CompletableFuture.completedFuture(
+        new DocumentReferenceResponse(id, STORE_ID, request.metadata));
+  }
+
+  public InputStream getDocumentContent(String documentId, String storeId) {
+    validateStoreId(storeId);
+    final var content = documents.get(documentId);
+    if (content == null) {
+      throw new CamundaServiceException("Document not found: " + documentId);
+    }
+    return new ByteArrayInputStream(content);
+  }
+
+  public CompletableFuture<Void> deleteDocument(String documentId, String storeId) {
+    validateStoreId(storeId);
+    final var content = documents.remove(documentId);
+    if (content == null) {
+      throw new CamundaServiceException("Document not found: " + documentId);
+    }
+    return CompletableFuture.completedFuture(null);
+  }
+
+  private void validateStoreId(String storeId) {
+    if (storeId != null && !storeId.equals(STORE_ID)) {
+      throw new CamundaServiceException(
+          "Unsupported store id: " + storeId + ", expected: " + STORE_ID);
+    }
+  }
+
+  public record DocumentCreateRequest(
+      String documentId,
+      String storeId,
+      InputStream contentInputStream,
+      DocumentMetadataModel metadata) {}
+
+  public record DocumentMetadataModel(
+      String contentType,
+      String fileName,
+      ZonedDateTime expiresAt,
+      Map<String, Object> additionalProperties) {}
+
+  public record DocumentReferenceResponse(
+      String documentId, String storeId, DocumentMetadataModel metadata) {}
+}

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -784,6 +784,197 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
+  /documents:
+    post:
+      tags:
+        - Documents
+      summary: Upload document (experimental)
+      description: |
+        Upload a document to the Camunda 8 cluster.
+
+        :::note
+        This endpoint is experimental. It currently only supports an in-memory document store, which
+        is not meant for production use.
+        :::
+      parameters:
+        - name: storeId
+          in: query
+          required: false
+          description: The ID of the document store to upload the document to.
+          schema:
+            type: string
+        - name: documentId
+          in: query
+          required: false
+          description: >
+            The ID of the document to upload. If not provided, a new ID will be generated.
+            Specifying an existing ID will result in an error if the document already exists.
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                file:
+                  type: string
+                  format: binary
+                metadata:
+                  $ref: "#/components/schemas/DocumentMetadata"
+              required:
+                - file
+            encoding:
+              metadata:
+                contentType: application/json
+      responses:
+        '201':
+          description: The document was uploaded successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentReference"
+        '400':
+          description: >
+            The document upload failed. More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+  /documents/{documentId}:
+    get:
+      tags:
+        - Documents
+      summary: Download document (experimental)
+      description: |
+        Download a document from the Camunda 8 cluster.
+
+        :::note
+        This endpoint is experimental. It currently only supports an in-memory document store, which
+        is not meant for production use.
+        :::
+      parameters:
+        - name: documentId
+          in: path
+          required: true
+          description: The ID of the document to download.
+          schema:
+            type: string
+        - name: storeId
+          in: query
+          required: false
+          description: The ID of the document store to download the document from.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The document was downloaded successfully.
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: >
+            The document with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        '500':
+          description: >
+            An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+    delete:
+      tags:
+        - Documents
+      summary: Delete document (experimental)
+      description: |
+        Delete a document from the Camunda 8 cluster.
+
+        :::note
+        This endpoint is experimental. It currently only supports an in-memory document store, which
+        is not meant for production use.
+        :::
+      parameters:
+        - name: documentId
+          in: path
+          required: true
+          description: The ID of the document to delete.
+          schema:
+            type: string
+        - name: storeId
+          in: query
+          required: false
+          description: The ID of the document store to delete the document from.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: The document was deleted successfully.
+        '404':
+          description: >
+            The document with the given ID was not found.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        '500':
+          description: >
+            An internal error occurred while processing the request.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+  /document/{documentId}/links:
+    post:
+      tags:
+        - Documents
+      summary: Create document link (experimental)
+      description: |
+        Create a link to a document in the Camunda 8 cluster.
+
+        :::note
+        This endpoint is experimental. It currently only supports an in-memory document store, which
+        is not meant for production use.
+        :::
+      parameters:
+        - name: documentId
+          in: path
+          required: true
+          description: The ID of the document to link.
+          schema:
+            type: string
+        - name: storeId
+          in: query
+          required: false
+          description: The ID of the document store to link the document from.
+          schema:
+            type: string
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DocumentLinkRequest"
+      responses:
+        '201':
+          description: The document link was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DocumentLink"
+        '400':
+          description: >
+            The document link creation failed. More details are provided in the response body.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
 
 components:
   schemas:
@@ -1627,9 +1818,56 @@ components:
           type: integer
           minimum: 0
           maximum: 100
+    DocumentReference:
+      type: object
+      properties:
+        documentType:
+          type: string
+          description: Document discriminator. Always set to "camunda".
+          enum:
+            - camunda
+        storeId:
+          type: string
+          description: The ID of the document store.
+        documentId:
+          type: string
+          description: The ID of the document.
+        metadata:
+          $ref: "#/components/schemas/DocumentMetadata"
+    DocumentMetadata:
+      type: object
+      additionalProperties: true
+      properties:
+        contentType:
+          type: string
+          description: The content type of the document.
+        fileName:
+          type: string
+          description: The name of the file.
+        expiresAt:
+          type: string
+          format: date-time
+          description: The date and time when the document expires.
+    DocumentLinkRequest:
+      type: object
+      properties:
+        expiresAt:
+          type: string
+          format: date-time
+          description: The date and time when the link expires.
+          nullable: true
+    DocumentLink:
+      type: object
+      properties:
+        url:
+          type: string
+          description: The link to the document.
+        expiresAt:
+          type: string
+          format: date-time
+          description: The date and time when the link expires.
   securitySchemes:
     bearerAuth:
       type: http
       scheme: bearer
       bearerFormat: JWT
-

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.gateway.rest;
 
+import static io.camunda.zeebe.gateway.rest.validator.DocumentValidator.validateDocumentMetadata;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobActivationRequest;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobErrorRequest;
 import static io.camunda.zeebe.gateway.rest.validator.JobRequestValidator.validateJobUpdateRequest;
@@ -16,6 +17,8 @@ import static io.camunda.zeebe.gateway.rest.validator.MultiTenancyValidator.vali
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateAssignmentRequest;
 import static io.camunda.zeebe.gateway.rest.validator.UserTaskRequestValidator.validateUpdateRequest;
 
+import io.camunda.service.DocumentServices.DocumentCreateRequest;
+import io.camunda.service.DocumentServices.DocumentMetadataModel;
 import io.camunda.service.JobServices.ActivateJobsRequest;
 import io.camunda.service.JobServices.UpdateJobChangeset;
 import io.camunda.service.MessageServices.CorrelateMessageRequest;
@@ -24,6 +27,7 @@ import io.camunda.service.security.auth.Authentication.Builder;
 import io.camunda.zeebe.auth.api.JwtAuthorizationBuilder;
 import io.camunda.zeebe.auth.impl.Authorization;
 import io.camunda.zeebe.gateway.protocol.rest.Changeset;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
 import io.camunda.zeebe.gateway.protocol.rest.JobActivationRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.JobErrorRequest;
@@ -35,14 +39,19 @@ import io.camunda.zeebe.gateway.protocol.rest.UserTaskCompletionRequest;
 import io.camunda.zeebe.gateway.protocol.rest.UserTaskUpdateRequest;
 import io.camunda.zeebe.protocol.impl.record.value.usertask.UserTaskRecord;
 import io.camunda.zeebe.util.Either;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.multipart.MultipartFile;
 
 public class RequestMapper {
 
@@ -175,6 +184,26 @@ public class RequestMapper {
                     updateRequest.getChangeset().getTimeout())));
   }
 
+  public static Either<ProblemDetail, DocumentCreateRequest> toDocumentCreateRequest(
+      final String documentId,
+      final String storeId,
+      final MultipartFile file,
+      final DocumentMetadata metadata) {
+    final InputStream inputStream;
+    try {
+      inputStream = file.getInputStream();
+    } catch (IOException e) {
+      return Either.left(
+          RestErrorMapper.createProblemDetail(
+              HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage(), "Failed to read document content"));
+    }
+    final var validationResponse = validateDocumentMetadata(metadata);
+    final var internalMetadata = toInternalDocumentMetadata(metadata, file);
+    return getResult(
+        validationResponse,
+        () -> new DocumentCreateRequest(documentId, storeId, inputStream, internalMetadata));
+  }
+
   public static <BrokerResponseT> CompletableFuture<ResponseEntity<Object>> executeServiceMethod(
       final Supplier<CompletableFuture<BrokerResponseT>> method,
       final Function<BrokerResponseT, ResponseEntity<Object>> result) {
@@ -236,6 +265,24 @@ public class RequestMapper {
       record.setPriority(changeset.getPriority()).setPriorityChanged();
     }
     return record;
+  }
+
+  private static DocumentMetadataModel toInternalDocumentMetadata(
+      DocumentMetadata metadata, MultipartFile file) {
+
+    if (metadata == null) {
+      return new DocumentMetadataModel(
+          file.getContentType(), file.getOriginalFilename(), null, Map.of());
+    }
+    final var expiresAt =
+        Optional.ofNullable(metadata.getExpiresAt()).map(ZonedDateTime::parse).orElse(null);
+    final var fileName =
+        Optional.ofNullable(metadata.getFileName()).orElse(file.getOriginalFilename());
+    final var contentType =
+        Optional.ofNullable(metadata.getContentType()).orElse(file.getContentType());
+
+    return new DocumentMetadataModel(
+        contentType, fileName, expiresAt, metadata.getAdditionalProperties());
   }
 
   private static <R> Map<String, Object> getMapOrEmpty(

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/RequestMapper.java
@@ -274,8 +274,12 @@ public class RequestMapper {
       return new DocumentMetadataModel(
           file.getContentType(), file.getOriginalFilename(), null, Map.of());
     }
-    final var expiresAt =
-        Optional.ofNullable(metadata.getExpiresAt()).map(ZonedDateTime::parse).orElse(null);
+    final ZonedDateTime expiresAt;
+    if (metadata.getExpiresAt() == null || metadata.getExpiresAt().isBlank()) {
+      expiresAt = null;
+    } else {
+      expiresAt = ZonedDateTime.parse(metadata.getExpiresAt());
+    }
     final var fileName =
         Optional.ofNullable(metadata.getFileName()).orElse(file.getOriginalFilename());
     final var contentType =

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DocumentController.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.service.CamundaServiceException;
+import io.camunda.service.DocumentServices;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentLinkRequest;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
+import io.camunda.zeebe.gateway.protocol.rest.ProblemDetail;
+import io.camunda.zeebe.gateway.rest.RequestMapper;
+import io.camunda.zeebe.gateway.rest.ResponseMapper;
+import io.camunda.zeebe.gateway.rest.RestErrorMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.concurrent.CompletableFuture;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
+
+@CamundaRestController
+@RequestMapping("/v2/documents")
+public class DocumentController {
+
+  private final DocumentServices documentServices;
+
+  @Autowired
+  public DocumentController(final DocumentServices documentServices) {
+    this.documentServices = documentServices;
+  }
+
+  @PostMapping(
+      consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CompletableFuture<ResponseEntity<Object>> createDocument(
+      @RequestParam(required = false) String documentId,
+      @RequestParam(required = false) String storeId,
+      @RequestPart("file") MultipartFile file,
+      @RequestPart(value = "metadata", required = false) DocumentMetadata metadata) {
+
+    return RequestMapper.toDocumentCreateRequest(documentId, storeId, file, metadata)
+        .fold(RestErrorMapper::mapProblemToCompletedResponse, this::createDocument);
+  }
+
+  private CompletableFuture<ResponseEntity<Object>> createDocument(
+      final DocumentServices.DocumentCreateRequest request) {
+
+    return RequestMapper.executeServiceMethod(
+        () ->
+            documentServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .createDocument(request),
+        ResponseMapper::toDocumentReference);
+  }
+
+  @GetMapping(
+      path = "/{documentId}",
+      produces = {
+        MediaType.APPLICATION_OCTET_STREAM_VALUE,
+        MediaType.APPLICATION_PROBLEM_JSON_VALUE
+      })
+  public ResponseEntity<StreamingResponseBody> getDocumentContent(
+      @PathVariable String documentId, @RequestParam(required = false) String storeId)
+      throws IOException {
+
+    try (final InputStream contentInputStream = getDocumentContentStream(documentId, storeId)) {
+      return ResponseEntity.ok().body(contentInputStream::transferTo);
+    }
+  }
+
+  @ExceptionHandler(CamundaServiceException.class)
+  public ResponseEntity<ProblemDetail> handleDocumentContentException(CamundaServiceException e) {
+    final var problemDetail =
+        RestErrorMapper.createProblemDetail(
+            HttpStatus.BAD_REQUEST, e.getMessage(), "Failed to get document content");
+    return RestErrorMapper.mapProblemToResponse(problemDetail);
+  }
+
+  private InputStream getDocumentContentStream(String documentId, String storeId) {
+    return documentServices
+        .withAuthentication(RequestMapper.getAuthentication())
+        .getDocumentContent(documentId, storeId);
+  }
+
+  @DeleteMapping(
+      path = "/{documentId}",
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public CompletableFuture<ResponseEntity<Object>> deleteDocument(
+      @PathVariable String documentId, @RequestParam(required = false) String storeId) {
+
+    return RequestMapper.executeServiceMethodWithNoContentResult(
+        () ->
+            documentServices
+                .withAuthentication(RequestMapper.getAuthentication())
+                .deleteDocument(documentId, storeId));
+  }
+
+  @PostMapping(
+      path = "/{documentId}/links",
+      consumes = MediaType.APPLICATION_JSON_VALUE,
+      produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_PROBLEM_JSON_VALUE})
+  public ResponseEntity<Void> createDocumentLink(
+      @PathVariable String documentId, @RequestBody DocumentLinkRequest linkRequest) {
+
+    // TODO: implement
+    final var problemDetail =
+        RestErrorMapper.createProblemDetail(
+            HttpStatus.NOT_IMPLEMENTED, "Not implemented", "Not implemented");
+    return RestErrorMapper.mapProblemToResponse(problemDetail);
+  }
+}

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/DocumentValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/DocumentValidator.java
@@ -29,6 +29,10 @@ public class DocumentValidator {
       violations.add("The file name must not be empty, if present");
     }
 
+    if (metadata.getContentType() != null && metadata.getContentType().isBlank()) {
+      violations.add("The content type must not be empty, if present");
+    }
+
     if (metadata.getExpiresAt() != null) {
       validateDate(metadata.getExpiresAt(), "expiresAt", violations);
     }

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/DocumentValidator.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/validator/DocumentValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.validator;
+
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.createProblemDetail;
+import static io.camunda.zeebe.gateway.rest.validator.RequestValidator.validateDate;
+
+import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
+import java.util.ArrayList;
+import java.util.Optional;
+import org.springframework.http.ProblemDetail;
+
+public class DocumentValidator {
+
+  public static Optional<ProblemDetail> validateDocumentMetadata(DocumentMetadata metadata) {
+
+    final var violations = new ArrayList<String>();
+
+    if (metadata == null) {
+      return Optional.empty();
+    }
+
+    if (metadata.getFileName() != null && metadata.getFileName().isBlank()) {
+      violations.add("The file name must not be empty, if present");
+    }
+
+    if (metadata.getExpiresAt() != null) {
+      validateDate(metadata.getExpiresAt(), "expiresAt", violations);
+    }
+    return createProblemDetail(violations);
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DocumentControllerTest.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.DocumentServices;
+import io.camunda.service.DocumentServices.DocumentCreateRequest;
+import io.camunda.service.DocumentServices.DocumentMetadataModel;
+import io.camunda.service.DocumentServices.DocumentReferenceResponse;
+import io.camunda.service.security.auth.Authentication;
+import io.camunda.zeebe.gateway.protocol.rest.DocumentMetadata;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import java.io.ByteArrayInputStream;
+import java.time.ZonedDateTime;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+
+@WebMvcTest(DocumentController.class)
+public class DocumentControllerTest extends RestControllerTest {
+
+  static final String DOCUMENTS_BASE_URL = "/v2/documents";
+
+  @MockBean DocumentServices documentServices;
+
+  @BeforeEach
+  void setUp() {
+    when(documentServices.withAuthentication(any(Authentication.class)))
+        .thenReturn(documentServices);
+  }
+
+  @Test
+  void shouldCreateDocumentWithNoMetadata() {
+    // given
+    final var filename = "file.txt";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content = new byte[] {1, 2, 3};
+
+    final var timestamp = ZonedDateTime.now();
+
+    final ArgumentCaptor<DocumentCreateRequest> requestCaptor =
+        ArgumentCaptor.forClass(DocumentCreateRequest.class);
+    when(documentServices.createDocument(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new DocumentReferenceResponse(
+                    "documentId",
+                    "default",
+                    new DocumentMetadataModel(
+                        contentType.toString(), filename, timestamp, Map.of()))));
+
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("file", content).contentType(contentType).filename(filename);
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            String.format(
+                """
+                {
+                  "documentId": "documentId",
+                  "storeId": "default",
+                  "metadata": {
+                    "contentType": "application/octet-stream",
+                    "fileName": "file.txt",
+                    "expiresAt": "%s"
+                  }
+                }
+                """,
+                timestamp));
+
+    verify(documentServices).createDocument(requestCaptor.capture());
+
+    final DocumentCreateRequest request = requestCaptor.getValue();
+    assertThat(request.documentId()).isNull();
+    assertThat(request.storeId()).isNull();
+    assertThat(request.metadata()).isNotNull();
+    assertThat(request.contentInputStream()).isNotNull();
+
+    try (final var stream = request.contentInputStream()) {
+      assertThat(stream.readAllBytes()).isEqualTo(content);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    final var metadata = request.metadata();
+    assertThat(metadata.fileName()).isEqualTo(filename);
+    assertThat(metadata.contentType()).isEqualTo(contentType.toString());
+  }
+
+  @Test
+  void shouldCreateDocumentWithMetadata() {
+    // given
+    final var filename = "file.txt";
+    final var contentType = MediaType.APPLICATION_OCTET_STREAM;
+    final var content = new byte[] {1, 2, 3};
+
+    final var timestamp = ZonedDateTime.now();
+
+    final ArgumentCaptor<DocumentCreateRequest> requestCaptor =
+        ArgumentCaptor.forClass(DocumentCreateRequest.class);
+    when(documentServices.createDocument(any()))
+        .thenReturn(
+            CompletableFuture.completedFuture(
+                new DocumentReferenceResponse(
+                    "documentId",
+                    "default",
+                    new DocumentMetadataModel(
+                        contentType.toString(), filename, timestamp, Map.of()))));
+
+    final var metadataToSend = new DocumentMetadata();
+    metadataToSend.setContentType(contentType.toString());
+    metadataToSend.setFileName(filename);
+    metadataToSend.setExpiresAt(timestamp.toString());
+
+    final var multipartBodyBuilder = new MultipartBodyBuilder();
+    multipartBodyBuilder.part("file", content).contentType(contentType).filename(filename);
+    multipartBodyBuilder.part("metadata", metadataToSend).contentType(MediaType.APPLICATION_JSON);
+
+    // when/then
+    webClient
+        .post()
+        .uri(DOCUMENTS_BASE_URL)
+        .contentType(MediaType.MULTIPART_FORM_DATA)
+        .bodyValue(multipartBodyBuilder.build())
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isCreated()
+        .expectBody()
+        .json(
+            String.format(
+                """
+                {
+                  "documentId": "documentId",
+                  "storeId": "default",
+                  "metadata": {
+                    "contentType": "application/octet-stream",
+                    "fileName": "file.txt",
+                    "expiresAt": "%s"
+                  }
+                }
+                """,
+                timestamp));
+
+    verify(documentServices).createDocument(requestCaptor.capture());
+
+    final DocumentCreateRequest request = requestCaptor.getValue();
+    assertThat(request.documentId()).isNull();
+    assertThat(request.storeId()).isNull();
+    assertThat(request.metadata()).isNotNull();
+    assertThat(request.contentInputStream()).isNotNull();
+
+    try (final var stream = request.contentInputStream()) {
+      assertThat(stream.readAllBytes()).isEqualTo(content);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    final var metadata = request.metadata();
+    assertThat(metadata.fileName()).isEqualTo(filename);
+    assertThat(metadata.contentType()).isEqualTo(contentType.toString());
+  }
+
+  @Test
+  void testGetDocumentContent() {
+    // given
+    final var content = new byte[] {1, 2, 3};
+
+    when(documentServices.getDocumentContent("documentId", null))
+        .thenReturn(new ByteArrayInputStream(content));
+
+    // when/then
+    webClient
+        .get()
+        .uri(DOCUMENTS_BASE_URL + "/documentId")
+        .accept(MediaType.APPLICATION_OCTET_STREAM)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectBody(byte[].class)
+        .isEqualTo(content);
+  }
+
+  @Test
+  void testDeleteDocument() {
+    // given
+    when(documentServices.deleteDocument("documentId", null))
+        .thenReturn(CompletableFuture.completedFuture(null));
+
+    // when/then
+    webClient
+        .delete()
+        .uri(DOCUMENTS_BASE_URL + "/documentId")
+        .exchange()
+        .expectStatus()
+        .isNoContent();
+  }
+
+  // TODO: test error cases
+}


### PR DESCRIPTION
## Description

This PR implements a first draft version of the Document API definition and the REST controller, backed by a mock document store implementation. This should allow integration testing of other parts of the document handling epic while the document store functionality is still under development.

* The OpenAPI definition is meant to be more or less stable, slight adjustments possible along the way
* The in-memory data store implementation will be removed when the service implementation is available

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

#20759 
