### PR TITLE
refactor: move REST endpoints of exported entities

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/DecisionDefinitionQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/DecisionDefinitionQueryImpl.java
@@ -110,7 +110,7 @@ public class DecisionDefinitionQueryImpl
   public ZeebeFuture<SearchQueryResponse<DecisionDefinition>> send() {
     final HttpZeebeFuture<SearchQueryResponse<DecisionDefinition>> result = new HttpZeebeFuture<>();
     httpClient.post(
-        "/decision-definitions/search",
+        "/exported/decision-definitions/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         DecisionDefinitionSearchQueryResponse.class,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/DecisionRequirementsQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/DecisionRequirementsQueryImpl.java
@@ -69,7 +69,7 @@ public class DecisionRequirementsQueryImpl
     final HttpZeebeFuture<SearchQueryResponse<DecisionRequirements>> result =
         new HttpZeebeFuture<>();
     httpClient.post(
-        "/decision-requirements/search",
+        "/exported/decision-requirements/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         DecisionRequirementsSearchQueryResponse.class,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/ProcessInstanceQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/ProcessInstanceQueryImpl.java
@@ -110,7 +110,7 @@ public class ProcessInstanceQueryImpl
   public ZeebeFuture<SearchQueryResponse<ProcessInstance>> send() {
     final HttpZeebeFuture<SearchQueryResponse<ProcessInstance>> result = new HttpZeebeFuture<>();
     httpClient.post(
-        "/process-instances/search",
+        "/exported/process-instances/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         ProcessInstanceSearchQueryResponse.class,

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/UserTaskQueryImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/search/query/UserTaskQueryImpl.java
@@ -68,7 +68,7 @@ public class UserTaskQueryImpl
   public HttpZeebeFuture<SearchQueryResponse<UserTask>> send() {
     final HttpZeebeFuture<SearchQueryResponse<UserTask>> result = new HttpZeebeFuture<>();
     httpClient.post(
-        "/user-tasks/search",
+        "/exported/user-tasks/search",
         jsonMapper.toJson(request),
         httpRequestConfig.build(),
         UserTaskSearchQueryResponse.class,

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -523,7 +523,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-  /user-tasks/search:
+  /exported/user-tasks/search:
     post:
       tags:
         - User task
@@ -565,7 +565,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-  /process-instances/search:
+  /exported/process-instances/search:
     post:
       tags:
         - Process Instance
@@ -607,7 +607,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-  /decision-definitions/search:
+  /exported/decision-definitions/search:
     post:
       tags:
         - Decision Definition
@@ -649,7 +649,7 @@ paths:
             application/problem+json:
               schema:
                 $ref: "#/components/schemas/ProblemDetail"
-  /decision-requirements/search:
+  /exported/decision-requirements/search:
     post:
       tags:
         - Decision Requirements

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestQueryController
-@RequestMapping("/v2/decision-definitions")
+@RequestMapping("/v2/exported/decision-definitions")
 public class DecisionDefinitionQueryController {
 
   @Autowired private DecisionDefinitionServices decisionDefinitionServices;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestQueryController
-@RequestMapping("/v2/decision-requirements")
+@RequestMapping("/v2/exported/decision-requirements")
 public class DecisionRequirementsQueryController {
 
   @Autowired private DecisionRequirementsServices decisionRequirementsServices;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestQueryController
-@RequestMapping("/v2/process-instances")
+@RequestMapping("/v2/exported/process-instances")
 public class ProcessInstanceQueryController {
 
   @Autowired private ProcessInstanceServices processInstanceServices;

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @CamundaRestQueryController
-@RequestMapping("/v2/user-tasks")
+@RequestMapping("/v2/exported/user-tasks")
 public class UserTaskQueryController {
 
   @Autowired private UserTaskServices userTaskServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/configuration/RestApiConfigurationTest.java
@@ -25,7 +25,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 
 abstract class RestApiConfigurationTest extends RestControllerTest {
 
-  static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/process-instances/search";
+  static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/exported/process-instances/search";
   static final String TOPOLOGY_URL = "/v2/topology";
 
   @MockBean ProcessInstanceServices processInstanceServices;

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionDefinitionQueryControllerTest.java
@@ -63,7 +63,7 @@ public class DecisionDefinitionQueryControllerTest extends RestControllerTest {
           .sortValues(new Object[] {"v"})
           .build();
 
-  static final String DECISION_DEFINITIONS_SEARCH_URL = "/v2/decision-definitions/search";
+  static final String DECISION_DEFINITIONS_SEARCH_URL = "/v2/exported/decision-definitions/search";
 
   @MockBean DecisionDefinitionServices decisionDefinitionServices;
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/DecisionRequirementsQueryControllerTest.java
@@ -62,7 +62,7 @@ public class DecisionRequirementsQueryControllerTest extends RestControllerTest 
           .sortValues(new Object[] {"v"})
           .build();
 
-  static final String DECISION_REQUIREMENTS_SEARCH_URL = "/v2/decision-requirements/search";
+  static final String DECISION_REQUIREMENTS_SEARCH_URL = "/v2/exported/decision-requirements/search";
 
   @MockBean DecisionRequirementsServices decisionRequirementsServices;
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/ProcessInstanceQueryControllerTest.java
@@ -63,7 +63,7 @@ public class ProcessInstanceQueryControllerTest extends RestControllerTest {
           .sortValues(new Object[] {"v"})
           .build();
 
-  static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/process-instances/search";
+  static final String PROCESS_INSTANCES_SEARCH_URL = "/v2/exported/process-instances/search";
 
   @MockBean ProcessInstanceServices processInstanceServices;
 

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/UserTaskQueryControllerTest.java
@@ -66,7 +66,7 @@ public class UserTaskQueryControllerTest extends RestControllerTest {
               ]
           }
       }""";
-  private static final String USER_TASKS_SEARCH_URL = "/v2/user-tasks/search";
+  private static final String USER_TASKS_SEARCH_URL = "/v2/exported/user-tasks/search";
   private static final SearchQueryResult<UserTaskEntity> SEARCH_QUERY_RESULT =
       new Builder<UserTaskEntity>()
           .total(1L)


### PR DESCRIPTION
## Description

Moves the C8 REST API endpoints that work with exported data to a dedicated context path:
* All search endpoints are moved to the "/v2/exported/\<entity>/search" equivalent.
* Tests are adjusted accordingly.
* The Java client is adjusted accordingly.

## Related issues

n/a
