### PR TITLE
Introduce clock state to persist clock modifications across restarts

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -83,6 +83,10 @@ public class Engine implements RecordProcessor {
 
     recordProcessorContext.addLifecycleListeners(typedRecordProcessors.getLifecycleListeners());
     recordProcessorMap = typedRecordProcessors.getRecordProcessorMap();
+
+    recordProcessorContext
+        .getClock()
+        .applyModification(processingState.getClockState().getModification());
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/ProcessingDbState.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.db.TransactionContext;
 import io.camunda.zeebe.db.ZeebeDb;
 import io.camunda.zeebe.engine.EngineConfiguration;
+import io.camunda.zeebe.engine.state.clock.DbClockState;
 import io.camunda.zeebe.engine.state.compensation.DbCompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.deployment.DbDecisionState;
 import io.camunda.zeebe.engine.state.deployment.DbDeploymentState;
@@ -34,6 +35,7 @@ import io.camunda.zeebe.engine.state.message.DbProcessMessageSubscriptionState;
 import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.migration.DbMigrationState;
 import io.camunda.zeebe.engine.state.mutable.MutableBannedInstanceState;
+import io.camunda.zeebe.engine.state.mutable.MutableClockState;
 import io.camunda.zeebe.engine.state.mutable.MutableCompensationSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDecisionState;
 import io.camunda.zeebe.engine.state.mutable.MutableDeploymentState;
@@ -95,6 +97,7 @@ public class ProcessingDbState implements MutableProcessingState {
   private final MutableUserTaskState userTaskState;
   private final MutableCompensationSubscriptionState compensationSubscriptionState;
   private final MutableUserState userState;
+  private final MutableClockState clockState;
   private final int partitionId;
 
   public ProcessingDbState(
@@ -139,6 +142,7 @@ public class ProcessingDbState implements MutableProcessingState {
     compensationSubscriptionState =
         new DbCompensationSubscriptionState(zeebeDb, transactionContext);
     userState = new DbUserState(zeebeDb, transactionContext);
+    clockState = new DbClockState(zeebeDb, transactionContext);
   }
 
   @Override
@@ -257,6 +261,11 @@ public class ProcessingDbState implements MutableProcessingState {
   @Override
   public MutableUserState getUserState() {
     return userState;
+  }
+
+  @Override
+  public MutableClockState getClockState() {
+    return clockState;
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockModification.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockModification.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.clock;
+
+import io.camunda.zeebe.db.DbValue;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.ObjectProperty;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+import java.time.Duration;
+import java.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class DbClockModification extends UnpackedObject implements DbValue {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DbClockModification.class);
+
+  private final EnumProperty<ModificationType> typeProperty =
+      new EnumProperty<>("type", ModificationType.class, ModificationType.NONE);
+  private final ObjectProperty<ClockRecord> modificationProperty =
+      new ObjectProperty<>("modification", new ClockRecord());
+
+  DbClockModification() {
+    super(2);
+    declareProperty(typeProperty).declareProperty(modificationProperty);
+  }
+
+  DbClockModification pinAt(final long pinnedEpoch) {
+    reset();
+    typeProperty.setValue(ModificationType.PIN);
+    modificationProperty.getValue().pinAt(pinnedEpoch);
+    return this;
+  }
+
+  DbClockModification offsetBy(final long offsetMillis) {
+    reset();
+    typeProperty.setValue(ModificationType.OFFSET);
+    modificationProperty.getValue().offsetBy(offsetMillis);
+    return this;
+  }
+
+  Modification modification() {
+    return switch (typeProperty.getValue()) {
+      case NONE -> Modification.none();
+      case PIN -> readPin();
+      case OFFSET -> readOffset();
+    };
+  }
+
+  private Modification readPin() {
+    final ClockRecord modification = modificationProperty.getValue();
+    if (!modificationProperty.isSet() || !modification.hasPinnedEpoch()) {
+      LOGGER.warn("Deserialized a PIN clock modification, but there is no pinned epoch");
+      return Modification.none();
+    }
+
+    return Modification.pinAt(Instant.ofEpochMilli(modification.getPinnedAtEpoch()));
+  }
+
+  private Modification readOffset() {
+    final ClockRecord modification = modificationProperty.getValue();
+    if (!modificationProperty.hasValue() || !modification.hasOffsetMillis()) {
+      LOGGER.warn("Deserialized an OFFSET clock modification, but there is no duration");
+      return Modification.none();
+    }
+
+    return Modification.offsetBy(Duration.ofMillis(modification.getOffsetMillis()));
+  }
+
+  // Do not remove values as this could break deserialization in the future
+  enum ModificationType {
+    NONE,
+    PIN,
+    OFFSET
+  };
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockModification.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockModification.java
@@ -10,67 +10,43 @@ package io.camunda.zeebe.engine.state.clock;
 import io.camunda.zeebe.db.DbValue;
 import io.camunda.zeebe.msgpack.UnpackedObject;
 import io.camunda.zeebe.msgpack.property.EnumProperty;
-import io.camunda.zeebe.msgpack.property.ObjectProperty;
-import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.msgpack.property.LongProperty;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
 import java.time.Duration;
 import java.time.Instant;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 final class DbClockModification extends UnpackedObject implements DbValue {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DbClockModification.class);
-
+  // depending on the intent, the value may be a timestamp (epoch milliseconds) or an offset (in
+  // milliseconds)
+  private final LongProperty timeProperty = new LongProperty("time", 0);
   private final EnumProperty<ModificationType> typeProperty =
       new EnumProperty<>("type", ModificationType.class, ModificationType.NONE);
-  private final ObjectProperty<ClockRecord> modificationProperty =
-      new ObjectProperty<>("modification", new ClockRecord());
 
   DbClockModification() {
     super(2);
-    declareProperty(typeProperty).declareProperty(modificationProperty);
+    declareProperty(typeProperty).declareProperty(timeProperty);
   }
 
   DbClockModification pinAt(final long pinnedEpoch) {
     reset();
     typeProperty.setValue(ModificationType.PIN);
-    modificationProperty.getValue().pinAt(pinnedEpoch);
+    timeProperty.setValue(pinnedEpoch);
     return this;
   }
 
   DbClockModification offsetBy(final long offsetMillis) {
     reset();
     typeProperty.setValue(ModificationType.OFFSET);
-    modificationProperty.getValue().offsetBy(offsetMillis);
+    timeProperty.setValue(offsetMillis);
     return this;
   }
 
   Modification modification() {
     return switch (typeProperty.getValue()) {
       case NONE -> Modification.none();
-      case PIN -> readPin();
-      case OFFSET -> readOffset();
+      case PIN -> Modification.pinAt(Instant.ofEpochMilli(timeProperty.getValue()));
+      case OFFSET -> Modification.offsetBy(Duration.ofMillis(timeProperty.getValue()));
     };
-  }
-
-  private Modification readPin() {
-    final ClockRecord modification = modificationProperty.getValue();
-    if (!modificationProperty.isSet() || !modification.hasPinnedEpoch()) {
-      LOGGER.warn("Deserialized a PIN clock modification, but there is no pinned epoch");
-      return Modification.none();
-    }
-
-    return Modification.pinAt(Instant.ofEpochMilli(modification.getPinnedAtEpoch()));
-  }
-
-  private Modification readOffset() {
-    final ClockRecord modification = modificationProperty.getValue();
-    if (!modificationProperty.hasValue() || !modification.hasOffsetMillis()) {
-      LOGGER.warn("Deserialized an OFFSET clock modification, but there is no duration");
-      return Modification.none();
-    }
-
-    return Modification.offsetBy(Duration.ofMillis(modification.getOffsetMillis()));
   }
 
   // Do not remove values as this could break deserialization in the future

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockState.java
@@ -16,14 +16,14 @@ import io.camunda.zeebe.protocol.ZbColumnFamilies;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
 
 public class DbClockState implements MutableClockState {
-  private static final DbString KEY = new DbString("MODIFICATION");
+  private static final String KEY = "MODIFICATION";
 
   private final ColumnFamily<DbString, DbClockModification> columnFamily;
+  private final DbString key = new DbString();
   private final DbClockModification value = new DbClockModification();
 
   public DbClockState(
       final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
-    final var key = new DbString();
     columnFamily =
         zeebeDb.createColumnFamily(ZbColumnFamilies.CLOCK, transactionContext, key, value);
   }
@@ -31,27 +31,31 @@ public class DbClockState implements MutableClockState {
   @Override
   public MutableClockState pinAt(final long epochMillis) {
     value.pinAt(epochMillis);
-    columnFamily.upsert(KEY, value);
+    key.wrapString(KEY);
+    columnFamily.upsert(key, value);
     return this;
   }
 
   @Override
   public MutableClockState offsetBy(final long offsetMillis) {
     value.offsetBy(offsetMillis);
-    columnFamily.upsert(KEY, value);
+    key.wrapString(KEY);
+    columnFamily.upsert(key, value);
     return this;
   }
 
   @Override
   public MutableClockState reset() {
     value.reset();
-    columnFamily.upsert(KEY, value);
+    key.wrapString(KEY);
+    columnFamily.upsert(key, value);
     return this;
   }
 
   @Override
   public Modification getModification() {
-    final var modification = columnFamily.get(KEY);
+    key.wrapString(KEY);
+    final var modification = columnFamily.get(key);
 
     if (modification == null) {
       return Modification.none();

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockState.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.clock;
+
+import io.camunda.zeebe.db.ColumnFamily;
+import io.camunda.zeebe.db.TransactionContext;
+import io.camunda.zeebe.db.ZeebeDb;
+import io.camunda.zeebe.db.impl.DbString;
+import io.camunda.zeebe.engine.state.mutable.MutableClockState;
+import io.camunda.zeebe.protocol.ZbColumnFamilies;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+
+public class DbClockState implements MutableClockState {
+  private static final DbString KEY = new DbString("MODIFICATION");
+
+  private final ColumnFamily<DbString, DbClockModification> columnFamily;
+  private final DbClockModification value = new DbClockModification();
+
+  public DbClockState(
+      final ZeebeDb<ZbColumnFamilies> zeebeDb, final TransactionContext transactionContext) {
+    final var key = new DbString();
+    columnFamily =
+        zeebeDb.createColumnFamily(ZbColumnFamilies.CLOCK, transactionContext, key, value);
+  }
+
+  @Override
+  public MutableClockState pinAt(final long epochMillis) {
+    value.pinAt(epochMillis);
+    columnFamily.upsert(KEY, value);
+    return this;
+  }
+
+  @Override
+  public MutableClockState offsetBy(final long offsetMillis) {
+    value.offsetBy(offsetMillis);
+    columnFamily.upsert(KEY, value);
+    return this;
+  }
+
+  @Override
+  public MutableClockState reset() {
+    value.reset();
+    return this;
+  }
+
+  @Override
+  public Modification getModification() {
+    final var modification = columnFamily.get(KEY);
+
+    if (modification == null) {
+      return Modification.none();
+    }
+
+    return modification.modification();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/clock/DbClockState.java
@@ -45,6 +45,7 @@ public class DbClockState implements MutableClockState {
   @Override
   public MutableClockState reset() {
     value.reset();
+    columnFamily.upsert(KEY, value);
     return this;
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ClockState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ClockState.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.immutable;
+
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+
+@FunctionalInterface
+public interface ClockState {
+  Modification getModification();
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/immutable/ProcessingState.java
@@ -63,4 +63,6 @@ public interface ProcessingState extends StreamProcessorLifecycleAware {
   int getPartitionId();
 
   boolean isEmpty(final ZbColumnFamilies column);
+
+  ClockState getClockState();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClockState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableClockState.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.mutable;
+
+import io.camunda.zeebe.engine.state.immutable.ClockState;
+
+public interface MutableClockState extends ClockState {
+  MutableClockState pinAt(final long epochMillis);
+
+  MutableClockState offsetBy(final long offsetMillis);
+
+  MutableClockState reset();
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/mutable/MutableProcessingState.java
@@ -78,5 +78,8 @@ public interface MutableProcessingState extends ProcessingState {
   @Override
   MutableUserState getUserState();
 
+  @Override
+  MutableClockState getClockState();
+
   KeyGenerator getKeyGenerator();
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/clock/DbClockModificationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/clock/DbClockModificationTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.clock.DbClockModification.ModificationType;
+import io.camunda.zeebe.msgpack.UnpackedObject;
+import io.camunda.zeebe.msgpack.property.EnumProperty;
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.stream.Stream;
+import org.agrona.ExpandableArrayBuffer;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class DbClockModificationTest {
+  @ParameterizedTest
+  @MethodSource("provideModifications")
+  void shouldSerializeModification(final TestCase testCase) {
+    // given
+    final var buffer = new ExpandableArrayBuffer();
+    final var writer = new DbClockModification();
+    final var reader = new DbClockModification();
+    testCase.applyModification(writer);
+
+    // when
+    writer.write(buffer, 0);
+    reader.wrap(buffer, 0, buffer.capacity());
+
+    // then
+    assertThat(reader.modification()).isEqualTo(testCase.expected());
+  }
+
+  @Test
+  void shouldReturnNoneIfPinDefaultValue() {
+    // given
+    final var buffer = new ExpandableArrayBuffer();
+    final var modification = Modification.pinAt(Instant.now());
+    final var writer = new DbClockModification();
+    final var modifier = new EvilPin();
+    final var reader = new DbClockModification();
+    writer.pinAt(modification.at().toEpochMilli());
+
+    // when
+    writer.write(buffer, 0);
+    modifier.wrap(buffer, 0, buffer.capacity());
+    modifier.property.reset();
+    modifier.write(buffer, 0);
+    reader.wrap(buffer, 0, buffer.capacity());
+
+    // then
+    assertThat(reader.modification()).isEqualTo(Modification.none());
+  }
+
+  @Test
+  void shouldReturnNoneIfNoOffsetValue() {
+    // given
+    final var buffer = new ExpandableArrayBuffer();
+    final var modification = Modification.offsetBy(Duration.ofMinutes(5));
+    final var writer = new DbClockModification();
+    final var modifier = new EvilOffset();
+    final var reader = new DbClockModification();
+    writer.offsetBy(modification.by().toMillis());
+
+    // when
+    writer.write(buffer, 0);
+    modifier.wrap(buffer, 0, buffer.capacity());
+    modifier.property.reset();
+    modifier.write(buffer, 0);
+    reader.wrap(buffer, 0, buffer.capacity());
+
+    // then
+    assertThat(reader.modification()).isEqualTo(Modification.none());
+  }
+
+  private static Stream<Named<TestCase>> provideModifications() {
+    final var pinnedAt = Instant.now().minusSeconds(10).truncatedTo(ChronoUnit.MILLIS);
+    final var offsetBy = Duration.ofMinutes(5);
+    return Stream.of(
+        Named.named("none", new TestCase.None()),
+        Named.named("pin", new TestCase.Pin(pinnedAt)),
+        Named.named("offset", new TestCase.Offset(offsetBy)));
+  }
+
+  private static final class EvilPin extends UnpackedObject {
+    private final LongProperty property = new LongProperty("pin", 0);
+
+    public EvilPin() {
+      super(2);
+      final var typeProperty =
+          new EnumProperty<>("type", ModificationType.class, ModificationType.NONE);
+      declareProperty(typeProperty).declareProperty(property);
+    }
+  }
+
+  private static final class EvilOffset extends UnpackedObject {
+    private final LongProperty property = new LongProperty("offset", 0);
+
+    public EvilOffset() {
+      super(2);
+      final var typeProperty =
+          new EnumProperty<>("type", ModificationType.class, ModificationType.NONE);
+      declareProperty(typeProperty).declareProperty(property);
+    }
+  }
+
+  private sealed interface TestCase {
+    Modification expected();
+
+    void applyModification(final DbClockModification modification);
+
+    record None() implements TestCase {
+
+      @Override
+      public Modification expected() {
+        return Modification.none();
+      }
+
+      @Override
+      public void applyModification(final DbClockModification modification) {
+        modification.reset();
+      }
+    }
+
+    record Pin(Instant at) implements TestCase {
+
+      @Override
+      public Modification expected() {
+        return Modification.pinAt(at);
+      }
+
+      @Override
+      public void applyModification(final DbClockModification modification) {
+        modification.pinAt(at.toEpochMilli());
+      }
+    }
+
+    record Offset(Duration offset) implements TestCase {
+
+      @Override
+      public Modification expected() {
+        return Modification.offsetBy(offset);
+      }
+
+      @Override
+      public void applyModification(final DbClockModification modification) {
+        modification.offsetBy(offset.toMillis());
+      }
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/clock/DbClockStateTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/clock/DbClockStateTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableClockState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+final class DbClockStateTest {
+  private MutableProcessingState processingState;
+  private MutableClockState state;
+
+  @BeforeEach
+  void beforeEach() {
+    state = processingState.getClockState();
+  }
+
+  @Test
+  void shouldDefaultToNone() {
+    // given
+    final var expected = Modification.none();
+
+    // when
+    final var actual = state.getModification();
+
+    // then
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldStoreModification() {
+    // given
+    final var modification = Modification.offsetBy(Duration.ofMinutes(10));
+
+    // when
+    state.offsetBy(modification.by().toMillis());
+
+    // then
+    assertThat(state.getModification()).isEqualTo(modification);
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/ZbColumnFamilies.java
@@ -178,7 +178,9 @@ public enum ZbColumnFamilies implements EnumValue {
   MESSAGE_CORRELATION(85),
 
   USERS(86),
-  USER_KEY_BY_USERNAME(87);
+  USER_KEY_BY_USERNAME(87),
+
+  CLOCK(88);
 
   private final int value;
 


### PR DESCRIPTION
## Description

This PR introduces a new engine state and column family that will allow persisting modifications to the state.

The modifications are serialized using a single data class, `DbClockModification`, which basically encodes the type of the modification and then the associated `ClockRecord`. This is required because we need to know the type of the modification when initializing the engine.

I would have liked a test to ensure it's truly persisted in the engine, but I couldn't find the right test infrastructure for such things. There are serialization tests, and persistence tests will eventually be added as engine tests once we have the processing (e.g. additions to the existing replay tests).

The state currently is only used when initializing the engine to apply any existing modification to the clock. For now, this is always none. There's also no test, as there is no real infrastructure for an `Engine` test - though if there is and I missed it, please let me know! I suspect this can be covered in the future with more complete engine tests anyway.

## Related issues

related to #21068 
