### PR TITLE
[CPT] I can assert the variables of a process instance

### DIFF
--- a/testing/camunda-process-test-java/pom.xml
+++ b/testing/camunda-process-test-java/pom.xml
@@ -80,6 +80,11 @@
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -15,6 +15,8 @@
  */
 package io.camunda.process.test.api.assertions;
 
+import java.util.Map;
+
 /** The assertion object to verify a process instance. */
 public interface ProcessInstanceAssert {
 
@@ -103,4 +105,15 @@ public interface ProcessInstanceAssert {
    * @return the assertion object
    */
   ProcessInstanceAssert hasVariable(String variableName, Object variableValue);
+
+  /**
+   * Verifies that the process instance has the given variables. The verification fails if at least
+   * one variable doesn't exist or has a different value.
+   *
+   * <p>The assertion waits until all variables exist and have the given value.
+   *
+   * @param variables the expected variables
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasVariables(Map<String, Object> variables);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/assertions/ProcessInstanceAssert.java
@@ -80,4 +80,27 @@ public interface ProcessInstanceAssert {
    * @return the assertion object
    */
   ProcessInstanceAssert hasTerminatedElements(String... elementNames);
+
+  /**
+   * Verifies that the process instance has the given variables. The verification fails if at least
+   * one variable doesn't exist.
+   *
+   * <p>The assertion waits until all variables exist.
+   *
+   * @param variableNames the variable names
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasVariableNames(String... variableNames);
+
+  /**
+   * Verifies that the process instance has the variable with the given value. The verification
+   * fails if the variable doesn't exist or has a different value.
+   *
+   * <p>The assertion waits until the variable exists and has the given value.
+   *
+   * @param variableName the variable name
+   * @param variableValue the variable value
+   * @return the assertion object
+   */
+  ProcessInstanceAssert hasVariable(String variableName, Object variableValue);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/AssertFormatUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/AssertFormatUtil.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AssertFormatUtil {
+
+  public static String formatProcessInstance(final long processInstanceKey) {
+    return String.format("Process instance [key: %s]", processInstanceKey);
+  }
+
+  public static String formatNames(final String[] names) {
+    return formatNames(Arrays.asList(names));
+  }
+
+  public static String formatNames(final List<String> names) {
+    return names.stream()
+        .map(elementName -> String.format("'%s'", elementName))
+        .collect(Collectors.joining(", ", "[", "]"));
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/CamundaDataSource.java
@@ -18,6 +18,7 @@ package io.camunda.process.test.impl.assertions;
 import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
 import io.camunda.process.test.impl.client.OperateApiClient;
 import io.camunda.process.test.impl.client.ProcessInstanceDto;
+import io.camunda.process.test.impl.client.VariableDto;
 import java.io.IOException;
 import java.util.List;
 
@@ -38,5 +39,10 @@ public class CamundaDataSource {
     return operateApiClient
         .findFlowNodeInstancesByProcessInstanceKey(processInstanceKey)
         .getItems();
+  }
+
+  public List<VariableDto> getVariablesByProcessInstanceKey(final long processInstanceKey)
+      throws IOException {
+    return operateApiClient.findVariablesByProcessInstanceKey(processInstanceKey).getItems();
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -18,17 +18,12 @@ package io.camunda.process.test.impl.assertions;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.process.test.api.assertions.ProcessInstanceAssert;
 import io.camunda.process.test.impl.client.FlowNodeInstanceDto;
 import io.camunda.process.test.impl.client.FlowNodeInstanceState;
 import io.camunda.process.test.impl.client.ProcessInstanceDto;
 import io.camunda.process.test.impl.client.ProcessInstanceState;
-import io.camunda.process.test.impl.client.VariableDto;
 import io.camunda.process.test.impl.client.ZeebeClientNotFoundException;
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -46,13 +41,13 @@ import org.awaitility.core.TerminalFailureException;
 public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssertj, Long>
     implements ProcessInstanceAssert {
 
-  private final ObjectMapper variableMapper = new ObjectMapper();
-
   private final CamundaDataSource dataSource;
+  private final VariableAssertj variableAssertj;
 
   public ProcessInstanceAssertj(final CamundaDataSource dataSource, final long processInstanceKey) {
     super(processInstanceKey, ProcessInstanceAssertj.class);
     this.dataSource = dataSource;
+    variableAssertj = new VariableAssertj(dataSource, processInstanceKey);
   }
 
   @Override
@@ -95,114 +90,14 @@ public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssert
 
   @Override
   public ProcessInstanceAssert hasVariableNames(final String... variableNames) {
-
-    final AtomicReference<Map<String, String>> reference =
-        new AtomicReference<>(Collections.emptyMap());
-
-    try {
-      Awaitility.await()
-          .ignoreException(ZeebeClientNotFoundException.class)
-          .untilAsserted(
-              () -> {
-                final Map<String, String> variables = getProcessInstanceVariables();
-                reference.set(variables);
-
-                assertThat(variables).containsKeys(variableNames);
-              });
-
-    } catch (final ConditionTimeoutException | TerminalFailureException e) {
-
-      final Map<String, String> actualVariables = reference.get();
-
-      final List<String> missingVariableNames =
-          Arrays.stream(variableNames)
-              .filter(variableName -> !actualVariables.containsKey(variableName))
-              .collect(Collectors.toList());
-
-      final String failureMessage =
-          String.format(
-              "%s should have the variables %s but %s don't exist. All process instance variables:\n%s",
-              formatProcessInstance(),
-              formatNames(variableNames),
-              formatNames(missingVariableNames),
-              formatVariables(actualVariables));
-      fail(failureMessage);
-    }
-
+    variableAssertj.hasVariableNames(variableNames);
     return this;
   }
 
   @Override
   public ProcessInstanceAssert hasVariable(final String variableName, final Object variableValue) {
-
-    final JsonNode expectedValue = toJson(variableValue);
-
-    final AtomicReference<Map<String, String>> reference =
-        new AtomicReference<>(Collections.emptyMap());
-
-    try {
-      Awaitility.await()
-          .ignoreException(ZeebeClientNotFoundException.class)
-          .untilAsserted(
-              () -> {
-                final Map<String, String> variables = getProcessInstanceVariables();
-                reference.set(variables);
-
-                assertThat(variables).containsKey(variableName);
-
-                final JsonNode actualValue = readJson(variables.get(variableName));
-                assertThat(actualValue).isEqualTo(expectedValue);
-              });
-
-    } catch (final ConditionTimeoutException | TerminalFailureException e) {
-
-      final Map<String, String> actualVariables = reference.get();
-
-      final String failureReason =
-          Optional.ofNullable(actualVariables.get(variableName))
-              .map(value -> String.format("was '%s'", value))
-              .orElse("the variable doesn't exist");
-
-      final String failureMessage =
-          String.format(
-              "%s should have a variable '%s' with value '%s' but %s. All process instance variables:\n%s",
-              formatProcessInstance(),
-              variableName,
-              expectedValue,
-              failureReason,
-              formatVariables(actualVariables));
-      fail(failureMessage);
-    }
-
+    variableAssertj.hasVariable(variableName, variableValue);
     return this;
-  }
-
-  private Map<String, String> getProcessInstanceVariables() throws IOException {
-    return dataSource.getVariablesByProcessInstanceKey(actual).stream()
-        .collect(Collectors.toMap(VariableDto::getName, VariableDto::getValue));
-  }
-
-  private static String formatVariables(final Map<String, String> variables) {
-    return variables.entrySet().stream()
-        .map(variable -> String.format("\t- '%s': %s", variable.getKey(), variable.getValue()))
-        .collect(Collectors.joining("\n"));
-  }
-
-  private JsonNode readJson(final String value) {
-    try {
-      return variableMapper.readValue(value, JsonNode.class);
-    } catch (final JsonProcessingException e) {
-      throw new RuntimeException(String.format("Failed to read JSON: '%s'", value), e);
-    }
-  }
-
-  private JsonNode toJson(final Object value) {
-    try {
-      return variableMapper.convertValue(value, JsonNode.class);
-    } catch (final IllegalArgumentException e) {
-      throw new RuntimeException(
-          String.format("Failed to transform value to JSON: '%s'", value), e);
-    }
   }
 
   private void hasProcessInstanceInState(
@@ -233,7 +128,9 @@ public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssert
       final String failureMessage =
           String.format(
               "%s should be %s but was %s.",
-              formatProcessInstance(), formatState(expectedState), actualState);
+              AssertFormatUtil.formatProcessInstance(actual),
+              formatState(expectedState),
+              actualState);
       fail(failureMessage);
     }
   }
@@ -289,9 +186,9 @@ public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssert
       final String failureMessage =
           String.format(
               "%s should have %s elements %s but the following elements were not %s:\n%s",
-              formatProcessInstance(),
+              AssertFormatUtil.formatProcessInstance(actual),
               formatState(expectedState),
-              formatNames(elementNames),
+              AssertFormatUtil.formatNames(elementNames),
               formatState(expectedState),
               elementsNotInState);
       fail(failureMessage);
@@ -304,20 +201,6 @@ public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssert
 
   private static boolean isEnded(final FlowNodeInstanceDto flowNodeInstance) {
     return flowNodeInstance.getEndDate() != null;
-  }
-
-  private String formatProcessInstance() {
-    return String.format("Process instance [key: %s]", actual);
-  }
-
-  private static String formatNames(final String[] elementNames) {
-    return formatNames(Arrays.asList(elementNames));
-  }
-
-  private static String formatNames(final List<String> elementNames) {
-    return elementNames.stream()
-        .map(elementName -> String.format("'%s'", elementName))
-        .collect(Collectors.joining(", ", "[", "]"));
   }
 
   private static String formatState(final ProcessInstanceState state) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/ProcessInstanceAssertj.java
@@ -100,6 +100,12 @@ public class ProcessInstanceAssertj extends AbstractAssert<ProcessInstanceAssert
     return this;
   }
 
+  @Override
+  public ProcessInstanceAssert hasVariables(final Map<String, Object> variables) {
+    variableAssertj.hasVariables(variables);
+    return this;
+  }
+
   private void hasProcessInstanceInState(
       final ProcessInstanceState expectedState, final Predicate<ProcessInstanceDto> waitCondition) {
 

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.process.test.impl.client.VariableDto;
-import io.camunda.process.test.impl.client.ZeebeClientNotFoundException;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,7 +53,6 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, Long> {
 
     try {
       Awaitility.await()
-          .ignoreException(ZeebeClientNotFoundException.class)
           .untilAsserted(
               () -> {
                 final Map<String, String> variables = getProcessInstanceVariables();
@@ -94,7 +92,6 @@ public class VariableAssertj extends AbstractAssert<VariableAssertj, Long> {
 
     try {
       Awaitility.await()
-          .ignoreException(ZeebeClientNotFoundException.class)
           .untilAsserted(
               () -> {
                 final Map<String, String> variables = getProcessInstanceVariables();

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/assertions/VariableAssertj.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.process.test.impl.client.VariableDto;
+import io.camunda.process.test.impl.client.ZeebeClientNotFoundException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.assertj.core.api.AbstractAssert;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
+import org.awaitility.core.TerminalFailureException;
+
+public class VariableAssertj extends AbstractAssert<VariableAssertj, Long> {
+
+  private final ObjectMapper jsonMapper = new ObjectMapper();
+
+  private final CamundaDataSource dataSource;
+
+  public VariableAssertj(final CamundaDataSource dataSource, final long processInstanceKey) {
+    super(processInstanceKey, VariableAssertj.class);
+    this.dataSource = dataSource;
+  }
+
+  public VariableAssertj hasVariableNames(final String... variableNames) {
+
+    final AtomicReference<Map<String, String>> reference =
+        new AtomicReference<>(Collections.emptyMap());
+
+    try {
+      Awaitility.await()
+          .ignoreException(ZeebeClientNotFoundException.class)
+          .untilAsserted(
+              () -> {
+                final Map<String, String> variables = getProcessInstanceVariables();
+                reference.set(variables);
+
+                assertThat(variables).containsKeys(variableNames);
+              });
+
+    } catch (final ConditionTimeoutException | TerminalFailureException e) {
+
+      final Map<String, String> actualVariables = reference.get();
+
+      final List<String> missingVariableNames =
+          Arrays.stream(variableNames)
+              .filter(variableName -> !actualVariables.containsKey(variableName))
+              .collect(Collectors.toList());
+
+      final String failureMessage =
+          String.format(
+              "%s should have the variables %s but %s don't exist. All process instance variables:\n%s",
+              AssertFormatUtil.formatProcessInstance(actual),
+              AssertFormatUtil.formatNames(variableNames),
+              AssertFormatUtil.formatNames(missingVariableNames),
+              formatVariables(actualVariables));
+      fail(failureMessage);
+    }
+
+    return this;
+  }
+
+  public VariableAssertj hasVariable(final String variableName, final Object variableValue) {
+
+    final JsonNode expectedValue = toJson(variableValue);
+
+    final AtomicReference<Map<String, String>> reference =
+        new AtomicReference<>(Collections.emptyMap());
+
+    try {
+      Awaitility.await()
+          .ignoreException(ZeebeClientNotFoundException.class)
+          .untilAsserted(
+              () -> {
+                final Map<String, String> variables = getProcessInstanceVariables();
+                reference.set(variables);
+
+                assertThat(variables).containsKey(variableName);
+
+                final JsonNode actualValue = readJson(variables.get(variableName));
+                assertThat(actualValue).isEqualTo(expectedValue);
+              });
+
+    } catch (final ConditionTimeoutException | TerminalFailureException e) {
+
+      final Map<String, String> actualVariables = reference.get();
+
+      final String failureReason =
+          Optional.ofNullable(actualVariables.get(variableName))
+              .map(value -> String.format("was '%s'", value))
+              .orElse("the variable doesn't exist");
+
+      final String failureMessage =
+          String.format(
+              "%s should have a variable '%s' with value '%s' but %s. All process instance variables:\n%s",
+              AssertFormatUtil.formatProcessInstance(actual),
+              variableName,
+              expectedValue,
+              failureReason,
+              formatVariables(actualVariables));
+      fail(failureMessage);
+    }
+
+    return this;
+  }
+
+  private Map<String, String> getProcessInstanceVariables() throws IOException {
+    return dataSource.getVariablesByProcessInstanceKey(actual).stream()
+        .collect(Collectors.toMap(VariableDto::getName, VariableDto::getValue));
+  }
+
+  private static String formatVariables(final Map<String, String> variables) {
+    return variables.entrySet().stream()
+        .map(variable -> String.format("\t- '%s': %s", variable.getKey(), variable.getValue()))
+        .collect(Collectors.joining("\n"));
+  }
+
+  private JsonNode readJson(final String value) {
+    try {
+      return jsonMapper.readValue(value, JsonNode.class);
+    } catch (final JsonProcessingException e) {
+      throw new RuntimeException(String.format("Failed to read JSON: '%s'", value), e);
+    }
+  }
+
+  private JsonNode toJson(final Object value) {
+    try {
+      return jsonMapper.convertValue(value, JsonNode.class);
+    } catch (final IllegalArgumentException e) {
+      throw new RuntimeException(
+          String.format("Failed to transform value to JSON: '%s'", value), e);
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
@@ -37,6 +37,7 @@ public class OperateApiClient {
 
   private static final String PROCESS_INSTANCE_GET_ENDPOINT = "/v1/process-instances/%d";
   private static final String FLOW_NODE_INSTANCES_SEARCH_ENDPOINT = "/v1/flownode-instances/search";
+  private static final String VARIABLES_SEARCH_ENDPOINT = "/v1/variables/search";
 
   private final ObjectMapper objectMapper =
       new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
@@ -108,6 +109,18 @@ public class OperateApiClient {
         String.format("{\"filter\": {\"processInstanceKey\":%d}}", processInstanceKey);
     final String responseBody = sendPostRequest(FLOW_NODE_INSTANCES_SEARCH_ENDPOINT, requestBody);
     return objectMapper.readValue(responseBody, FlowNodeInstancesResponseDto.class);
+  }
+
+  public VariableResponseDto findVariablesByProcessInstanceKey(final long processInstanceKey)
+      throws IOException {
+    ensureAuthenticated();
+
+    final String requestBody =
+        String.format(
+            "{\"filter\": {\"processInstanceKey\":%d, \"scopeKey\":%d}}",
+            processInstanceKey, processInstanceKey);
+    final String responseBody = sendPostRequest(VARIABLES_SEARCH_ENDPOINT, requestBody);
+    return objectMapper.readValue(responseBody, VariableResponseDto.class);
   }
 
   private static String getReponseAsString(final ClassicHttpResponse response) {

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/VariableDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/VariableDto.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public class VariableDto {
+
+  private long key;
+  private long processInstanceKey;
+  private long scopeKey;
+  private String name;
+  private String value;
+  private boolean truncated;
+  private String tenantId;
+
+  public long getKey() {
+    return key;
+  }
+
+  public void setKey(final long key) {
+    this.key = key;
+  }
+
+  public long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public void setProcessInstanceKey(final long processInstanceKey) {
+    this.processInstanceKey = processInstanceKey;
+  }
+
+  public long getScopeKey() {
+    return scopeKey;
+  }
+
+  public void setScopeKey(final long scopeKey) {
+    this.scopeKey = scopeKey;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(final String name) {
+    this.name = name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+
+  public void setValue(final String value) {
+    this.value = value;
+  }
+
+  public boolean isTruncated() {
+    return truncated;
+  }
+
+  public void setTruncated(final boolean truncated) {
+    this.truncated = truncated;
+  }
+
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  public void setTenantId(final String tenantId) {
+    this.tenantId = tenantId;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/VariableResponseDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/VariableResponseDto.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+import java.util.List;
+
+public class VariableResponseDto {
+
+  private List<VariableDto> items;
+  private long total;
+
+  public List<VariableDto> getItems() {
+    return items;
+  }
+
+  public void setItems(final List<VariableDto> items) {
+    this.items = items;
+  }
+
+  public long getTotal() {
+    return total;
+  }
+
+  public void setTotal(final long total) {
+    this.total = total;
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -34,6 +34,7 @@ public class CamundaProcessTestExtensionIT {
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .name("start")
+            .zeebeOutputExpression("\"active\"", "status")
             .userTask()
             .name("task")
             .endEvent()
@@ -51,6 +52,7 @@ public class CamundaProcessTestExtensionIT {
     CamundaAssert.assertThat(processInstance)
         .isActive()
         .hasCompletedElements("start")
-        .hasActiveElements("task");
+        .hasActiveElements("task")
+        .hasVariable("status", "active");
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/ProcessInstanceAssertTest.java
@@ -57,7 +57,7 @@ public class ProcessInstanceAssertTest {
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
     CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofMillis(200));
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
   }
 
   @AfterEach

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -1,0 +1,282 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.api;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.process.test.impl.assertions.CamundaDataSource;
+import io.camunda.process.test.impl.client.VariableDto;
+import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class VariableAssertTest {
+
+  private static final long PROCESS_INSTANCE_KEY = 1L;
+  private static final Map<String, Object> CONTEXT_VARIABLE_VALUE;
+
+  static {
+    CONTEXT_VARIABLE_VALUE = new HashMap<>();
+    CONTEXT_VARIABLE_VALUE.put("a", 1);
+    CONTEXT_VARIABLE_VALUE.put("b", 2);
+  }
+
+  @Mock private CamundaDataSource camundaDataSource;
+  @Mock private ProcessInstanceEvent processInstanceEvent;
+
+  @BeforeEach
+  void configureAssertions() {
+    CamundaAssert.initialize(camundaDataSource);
+    CamundaAssert.setAssertionInterval(Duration.ZERO);
+    CamundaAssert.setAssertionTimeout(Duration.ofMillis(200));
+  }
+
+  @AfterEach
+  void resetAssertions() {
+    CamundaAssert.setAssertionInterval(CamundaAssert.DEFAULT_ASSERTION_INTERVAL);
+    CamundaAssert.setAssertionTimeout(CamundaAssert.DEFAULT_ASSERTION_TIMEOUT);
+  }
+
+  private static VariableDto newVariable(final String variableName, final String variableValue) {
+    final VariableDto variable = new VariableDto();
+    variable.setProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    variable.setName(variableName);
+    variable.setValue(variableValue);
+    return variable;
+  }
+
+  private static Stream<Arguments> variableValues() {
+    return Stream.of(
+        Arguments.of("null", null),
+        Arguments.of("1", 1),
+        Arguments.of("1.5", 1.5),
+        Arguments.of("\"a\"", "a"),
+        Arguments.of("true", true),
+        Arguments.of("[1,2]", Arrays.asList(1, 2)),
+        Arguments.of("{\"a\":1,\"b\":2}", CONTEXT_VARIABLE_VALUE),
+        Arguments.of("{\"b\":2,\"a\":1}", CONTEXT_VARIABLE_VALUE));
+  }
+
+  @Nested
+  class HasVariableNames {
+
+    @Test
+    void shouldHasVariableNames() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariableNames("a", "b");
+    }
+
+    @Test
+    void shouldWaitUntilHasVariableNames() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableA))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariableNames("a", "b");
+
+      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfVariableNotExist() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () ->
+                  CamundaAssert.assertThat(processInstanceEvent)
+                      .hasVariableNames("a", "b", "c", "d"))
+          .hasMessage(
+              "Process instance [key: %d] should have the variables ['a', 'b', 'c', 'd'] but ['c', 'd'] don't exist. "
+                  + "All process instance variables:\n"
+                  + "\t- 'a': 1\n"
+                  + "\t- 'b': 2",
+              PROCESS_INSTANCE_KEY);
+    }
+  }
+
+  @Nested
+  class HasVariable {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.process.test.api.VariableAssertTest#variableValues")
+    void shouldHasVariable(final String variableValue, final Object expectedValue)
+        throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", variableValue);
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableA));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", expectedValue);
+    }
+
+    @Test
+    void shouldWaitUntilHasVariable() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableB))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 1);
+
+      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldWaitUntilVariableHasValue() throws IOException {
+      // given
+      final VariableDto variableValue1 = newVariable("a", "1");
+      final VariableDto variableValue2 = newVariable("a", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableValue1))
+          .thenReturn(Collections.singletonList(variableValue2));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 2);
+
+      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfVariableNotExist() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasVariable("c", 3))
+          .hasMessage(
+              "Process instance [key: %d] should have a variable 'c' with value '3' but the variable doesn't exist. "
+                  + "All process instance variables:\n"
+                  + "\t- 'a': 1\n"
+                  + "\t- 'b': 2",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfVariableHasDifferentValue() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", 2))
+          .hasMessage(
+              "Process instance [key: %d] should have a variable 'a' with value '2' but was '1'. "
+                  + "All process instance variables:\n"
+                  + "\t- 'a': 1\n"
+                  + "\t- 'b': 2",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.process.test.api.VariableAssertTest#variableValues")
+    void shouldFailWithMessage(final String variableValue) throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", variableValue);
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableA));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasVariable("a", -1))
+          .hasMessage(
+              "Process instance [key: %d] should have a variable 'a' with value '-1' but was '%s'. "
+                  + "All process instance variables:\n"
+                  + "\t- 'a': %s",
+              PROCESS_INSTANCE_KEY, variableValue, variableValue);
+    }
+  }
+}

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -279,4 +279,155 @@ public class VariableAssertTest {
               PROCESS_INSTANCE_KEY, variableValue, variableValue);
     }
   }
+
+  @Nested
+  class HasVariables {
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.process.test.api.VariableAssertTest#variableValues")
+    void shouldHasVariables(final String variableValue, final Object expectedValue)
+        throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", variableValue);
+      final VariableDto variableB = newVariable("b", "100");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", expectedValue);
+      expectedVariables.put("b", 100);
+      CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
+    }
+
+    @Test
+    void shouldWaitUntilHasAllVariables() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableA))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", 1);
+      expectedVariables.put("b", 2);
+      CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
+
+      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldWaitUntilAllVariablesHaveValue() throws IOException {
+      // given
+      final VariableDto variableValue1 = newVariable("a", "1");
+      final VariableDto variableValue2 = newVariable("a", "2");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableValue1, variableB))
+          .thenReturn(Arrays.asList(variableValue2, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", 2);
+      expectedVariables.put("b", 2);
+      CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables);
+
+      verify(camundaDataSource, times(2)).getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfOneVariableNotExist() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", 1);
+      expectedVariables.put("c", 3);
+
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables))
+          .hasMessage(
+              "Process instance [key: %d] should have the variables {\"a\":1,\"c\":3} but ['c'] don't match. "
+                  + "All process instance variables:\n"
+                  + "\t- 'a': 1\n"
+                  + "\t- 'b': 2",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @Test
+    void shouldFailIfVariableHasDifferentValue() throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", "1");
+      final VariableDto variableB = newVariable("b", "2");
+      final VariableDto variableC = newVariable("c", "3");
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Arrays.asList(variableA, variableB, variableC));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", 1);
+      expectedVariables.put("b", 1);
+
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables))
+          .hasMessage(
+              "Process instance [key: %d] should have the variables {\"a\":1,\"b\":1} but ['b'] don't match. "
+                  + "All process instance variables:\n"
+                  + "\t- 'a': 1\n"
+                  + "\t- 'b': 2\n"
+                  + "\t- 'c': 3",
+              PROCESS_INSTANCE_KEY);
+    }
+
+    @ParameterizedTest
+    @MethodSource("io.camunda.process.test.api.VariableAssertTest#variableValues")
+    void shouldFailWithMessage(final String variableValue) throws IOException {
+      // given
+      final VariableDto variableA = newVariable("a", variableValue);
+
+      when(camundaDataSource.getVariablesByProcessInstanceKey(PROCESS_INSTANCE_KEY))
+          .thenReturn(Collections.singletonList(variableA));
+
+      // when
+      when(processInstanceEvent.getProcessInstanceKey()).thenReturn(PROCESS_INSTANCE_KEY);
+
+      // then
+      final Map<String, Object> expectedVariables = new HashMap<>();
+      expectedVariables.put("a", -1);
+
+      Assertions.assertThatThrownBy(
+              () -> CamundaAssert.assertThat(processInstanceEvent).hasVariables(expectedVariables))
+          .hasMessage(
+              "Process instance [key: %d] should have the variables {\"a\":-1} but ['a'] don't match. "
+                  + "All process instance variables:\n"
+                  + "\t- 'a': %s",
+              PROCESS_INSTANCE_KEY, variableValue);
+    }
+  }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/VariableAssertTest.java
@@ -60,7 +60,7 @@ public class VariableAssertTest {
   void configureAssertions() {
     CamundaAssert.initialize(camundaDataSource);
     CamundaAssert.setAssertionInterval(Duration.ZERO);
-    CamundaAssert.setAssertionTimeout(Duration.ofMillis(200));
+    CamundaAssert.setAssertionTimeout(Duration.ofSeconds(1));
   }
 
   @AfterEach

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
@@ -36,6 +36,7 @@ public class CamundaSpringProcessTestListenerIT {
         Bpmn.createExecutableProcess("process")
             .startEvent()
             .name("start")
+            .zeebeOutputExpression("\"active\"", "status")
             .userTask()
             .name("task")
             .endEvent()
@@ -53,6 +54,7 @@ public class CamundaSpringProcessTestListenerIT {
     CamundaAssert.assertThat(processInstance)
         .isActive()
         .hasCompletedElements("start")
-        .hasActiveElements("task");
+        .hasActiveElements("task")
+        .hasVariable("status", "active");
   }
 }


### PR DESCRIPTION
## Description

The PR extends the assertions of CPT to verify process instance variables.

- `hasVariableNames("a", "b")` 
- `hasVariable("a", 1)`
- `hasVariables(variables)`

Out of scope:
- Local variables
- Verify not existing variables 

## Related issues

contributes to #19175 
