### PR TITLE
feat: logstream uses a controllable clock to assign record timestamps

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionContext.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.broker.partitioning.topology.TopologyManager;
 import io.camunda.zeebe.broker.transport.adminapi.AdminApiRequestHandler;
 import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.util.health.HealthMonitor;
 import java.util.List;
@@ -71,4 +72,8 @@ public interface PartitionContext {
   DynamicPartitionConfig getDynamicPartitionConfig();
 
   void setDynamicPartitionConfig(DynamicPartitionConfig partitionConfig);
+
+  ControllableStreamClock getStreamClock();
+
+  void setStreamClock(ControllableStreamClock clock);
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/PartitionStartupAndTransitionContextImpl.java
@@ -42,6 +42,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.ScheduledTimer;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -101,6 +102,7 @@ public class PartitionStartupAndTransitionContextImpl
   private AdminApiRequestHandler adminApiService;
   private PartitionAdminAccess adminAccess;
   private final MeterRegistry meterRegistry;
+  private ControllableStreamClock clock;
 
   public PartitionStartupAndTransitionContextImpl(
       final int nodeId,
@@ -399,6 +401,16 @@ public class PartitionStartupAndTransitionContextImpl
   @Override
   public void setDynamicPartitionConfig(final DynamicPartitionConfig partitionConfig) {
     dynamicPartitionConfig = partitionConfig;
+  }
+
+  @Override
+  public ControllableStreamClock getStreamClock() {
+    return clock;
+  }
+
+  @Override
+  public void setStreamClock(final ControllableStreamClock clock) {
+    this.clock = clock;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -8,13 +8,14 @@
 package io.camunda.zeebe.broker.system.partitions.impl.steps;
 
 import io.atomix.raft.RaftServer.Role;
-import io.camunda.zeebe.broker.logstreams.AtomixLogStorage;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionContext;
 import io.camunda.zeebe.broker.system.partitions.PartitionTransitionStep;
 import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
+import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import io.camunda.zeebe.stream.api.StreamClock;
 import java.util.function.Supplier;
 
 public final class LogStreamPartitionTransitionStep implements PartitionTransitionStep {
@@ -37,6 +38,7 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
     if (logStream != null
         && (shouldInstallOnTransition(targetRole, context.getCurrentRole())
             || targetRole == Role.INACTIVE)) {
+      context.setStreamClock(null);
       context.getComponentHealthMonitor().removeComponent(logStream.getLogName());
       logStream.close();
       context.setLogStream(null);
@@ -49,8 +51,8 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     if ((context.getLogStream() == null && targetRole != Role.INACTIVE)
         || shouldInstallOnTransition(targetRole, context.getCurrentRole())) {
-      final var logStorage = context.getLogStorage();
-      context.setLogStream(buildLogStream(context, logStorage));
+      context.setStreamClock(StreamClock.controllable(ActorClock.current()));
+      context.setLogStream(buildLogStream(context));
 
       return CompletableActorFuture.completed(null);
     } else {
@@ -63,16 +65,16 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
     return "LogStream";
   }
 
-  private LogStream buildLogStream(
-      final PartitionTransitionContext context, final AtomixLogStorage atomixLogStorage) {
+  private LogStream buildLogStream(final PartitionTransitionContext context) {
     final var flowControlCfg = context.getBrokerCfg().getFlowControl();
     return logStreamBuilderSupplier
         .get()
-        .withLogStorage(atomixLogStorage)
+        .withLogStorage(context.getLogStorage())
         .withLogName("logStream-" + context.getRaftPartition().name())
         .withPartitionId(context.getPartitionId())
         .withMaxFragmentSize(context.getMaxFragmentSize())
         .withActorSchedulingService(context.getActorSchedulingService())
+        .withClock(context.getStreamClock())
         .withRequestLimit(
             flowControlCfg.getRequest() != null
                 ? flowControlCfg.getRequest().buildLimit()

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/LogStreamPartitionTransitionStep.java
@@ -16,6 +16,7 @@ import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.api.StreamClock;
+import java.time.InstantSource;
 import java.util.function.Supplier;
 
 public final class LogStreamPartitionTransitionStep implements PartitionTransitionStep {
@@ -51,7 +52,9 @@ public final class LogStreamPartitionTransitionStep implements PartitionTransiti
       final PartitionTransitionContext context, final long term, final Role targetRole) {
     if ((context.getLogStream() == null && targetRole != Role.INACTIVE)
         || shouldInstallOnTransition(targetRole, context.getCurrentRole())) {
-      context.setStreamClock(StreamClock.controllable(ActorClock.current()));
+      final var clockSource =
+          ActorClock.current() != null ? ActorClock.current() : InstantSource.system();
+      context.setStreamClock(StreamClock.controllable(clockSource));
       context.setLogStream(buildLogStream(context));
 
       return CompletableActorFuture.completed(null);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -184,6 +184,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .streamProcessorMode(streamProcessorMode)
         .partitionCommandSender(context.getPartitionCommandSender())
         .scheduledCommandCache(scheduledCommandCache)
+        .clock(context.getStreamClock())
         .build();
   }
 }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -182,7 +182,7 @@ public final class ExporterRule implements TestRule {
 
     @Override
     protected void before() {
-      streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
+      streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get(), clock);
       streams.createLogStream(STREAM_NAME, partitionId);
     }
   }

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/partitions/TestPartitionTransitionContext.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.testing.TestActorFuture;
 import io.camunda.zeebe.snapshots.PersistedSnapshotStore;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.transport.impl.AtomixServerTransport;
 import io.camunda.zeebe.util.health.HealthMonitor;
@@ -75,6 +76,7 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   private DynamicPartitionConfig partitionConfig;
   private CommandApiService commandApiService;
   private MeterRegistry meterRegistry;
+  private ControllableStreamClock clock;
 
   @Override
   public int getPartitionId() {
@@ -167,6 +169,16 @@ public class TestPartitionTransitionContext implements PartitionTransitionContex
   @Override
   public void setDynamicPartitionConfig(final DynamicPartitionConfig partitionConfig) {
     this.partitionConfig = partitionConfig;
+  }
+
+  @Override
+  public ControllableStreamClock getStreamClock() {
+    return clock;
+  }
+
+  @Override
+  public void setStreamClock(final ControllableStreamClock clock) {
+    this.clock = clock;
   }
 
   @Override

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/perf/TestEngine.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.stream.impl.StreamProcessorMode;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
 import io.camunda.zeebe.util.FeatureFlags;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -46,7 +47,8 @@ public final class TestEngine {
         new TestStreams(
             testContext.temporaryFolder(),
             testContext.autoCloseableRule(),
-            testContext.actorScheduler());
+            testContext.actorScheduler(),
+            InstantSource.system());
     testStreams.withStreamProcessorMode(StreamProcessorMode.PROCESSING);
     // for performance reasons we want to enable batch processing
     testStreams.maxCommandsInBatch(100);

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/streamprocessor/EngineErrorHandlingTest.java
@@ -53,6 +53,7 @@ import io.camunda.zeebe.stream.api.state.KeyGenerator;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.test.util.TestUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -86,7 +87,8 @@ public final class EngineErrorHandlingTest {
 
   @Before
   public void setUp() {
-    streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
+    streams =
+        new TestStreams(tempFolder, closeables, actorSchedulerRule.get(), InstantSource.system());
     mockCommandResponseWriter = streams.getMockedResponseWriter();
     streams.createLogStream(STREAM_NAME);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/StreamProcessorRule.java
@@ -272,7 +272,7 @@ public final class StreamProcessorRule implements TestRule, CommandWriter {
 
     @Override
     protected void before() {
-      streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get());
+      streams = new TestStreams(tempFolder, closeables, actorSchedulerRule.get(), clock);
       streams.withStreamProcessorMode(streamProcessorMode);
       streams.maxCommandsInBatch(maxCommandsInBatch);
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -39,6 +39,7 @@ import io.camunda.zeebe.scheduler.ActorScheduler;
 import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.ReadonlyStreamProcessorContext;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.impl.StreamProcessor;
 import io.camunda.zeebe.stream.impl.StreamProcessorBuilder;
@@ -55,6 +56,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -83,6 +85,7 @@ public final class TestStreams {
   private final TemporaryFolder dataDirectory;
   private final AutoCloseableRule closeables;
   private final ActorScheduler actorScheduler;
+  private final InstantSource clock;
 
   private final CommandResponseWriter mockCommandResponseWriter;
   private final Map<String, LogContext> logContextMap = new HashMap<>();
@@ -95,10 +98,12 @@ public final class TestStreams {
   public TestStreams(
       final TemporaryFolder dataDirectory,
       final AutoCloseableRule closeables,
-      final ActorScheduler actorScheduler) {
+      final ActorScheduler actorScheduler,
+      final InstantSource clock) {
     this.dataDirectory = dataDirectory;
     this.closeables = closeables;
     this.actorScheduler = actorScheduler;
+    this.clock = clock;
 
     mockCommandResponseWriter = mock(CommandResponseWriter.class);
     when(mockCommandResponseWriter.intent(any())).thenReturn(mockCommandResponseWriter);
@@ -151,6 +156,7 @@ public final class TestStreams {
             .withLogName(name)
             .withLogStorage(logStorage)
             .withPartitionId(partitionId)
+            .withClock(clock)
             .withActorSchedulingService(actorScheduler)
             .build();
 
@@ -270,7 +276,8 @@ public final class TestStreams {
             .recordProcessors(List.of(new Engine(wrappedFactory, new EngineConfiguration())))
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
-            .partitionCommandSender(mock(InterPartitionCommandSender.class));
+            .partitionCommandSender(mock(InterPartitionCommandSender.class))
+            .clock(StreamClock.controllable(clock));
 
     processorConfiguration.accept(builder);
 

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/LogStreamImpl.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.logstreams.log.LogStreamReader;
 import io.camunda.zeebe.logstreams.log.LogStreamWriter;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.logstreams.storage.LogStorage.CommitListener;
+import java.time.InstantSource;
 import java.util.Collection;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.slf4j.Logger;
@@ -42,6 +43,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
       final int partitionId,
       final int maxFragmentSize,
       final LogStorage logStorage,
+      final InstantSource clock,
       final Limit requestLimit,
       final RateLimit writeRateLimit) {
     this.logName = logName;
@@ -54,6 +56,7 @@ public final class LogStreamImpl implements LogStream, CommitListener {
             logStorage,
             getWriteBuffersInitialPosition(),
             maxFragmentSize,
+            clock,
             new SequencerMetrics(partitionId),
             flowControl);
     logStorage.addCommitListener(this);

--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/log/LogStreamBuilder.java
@@ -11,6 +11,7 @@ import com.netflix.concurrency.limits.Limit;
 import io.camunda.zeebe.logstreams.impl.flowcontrol.RateLimit;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import java.time.InstantSource;
 
 /** Builder pattern for the {@link LogStream} */
 public interface LogStreamBuilder {
@@ -56,6 +57,9 @@ public interface LogStreamBuilder {
    * @return this builder
    */
   LogStreamBuilder withLogName(String logName);
+
+  /** Clock used to assign record timestamps */
+  LogStreamBuilder withClock(InstantSource clock);
 
   LogStreamBuilder withRequestLimit(Limit requestLimit);
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/LogStorageAppenderTest.java
@@ -25,6 +25,7 @@ import io.camunda.zeebe.logstreams.util.ListLogStorage;
 import io.camunda.zeebe.logstreams.util.TestEntry;
 import io.camunda.zeebe.scheduler.ActorScheduler;
 import java.nio.ByteBuffer;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -62,6 +63,7 @@ final class LogStorageAppenderTest {
             logStorage,
             INITIAL_POSITION,
             4 * 1024 * 1024,
+            InstantSource.system(),
             new SequencerMetrics(PARTITION_ID),
             new FlowControl(logStreamMetrics));
     reader = new LogStreamReaderImpl(logStorage.newReader());

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/impl/log/SequencerTest.java
@@ -19,6 +19,7 @@ import io.camunda.zeebe.logstreams.storage.LogStorageReader;
 import io.camunda.zeebe.logstreams.util.TestEntry;
 import io.camunda.zeebe.test.util.asserts.EitherAssert;
 import io.camunda.zeebe.util.buffer.BufferWriter;
+import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.locks.LockSupport;
@@ -44,6 +45,7 @@ final class SequencerTest {
             logStorage,
             initialPosition,
             16,
+            InstantSource.system(),
             new SequencerMetrics(1),
             new FlowControl(logStreamMetrics));
 
@@ -65,6 +67,7 @@ final class SequencerTest {
             logStorage,
             initialPosition,
             16,
+            InstantSource.system(),
             new SequencerMetrics(1),
             new FlowControl(logStreamMetrics));
     final var entries =
@@ -86,7 +89,12 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
+            logStorage,
+            1,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(1),
+            new FlowControl(logStreamMetrics));
     final var entry = TestEntry.ofDefaults();
 
     // when
@@ -103,7 +111,12 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
+            logStorage,
+            1,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(1),
+            new FlowControl(logStreamMetrics));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
 
@@ -121,7 +134,12 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
+            logStorage,
+            1,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(1),
+            new FlowControl(logStreamMetrics));
     final var entry = TestEntry.ofDefaults();
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();
 
@@ -143,7 +161,12 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
+            logStorage,
+            1,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(1),
+            new FlowControl(logStreamMetrics));
     final var entry = TestEntry.ofDefaults();
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();
 
@@ -170,7 +193,12 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
+            logStorage,
+            1,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(1),
+            new FlowControl(logStreamMetrics));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();
@@ -192,7 +220,12 @@ final class SequencerTest {
     final var logStreamMetrics = new LogStreamMetrics(1);
     final var sequencer =
         new Sequencer(
-            logStorage, 1, 16, new SequencerMetrics(1), new FlowControl(logStreamMetrics));
+            logStorage,
+            1,
+            16,
+            InstantSource.system(),
+            new SequencerMetrics(1),
+            new FlowControl(logStreamMetrics));
     final var entries =
         List.of(TestEntry.ofDefaults(), TestEntry.ofDefaults(), TestEntry.ofDefaults());
     final var testFailures = new ConcurrentLinkedQueue<Throwable>();

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/log/LogStreamWriterTest.java
@@ -223,6 +223,19 @@ public final class LogStreamWriterTest {
     return event;
   }
 
+  @Test
+  public void shouldWriteEventWithTimestampFromClock() {
+    // given
+    logStreamRule.getClock().setCurrentTime(123456789L);
+    final long position = tryWrite(TestEntry.ofDefaults());
+
+    // when
+    final LoggedEvent event = getWrittenEvent(position);
+
+    // then
+    assertThat(event.getTimestamp()).isEqualTo(123456789L);
+  }
+
   private List<LoggedEvent> getWrittenEvents(final long position) {
     final List<LoggedEvent> events = new ArrayList<>();
 

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/LogStreamRule.java
@@ -72,7 +72,8 @@ public final class LogStreamRule extends ExternalResource {
             .withActorSchedulingService(actorScheduler)
             .withPartitionId(0)
             .withLogName("logStream-0")
-            .withLogStorage(listLogStorage);
+            .withLogStorage(listLogStorage)
+            .withClock(clock);
 
     // apply additional configs
     streamBuilder.accept(builder);

--- a/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
+++ b/zeebe/logstreams/src/test/java/io/camunda/zeebe/logstreams/util/SyncLogStreamBuilder.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.logstreams.log.LogStreamBuilder;
 import io.camunda.zeebe.logstreams.storage.LogStorage;
 import io.camunda.zeebe.scheduler.ActorSchedulingService;
+import java.time.InstantSource;
 
 public final class SyncLogStreamBuilder implements LogStreamBuilder {
   private final LogStreamBuilder delegate;
@@ -53,6 +54,12 @@ public final class SyncLogStreamBuilder implements LogStreamBuilder {
   @Override
   public SyncLogStreamBuilder withLogName(final String logName) {
     delegate.withLogName(logName);
+    return this;
+  }
+
+  @Override
+  public SyncLogStreamBuilder withClock(final InstantSource clock) {
+    delegate.withClock(clock);
     return this;
   }
 

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -20,7 +20,6 @@ import io.camunda.zeebe.scheduler.clock.ActorClock;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
 import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
 import io.camunda.zeebe.stream.api.RecordProcessor;
-import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
 import io.camunda.zeebe.stream.impl.metrics.StreamProcessorMetrics;
@@ -153,7 +152,6 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
     final var reader = logStream.newLogStreamReader();
     logStreamReader = reader;
     streamProcessorContext.logStreamReader(reader);
-    streamProcessorContext.clock(StreamClock.controllable(ActorClock.current()));
   }
 
   @Override

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessor;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
@@ -159,6 +160,11 @@ public final class StreamProcessorBuilder {
 
   public StreamProcessorBuilder processingFilter(final EventFilter processingFilter) {
     streamProcessorContext.processingFilter(processingFilter);
+    return this;
+  }
+
+  public StreamProcessorBuilder clock(final ControllableStreamClock clock) {
+    streamProcessorContext.clock(clock);
     return this;
   }
 }

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -30,6 +30,7 @@ import io.camunda.zeebe.stream.api.CommandResponseWriter;
 import io.camunda.zeebe.stream.api.EmptyProcessingResult;
 import io.camunda.zeebe.stream.api.InterPartitionCommandSender;
 import io.camunda.zeebe.stream.api.RecordProcessor;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.impl.TestScheduledCommandCache.TestCommandCache;
 import io.camunda.zeebe.stream.impl.state.DbKeyGenerator;
@@ -288,6 +289,7 @@ public final class StreamPlatform {
 
     final var builder =
         StreamProcessor.builder()
+            .clock(StreamClock.controllable(clock))
             .logStream(stream.getAsyncLogStream())
             .zeebeDb(zeebeDb)
             .actorSchedulingService(actorScheduler)

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -42,6 +42,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.InstantSource;
 import java.util.Arrays;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -74,16 +75,19 @@ public final class StreamPlatform {
   private final StreamProcessorLifecycleAware mockProcessorLifecycleAware;
   private final StreamProcessorListener mockStreamProcessorListener;
   private TestCommandCache scheduledCommandCache;
+  private final InstantSource clock;
 
   public StreamPlatform(
       final Path dataDirectory,
       final List<AutoCloseable> closeables,
       final ActorScheduler actorScheduler,
-      final ZeebeDbFactory zeebeDbFactory) {
+      final ZeebeDbFactory zeebeDbFactory,
+      final InstantSource clock) {
     this.dataDirectory = dataDirectory;
     this.closeables = closeables;
     this.actorScheduler = actorScheduler;
     this.zeebeDbFactory = zeebeDbFactory;
+    this.clock = clock;
 
     mockCommandResponseWriter = mock(CommandResponseWriter.class);
     when(mockCommandResponseWriter.intent(any())).thenReturn(mockCommandResponseWriter);
@@ -153,6 +157,7 @@ public final class StreamPlatform {
         SyncLogStream.builder()
             .withLogName(STREAM_NAME + partitionId)
             .withLogStorage(logStorage)
+            .withClock(clock)
             .withPartitionId(partitionId)
             .withActorSchedulingService(actorScheduler)
             .build();

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatformExtension.java
@@ -109,7 +109,7 @@ public class StreamPlatformExtension implements BeforeEachCallback {
         final var factory = DefaultZeebeDbFactory.defaultFactory();
 
         // streams
-        streamPlatform = new StreamPlatform(tempFolder, closables, actorScheduler, factory);
+        streamPlatform = new StreamPlatform(tempFolder, closables, actorScheduler, factory, clock);
 
       } catch (final Exception e) {
         ExceptionUtils.throwAsUncheckedException(e);


### PR DESCRIPTION
When building the logstream, we now create a `ControllableStreamClock`. It is based on the current actor clock for backwards compatibility with the old `ControllableActorClock`.

The newly created clock is part of the `PartitionContext`. It is used by the `Sequencer` to assign record timestamps and by the `StreamProcessor` so that the engine uses the same clock.

Relates to https://github.com/camunda/camunda/issues/21051