### PR TITLE
Add RESET clock command

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/clock/ClockProcessors.java
@@ -24,9 +24,9 @@ public final class ClockProcessors {
       final KeyGenerator keyGenerator,
       final ControllableStreamClock clock,
       final CommandDistributionBehavior commandDistributionBehavior) {
-    typedRecordProcessors.onCommand(
-        ValueType.CLOCK,
-        ClockIntent.PIN,
-        new ClockPinProcessor(writers, keyGenerator, clock, commandDistributionBehavior));
+    final var clockProcessor =
+        new ClockProcessor(writers, keyGenerator, clock, commandDistributionBehavior);
+    typedRecordProcessors.onCommand(ValueType.CLOCK, ClockIntent.PIN, clockProcessor);
+    typedRecordProcessors.onCommand(ValueType.CLOCK, ClockIntent.RESET, clockProcessor);
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClockResettedApplier.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/ClockResettedApplier.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.state.appliers;
+
+import io.camunda.zeebe.engine.state.TypedEventApplier;
+import io.camunda.zeebe.engine.state.mutable.MutableClockState;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
+import io.camunda.zeebe.protocol.record.intent.ClockIntent;
+
+public final class ClockResettedApplier implements TypedEventApplier<ClockIntent, ClockRecord> {
+
+  private final MutableClockState clockState;
+
+  public ClockResettedApplier(final MutableClockState clockState) {
+    this.clockState = clockState;
+  }
+
+  @Override
+  public void applyState(final long key, final ClockRecord value) {
+    clockState.reset();
+  }
+}

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/state/appliers/EventAppliers.java
@@ -424,6 +424,7 @@ public final class EventAppliers implements EventApplier {
 
   private void registerClockAppliers(final MutableProcessingState state) {
     register(ClockIntent.PINNED, new ClockPinnedApplier(state.getClockState()));
+    register(ClockIntent.RESETTED, new ClockResettedApplier(state.getClockState()));
   }
 
   private <I extends Intent> void register(final I intent, final TypedEventApplier<I, ?> applier) {

--- a/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClockIntent.java
+++ b/zeebe/protocol/src/main/java/io/camunda/zeebe/protocol/record/intent/ClockIntent.java
@@ -17,7 +17,9 @@ package io.camunda.zeebe.protocol.record.intent;
 
 public enum ClockIntent implements Intent {
   PIN((short) 0, false),
-  PINNED((short) 1, true);
+  PINNED((short) 1, true),
+  RESET((short) 2, false),
+  RESETTED((short) 3, true);
 
   private final short value;
   private final boolean isEvent;
@@ -37,6 +39,10 @@ public enum ClockIntent implements Intent {
         return PIN;
       case 1:
         return PINNED;
+      case 2:
+        return RESET;
+      case 3:
+        return RESETTED;
       default:
         return Intent.UNKNOWN;
     }


### PR DESCRIPTION
## Description

This PR adds a new RESET/RESETTED intent pair to the clock records. This allows resetting any existing modifications to the clock. It is also distributed across all partitions, and applied on engine initialization.

## Related issues

closes #21068 
