### PR TITLE
Introduce clock PIN command to pin the controllable stream clock

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/Engine.java
@@ -46,7 +46,7 @@ public class Engine implements RecordProcessor {
       "Expected to process record '%s' without errors, but exception occurred with message '%s'.";
 
   private static final EnumSet<ValueType> SUPPORTED_VALUETYPES =
-      EnumSet.range(ValueType.JOB, ValueType.USER);
+      EnumSet.range(ValueType.JOB, ValueType.CLOCK);
 
   private EventApplier eventApplier;
   private RecordProcessorMap recordProcessorMap;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/EngineProcessors.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.engine.metrics.ProcessEngineMetrics;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviors;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnBehaviorsImpl;
 import io.camunda.zeebe.engine.processing.bpmn.behavior.BpmnJobActivationBehavior;
+import io.camunda.zeebe.engine.processing.clock.ClockProcessors;
 import io.camunda.zeebe.engine.processing.common.DecisionBehavior;
 import io.camunda.zeebe.engine.processing.deployment.DeploymentCreateProcessor;
 import io.camunda.zeebe.engine.processing.deployment.distribute.DeploymentDistributeProcessor;
@@ -199,6 +200,13 @@ public final class EngineProcessors {
         typedRecordProcessors,
         processingState,
         writers,
+        commandDistributionBehavior);
+
+    ClockProcessors.addClockProcessors(
+        typedRecordProcessors,
+        writers,
+        processingState.getKeyGenerator(),
+        clock,
         commandDistributionBehavior);
 
     return typedRecordProcessors;

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clock;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.DistributedTypedRecordProcessor;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.SideEffectWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.StateWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.TypedResponseWriter;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
+import io.camunda.zeebe.stream.api.records.TypedRecord;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+import java.time.Instant;
+
+public final class ClockPinProcessor implements DistributedTypedRecordProcessor<ClockRecord> {
+  private final SideEffectWriter sideEffectWriter;
+  private final StateWriter stateWriter;
+  private final KeyGenerator keyGenerator;
+  private final ControllableStreamClock clock;
+  private final CommandDistributionBehavior commandDistributionBehavior;
+  private final TypedResponseWriter responseWriter;
+
+  public ClockPinProcessor(
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ControllableStreamClock clock,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    sideEffectWriter = writers.sideEffect();
+    stateWriter = writers.state();
+    this.keyGenerator = keyGenerator;
+    responseWriter = writers.response();
+    this.clock = clock;
+
+    this.commandDistributionBehavior = commandDistributionBehavior;
+  }
+
+  @Override
+  public void processNewCommand(final TypedRecord<ClockRecord> command) {
+    final long eventKey = keyGenerator.nextKey();
+    final var clockRecord = command.getValue();
+
+    applyClockModification(eventKey, clockRecord);
+    if (command.hasRequestMetadata()) {
+      responseWriter.writeEventOnCommand(eventKey, ClockIntent.PINNED, clockRecord, command);
+    }
+
+    commandDistributionBehavior.distributeCommand(eventKey, command);
+  }
+
+  @Override
+  public void processDistributedCommand(final TypedRecord<ClockRecord> command) {
+    applyClockModification(command.getKey(), command.getValue());
+    commandDistributionBehavior.acknowledgeCommand(command);
+  }
+
+  private void applyClockModification(final long key, final ClockRecord clockRecord) {
+    final long pinnedAtEpoch = clockRecord.getPinnedAtEpoch();
+
+    sideEffectWriter.appendSideEffect(
+        () -> {
+          clock.pinAt(Instant.ofEpochMilli(pinnedAtEpoch));
+          return true;
+        });
+    stateWriter.appendFollowUpEvent(key, ClockIntent.PINNED, clockRecord);
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockPinProcessor.java
@@ -62,7 +62,7 @@ public final class ClockPinProcessor implements DistributedTypedRecordProcessor<
   }
 
   private void applyClockModification(final long key, final ClockRecord clockRecord) {
-    final long pinnedAtEpoch = clockRecord.getPinnedAtEpoch();
+    final long pinnedAtEpoch = clockRecord.getTime();
 
     sideEffectWriter.appendSideEffect(
         () -> {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
@@ -15,7 +15,7 @@ import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.state.KeyGenerator;
 
-public class ClockProcessors {
+public final class ClockProcessors {
   private ClockProcessors() {}
 
   public static void addClockProcessors(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clock;
+
+import io.camunda.zeebe.engine.processing.distribution.CommandDistributionBehavior;
+import io.camunda.zeebe.engine.processing.streamprocessor.TypedRecordProcessors;
+import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
+import io.camunda.zeebe.stream.api.state.KeyGenerator;
+
+public class ClockProcessors {
+  private ClockProcessors() {}
+
+  public static void addClockProcessors(
+      final TypedRecordProcessors typedRecordProcessors,
+      final Writers writers,
+      final KeyGenerator keyGenerator,
+      final ControllableStreamClock clock,
+      final CommandDistributionBehavior commandDistributionBehavior) {
+    typedRecordProcessors.onCommand(
+        ValueType.CLOCK,
+        ClockIntent.PIN,
+        new ClockPinProcessor(writers, keyGenerator, clock, commandDistributionBehavior));
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContext.java
@@ -12,8 +12,8 @@ import io.camunda.zeebe.engine.processing.streamprocessor.writers.Writers;
 import io.camunda.zeebe.engine.state.immutable.ScheduledTaskState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
-import java.time.InstantSource;
 import java.util.function.Supplier;
 
 public interface TypedRecordProcessorContext {
@@ -33,5 +33,5 @@ public interface TypedRecordProcessorContext {
 
   EngineConfiguration getConfig();
 
-  InstantSource getClock();
+  ControllableStreamClock getClock();
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/TypedRecordProcessorContextImpl.java
@@ -17,8 +17,8 @@ import io.camunda.zeebe.engine.state.message.TransientPendingSubscriptionState;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessorContext;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.scheduling.ProcessingScheduleService;
-import java.time.InstantSource;
 import java.util.Objects;
 import java.util.function.Supplier;
 
@@ -33,7 +33,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   private final EngineConfiguration config;
   private final TransientPendingSubscriptionState transientMessageSubscriptionState;
   private final TransientPendingSubscriptionState transientProcessMessageSubscriptionState;
-  private final InstantSource clock;
+  private final ControllableStreamClock clock;
 
   public TypedRecordProcessorContextImpl(
       final RecordProcessorContext context,
@@ -103,7 +103,7 @@ public class TypedRecordProcessorContextImpl implements TypedRecordProcessorCont
   }
 
   @Override
-  public InstantSource getClock() {
+  public ControllableStreamClock getClock() {
     return clock;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClockPinnedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClockPinnedApplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableClockState;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+
+public final class ClockPinnedApplier implements TypedEventApplier<ClockIntent, ClockRecord> {
+
+  private final MutableClockState clockState;
+
+  public ClockPinnedApplier(final MutableClockState clockState) {
+    this.clockState = clockState;
+  }
+
+  @Override
+  public void applyState(final long key, final ClockRecord value) {
+    clockState.pinAt(value.getPinnedAtEpoch());
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClockPinnedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClockPinnedApplier.java
@@ -22,6 +22,6 @@ public final class ClockPinnedApplier implements TypedEventApplier<ClockIntent, 
 
   @Override
   public void applyState(final long key, final ClockRecord value) {
-    clockState.pinAt(value.getPinnedAtEpoch());
+    clockState.pinAt(value.getTime());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.engine.state.mutable.MutableProcessMessageSubscriptionSt
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.CompensationSubscriptionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
@@ -107,6 +108,7 @@ public final class EventAppliers implements EventApplier {
     registerResourceDeletionAppliers();
 
     registerUserAppliers(state);
+    registerClockAppliers(state);
     return this;
   }
 
@@ -418,6 +420,10 @@ public final class EventAppliers implements EventApplier {
   private void registerResourceDeletionAppliers() {
     register(ResourceDeletionIntent.DELETING, NOOP_EVENT_APPLIER);
     register(ResourceDeletionIntent.DELETED, NOOP_EVENT_APPLIER);
+  }
+
+  private void registerClockAppliers(final MutableProcessingState state) {
+    register(ClockIntent.PINNED, new ClockPinnedApplier(state.getClockState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinMultiplePartitionsTest.java
@@ -7,4 +7,83 @@
  */
 package io.camunda.zeebe.engine.processing.clock;
 
-public class ClockPinMultiplePartitionsTest {}
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.ClockClient;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
+import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.awaitility.Awaitility;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class ClockPinMultiplePartitionsTest {
+  private static final int PARTITION_COUNT = 3;
+  @ClassRule public static final EngineRule ENGINE = EngineRule.multiplePartition(PARTITION_COUNT);
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private final ClockClient clockClient = ENGINE.clock();
+
+  @Test
+  public void shouldWriteDistributingRecordsForOtherPartitionsOnPin() {
+    // given
+    final var now = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+    // when
+    final var record = clockClient.pinAt(now);
+
+    // then
+    final var key = record.getKey();
+    final var commandDistributionRecords =
+        RecordingExporter.commandDistributionRecords()
+            .withIntent(CommandDistributionIntent.DISTRIBUTING)
+            .valueFilter(v -> v.getValueType().equals(ValueType.CLOCK))
+            .limit(2)
+            .asList();
+
+    assertThat(commandDistributionRecords).extracting(Record::getKey).containsOnly(key);
+    assertThat(commandDistributionRecords)
+        .extracting(Record::getValue)
+        .extracting(CommandDistributionRecordValue::getPartitionId)
+        .containsExactly(2, 3);
+  }
+
+  @Test
+  public void shouldPinClockOnAllPartitions() {
+    // given
+    final var pinnedNow = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+
+    // when
+    final var record = clockClient.pinAt(pinnedNow);
+
+    // then
+    for (int i = 1; i <= PARTITION_COUNT; i++) {
+      // required to ensure we apply the side effect of the clock
+      final var partitionId = i;
+      Awaitility.await("until side effect has been applied")
+          .until(
+              () ->
+                  RecordingExporter.clockRecords(ClockIntent.PINNED)
+                      .withPartitionId(partitionId)
+                      .withRecordKey(record.getKey())
+                      .exists());
+
+      // then
+      assertThat(ENGINE.getStreamClock(partitionId).instant()).isEqualTo(pinnedNow);
+      assertThat(ENGINE.getProcessingState(partitionId).getClockState().getModification())
+          .isEqualTo(Modification.pinAt(pinnedNow));
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinMultiplePartitionsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinMultiplePartitionsTest.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clock;
+
+public class ClockPinMultiplePartitionsTest {}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.clock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.engine.util.client.ClockClient;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class ClockPinTest {
+  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+
+  @Rule
+  public final RecordingExporterTestWatcher recordingExporterTestWatcher =
+      new RecordingExporterTestWatcher();
+
+  private ClockClient clockClient;
+
+  @Before
+  public void before() {
+    clockClient = ENGINE_RULE.clock();
+  }
+
+  @Test
+  public void shouldResetClock() {
+    // given
+    final var fakeNow = Instant.now().minusSeconds(180).truncatedTo(ChronoUnit.MILLIS);
+
+    // when
+    final var record = clockClient.pinAt(fakeNow);
+    // required to ensure we apply the side effect of the clock
+    ENGINE_RULE.awaitProcessingOf(record);
+
+    // then
+    assertThat(ENGINE_RULE.getStreamClock().instant()).isEqualTo(fakeNow);
+    assertThat(ENGINE_RULE.getProcessingState().getClockState().getModification())
+        .isEqualTo(Modification.pinAt(fakeNow));
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/clock/ClockPinTest.java
@@ -15,24 +15,18 @@ import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modificat
 import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 
 public final class ClockPinTest {
-  @ClassRule public static final EngineRule ENGINE_RULE = EngineRule.singlePartition();
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporterTestWatcher =
       new RecordingExporterTestWatcher();
 
-  private ClockClient clockClient;
-
-  @Before
-  public void before() {
-    clockClient = ENGINE_RULE.clock();
-  }
+  private final ClockClient clockClient = ENGINE.clock();
 
   @Test
   public void shouldResetClock() {
@@ -42,11 +36,11 @@ public final class ClockPinTest {
     // when
     final var record = clockClient.pinAt(fakeNow);
     // required to ensure we apply the side effect of the clock
-    ENGINE_RULE.awaitProcessingOf(record);
+    ENGINE.awaitProcessingOf(record);
 
     // then
-    assertThat(ENGINE_RULE.getStreamClock().instant()).isEqualTo(fakeNow);
-    assertThat(ENGINE_RULE.getProcessingState().getClockState().getModification())
+    assertThat(ENGINE.getStreamClock().instant()).isEqualTo(fakeNow);
+    assertThat(ENGINE.getProcessingState().getClockState().getModification())
         .isEqualTo(Modification.pinAt(fakeNow));
   }
 }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ClockEventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/ClockEventAppliersTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.state.mutable.MutableClockState;
+import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
+import io.camunda.zeebe.engine.util.ProcessingStateExtension;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ProcessingStateExtension.class)
+public class ClockEventAppliersTest {
+  /** Injected by {@link ProcessingStateExtension} */
+  private MutableProcessingState processingState;
+
+  private MutableClockState state;
+
+  @BeforeEach
+  void beforeEach() {
+    state = processingState.getClockState();
+  }
+
+  @Nested
+  final class PinnedTest {
+    private ClockPinnedApplier applier;
+
+    @BeforeEach
+    void beforeEach() {
+      applier = new ClockPinnedApplier(state);
+    }
+
+    @Test
+    void shouldPinClock() {
+      // given
+      final var clock = new ClockRecord().pinAt(5);
+
+      // when
+      applier.applyState(1, clock);
+
+      // then
+      assertThat(state.getModification()).isEqualTo(Modification.pinAt(Instant.ofEpochMilli(5)));
+    }
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/state/appliers/EventAppliersTest.java
@@ -18,7 +18,6 @@ import io.camunda.zeebe.engine.state.EventApplier.NoSuchEventApplier;
 import io.camunda.zeebe.engine.state.TypedEventApplier;
 import io.camunda.zeebe.engine.state.mutable.MutableProcessingState;
 import io.camunda.zeebe.protocol.record.RecordValue;
-import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.protocol.record.intent.ProcessIntent;
 import io.camunda.zeebe.protocol.record.intent.management.CheckpointIntent;
@@ -168,10 +167,7 @@ public class EventAppliersTest {
             .flatMap(c -> Arrays.stream(c.getEnumConstants()))
             .filter(Intent::isEvent)
             // CheckpointIntent is not handled by the engine
-            // ClockIntent will be handled in a follow up PR
-            .filter(
-                intent ->
-                    !(intent instanceof CheckpointIntent) && !(intent instanceof ClockIntent));
+            .filter(intent -> !(intent instanceof CheckpointIntent));
 
     // when
     eventAppliers.registerEventAppliers(mock(MutableProcessingState.class));

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -265,6 +265,10 @@ public final class EngineRule extends ExternalResource {
     return environmentRule.getProcessingState();
   }
 
+  public ProcessingState getProcessingState(final int partitionId) {
+    return environmentRule.getProcessingState(partitionId);
+  }
+
   public StreamProcessor getStreamProcessor(final int partitionId) {
     return environmentRule.getStreamProcessor(partitionId);
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.engine.state.DefaultZeebeDbFactory;
 import io.camunda.zeebe.engine.state.ProcessingDbState;
 import io.camunda.zeebe.engine.state.immutable.ProcessingState;
 import io.camunda.zeebe.engine.util.TestInterPartitionCommandSender.CommandInterceptor;
+import io.camunda.zeebe.engine.util.client.ClockClient;
 import io.camunda.zeebe.engine.util.client.DecisionEvaluationClient;
 import io.camunda.zeebe.engine.util.client.DeploymentClient;
 import io.camunda.zeebe.engine.util.client.IncidentClient;
@@ -44,6 +45,7 @@ import io.camunda.zeebe.protocol.record.value.JobRecordValue;
 import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.records.TypedRecord;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
@@ -267,6 +269,14 @@ public final class EngineRule extends ExternalResource {
     return environmentRule.getStreamProcessor(partitionId);
   }
 
+  public StreamClock getStreamClock() {
+    return getStreamClock(PARTITION_ID);
+  }
+
+  public StreamClock getStreamClock(final int partitionId) {
+    return environmentRule.getStreamClock(partitionId);
+  }
+
   public long getLastProcessedPosition() {
     return lastProcessedPosition;
   }
@@ -434,6 +444,10 @@ public final class EngineRule extends ExternalResource {
           "Cannot intercept inter-partition commands before the engine is started");
     }
     interPartitionCommandSenders.forEach(sender -> sender.intercept(interceptor));
+  }
+
+  public ClockClient clock() {
+    return new ClockClient(environmentRule);
   }
 
   private static final class VersatileBlob implements DbKey, DbValue {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/EngineRule.java
@@ -206,6 +206,10 @@ public final class EngineRule extends ExternalResource {
     interPartitionCommandSenders.forEach(s -> s.initializeWriters(partitionCount));
   }
 
+  public void snapshot() {
+    environmentRule.snapshot();
+  }
+
   public void forEachPartition(final Consumer<Integer> partitionIdConsumer) {
     int partitionId = PARTITION_ID;
     for (int i = 0; i < partitionCount; i++) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -142,6 +142,10 @@ public class StreamProcessingComposite implements CommandWriter {
     return processingState;
   }
 
+  public MutableProcessingState getProcessingState(final String streamName) {
+    return streams.getProcessingState(streamName);
+  }
+
   public RecordStream events() {
     return new RecordStream(streams.events(getLogName(partitionId)));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessingComposite.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.TenantOwned;
 import io.camunda.zeebe.scheduler.Actor;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorListener;
@@ -131,6 +132,10 @@ public class StreamProcessingComposite implements CommandWriter {
 
   public StreamProcessor getStreamProcessor(final int partitionId) {
     return streams.getStreamProcessor(getLogName(partitionId));
+  }
+
+  public StreamClock getStreamClock(final int partitionId) {
+    return streams.getStreamClock(getLogName(partitionId));
   }
 
   public MutableProcessingState getProcessingState() {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -183,6 +183,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
     return streamProcessingComposite.getProcessingState();
   }
 
+  public MutableProcessingState getProcessingState(final int partitionId) {
+    return streamProcessingComposite.getProcessingState(getLogName(partitionId));
+  }
+
   public RecordStream events() {
     return new RecordStream(streams.events(getLogName(startPartitionId)));
   }

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessorContext;
@@ -160,6 +161,10 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
   public StreamProcessor getStreamProcessor(final int partitionId) {
     return streamProcessingComposite.getStreamProcessor(partitionId);
+  }
+
+  public StreamClock getStreamClock(final int partitionId) {
+    return streamProcessingComposite.getStreamClock(partitionId);
   }
 
   public SynchronousLogStream getLogStream(final int partitionId) {

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClockClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/ClockClient.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.util.client;
+
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import java.time.Instant;
+import java.util.function.Function;
+
+public class ClockClient {
+  private static final Function<Long, Record<ClockRecordValue>> SUCCESS_EXPECTATION =
+      (position) ->
+          RecordingExporter.clockRecords(ClockIntent.PINNED)
+              .withSourceRecordPosition(position)
+              .getFirst();
+
+  private final CommandWriter writer;
+  private final ClockRecord record = new ClockRecord();
+  private final Function<Long, Record<ClockRecordValue>> expectation = SUCCESS_EXPECTATION;
+
+  public ClockClient(final CommandWriter writer) {
+    this.writer = writer;
+  }
+
+  public Record<ClockRecordValue> pinAt(final Instant now) {
+    final long position = writer.writeCommand(ClockIntent.PIN, record.pinAt(now.toEpochMilli()));
+    return expectation.apply(position);
+  }
+}

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/distribution/CommandDistributionRecord.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.msgpack.property.ObjectProperty;
 import io.camunda.zeebe.msgpack.spec.MsgPackReader;
 import io.camunda.zeebe.msgpack.spec.MsgPackWriter;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
 import io.camunda.zeebe.protocol.impl.record.value.message.MessageSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.resource.ResourceDeletionRecord;
@@ -39,6 +40,7 @@ public final class CommandDistributionRecord extends UnifiedRecordValue
     RECORDS_BY_TYPE.put(ValueType.RESOURCE_DELETION, ResourceDeletionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.SIGNAL, SignalRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER, UserRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.CLOCK, ClockRecord::new);
   }
 
   /*

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClockIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClockIntent.java
@@ -16,13 +16,15 @@
 package io.camunda.zeebe.protocol.record.intent;
 
 public enum ClockIntent implements Intent {
-  PIN((short) 0),
-  PINNED((short) 1);
+  PIN((short) 0, false),
+  PINNED((short) 1, true);
 
   private final short value;
+  private final boolean isEvent;
 
-  ClockIntent(final short value) {
+  ClockIntent(final short value, final boolean isEvent) {
     this.value = value;
+    this.isEvent = isEvent;
   }
 
   public short getIntent() {
@@ -47,6 +49,6 @@ public enum ClockIntent implements Intent {
 
   @Override
   public boolean isEvent() {
-    return true;
+    return isEvent;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/TypedEventRegistry.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DecisionRecord;
@@ -96,6 +97,7 @@ public final class TypedEventRegistry {
     registry.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord.class);
     registry.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord.class);
     registry.put(ValueType.USER, UserRecord.class);
+    registry.put(ValueType.CLOCK, ClockRecord.class);
 
     EVENT_REGISTRY = Collections.unmodifiableMap(registry);
 

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ClockRecordStream.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/ClockRecordStream.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.test.util.record;
+
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
+import java.util.stream.Stream;
+
+public class ClockRecordStream extends ExporterRecordStream<ClockRecordValue, ClockRecordStream> {
+
+  public ClockRecordStream(final Stream<Record<ClockRecordValue>> wrappedStream) {
+    super(wrappedStream);
+  }
+
+  @Override
+  protected ClockRecordStream supply(final Stream<Record<ClockRecordValue>> wrappedStream) {
+    return new ClockRecordStream(wrappedStream);
+  }
+}

--- a/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
+++ b/zeebe/test-util/src/main/java/io/camunda/zeebe/test/util/record/RecordingExporter.java
@@ -12,6 +12,7 @@ import io.camunda.zeebe.exporter.api.context.Controller;
 import io.camunda.zeebe.protocol.record.Record;
 import io.camunda.zeebe.protocol.record.RecordValue;
 import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
 import io.camunda.zeebe.protocol.record.intent.CommandDistributionIntent;
 import io.camunda.zeebe.protocol.record.intent.DecisionEvaluationIntent;
 import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
@@ -35,6 +36,7 @@ import io.camunda.zeebe.protocol.record.intent.TimerIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableDocumentIntent;
 import io.camunda.zeebe.protocol.record.intent.VariableIntent;
+import io.camunda.zeebe.protocol.record.value.ClockRecordValue;
 import io.camunda.zeebe.protocol.record.value.CommandDistributionRecordValue;
 import io.camunda.zeebe.protocol.record.value.CompensationSubscriptionRecordValue;
 import io.camunda.zeebe.protocol.record.value.DecisionEvaluationRecordValue;
@@ -427,6 +429,14 @@ public final class RecordingExporter implements Exporter {
 
   public static UserRecordStream userRecords() {
     return new UserRecordStream(records(ValueType.USER, UserRecordValue.class));
+  }
+
+  public static ClockRecordStream clockRecords() {
+    return new ClockRecordStream(records(ValueType.CLOCK, ClockRecordValue.class));
+  }
+
+  public static ClockRecordStream clockRecords(final ClockIntent intent) {
+    return clockRecords().withIntent(intent);
   }
 
   public static void autoAcknowledge(final boolean shouldAcknowledgeRecords) {


### PR DESCRIPTION
## Description

This PR introduces a new PIN command processor, as well as all the wiring for the engine to process the command. It does not yet test the distribution, though the code is added. This will be added in a follow up.

Pinning is executed as a side effect to ensure we have persisted the state changes before modifying the clock. I'm not 100% sure this is required, but I figured better safe than sorry.

## Related issues

related to #21068 
