### PR TITLE
ci: disable Docker to GHA cache in PRs

### DIFF
--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -98,9 +98,6 @@ jobs:
           context: .
           push: true
           tags: ${{ env.TASKLIST_TEST_DOCKER_IMAGE }}
-          cache-from: type=gha,ignore-error=true
-          cache-to: type=gha,mode=max,ignore-error=true
-          no-cache-filters: build,distball,dist
           file: tasklist.Dockerfile
       - name: Run Docker tests
         run: mvn -pl tasklist/qa/integration-tests -DskipChecks -Dtest=StartupIT -Dsurefire.failIfNoSpecifiedTests=false -Dspring.profiles.active=docker-test test


### PR DESCRIPTION
## Description

In an effort to reduce Github Actions cache usage to safe(r) levels for #18759 (see also [CI Health dashboard](https://dashboard.int.camunda.com/d/bdmo5l8puugaoc/ci-health-camunda-camunda-monorepo) bottom row) I want to turn off caches on PR builds that don't bring much value (e.g. have high miss rate).

Looking e.g. at https://github.com/camunda/camunda/actions/caches?query=branch%3Arefs%2Fpull%2F21063%2Fmerge shows us that several large (>100MB) caches are only "used" during their creation (same timestamps) and built again in later runs:

![image](https://github.com/user-attachments/assets/936881a2-6f1e-4dc5-b29f-9e391aa8a4ce)

The [Tasklist Docker tests workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/tasklist-docker-tests.yml) is the only one that runs on PRs (and e.g. all Maven dependency update PRs from Renovate) that uses [the experimental cache feature of the docker-push-action](https://github.com/moby/buildkit/?tab=readme-ov-file#github-actions-cache-experimental), others like the comparable [Operate Docker tests workflow](https://github.com/camunda/camunda/blob/main/.github/workflows/operate-docker-tests.yml) don't and work well. [Github search](https://github.com/search?q=repo%3Acamunda%2Fcamunda+cache-to%3A+type%3Dgha&type=code)

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #18750
