### PR TITLE
feat: use controllable clock for processing metrics

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/context/ExporterContext.java
@@ -13,6 +13,7 @@ import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.camunda.zeebe.util.EnsureUtil;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.InstantSource;
 import org.slf4j.Logger;
 
 public final class ExporterContext implements Context {
@@ -23,6 +24,7 @@ public final class ExporterContext implements Context {
   private final Configuration configuration;
   private final int partitionId;
   private final MeterRegistry meterRegistry;
+  private final InstantSource clock;
 
   private RecordFilter filter = DEFAULT_FILTER;
 
@@ -30,11 +32,13 @@ public final class ExporterContext implements Context {
       final Logger logger,
       final Configuration configuration,
       final int partitionId,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      final InstantSource clock) {
     this.logger = logger;
     this.configuration = configuration;
     this.partitionId = partitionId;
     this.meterRegistry = meterRegistry;
+    this.clock = clock;
   }
 
   @Override
@@ -45,6 +49,11 @@ public final class ExporterContext implements Context {
   @Override
   public Logger getLogger() {
     return logger;
+  }
+
+  @Override
+  public InstantSource clock() {
+    return clock;
   }
 
   @Override

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/repo/ExporterRepository.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.util.jar.ExternalJarLoadException;
 import io.camunda.zeebe.util.jar.ExternalJarRepository;
 import io.camunda.zeebe.util.jar.ThreadContextUtil;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.InstantSource;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -92,7 +93,11 @@ public final class ExporterRepository {
       final Exporter instance = descriptor.newInstance();
       final ExporterContext context =
           new ExporterContext(
-              LOG, descriptor.getConfiguration(), NULL_PARTITION_ID, new SimpleMeterRegistry());
+              LOG,
+              descriptor.getConfiguration(),
+              NULL_PARTITION_ID,
+              new SimpleMeterRegistry(),
+              InstantSource.system());
 
       ThreadContextUtil.runCheckedWithClassLoader(
           () -> instance.configure(context), instance.getClass().getClassLoader());

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainer.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.util.buffer.BufferUtil;
 import io.camunda.zeebe.util.jar.ThreadContextUtil;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.Optional;
 import org.agrona.DirectBuffer;
 import org.slf4j.Logger;
@@ -51,14 +52,16 @@ final class ExporterContainer implements Controller {
       final ExporterDescriptor descriptor,
       final int partitionId,
       final ExporterInitializationInfo initializationInfo,
-      final MeterRegistry meterRegistry) {
+      final MeterRegistry meterRegistry,
+      final InstantSource clock) {
     this.initializationInfo = initializationInfo;
     context =
         new ExporterContext(
             Loggers.getExporterLogger(descriptor.getId()),
             descriptor.getConfiguration(),
             partitionId,
-            meterRegistry);
+            meterRegistry,
+            clock);
 
     exporter = descriptor.newInstance();
   }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterDirectorContext.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.logstreams.log.LogStream;
 import io.camunda.zeebe.stream.api.EventFilter;
 import io.micrometer.core.instrument.MeterRegistry;
 import java.time.Duration;
+import java.time.InstantSource;
 import java.util.Map;
 
 public final class ExporterDirectorContext {
@@ -31,6 +32,7 @@ public final class ExporterDirectorContext {
   private Duration distributionInterval = DEFAULT_DISTRIBUTION_INTERVAL;
   private EventFilter positionsToSkipFilter;
   private MeterRegistry meterRegistry;
+  private InstantSource clock;
 
   public int getId() {
     return id;
@@ -70,6 +72,10 @@ public final class ExporterDirectorContext {
 
   public MeterRegistry getMeterRegistry() {
     return meterRegistry;
+  }
+
+  public InstantSource getClock() {
+    return clock;
   }
 
   public ExporterDirectorContext id(final int id) {
@@ -121,6 +127,11 @@ public final class ExporterDirectorContext {
 
   public ExporterDirectorContext positionsToSkipFilter(final EventFilter skipPositionsFilter) {
     positionsToSkipFilter = skipPositionsFilter;
+    return this;
+  }
+
+  public ExporterDirectorContext clock(final InstantSource clock) {
+    this.clock = clock;
     return this;
   }
 

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/ExporterDirectorPartitionTransitionStep.java
@@ -117,6 +117,7 @@ public final class ExporterDirectorPartitionTransitionStep implements PartitionT
         new ExporterDirectorContext()
             .id(EXPORTER_PROCESSOR_ID)
             .name(Actor.buildActorName("Exporter", context.getPartitionId()))
+            .clock(context.getStreamClock())
             .logStream(context.getLogStream())
             .zeebeDb(context.getZeebeDb())
             .partitionMessagingService(context.getMessagingService())

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/metrics/MetricsExporterTest.java
@@ -92,13 +92,15 @@ class MetricsExporterTest {
   }
 
   @Test
-  void shouldCleanupProcessInstancesWithSameStartTime() {
+  void shouldCleanupProcessInstancesWithSameStartTime() throws Exception {
     // given
     final var processCache = new TtlKeyCache();
     final var exporter =
         new MetricsExporter(new ExecutionLatencyMetrics(), processCache, new TtlKeyCache());
     final var controller = new ExporterTestController();
     exporter.open(controller);
+    exporter.configure(new ExporterTestContext());
+
     exporter.export(
         ImmutableRecord.<ProcessInstanceRecord>builder()
             .withRecordType(RecordType.EVENT)
@@ -126,13 +128,14 @@ class MetricsExporterTest {
   }
 
   @Test
-  void shouldCleanupJobWithSameStartTime() {
+  void shouldCleanupJobWithSameStartTime() throws Exception {
     // given
     final var jobCache = new TtlKeyCache();
     final var exporter =
         new MetricsExporter(new ExecutionLatencyMetrics(), new TtlKeyCache(), jobCache);
     final var controller = new ExporterTestController();
     exporter.open(controller);
+    exporter.configure(new ExporterTestContext());
     exporter.export(
         ImmutableRecord.builder()
             .withRecordType(RecordType.EVENT)

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterContainerRuntime.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.nio.file.Path;
+import java.time.InstantSource;
 import org.agrona.CloseHelper;
 
 /**
@@ -92,7 +93,8 @@ public final class ExporterContainerRuntime implements CloseableSilently {
       final MeterRegistry meterRegistry) {
 
     final var container =
-        new ExporterContainer(descriptor, partitionId, initializationInfo, meterRegistry);
+        new ExporterContainer(
+            descriptor, partitionId, initializationInfo, meterRegistry, InstantSource.system());
     container.initContainer(actor.getActorControl(), metrics, state, ExporterPhase.EXPORTING);
 
     return container;

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExternalExporterContainerTest.java
@@ -24,6 +24,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.time.InstantSource;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.dynamic.DynamicType.Unloaded;
 import org.agrona.CloseHelper;
@@ -133,7 +134,11 @@ final class ExternalExporterContainerTest {
     final var expectedClassLoader = descriptor.newInstance().getClass().getClassLoader();
     final var container =
         new ExporterContainer(
-            descriptor, 0, new ExporterInitializationInfo(0, null), new SimpleMeterRegistry());
+            descriptor,
+            0,
+            new ExporterInitializationInfo(0, null),
+            new SimpleMeterRegistry(),
+            InstantSource.system());
 
     // when
     container.close();
@@ -155,7 +160,12 @@ final class ExternalExporterContainerTest {
     final var registry = new SimpleMeterRegistry();
 
     final var container =
-        new ExporterContainer(descriptor, 0, new ExporterInitializationInfo(0, null), registry);
+        new ExporterContainer(
+            descriptor,
+            0,
+            new ExporterInitializationInfo(0, null),
+            registry,
+            InstantSource.system());
 
     // when
     container.configureExporter();

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -32,8 +32,11 @@ public interface Context {
   Logger getLogger();
 
   /**
-   * @return a clock that provides the current time. Use this instead of system time to ensure that
-   *     time is controllable.
+   * A clock that provides the current time. Use this instead of system time to ensure that time is
+   * controllable. Especially relevant when comparing the "current" time against record timestamps.
+   *
+   * <p>This clock is not used by the {@link Controller} to trigger scheduled tasks, these still
+   * rely on uncontrollable system time.
    */
   InstantSource clock();
 

--- a/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
+++ b/zeebe/exporter-api/src/main/java/io/camunda/zeebe/exporter/api/context/Context.java
@@ -18,6 +18,7 @@ package io.camunda.zeebe.exporter.api.context;
 import io.camunda.zeebe.protocol.record.RecordType;
 import io.camunda.zeebe.protocol.record.ValueType;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.InstantSource;
 import org.slf4j.Logger;
 
 /** Encapsulates context associated with the exporter on open. */
@@ -29,6 +30,12 @@ public interface Context {
    * @return pre-configured logger for this exporter
    */
   Logger getLogger();
+
+  /**
+   * @return a clock that provides the current time. Use this instead of system time to ensure that
+   *     time is controllable.
+   */
+  InstantSource clock();
 
   /**
    * @return configuration for this exporter

--- a/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
+++ b/zeebe/exporter-test/src/main/java/io/camunda/zeebe/exporter/test/ExporterTestContext.java
@@ -11,6 +11,7 @@ import io.camunda.zeebe.exporter.api.context.Configuration;
 import io.camunda.zeebe.exporter.api.context.Context;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.InstantSource;
 import java.util.Objects;
 import net.jcip.annotations.NotThreadSafe;
 import org.slf4j.Logger;
@@ -37,6 +38,11 @@ public final class ExporterTestContext implements Context {
   @Override
   public Logger getLogger() {
     return DEFAULT_LOGGER;
+  }
+
+  @Override
+  public InstantSource clock() {
+    return InstantSource.system();
   }
 
   @Override


### PR DESCRIPTION
## Description

This ensures that metrics published by the `ProcessingStateMachine` and the `MetricsExporter` are respecting the controllable clock.

To support this in the `MetricsExporter`, the `ExporterContext` was extended to provide an `InstantSource` that all exporters can use.

## Related issues

closes #21051
