### PR TITLE
feat: Create /license endpoint to expose Camunda license status

### DIFF
--- a/dist/src/main/java/io/camunda/application/commons/service/ManagementServicesConfiguration.java
+++ b/dist/src/main/java/io/camunda/application/commons/service/ManagementServicesConfiguration.java
@@ -6,11 +6,11 @@
  * except in compliance with the Camunda License 1.0.
  */
 
-package io.camunda.webapps;
+package io.camunda.application.commons.service;
 
+import io.camunda.application.commons.service.ManagementServicesConfiguration.LicenseKeyProperties;
 import io.camunda.service.ManagementServices;
 import io.camunda.service.license.CamundaLicense;
-import io.camunda.webapps.ManagementServicesConfiguration.LicenseKeyProperties;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -28,8 +28,8 @@ public class ManagementServicesConfiguration {
   }
 
   @Bean
-  public ManagementServices managementService(final CamundaLicense camundaLicense) {
-    return new ManagementServices(camundaLicense);
+  public ManagementServices managementServices() {
+    return new ManagementServices(camundaLicense());
   }
 
   @Bean

--- a/service/src/main/java/io/camunda/service/ManagementServices.java
+++ b/service/src/main/java/io/camunda/service/ManagementServices.java
@@ -21,7 +21,7 @@ public final class ManagementServices {
     return license.isValid();
   }
 
-  public boolean isCamundaLicenseSelfManaged() {
-    return license.isSelfManaged();
+  public String getCamundaLicenseType() {
+    return license.getLicenseType();
   }
 }

--- a/service/src/test/java/io/camunda/service/license/CamundaLicenseTest.java
+++ b/service/src/test/java/io/camunda/service/license/CamundaLicenseTest.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.service.license;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -54,14 +55,13 @@ public class CamundaLicenseTest {
   }
 
   @Test
-  public void shouldReturnTrueFromIsSelfManagedWhenPropertyIsSetToSelfManaged()
-      throws InvalidLicenseException {
+  public void shouldReturnProperLicenseTypeFromLicenseProperty() throws InvalidLicenseException {
     // given
     final CamundaLicense testLicense = spy(CamundaLicense.class);
     final LicenseKey mockKey = mock(LicenseKey.class);
 
     final Map<String, String> testProperties = new HashMap<>();
-    testProperties.put("environmentMode", "self-managed");
+    testProperties.put("licenseType", "self-managed");
     when(mockKey.getProperties()).thenReturn(testProperties);
 
     Mockito.doReturn(mockKey).when(testLicense).getLicenseKey(anyString());
@@ -70,12 +70,11 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense("whatever");
 
     // then
-    assertTrue(testLicense.isSelfManaged());
+    assertEquals("self-managed", testLicense.getLicenseType());
   }
 
   @Test
-  public void shouldReturnTrueFromIsSelfManagedWhenPropertyDoesNotExist()
-      throws InvalidLicenseException {
+  public void shouldReturnUnknownWhenLicensePropertyDoesNotExist() throws InvalidLicenseException {
     // given
     final CamundaLicense testLicense = spy(CamundaLicense.class);
     final LicenseKey mockKey = mock(LicenseKey.class);
@@ -89,7 +88,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense("whatever");
 
     // then
-    assertTrue(testLicense.isSelfManaged());
+    assertEquals("unknown", testLicense.getLicenseType());
   }
 
   @Test
@@ -108,7 +107,7 @@ public class CamundaLicenseTest {
     testLicense.initializeWithLicense("whatever");
 
     // then
-    assertFalse(testLicense.isSelfManaged());
+    assertEquals("saas", testLicense.getLicenseType());
     assertTrue(testLicense.isValid());
   }
 }

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1058,6 +1058,7 @@ components:
           nullable: false
         licenseType:
           description: Will return the license type property of the Camunda License
+          type: string
     BrokerInfo:
       description: Provides information on a broker node.
       type: object

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -37,6 +37,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TopologyResponse"
+  /license:
+    get:
+      tags:
+        - License
+      summary: Get status of Camunda License
+      description: Obtains the status of the current Camunda License
+      responses:
+        '200':
+          description: Obtains the current status of the Camunda license
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LicenseResponse"
   /jobs/activation:
     post:
       tags:
@@ -1035,6 +1048,16 @@ components:
           description: The version of the Zeebe Gateway.
           type: string
           nullable: true
+    LicenseResponse:
+      description: The response of a license request.
+      type: object
+      properties:
+        validLicense:
+          description: True if the Camunda License is valid, false if otherwise
+          type: boolean
+          nullable: false
+        licenseType:
+          description: Will return the license type property of the Camunda License
     BrokerInfo:
       description: Provides information on a broker node.
       type: object

--- a/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
+++ b/zeebe/gateway-rest/src/main/java/io/camunda/zeebe/gateway/rest/controller/LicenseController.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.gateway.protocol.rest.LicenseResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@CamundaRestController
+@RequestMapping(path = {"/v2"})
+public class LicenseController {
+
+  @Autowired private ManagementServices managementServices;
+
+  @GetMapping(path = "/license", produces = MediaType.APPLICATION_JSON_VALUE)
+  public LicenseResponse get() {
+    final LicenseResponse response = new LicenseResponse();
+    response.setValidLicense(managementServices.isCamundaLicenseValid());
+    response.setLicenseType(managementServices.getCamundaLicenseType());
+
+    return response;
+  }
+}

--- a/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
+++ b/zeebe/gateway-rest/src/test/java/io/camunda/zeebe/gateway/rest/controller/LicenseControllerTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.rest.controller;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.camunda.service.ManagementServices;
+import io.camunda.zeebe.gateway.rest.RestControllerTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+@WebMvcTest(value = LicenseController.class, properties = "camunda.rest.query.enabled=true")
+public class LicenseControllerTest extends RestControllerTest {
+
+  static final String LICENSE_URL = "/v2/license";
+
+  static final String EXPECTED_LICENSE_RESPONSE =
+      """
+      {
+          "validLicense": true,
+          "licenseType": "saas"
+      }""";
+
+  @MockBean ManagementServices managementServices;
+
+  @Test
+  void shouldReturnProperSaaSResponse() {
+    // given
+    when(managementServices.isCamundaLicenseValid()).thenReturn(true);
+    when(managementServices.getCamundaLicenseType()).thenReturn("saas");
+
+    // when / then
+    webClient
+        .get()
+        .uri(LICENSE_URL)
+        .accept(MediaType.APPLICATION_JSON)
+        .exchange()
+        .expectStatus()
+        .isOk()
+        .expectHeader()
+        .contentType(MediaType.APPLICATION_JSON)
+        .expectBody()
+        .json(EXPECTED_LICENSE_RESPONSE);
+
+    verify(managementServices).isCamundaLicenseValid();
+    verify(managementServices).getCamundaLicenseType();
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Create a `GET /license` endpoint to return license information


```
GET /license
{
   "validLicense": true,
   "environment": "self-managed"
}
```

The endpoint can be accessed through something like this `http://localhost:8080/v2/license`

- `validLicense` will be `true` or `false`. The value is determined whether the Camunda license is valid or not
- `environment` will return one of two strings, `saas` or `self-managed`. The value reflects the current running mode Camunda is in

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/pull/21156
