### PR TITLE
feat: trigger scheduled tasks according to controllable clock

### DIFF
--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
@@ -87,6 +87,10 @@ public class ControlledActorSchedulerExtension implements BeforeEachCallback, Af
     clock.setCurrentTime(currentTime);
   }
 
+  public ControlledActorClock getClock() {
+    return clock;
+  }
+
   static final class ControlledActorThreadFactory implements ActorThreadFactory {
     private ControlledActorThread controlledThread;
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -35,6 +36,7 @@ public class ProcessingScheduleServiceImpl
   private final BooleanSupplier abortCondition;
   private final Supplier<LogStreamWriter> writerSupplier;
   private final StageableScheduledCommandCache commandCache;
+  private final InstantSource clock;
   private LogStreamWriter logStreamWriter;
   private ActorControl actorControl;
   private AbortableRetryStrategy writeRetryStrategy;
@@ -44,11 +46,12 @@ public class ProcessingScheduleServiceImpl
       final Supplier<Phase> streamProcessorPhaseSupplier,
       final BooleanSupplier abortCondition,
       final Supplier<LogStreamWriter> writerSupplier,
-      final StageableScheduledCommandCache commandCache) {
+      final StageableScheduledCommandCache commandCache, final InstantSource clock) {
     this.streamProcessorPhaseSupplier = streamProcessorPhaseSupplier;
     this.abortCondition = abortCondition;
     this.writerSupplier = writerSupplier;
     this.commandCache = commandCache;
+    this.clock = clock;
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import java.time.Duration;
 import java.time.InstantSource;
+import java.util.PriorityQueue;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
@@ -32,11 +33,14 @@ public class ProcessingScheduleServiceImpl
 
   private static final ScheduledTask NOOP_SCHEDULED_TASK = () -> {};
   private static final Logger LOG = Loggers.STREAM_PROCESSING;
+  private static final int PERIODIC_CHECK_INTERVAL_MS = 1000;
+
   private final Supplier<StreamProcessor.Phase> streamProcessorPhaseSupplier;
   private final BooleanSupplier abortCondition;
   private final Supplier<LogStreamWriter> writerSupplier;
   private final StageableScheduledCommandCache commandCache;
   private final InstantSource clock;
+  private final PriorityQueue<ScheduledTaskImpl> scheduledTasks = new PriorityQueue<>();
   private LogStreamWriter logStreamWriter;
   private ActorControl actorControl;
   private AbortableRetryStrategy writeRetryStrategy;
@@ -46,7 +50,8 @@ public class ProcessingScheduleServiceImpl
       final Supplier<Phase> streamProcessorPhaseSupplier,
       final BooleanSupplier abortCondition,
       final Supplier<LogStreamWriter> writerSupplier,
-      final StageableScheduledCommandCache commandCache, final InstantSource clock) {
+      final StageableScheduledCommandCache commandCache,
+      final InstantSource clock) {
     this.streamProcessorPhaseSupplier = streamProcessorPhaseSupplier;
     this.abortCondition = abortCondition;
     this.writerSupplier = writerSupplier;
@@ -55,13 +60,12 @@ public class ProcessingScheduleServiceImpl
   }
 
   @Override
-  public ScheduledTask runDelayed(final Duration delay, final Runnable followUpTask) {
+  public ScheduledTask runDelayed(final Duration delay, final Runnable task) {
     if (actorControl == null) {
       LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
-    final var scheduledTimer = actorControl.schedule(delay, followUpTask);
-    return scheduledTimer::cancel;
+    return schedule(clock.millis() + delay.toMillis(), task);
   }
 
   @Override
@@ -80,8 +84,7 @@ public class ProcessingScheduleServiceImpl
       LOG.warn("ProcessingScheduleService hasn't been opened yet, ignore scheduled task.");
       return NOOP_SCHEDULED_TASK;
     }
-    final var scheduledTimer = actorControl.runAt(timestamp, task);
-    return scheduledTimer::cancel;
+    return schedule(timestamp, task);
   }
 
   @Override
@@ -109,6 +112,8 @@ public class ProcessingScheduleServiceImpl
     logStreamWriter = writerSupplier.get();
     actorControl = control;
     openFuture.complete(null);
+    actorControl.runAtFixedRate(
+        Duration.ofMillis(PERIODIC_CHECK_INTERVAL_MS), this::processScheduledTasks);
     return openFuture;
   }
 
@@ -118,6 +123,27 @@ public class ProcessingScheduleServiceImpl
     logStreamWriter = null;
     writeRetryStrategy = null;
     openFuture = null;
+  }
+
+  private void processScheduledTasks() {
+    final var now = clock.millis();
+    while (scheduledTasks.peek() != null && scheduledTasks.peek().scheduledTime <= now) {
+      final var expiredTask = scheduledTasks.poll();
+      actorControl.submit(expiredTask.runnable);
+    }
+  }
+
+  private ScheduledTask schedule(final long timestamp, final Runnable task) {
+    final var scheduledTask = new ScheduledTaskImpl(timestamp, task);
+    actorControl.run(
+        () -> {
+          final var delay = timestamp - clock.millis();
+          scheduledTasks.add(scheduledTask);
+          if (delay < PERIODIC_CHECK_INTERVAL_MS / 2) {
+            actorControl.schedule(Duration.ofMillis(delay), this::processScheduledTasks);
+          }
+        });
+    return scheduledTask;
   }
 
   Runnable toRunnable(final Task task) {
@@ -182,5 +208,26 @@ public class ProcessingScheduleServiceImpl
             }
           });
     };
+  }
+
+  /** Note: this class has a natural ordering that is inconsistent with equals. */
+  private final class ScheduledTaskImpl implements ScheduledTask, Comparable<ScheduledTaskImpl> {
+    private final long scheduledTime;
+    private final Runnable runnable;
+
+    private ScheduledTaskImpl(final long scheduledTime, final Runnable runnable) {
+      this.scheduledTime = scheduledTime;
+      this.runnable = runnable;
+    }
+
+    @Override
+    public void cancel() {
+      actorControl.run(() -> scheduledTasks.remove(this));
+    }
+
+    @Override
+    public int compareTo(final ProcessingScheduleServiceImpl.ScheduledTaskImpl o) {
+      return Long.compare(scheduledTime, o.scheduledTime);
+    }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -170,13 +170,15 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               streamProcessorContext::getStreamProcessorPhase,
               streamProcessorContext.getAbortCondition(),
               logStream::newLogStreamWriter,
-              scheduledCommandCache);
+              scheduledCommandCache,
+              streamProcessorContext.getClock());
       asyncScheduleService =
           new ProcessingScheduleServiceImpl(
               streamProcessorContext::getStreamProcessorPhase, // this is volatile
               streamProcessorContext.getAbortCondition(),
               logStream::newLogStreamWriter,
-              scheduledCommandCache);
+              scheduledCommandCache,
+              streamProcessorContext.getClock());
       asyncActor = new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);
       final var extendedProcessingScheduleService =
           new ExtendedProcessingScheduleServiceImpl(

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.stream.util.Records;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
 import io.camunda.zeebe.util.Either;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -62,7 +63,7 @@ class ProcessingScheduleServiceTest {
     lifecycleSupplier = new LifecycleSupplier();
     final var processingScheduleService =
         new ProcessingScheduleServiceImpl(
-            lifecycleSupplier, lifecycleSupplier, () -> testWriter, commandCache);
+            lifecycleSupplier, lifecycleSupplier, () -> testWriter, commandCache, InstantSource.system());
 
     scheduleService = new TestScheduleServiceActorDecorator(processingScheduleService);
     actorScheduler.submitActor(scheduleService);
@@ -155,7 +156,8 @@ class ProcessingScheduleServiceTest {
             lifecycleSupplier,
             lifecycleSupplier,
             () -> testWriter,
-            new NoopScheduledCommandCache());
+            new NoopScheduledCommandCache(),
+            InstantSource.system());
     final var mockedTask = spy(new DummyTask());
 
     // when
@@ -177,7 +179,8 @@ class ProcessingScheduleServiceTest {
                 () -> {
                   throw new RuntimeException("expected");
                 },
-                new NoopScheduledCommandCache()));
+                new NoopScheduledCommandCache(),
+                InstantSource.system()));
 
     // when
     final var actorFuture = actorScheduler.submitActor(notOpenScheduleService);
@@ -628,7 +631,8 @@ class ProcessingScheduleServiceTest {
               lifecycleSupplier,
               lifecycleSupplier,
               () -> testWriter,
-              new NoopScheduledCommandCache());
+              new NoopScheduledCommandCache(),
+              InstantSource.system());
       final var mockedTask = spy(new DummyTask());
 
       // when

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -63,7 +63,11 @@ class ProcessingScheduleServiceTest {
     lifecycleSupplier = new LifecycleSupplier();
     final var processingScheduleService =
         new ProcessingScheduleServiceImpl(
-            lifecycleSupplier, lifecycleSupplier, () -> testWriter, commandCache, InstantSource.system());
+            lifecycleSupplier,
+            lifecycleSupplier,
+            () -> testWriter,
+            commandCache,
+            actorScheduler.getClock());
 
     scheduleService = new TestScheduleServiceActorDecorator(processingScheduleService);
     actorScheduler.submitActor(scheduleService);
@@ -571,8 +575,8 @@ class ProcessingScheduleServiceTest {
 
       // then
       final var inOrder = inOrder(mockedTask2, mockedTask);
-      inOrder.verify(mockedTask).execute(any());
       inOrder.verify(mockedTask2).execute(any());
+      inOrder.verify(mockedTask).execute(any());
       inOrder.verifyNoMoreInteractions();
     }
 


### PR DESCRIPTION
The implementation is admittedly a bit crude but it works and I hope that it's good enough.
The idea is that `ProcessingScheduleServiceImpl` does not "forward" scheduled tasks to the underlying actor scheduler where we don't have control over the clock, but that it schedules them internally and only has the actor scheduler periodically call to check if any timers are now expired. That way, we have control over the clock we use to decide if a scheduled tasks is expired or not.

Right now the service is called every second. If a task is scheduled for less than half of that, we schedule an additional check a bit earlier, right when the task is supposed to expire. This is purely an optimization, mostly done so that we don't have to adjust a lot of tests that assume that something scheduled with zero delay will trigger more or less immediately.

Relates to https://github.com/camunda/camunda/issues/21051