### PR TITLE
[Backport stable/8.5] test: ensure that controlled actor scheduler starts idle

### DIFF
--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerExtension.java
@@ -64,6 +64,7 @@ public class ControlledActorSchedulerExtension implements BeforeEachCallback, Af
     actorScheduler = builder.build();
     controlledActorTaskRunner = actorTaskRunnerFactory.controlledThread;
     actorScheduler.start();
+    controlledActorTaskRunner.waitUntilDone();
   }
 
   public ActorFuture<Void> submitActor(final Actor actor) {

--- a/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
+++ b/zeebe/scheduler/src/test/java/io/camunda/zeebe/scheduler/testing/ControlledActorSchedulerRule.java
@@ -50,6 +50,7 @@ public final class ControlledActorSchedulerRule extends ExternalResource {
   @Override
   protected void before() {
     actorScheduler.start();
+    controlledActorTaskRunner.waitUntilDone();
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #21043 to `stable/8.5`.

relates to #13493
original author: @lenaschoenburg