### PR TITLE
Cleanup zeebeci after refactoring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,19 +455,12 @@ jobs:
 
   test-summary:
     # Used as migration path to support old Zeebe CI Test summary
+    # TODO: can be removed after 2024-08-16, remaining PRs need to be rebased
     name: Test summary
     runs-on: ubuntu-latest
     needs:
       - zeebe-ci
     steps:
-      - uses: actions/checkout@v4
-      - name: Check for aborted jobs
-        continue-on-error: true
-        uses: ./.github/actions/observe-aborted-jobs
-        with:
-          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
-          secret_vault_address: ${{ secrets.VAULT_ADDR }}
-          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 
   notify-if-failed:

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -486,25 +486,3 @@ jobs:
           gh pr review ${{ github.event.pull_request.number }} --approve
           # Call the API directly to work around https://github.com/cli/cli/issues/8352
           gh api graphql -f query='mutation PullRequestAutoMerge {enablePullRequestAutoMerge(input: {pullRequestId: "${{ github.event.pull_request.node_id }}"}) {clientMutationId}}'
-  # This job will trigger another workflow such that it will trigger a re-run of this failing workflow
-  # We can't automatically do this here, since you can only re-run a workflow if it has finished,
-  # and while this job is running, the workflow clearly hasn't finished
-  #
-  # It will only retry if the workflow failed, the run count is < 3 (to avoid infinite loops), and
-  # the author is backport-action, renovate, or camundait (for release PRs)
-  retry-workflow:
-    name: Retry release, renovate, or backport PRs automatically
-    needs: [ test-summary ]
-    if: |
-      failure() &&
-      fromJSON(github.run_attempt) < 3 &&
-      github.repository == 'camunda/camunda' &&
-      (github.actor == 'backport-action' || github.actor == 'renovate[bot]' || github.actor == 'camundait') &&
-      github.event_name != 'merge_queue'
-    runs-on: ubuntu-latest
-    env:
-      GH_REPO: ${{ github.repository }}
-      GH_TOKEN: ${{ github.token }}
-    steps:
-      - name: Retry workflow run ${{ github.run_id }}
-        run: gh workflow run retry-workflow.yml -F run_id=${{ github.run_id }}


### PR DESCRIPTION
## Description

Cleanup after refactoring zeebe-ci into the Unified CI:

* `./.github/actions/observe-aborted-jobs` must only be called once per workflow, `check-results` job already does it
* remove (probably) non-functional retry mechanism after [discussion](https://camunda.slack.com/archives/C071KP5BTHB/p1723630668915569?thread_ts=1723559734.451389&cid=C071KP5BTHB)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
