### PR TITLE
ci: continue on deletion error

### DIFF
--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   delete-old-benchmarks:
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
## Description
When deletion of benchmarks fail, we still want to create new benchmarks or update them. For example happened here https://github.com/camunda/camunda/actions/runs/10383508735/job/28748575997

were rerun weekly benchmark of course fails to delete previous benchmarks, as they are gone already. But we just wanted to update the benchmarks

See also https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions
