### PR TITLE
feat: add ZeebeVersionTag extension element to BPMN model API

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/Bpmn.java
@@ -238,6 +238,7 @@ import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskHeadersImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeTaskScheduleImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskFormImpl;
 import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeUserTaskImpl;
+import io.camunda.zeebe.model.bpmn.impl.instance.zeebe.ZeebeVersionTagImpl;
 import io.camunda.zeebe.model.bpmn.instance.Definitions;
 import io.camunda.zeebe.model.bpmn.instance.Process;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnDiagram;
@@ -666,6 +667,7 @@ public class Bpmn {
     ZeebeExecutionListenersImpl.registerType(bpmnModelBuilder);
     ZeebeExecutionListenerImpl.registerType(bpmnModelBuilder);
     ZeebePriorityDefinitionImpl.registerType(bpmnModelBuilder);
+    ZeebeVersionTagImpl.registerType(bpmnModelBuilder);
   }
 
   /**

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ProcessBuilder.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.model.bpmn.instance.StartEvent;
 import io.camunda.zeebe.model.bpmn.instance.SubProcess;
 import io.camunda.zeebe.model.bpmn.instance.bpmndi.BpmnShape;
 import io.camunda.zeebe.model.bpmn.instance.dc.Bounds;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeVersionTag;
 import java.util.Collection;
 import java.util.function.Consumer;
 
@@ -36,7 +37,7 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder>
 
   public ProcessBuilder(final BpmnModelInstance modelInstance, final Process process) {
     super(modelInstance, process, ProcessBuilder.class);
-    this.zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
+    zeebeExecutionListenersBuilder = new ZeebeExecutionListenersBuilderImpl<>(myself);
   }
 
   public StartEventBuilder startEvent() {
@@ -147,5 +148,10 @@ public class ProcessBuilder extends AbstractProcessBuilder<ProcessBuilder>
   public ProcessBuilder zeebeExecutionListener(
       final Consumer<ExecutionListenerBuilder> executionListenerBuilderConsumer) {
     return zeebeExecutionListenersBuilder.zeebeExecutionListener(executionListenerBuilderConsumer);
+  }
+
+  public ProcessBuilder versionTag(final String value) {
+    addExtensionElement(ZeebeVersionTag.class, versionTag -> versionTag.setValue(value));
+    return this;
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -97,6 +97,8 @@ public class ZeebeConstants {
   public static final String ELEMENT_EXECUTION_LISTENERS = "executionListeners";
   public static final String ELEMENT_EXECUTION_LISTENER = "executionListener";
 
+  public static final String ELEMENT_VERSION_TAG = "versionTag";
+
   /** Form key format used for camunda-forms format */
   public static final String USER_TASK_FORM_KEY_CAMUNDA_FORMS_FORMAT = "camunda-forms";
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeVersionTagImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeVersionTagImpl.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.impl.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.impl.ZeebeConstants;
+import io.camunda.zeebe.model.bpmn.impl.instance.BpmnModelElementInstanceImpl;
+import io.camunda.zeebe.model.bpmn.instance.zeebe.ZeebeVersionTag;
+import org.camunda.bpm.model.xml.ModelBuilder;
+import org.camunda.bpm.model.xml.impl.instance.ModelTypeInstanceContext;
+import org.camunda.bpm.model.xml.type.ModelElementTypeBuilder;
+import org.camunda.bpm.model.xml.type.attribute.Attribute;
+
+public class ZeebeVersionTagImpl extends BpmnModelElementInstanceImpl implements ZeebeVersionTag {
+
+  private static Attribute<String> valueAttribute;
+
+  public ZeebeVersionTagImpl(final ModelTypeInstanceContext instanceContext) {
+    super(instanceContext);
+  }
+
+  @Override
+  public String getValue() {
+    return valueAttribute.getValue(this);
+  }
+
+  @Override
+  public void setValue(final String value) {
+    valueAttribute.setValue(this, value);
+  }
+
+  public static void registerType(final ModelBuilder modelBuilder) {
+    final ModelElementTypeBuilder typeBuilder =
+        modelBuilder
+            .defineType(ZeebeVersionTag.class, ZeebeConstants.ELEMENT_VERSION_TAG)
+            .namespaceUri(BpmnModelConstants.ZEEBE_NS)
+            .instanceProvider(ZeebeVersionTagImpl::new);
+    valueAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_VALUE)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .required()
+            .build();
+    typeBuilder.build();
+  }
+}

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeVersionTag.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeVersionTag.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstance;
+
+public interface ZeebeVersionTag extends BpmnModelElementInstance {
+
+  String getValue();
+
+  void setValue(String value);
+}

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeVersionTagTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeVersionTagTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.zeebe.model.bpmn.instance.zeebe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import io.camunda.zeebe.model.bpmn.impl.BpmnModelConstants;
+import io.camunda.zeebe.model.bpmn.instance.BpmnModelElementInstanceTest;
+import io.camunda.zeebe.model.bpmn.instance.Process;
+import java.io.ByteArrayInputStream;
+import java.util.Collection;
+import java.util.Collections;
+import org.junit.Test;
+
+public class ZeebeVersionTagTest extends BpmnModelElementInstanceTest {
+
+  @Override
+  public TypeAssumption getTypeAssumption() {
+    return new TypeAssumption(BpmnModelConstants.ZEEBE_NS, false);
+  }
+
+  @Override
+  public Collection<ChildElementAssumption> getChildElementAssumptions() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Collection<AttributeAssumption> getAttributesAssumptions() {
+    return Collections.singletonList(
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "value", false, true));
+  }
+
+  @Test
+  public void shouldReadVersionTagFromXml() {
+    // given
+    final BpmnModelInstance modelInstance =
+        Bpmn.createExecutableProcess("process").versionTag("v1").startEvent().done();
+    final String modelXml = Bpmn.convertToString(modelInstance);
+
+    // when
+    final Process process =
+        Bpmn.readModelFromStream(new ByteArrayInputStream(modelXml.getBytes()))
+            .getModelElementById("process");
+    final ZeebeVersionTag versionTag = process.getSingleExtensionElement(ZeebeVersionTag.class);
+
+    // then
+    assertThat(versionTag).isNotNull().extracting(ZeebeVersionTag::getValue).isEqualTo("v1");
+  }
+}


### PR DESCRIPTION
## Description
Adds a new `ZeebeVersionTag` extension element to the BPMN model API that represents the XML element `zeebe:versionTag` which will be used to set a custom version tag for a BPMN process or DMN decision.
Zeebe will later use the model API to read the version tag from a diagram's XML in order to support "version tag" binding for call activities and business rule tasks.

## Related issues
closes #21124