### PR TITLE
Introduce new clock record value, intent, and implementation record

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
@@ -167,7 +168,10 @@ public class EventAppliersTest {
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
-            .filter(intent -> !(intent instanceof CheckpointIntent));
+            // ClockIntent will be handled in a follow up PR
+            .filter(
+                intent ->
+                    !(intent instanceof CheckpointIntent) && !(intent instanceof ClockIntent));
 
     // when
     eventAppliers.registerEventAppliers(mock(MutableProcessingState.class));

--- a/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/test/java/io/camunda/zeebe/exporter/TestSupport.java
@@ -127,7 +127,11 @@ final class TestSupport {
    */
   static Stream<ValueType> provideValueTypes() {
     final var excludedValueTypes =
-        EnumSet.of(ValueType.SBE_UNKNOWN, ValueType.NULL_VAL, ValueType.PROCESS_INSTANCE_RESULT);
+        EnumSet.of(
+            ValueType.SBE_UNKNOWN,
+            ValueType.NULL_VAL,
+            ValueType.PROCESS_INSTANCE_RESULT,
+            ValueType.CLOCK);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
+++ b/zeebe/exporters/opensearch-exporter/src/test/java/io/camunda/zeebe/exporter/opensearch/TestSupport.java
@@ -115,7 +115,11 @@ final class TestSupport {
    */
   static Stream<ValueType> provideValueTypes() {
     final var excludedValueTypes =
-        EnumSet.of(ValueType.SBE_UNKNOWN, ValueType.NULL_VAL, ValueType.PROCESS_INSTANCE_RESULT);
+        EnumSet.of(
+            ValueType.SBE_UNKNOWN,
+            ValueType.NULL_VAL,
+            ValueType.PROCESS_INSTANCE_RESULT,
+            ValueType.CLOCK);
     return EnumSet.complementOf(excludedValueTypes).stream();
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
@@ -12,41 +12,29 @@ import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 
 public final class ClockRecord extends UnifiedRecordValue implements ClockRecordValue {
-  private final LongProperty pinProperty = new LongProperty("pin", 0);
-  private final LongProperty offsetProperty = new LongProperty("offset", 0);
+  // depending on the intent, the value may be a timestamp (epoch milliseconds) or an offset (in
+  // milliseconds)
+  private final LongProperty timeProperty = new LongProperty("time", 0);
 
   public ClockRecord() {
     super(2);
-    declareProperty(pinProperty).declareProperty(offsetProperty);
-  }
-
-  public boolean hasPinnedEpoch() {
-    return pinProperty.isSet();
+    declareProperty(timeProperty);
   }
 
   @Override
-  public long getPinnedAtEpoch() {
-    return pinProperty.getValue();
-  }
-
-  @Override
-  public long getOffsetMillis() {
-    return offsetProperty.getValue();
-  }
-
-  public boolean hasOffsetMillis() {
-    return offsetProperty.isSet();
+  public long getTime() {
+    return timeProperty.getValue();
   }
 
   public ClockRecord pinAt(final long pinnedEpoch) {
     reset();
-    pinProperty.setValue(pinnedEpoch);
+    timeProperty.setValue(pinnedEpoch);
     return this;
   }
 
   public ClockRecord offsetBy(final long offsetMillis) {
     reset();
-    offsetProperty.setValue(offsetMillis);
+    timeProperty.setValue(offsetMillis);
     return this;
   }
 }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
@@ -20,7 +20,6 @@ public final class ClockRecord extends UnifiedRecordValue implements ClockRecord
     declareProperty(pinProperty).declareProperty(offsetProperty);
   }
 
-  @Override
   public boolean hasPinnedEpoch() {
     return pinProperty.isSet();
   }
@@ -35,7 +34,6 @@ public final class ClockRecord extends UnifiedRecordValue implements ClockRecord
     return offsetProperty.getValue();
   }
 
-  @Override
   public boolean hasOffsetMillis() {
     return offsetProperty.isSet();
   }

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.protocol.impl.record.value.clock;
+
+import io.camunda.zeebe.msgpack.property.LongProperty;
+import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
+
+public final class ClockRecord extends UnifiedRecordValue implements ClockRecordValue {
+  private final LongProperty pinProperty = new LongProperty("pin", 0);
+  private final LongProperty offsetProperty = new LongProperty("offset", 0);
+
+  public ClockRecord() {
+    super(2);
+    declareProperty(pinProperty).declareProperty(offsetProperty);
+  }
+
+  @Override
+  public boolean hasPinnedEpoch() {
+    return pinProperty.isSet();
+  }
+
+  @Override
+  public long getPinnedAtEpoch() {
+    return pinProperty.getValue();
+  }
+
+  @Override
+  public long getOffsetMillis() {
+    return offsetProperty.getValue();
+  }
+
+  @Override
+  public boolean hasOffsetMillis() {
+    return offsetProperty.isSet();
+  }
+
+  public ClockRecord pinAt(final long pinnedEpoch) {
+    reset();
+    pinProperty.setValue(pinnedEpoch);
+    return this;
+  }
+
+  public ClockRecord offsetBy(final long offsetMillis) {
+    reset();
+    offsetProperty.setValue(offsetMillis);
+    return this;
+  }
+}

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.protocol.impl.record.CopiedRecord;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
 import io.camunda.zeebe.protocol.impl.record.VersionInfo;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -2480,6 +2481,30 @@ final class JsonSerializableToJsonTest {
           "name": "Foo Bar",
           "email": "foo@bar",
           "password": "f00b4r"
+        }
+        """
+      },
+
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      //////////////////////////////////////// ClockRecord ////////////////////////////////////////
+      /////////////////////////////////////////////////////////////////////////////////////////////
+      {
+        "ClockRecord (pin)",
+        (Supplier<ClockRecord>) () -> new ClockRecord().pinAt(5),
+        """
+        {
+          "pinnedAtEpoch": 5,
+          "offsetMillis": 0
+        }
+        """
+      },
+      {
+        "ClockRecord (offset)",
+        (Supplier<ClockRecord>) () -> new ClockRecord().offsetBy(5),
+        """
+        {
+          "pinnedAtEpoch": 0,
+          "offsetMillis": 5
         }
         """
       },

--- a/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
+++ b/zeebe/protocol-impl/src/test/java/io/camunda/zeebe/protocol/impl/JsonSerializableToJsonTest.java
@@ -2493,18 +2493,30 @@ final class JsonSerializableToJsonTest {
         (Supplier<ClockRecord>) () -> new ClockRecord().pinAt(5),
         """
         {
-          "pinnedAtEpoch": 5,
-          "offsetMillis": 0
+          "time": 5
         }
         """
       },
       {
         "ClockRecord (offset)",
-        (Supplier<ClockRecord>) () -> new ClockRecord().offsetBy(5),
+        (Supplier<ClockRecord>) () -> new ClockRecord().offsetBy(30),
         """
         {
-          "pinnedAtEpoch": 0,
-          "offsetMillis": 5
+          "time": 30
+        }
+        """
+      },
+      {
+        "ClockRecord (none)",
+        (Supplier<ClockRecord>)
+            () -> {
+              final var record = new ClockRecord().offsetBy(30);
+              record.reset();
+              return record;
+            },
+        """
+        {
+          "time": 0
         }
         """
       },

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/ValueTypeMapping.java
@@ -15,6 +15,7 @@
  */
 package io.camunda.zeebe.protocol.record;
 
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
@@ -52,6 +53,7 @@ import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
+import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
@@ -231,6 +233,7 @@ public final class ValueTypeMapping {
         ValueType.MESSAGE_CORRELATION,
         new Mapping<>(MessageCorrelationRecordValue.class, MessageCorrelationIntent.class));
     mapping.put(ValueType.USER, new Mapping<>(UserRecordValue.class, UserIntent.class));
+    mapping.put(ValueType.CLOCK, new Mapping<>(ClockRecordValue.class, ClockIntent.class));
     return mapping;
   }
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClockIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClockIntent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.intent;
+
+public enum ClockIntent implements Intent {
+  PIN((short) 0),
+  PINNED((short) 1);
+
+  private final short value;
+
+  ClockIntent(final short value) {
+    this.value = value;
+  }
+
+  public short getIntent() {
+    return value;
+  }
+
+  public static Intent from(final short value) {
+    switch (value) {
+      case 0:
+        return PIN;
+      case 1:
+        return PINNED;
+      default:
+        return Intent.UNKNOWN;
+    }
+  }
+
+  @Override
+  public short value() {
+    return value;
+  }
+
+  @Override
+  public boolean isEvent() {
+    return true;
+  }
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -148,6 +148,8 @@ public interface Intent {
         return MessageCorrelationIntent.from(intent);
       case USER:
         return UserIntent.from(intent);
+      case CLOCK:
+        return ClockIntent.from(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;
@@ -227,6 +229,8 @@ public interface Intent {
         return MessageCorrelationIntent.valueOf(intent);
       case USER:
         return UserIntent.valueOf(intent);
+      case CLOCK:
+        return ClockIntent.valueOf(intent);
       case NULL_VAL:
       case SBE_UNKNOWN:
         return Intent.UNKNOWN;

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/Intent.java
@@ -60,7 +60,8 @@ public interface Intent {
           ProcessInstanceMigrationIntent.class,
           CompensationSubscriptionIntent.class,
           MessageCorrelationIntent.class,
-          UserIntent.class);
+          UserIntent.class,
+          ClockIntent.class);
   short NULL_VAL = 255;
   Intent UNKNOWN = UnknownIntent.UNKNOWN;
 

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClockRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClockRecordValue.java
@@ -28,17 +28,11 @@ import org.immutables.value.Value;
 @Value.Immutable
 @ImmutableProtocol(builder = ImmutableClockRecordValue.Builder.class)
 public interface ClockRecordValue extends RecordValue {
-  /** Returns true if this record has a pinned epoch set. */
-  boolean hasPinnedEpoch();
-
   /**
    * Returns the pinned value of this clock, if any; if none, returns an instant at the {@code 0}
    * epoch.
    */
   long getPinnedAtEpoch();
-
-  /** Returns true if this record has an offset set. */
-  boolean hasOffsetMillis();
 
   /**
    * Returns the relative offset duration of this clock, if any; if none, returns a duration offset

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClockRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClockRecordValue.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.protocol.record.value;
+
+import io.camunda.zeebe.protocol.record.ImmutableProtocol;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import org.immutables.value.Value;
+
+/**
+ * Represents a stream clock event or command.
+ *
+ * <p>See {@link ClockIntent} for intents.
+ */
+@Value.Immutable
+@ImmutableProtocol(builder = ImmutableClockRecordValue.Builder.class)
+public interface ClockRecordValue extends RecordValue {
+  /** Returns true if this record has a pinned epoch set. */
+  boolean hasPinnedEpoch();
+
+  /**
+   * Returns the pinned value of this clock, if any; if none, returns an instant at the {@code 0}
+   * epoch.
+   */
+  long getPinnedAtEpoch();
+
+  /** Returns true if this record has an offset set. */
+  boolean hasOffsetMillis();
+
+  /**
+   * Returns the relative offset duration of this clock, if any; if none, returns a duration offset
+   * by {@code 0} milliseconds.
+   */
+  long getOffsetMillis();
+}

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClockRecordValue.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/value/ClockRecordValue.java
@@ -29,14 +29,14 @@ import org.immutables.value.Value;
 @ImmutableProtocol(builder = ImmutableClockRecordValue.Builder.class)
 public interface ClockRecordValue extends RecordValue {
   /**
-   * Returns the pinned value of this clock, if any; if none, returns an instant at the {@code 0}
-   * epoch.
+   * Returns the value of this clock modification, if any.
+   *
+   * <ol>
+   *   <li>If the associated intent is a pin, then the time is a Unix timestamp as epoch
+   *       milliseconds
+   *   <li>If the associated intent is an offset, then time would be the duration in milliseconds
+   *   <li>If the associated intent is a reset, then this value has no meaning, and will be 0
+   * </ol>
    */
-  long getPinnedAtEpoch();
-
-  /**
-   * Returns the relative offset duration of this clock, if any; if none, returns a duration offset
-   * by {@code 0} milliseconds.
-   */
-  long getOffsetMillis();
+  long getTime();
 }

--- a/zeebe/protocol/src/main/resources/protocol.xml
+++ b/zeebe/protocol/src/main/resources/protocol.xml
@@ -56,6 +56,7 @@
       <validValue name="COMPENSATION_SUBSCRIPTION">39</validValue>
       <validValue name="MESSAGE_CORRELATION">40</validValue>
       <validValue name="USER">41</validValue>
+      <validValue name="CLOCK">42</validValue>
 
       <!-- Management records / record not related to process automation -->
       <validValue name="CHECKPOINT">254</validValue>

--- a/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
+++ b/zeebe/protocol/src/test/java/io/camunda/zeebe/protocol/record/intent/IntentEncodingDecodingTest.java
@@ -76,6 +76,7 @@ final class IntentEncodingDecodingTest {
     result.addAll(buildParameterSets(SignalIntent.class, SignalIntent::from));
     result.addAll(
         buildParameterSets(SignalSubscriptionIntent.class, SignalSubscriptionIntent::from));
+    result.addAll(buildParameterSets(ClockIntent.class, ClockIntent::from));
 
     return result.stream();
   }


### PR DESCRIPTION
## Description

This PR adds a new `ClockRecordValue`, its companion intent `ClockIntent` (with only `PIN` and `PINNED` for now), and basic `ClockRecord` implementation.

Since our general model with record values is to share the same value for all intents, the implementation has all possible properties. Unfortunately this means we serialize unnecessary things (e.g. none will still serialize all 0s). We could remove the default value to omit this, but then this could cause issues during serialization (as it has happened in the past).

This is done first since this record will be stored in the state in a follow up PR.

## Related issues

related to #21068 
