### PR TITLE
feat: add support for binding type `versionTag` to BPMN Model API

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractBusinessRuleTaskBuilder.java
@@ -94,4 +94,17 @@ public abstract class AbstractBusinessRuleTaskBuilder<B extends AbstractBusiness
     calledDecision.setBindingType(bindingType);
     return myself;
   }
+
+  /**
+   * Sets the version tag for the decision that is called.
+   *
+   * @param versionTag the version tag for the decision
+   * @return the builder object
+   */
+  public B zeebeVersionTag(final String versionTag) {
+    final ZeebeCalledDecision calledDecision =
+        getCreateSingleExtensionElement(ZeebeCalledDecision.class);
+    calledDecision.setVersionTag(versionTag);
+    return myself;
+  }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractCallActivityBuilder.java
@@ -77,4 +77,11 @@ public class AbstractCallActivityBuilder<B extends AbstractCallActivityBuilder<B
     calledElement.setBindingType(bindingType);
     return myself;
   }
+
+  public B zeebeVersionTag(final String versionTag) {
+    final ZeebeCalledElement calledElement =
+        getCreateSingleExtensionElement(ZeebeCalledElement.class);
+    calledElement.setVersionTag(versionTag);
+    return myself;
+  }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/AbstractUserTaskBuilder.java
@@ -187,6 +187,14 @@ public abstract class AbstractUserTaskBuilder<B extends AbstractUserTaskBuilder<
   }
 
   @Override
+  public B zeebeFormVersionTag(final String versionTag) {
+    final ZeebeFormDefinition formDefinition =
+        getCreateSingleExtensionElement(ZeebeFormDefinition.class);
+    formDefinition.setVersionTag(versionTag);
+    return myself;
+  }
+
+  @Override
   public B zeebeTaskPriority(final String priority) {
     final ZeebePriorityDefinition priorityDefinition =
         myself.getCreateSingleExtensionElement(ZeebePriorityDefinition.class);

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/builder/ZeebeUserTaskPropertiesBuilder.java
@@ -178,6 +178,14 @@ public interface ZeebeUserTaskPropertiesBuilder<B extends ZeebeUserTaskPropertie
   B zeebeFormBindingType(final ZeebeBindingType bindingType);
 
   /**
+   * Sets the version tag for the user task's form.
+   *
+   * @param versionTag the version tag to set
+   * @return the builder object
+   */
+  B zeebeFormVersionTag(final String versionTag);
+
+  /**
    * Sets a static priority for the user task.
    *
    * @param priority the priority value to set

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/ZeebeConstants.java
@@ -60,6 +60,7 @@ public class ZeebeConstants {
   public static final String ATTRIBUTE_RESULT_VARIABLE = "resultVariable";
 
   public static final String ATTRIBUTE_BINDING_TYPE = "bindingType";
+  public static final String ATTRIBUTE_VERSION_TAG = "versionTag";
 
   public static final String ATTRIBUTE_PRIORITY = "priority";
 

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledDecisionImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledDecisionImpl.java
@@ -31,6 +31,7 @@ public class ZeebeCalledDecisionImpl extends BpmnModelElementInstanceImpl
   private static Attribute<String> decisionIdAttribute;
   private static Attribute<String> resultVariableAttribute;
   private static Attribute<ZeebeBindingType> bindingTypeAttribute;
+  private static Attribute<String> versionTagAttribute;
 
   public ZeebeCalledDecisionImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -64,6 +65,12 @@ public class ZeebeCalledDecisionImpl extends BpmnModelElementInstanceImpl
             .defaultValue(ZeebeBindingType.latest)
             .build();
 
+    versionTagAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_VERSION_TAG)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
+            .build();
+
     typeBuilder.build();
   }
 
@@ -95,5 +102,15 @@ public class ZeebeCalledDecisionImpl extends BpmnModelElementInstanceImpl
   @Override
   public void setBindingType(final ZeebeBindingType bindingType) {
     bindingTypeAttribute.setValue(this, bindingType);
+  }
+
+  @Override
+  public String getVersionTag() {
+    return versionTagAttribute.getValue(this);
+  }
+
+  @Override
+  public void setVersionTag(final String versionTag) {
+    versionTagAttribute.setValue(this, versionTag);
   }
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeCalledElementImpl.java
@@ -32,6 +32,7 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
   private static Attribute<Boolean> propagateAllChildVariablesAttribute;
   private static Attribute<Boolean> propagateAllParentVariablesAttribute;
   private static Attribute<ZeebeBindingType> bindingTypeAttribute;
+  private static Attribute<String> versionTagAttribute;
 
   public ZeebeCalledElementImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -79,6 +80,16 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
     bindingTypeAttribute.setValue(this, bindingType);
   }
 
+  @Override
+  public String getVersionTag() {
+    return versionTagAttribute.getValue(this);
+  }
+
+  @Override
+  public void setVersionTag(final String versionTag) {
+    versionTagAttribute.setValue(this, versionTag);
+  }
+
   public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
@@ -111,6 +122,12 @@ public class ZeebeCalledElementImpl extends BpmnModelElementInstanceImpl
             .enumAttribute(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, ZeebeBindingType.class)
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .defaultValue(ZeebeBindingType.latest)
+            .build();
+
+    versionTagAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_VERSION_TAG)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
     typeBuilder.build();

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/impl/instance/zeebe/ZeebeFormDefinitionImpl.java
@@ -32,6 +32,7 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
   protected static Attribute<String> formIdAttribute;
   protected static Attribute<String> externalReferenceAttribute;
   private static Attribute<ZeebeBindingType> bindingTypeAttribute;
+  private static Attribute<String> versionTagAttribute;
 
   public ZeebeFormDefinitionImpl(final ModelTypeInstanceContext instanceContext) {
     super(instanceContext);
@@ -77,6 +78,16 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
     bindingTypeAttribute.setValue(this, bindingType);
   }
 
+  @Override
+  public String getVersionTag() {
+    return versionTagAttribute.getValue(this);
+  }
+
+  @Override
+  public void setVersionTag(final String versionTag) {
+    versionTagAttribute.setValue(this, versionTag);
+  }
+
   public static void registerType(final ModelBuilder modelBuilder) {
     final ModelElementTypeBuilder typeBuilder =
         modelBuilder
@@ -107,6 +118,12 @@ public class ZeebeFormDefinitionImpl extends BpmnModelElementInstanceImpl
             .enumAttribute(ZeebeConstants.ATTRIBUTE_BINDING_TYPE, ZeebeBindingType.class)
             .namespace(BpmnModelConstants.ZEEBE_NS)
             .defaultValue(ZeebeBindingType.latest)
+            .build();
+
+    versionTagAttribute =
+        typeBuilder
+            .stringAttribute(ZeebeConstants.ATTRIBUTE_VERSION_TAG)
+            .namespace(BpmnModelConstants.ZEEBE_NS)
             .build();
 
     typeBuilder.build();

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeBindingType.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeBindingType.java
@@ -17,5 +17,6 @@ package io.camunda.zeebe.model.bpmn.instance.zeebe;
 
 public enum ZeebeBindingType {
   deployment,
-  latest
+  latest,
+  versionTag
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecision.java
@@ -55,4 +55,16 @@ public interface ZeebeCalledDecision extends BpmnModelElementInstance {
    * @param bindingType the binding type for the decision
    */
   void setBindingType(ZeebeBindingType bindingType);
+
+  /**
+   * @return The version tag of the decision that is called
+   */
+  String getVersionTag();
+
+  /**
+   * Sets the version tag of the decision that is called.
+   *
+   * @param versionTag the version tag of the decision
+   */
+  void setVersionTag(String versionTag);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElement.java
@@ -34,4 +34,8 @@ public interface ZeebeCalledElement extends BpmnModelElementInstance {
   ZeebeBindingType getBindingType();
 
   void setBindingType(ZeebeBindingType bindingType);
+
+  String getVersionTag();
+
+  void setVersionTag(String versionTag);
 }

--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinition.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinition.java
@@ -34,4 +34,8 @@ public interface ZeebeFormDefinition extends BpmnModelElementInstance {
   ZeebeBindingType getBindingType();
 
   void setBindingType(ZeebeBindingType bindingType);
+
+  String getVersionTag();
+
+  void setVersionTag(String versionTag);
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/BusinessRuleTaskBuilderTest.java
@@ -128,4 +128,23 @@ public class BusinessRuleTaskBuilderTest {
         .extracting(ZeebeCalledDecision::getBindingType)
         .containsExactly(bindingType);
   }
+
+  @Test
+  void shouldSetVersionTag() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .businessRuleTask("task", task -> task.zeebeVersionTag("v1"))
+            .done();
+
+    // then
+    final ModelElementInstance businessRuleTask = instance.getModelElementById("task");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) businessRuleTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledDecision.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledDecision::getVersionTag)
+        .containsExactly("v1");
+  }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/CallActivityBuilderTest.java
@@ -130,4 +130,23 @@ public class CallActivityBuilderTest {
         .extracting(ZeebeCalledElement::getBindingType)
         .containsExactly(bindingType);
   }
+
+  @Test
+  void shouldSetVersionTag() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .callActivity("callActivity", c -> c.zeebeVersionTag("v1"))
+            .done();
+
+    // then
+    final ModelElementInstance callActivity = instance.getModelElementById("callActivity");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) callActivity.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeCalledElement.class))
+        .hasSize(1)
+        .extracting(ZeebeCalledElement::getVersionTag)
+        .containsExactly("v1");
+  }
 }

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/builder/UserTaskBuilderTest.java
@@ -287,6 +287,27 @@ class UserTaskBuilderTest {
   }
 
   @Test
+  void shouldSetFormVersionTag() {
+    // when
+    final BpmnModelInstance instance =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("userTask")
+            .zeebeFormVersionTag("v1")
+            .endEvent()
+            .done();
+
+    // then
+    final ModelElementInstance userTask = instance.getModelElementById("userTask");
+    final ExtensionElements extensionElements =
+        (ExtensionElements) userTask.getUniqueChildElementByType(ExtensionElements.class);
+    assertThat(extensionElements.getChildElementsByType(ZeebeFormDefinition.class))
+        .hasSize(1)
+        .extracting(ZeebeFormDefinition::getVersionTag)
+        .containsExactly("v1");
+  }
+
+  @Test
   void shouldSetPriorityOnZeebeUserTask() {
     final String priority = "20";
     final BpmnModelInstance instance =

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecisionTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledDecisionTest.java
@@ -47,7 +47,8 @@ public class ZeebeCalledDecisionTest extends BpmnModelElementInstanceTest {
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "decisionId", false, true),
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "resultVariable", false, true),
         new AttributeAssumption(
-            BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest));
+            BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "versionTag", false, false));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElementTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeCalledElementTest.java
@@ -50,7 +50,8 @@ public class ZeebeCalledElementTest extends BpmnModelElementInstanceTest {
         new AttributeAssumption(
             BpmnModelConstants.ZEEBE_NS, "propagateAllParentVariables", false, false, true),
         new AttributeAssumption(
-            BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest));
+            BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "versionTag", false, false));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/instance/zeebe/ZeebeFormDefinitionTest.java
@@ -48,7 +48,8 @@ public class ZeebeFormDefinitionTest extends BpmnModelElementInstanceTest {
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "formId", false, false),
         new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "externalReference", false, false),
         new AttributeAssumption(
-            BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest));
+            BpmnModelConstants.ZEEBE_NS, "bindingType", false, false, ZeebeBindingType.latest),
+        new AttributeAssumption(BpmnModelConstants.ZEEBE_NS, "versionTag", false, false));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/BusinessRuleTaskValidatorTest.java
@@ -85,7 +85,7 @@ class BusinessRuleTaskValidatorTest {
         process,
         ExpectedValidationResult.expect(
             ZeebeCalledDecision.class,
-            "Attribute 'bindingType' must be one of: deployment, latest"));
+            "Attribute 'bindingType' must be one of: deployment, latest, versionTag"));
   }
 
   @Test

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeCallActivityTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeCallActivityTest.java
@@ -57,7 +57,7 @@ public class ZeebeCallActivityTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 ZeebeCalledElement.class,
-                "Attribute 'bindingType' must be one of: deployment, latest"))
+                "Attribute 'bindingType' must be one of: deployment, latest, versionTag"))
       },
       {
         Bpmn.createExecutableProcess("process")

--- a/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskValidatorFormTest.java
+++ b/zeebe/bpmn-model/src/test/java/io/camunda/zeebe/model/bpmn/validation/ZeebeTaskValidatorFormTest.java
@@ -365,7 +365,7 @@ public class ZeebeTaskValidatorFormTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 ZeebeFormDefinition.class,
-                "Attribute 'bindingType' must be one of: deployment, latest"))
+                "Attribute 'bindingType' must be one of: deployment, latest, versionTag"))
       },
       /////////////////////////////////////////////////////////////////////////////////////////////
       ////////////////////////////////// Native user tasks ////////////////////////////////////////
@@ -660,7 +660,7 @@ public class ZeebeTaskValidatorFormTest extends AbstractZeebeValidationTest {
         singletonList(
             expect(
                 ZeebeFormDefinition.class,
-                "Attribute 'bindingType' must be one of: deployment, latest"))
+                "Attribute 'bindingType' must be one of: deployment, latest, versionTag"))
       }
     };
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -131,6 +131,8 @@ public final class BpmnDecisionBehavior {
     return switch (bindingType) {
       case deployment -> getDecisionVersionInSameDeployment(decisionId, context);
       case latest -> getLatestDecisionVersion(decisionId, context.getTenantId());
+      // will be implemented with https://github.com/camunda/camunda/issues/21040
+      case versionTag -> Either.left(new Failure("Binding type 'versionTag' not supported"));
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -203,6 +203,8 @@ public final class BpmnUserTaskBehavior {
     return switch (bindingType) {
       case deployment -> findFormByIdInSameDeployment(formId, context, scopeKey);
       case latest -> findLatestFormById(formId, context.getTenantId(), scopeKey);
+      // will be implemented with https://github.com/camunda/camunda/issues/21041
+      case versionTag -> Either.left(new Failure("Binding type 'versionTag' not supported"));
     };
   }
 

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/container/CallActivityProcessor.java
@@ -213,6 +213,8 @@ public final class CallActivityProcessor
     return switch (bindingType) {
       case deployment -> getProcessVersionInSameDeployment(processId, context);
       case latest -> getLatestProcessVersion(processId, context.getTenantId());
+      // will be implemented with https://github.com/camunda/camunda/issues/21038
+      case versionTag -> Either.left(new Failure("Binding type 'versionTag' not supported"));
     };
   }
 


### PR DESCRIPTION
## Description
Adds support for the new binding type `versionTag` to the BPMN Model API.

## Related issues
closes #21034