### PR TITLE
Add message correlation to the Java client

### DIFF
--- a/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/ZeebeClient.java
@@ -20,6 +20,7 @@ import io.camunda.zeebe.client.api.command.AssignUserTaskCommandStep1;
 import io.camunda.zeebe.client.api.command.BroadcastSignalCommandStep1;
 import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteUserTaskCommandStep1;
+import io.camunda.zeebe.client.api.command.CorrelateMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
@@ -295,6 +296,23 @@ public interface ZeebeClient extends AutoCloseable, JobClient {
    * @return a builder for the command
    */
   PublishMessageCommandStep1 newPublishMessageCommand();
+
+  /**
+   * Command to correlate a message and wait for it to be correlated against a process instance.
+   *
+   * <pre>
+   * zeebeClient
+   *  .newCorrelateMessageCommand()
+   *  .messageName("order canceled")
+   *  .correlationKey(orderId)
+   *  .variables(json)
+   *  .tenantId("tenant")
+   *  .send();
+   * </pre>
+   *
+   * @return a builder for the command
+   */
+  CorrelateMessageCommandStep1 newCorrelateMessageCommand();
 
   /**
    * Command to broadcast a signal.

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.client.api.command;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/command/CorrelateMessageCommandStep1.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.client.api.command;
+
+import io.camunda.zeebe.client.api.response.CorrelateMessageResponse;
+import java.io.InputStream;
+import java.util.Map;
+
+public interface CorrelateMessageCommandStep1 {
+  /**
+   * Set the name of the message.
+   *
+   * @param messageName the name of the message
+   * @return the builder for this command
+   */
+  CorrelateMessageCommandStep2 messageName(String messageName);
+
+  interface CorrelateMessageCommandStep2 {
+    /**
+     * Set the value of the correlation key of the message.
+     *
+     * <p>This value will be used together with the message name to find matching message
+     * subscriptions.
+     *
+     * @param correlationKey the correlation key value of the message
+     * @return the builder for this command
+     */
+    CorrelateMessageCommandStep3 correlationKey(String correlationKey);
+
+    /**
+     * Skip specifying a correlation key for the message.
+     *
+     * <p>This method allows the message to be correlated without a correlation key, making it
+     * suitable for scenarios where the correlation key is not necessary (e.g. for the message start
+     * event). When used, this will create a new process instance without checking for an active
+     * instance with the same correlation key.
+     *
+     * @return the builder for this command, continuing to the next step without a correlation key.
+     */
+    CorrelateMessageCommandStep3 withoutCorrelationKey();
+  }
+
+  interface CorrelateMessageCommandStep3
+      extends CommandWithTenantStep<CorrelateMessageCommandStep3>,
+          FinalCommandStep<CorrelateMessageResponse> {
+
+    /**
+     * Set the variables of the message.
+     *
+     * @param variables the variables (JSON) as stream
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CorrelateMessageCommandStep3 variables(InputStream variables);
+
+    /**
+     * Set the variables of the message.
+     *
+     * @param variables the variables (JSON) as String
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CorrelateMessageCommandStep3 variables(String variables);
+
+    /**
+     * Set the variables of the message.
+     *
+     * @param variables the variables as map
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CorrelateMessageCommandStep3 variables(Map<String, Object> variables);
+
+    /**
+     * Set the variables of the message.
+     *
+     * @param variables the variables as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CorrelateMessageCommandStep3 variables(Object variables);
+
+    /**
+     * Set a single variable of the message.
+     *
+     * @param key the key of the variable as string
+     * @param value the value of the variable as object
+     * @return the builder for this command. Call {@link #send()} to complete the command and send
+     *     it to the broker.
+     */
+    CorrelateMessageCommandStep3 variable(String key, Object value);
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.client.api.response;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/api/response/CorrelateMessageResponse.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.client.api.response;
+
+public interface CorrelateMessageResponse {
+  /**
+   * Returns the record key of the message that was correlated.
+   *
+   * @return record key of the message.
+   */
+  Long getMessageKey();
+
+  /**
+   * Returns the tenant id of the message that was correlated.
+   *
+   * @return identifier of the tenant that owns the correlated message.
+   */
+  String getTenantId();
+
+  /**
+   * Returns the process instance key this messages was correlated with.
+   *
+   * @return key of the correlated process instance
+   */
+  Long getProcessInstanceKey();
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/ZeebeClientImpl.java
@@ -29,6 +29,7 @@ import io.camunda.zeebe.client.api.command.CancelProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.ClientException;
 import io.camunda.zeebe.client.api.command.CompleteJobCommandStep1;
 import io.camunda.zeebe.client.api.command.CompleteUserTaskCommandStep1;
+import io.camunda.zeebe.client.api.command.CorrelateMessageCommandStep1;
 import io.camunda.zeebe.client.api.command.CreateProcessInstanceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeleteResourceCommandStep1;
 import io.camunda.zeebe.client.api.command.DeployProcessCommandStep1;
@@ -58,6 +59,7 @@ import io.camunda.zeebe.client.impl.command.AssignUserTaskCommandImpl;
 import io.camunda.zeebe.client.impl.command.BroadcastSignalCommandImpl;
 import io.camunda.zeebe.client.impl.command.CancelProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.CompleteUserTaskCommandImpl;
+import io.camunda.zeebe.client.impl.command.CorrelateMessageCommandImpl;
 import io.camunda.zeebe.client.impl.command.CreateProcessInstanceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeleteResourceCommandImpl;
 import io.camunda.zeebe.client.impl.command.DeployProcessCommandImpl;
@@ -398,6 +400,11 @@ public final class ZeebeClientImpl implements ZeebeClient {
   public PublishMessageCommandStep1 newPublishMessageCommand() {
     return new PublishMessageCommandImpl(
         asyncStub, config, jsonMapper, credentialsProvider::shouldRetryRequest);
+  }
+
+  @Override
+  public CorrelateMessageCommandStep1 newCorrelateMessageCommand() {
+    return new CorrelateMessageCommandImpl(httpClient, jsonMapper);
   }
 
   @Override

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CorrelateMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CorrelateMessageCommandImpl.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.client.impl.command;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CorrelateMessageCommandImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/command/CorrelateMessageCommandImpl.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.client.impl.command;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.ZeebeFuture;
+import io.camunda.zeebe.client.api.command.CorrelateMessageCommandStep1;
+import io.camunda.zeebe.client.api.command.CorrelateMessageCommandStep1.CorrelateMessageCommandStep2;
+import io.camunda.zeebe.client.api.command.CorrelateMessageCommandStep1.CorrelateMessageCommandStep3;
+import io.camunda.zeebe.client.api.command.FinalCommandStep;
+import io.camunda.zeebe.client.api.response.CorrelateMessageResponse;
+import io.camunda.zeebe.client.impl.http.HttpClient;
+import io.camunda.zeebe.client.impl.http.HttpZeebeFuture;
+import io.camunda.zeebe.client.impl.response.CorrelateMessageResponseImpl;
+import io.camunda.zeebe.client.protocol.rest.MessageCorrelationRequest;
+import io.camunda.zeebe.client.protocol.rest.MessageCorrelationResponse;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.hc.client5.http.config.RequestConfig;
+
+public class CorrelateMessageCommandImpl extends CommandWithVariables<CorrelateMessageCommandImpl>
+    implements CorrelateMessageCommandStep1,
+        CorrelateMessageCommandStep2,
+        CorrelateMessageCommandStep3 {
+
+  private final HttpClient httpClient;
+  private final JsonMapper jsonMapper;
+  private final MessageCorrelationRequest request = new MessageCorrelationRequest();
+  private final RequestConfig.Builder httpRequestConfig;
+
+  public CorrelateMessageCommandImpl(final HttpClient httpClient, final JsonMapper jsonMapper) {
+    super(jsonMapper);
+    this.httpClient = httpClient;
+    this.jsonMapper = jsonMapper;
+    httpRequestConfig = httpClient.newRequestConfig();
+  }
+
+  @Override
+  public CorrelateMessageCommandStep2 messageName(final String messageName) {
+    request.setName(messageName);
+    return this;
+  }
+
+  @Override
+  public CorrelateMessageCommandStep3 tenantId(final String tenantId) {
+    request.setTenantId(tenantId);
+    return this;
+  }
+
+  @Override
+  public CorrelateMessageCommandStep3 correlationKey(final String correlationKey) {
+    request.setCorrelationKey(correlationKey);
+    return this;
+  }
+
+  @Override
+  public CorrelateMessageCommandStep3 withoutCorrelationKey() {
+    return this;
+  }
+
+  @Override
+  public FinalCommandStep<CorrelateMessageResponse> requestTimeout(final Duration requestTimeout) {
+    httpRequestConfig.setResponseTimeout(requestTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    return this;
+  }
+
+  @Override
+  public ZeebeFuture<CorrelateMessageResponse> send() {
+    final HttpZeebeFuture<CorrelateMessageResponse> result = new HttpZeebeFuture<>();
+    final CorrelateMessageResponseImpl response = new CorrelateMessageResponseImpl(jsonMapper);
+    httpClient.post(
+        "/messages/correlation",
+        jsonMapper.toJson(request),
+        httpRequestConfig.build(),
+        MessageCorrelationResponse.class,
+        response::setResponse,
+        result);
+    return result;
+  }
+
+  @Override
+  protected CorrelateMessageCommandImpl setVariablesInternal(final String variables) {
+    request.setVariables(jsonMapper.fromJsonAsMap(variables));
+    return this;
+  }
+}

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CorrelateMessageResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CorrelateMessageResponseImpl.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.client.impl.response;
 

--- a/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CorrelateMessageResponseImpl.java
+++ b/clients/java/src/main/java/io/camunda/zeebe/client/impl/response/CorrelateMessageResponseImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.client.impl.response;
+
+import io.camunda.zeebe.client.api.JsonMapper;
+import io.camunda.zeebe.client.api.response.CorrelateMessageResponse;
+import io.camunda.zeebe.client.protocol.rest.MessageCorrelationResponse;
+
+public final class CorrelateMessageResponseImpl implements CorrelateMessageResponse {
+
+  private final JsonMapper jsonMapper;
+  private long key;
+  private String tenantId;
+  private long processInstanceKey;
+
+  public CorrelateMessageResponseImpl(final JsonMapper jsonMapper) {
+    this.jsonMapper = jsonMapper;
+  }
+
+  @Override
+  public Long getMessageKey() {
+    return key;
+  }
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public Long getProcessInstanceKey() {
+    return processInstanceKey;
+  }
+
+  public CorrelateMessageResponseImpl setResponse(final MessageCorrelationResponse response) {
+    key = response.getKey();
+    tenantId = response.getTenantId();
+    processInstanceKey = response.getProcessInstanceKey();
+    return this;
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CorrelateMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CorrelateMessageTest.java
@@ -1,9 +1,17 @@
 /*
- * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
- * one or more contributor license agreements. See the NOTICE file distributed
- * with this work for additional information regarding copyright ownership.
- * Licensed under the Camunda License 1.0. You may not use this file
- * except in compliance with the Camunda License 1.0.
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package io.camunda.zeebe.client.process;
 

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CorrelateMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CorrelateMessageTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.client.process;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.camunda.zeebe.client.api.command.InternalClientException;
+import io.camunda.zeebe.client.protocol.rest.MessageCorrelationRequest;
+import io.camunda.zeebe.client.util.ClientRestTest;
+import java.util.Collections;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+final class CorrelateMessageTest extends ClientRestTest {
+
+  @Test
+  void shouldCorrelateMessageWithCorrelationKey() {
+    // given
+    final String messageName = "name";
+    final String correlationKey = "correlationKey";
+    final String tenantId = "tenant";
+    final Map<String, Object> variables = Collections.singletonMap("foo", "bar");
+
+    // when
+    client
+        .newCorrelateMessageCommand()
+        .messageName(messageName)
+        .correlationKey(correlationKey)
+        .tenantId(tenantId)
+        .variables(variables)
+        .send()
+        .join();
+
+    // then
+    final MessageCorrelationRequest request =
+        gatewayService.getLastRequest(MessageCorrelationRequest.class);
+    assertThat(request.getName()).isEqualTo(messageName);
+    assertThat(request.getCorrelationKey()).isEqualTo(correlationKey);
+    assertThat(request.getTenantId()).isEqualTo(tenantId);
+    assertThat(request.getVariables()).isEqualTo(variables);
+  }
+
+  @Test
+  void shouldCorrelateMessageWithoutCorrelationKey() {
+    // given
+    final String messageName = "name";
+    final String tenantId = "tenant";
+    final Map<String, Object> variables = Collections.singletonMap("foo", "bar");
+
+    // when
+    client
+        .newCorrelateMessageCommand()
+        .messageName(messageName)
+        .withoutCorrelationKey()
+        .tenantId(tenantId)
+        .variables(variables)
+        .send()
+        .join();
+
+    // then
+    final MessageCorrelationRequest request =
+        gatewayService.getLastRequest(MessageCorrelationRequest.class);
+    assertThat(request.getName()).isEqualTo(messageName);
+    assertThat(request.getCorrelationKey()).isNull();
+    assertThat(request.getTenantId()).isEqualTo(tenantId);
+    assertThat(request.getVariables()).isEqualTo(variables);
+  }
+
+  @Test
+  void shouldThrowExceptionWhenVariablesAreNotInMapStructure() {
+    // given
+    final String messageName = "name";
+    final String tenantId = "tenant";
+    final String variables = "[]";
+
+    // when then
+    assertThatThrownBy(
+            () ->
+                client
+                    .newCorrelateMessageCommand()
+                    .messageName(messageName)
+                    .withoutCorrelationKey()
+                    .tenantId(tenantId)
+                    .variables(variables))
+        .isInstanceOf(InternalClientException.class)
+        .hasMessageContaining(
+            String.format("Failed to deserialize json '%s' to 'Map<String, Object>'", variables));
+  }
+}

--- a/clients/java/src/test/java/io/camunda/zeebe/client/process/CorrelateMessageTest.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/process/CorrelateMessageTest.java
@@ -67,7 +67,7 @@ final class CorrelateMessageTest extends ClientRestTest {
     final MessageCorrelationRequest request =
         gatewayService.getLastRequest(MessageCorrelationRequest.class);
     assertThat(request.getName()).isEqualTo(messageName);
-    assertThat(request.getCorrelationKey()).isNull();
+    assertThat(request.getCorrelationKey()).isEmpty();
     assertThat(request.getTenantId()).isEqualTo(tenantId);
     assertThat(request.getVariables()).isEqualTo(variables);
   }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayPaths.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayPaths.java
@@ -28,6 +28,7 @@ public class RestGatewayPaths {
   private static final String URL_USER_TASK_UNASSIGNMENT =
       REST_API_PATH + "/user-tasks/%s/assignee";
   private static final String URL_USER_TASK_UPDATE = REST_API_PATH + "/user-tasks/%s";
+  private static final String URL_MESSAGE_CORRELATION = REST_API_PATH + "/message/correlation";
 
   /**
    * @return the topology request URL
@@ -73,5 +74,9 @@ public class RestGatewayPaths {
    */
   public static String getUserTaskUpdateUrl(final long userTaskKey) {
     return String.format(URL_USER_TASK_UPDATE, userTaskKey);
+  }
+
+  public static String getMessageCorrelationUrl() {
+    return URL_MESSAGE_CORRELATION;
   }
 }

--- a/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
+++ b/clients/java/src/test/java/io/camunda/zeebe/client/util/RestGatewayService.java
@@ -21,6 +21,7 @@ import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import io.camunda.zeebe.client.impl.ZeebeObjectMapper;
 import io.camunda.zeebe.client.protocol.rest.JobActivationResponse;
+import io.camunda.zeebe.client.protocol.rest.MessageCorrelationResponse;
 import io.camunda.zeebe.client.protocol.rest.ProblemDetail;
 import io.camunda.zeebe.client.protocol.rest.TopologyResponse;
 import java.util.List;
@@ -67,6 +68,19 @@ public class RestGatewayService {
         .register(
             WireMock.get(RestGatewayPaths.getTopologyUrl())
                 .willReturn(WireMock.okJson(JSON_MAPPER.toJson(topologyResponse))));
+  }
+
+  /**
+   * Register the given response for a message correlation request.
+   *
+   * @param response the response to provide upon a message correlation request
+   */
+  public void onCorrelateMessageRequest(final MessageCorrelationResponse response) {
+    mockInfo
+        .getWireMock()
+        .register(
+            WireMock.get(RestGatewayPaths.getMessageCorrelationUrl())
+                .willReturn(WireMock.okJson(JSON_MAPPER.toJson(response))));
   }
 
   /**

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/ResultBuilderBackedTypedResponseWriter.java
@@ -27,6 +27,16 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
   @Override
   public void writeRejectionOnCommand(
       final TypedRecord<?> command, final RejectionType type, final String reason) {
+    writeRejection(command, type, reason, command.getRequestId(), command.getRequestStreamId());
+  }
+
+  @Override
+  public void writeRejection(
+      final TypedRecord<?> command,
+      final RejectionType type,
+      final String reason,
+      final long requestId,
+      final int requestStreamId) {
     resultBuilder()
         .withResponse(
             RecordType.COMMAND_REJECTION,
@@ -36,8 +46,8 @@ public class ResultBuilderBackedTypedResponseWriter extends AbstractResultBuilde
             command.getValueType(),
             type,
             reason,
-            command.getRequestId(),
-            command.getRequestStreamId());
+            requestId,
+            requestStreamId);
   }
 
   @Override

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/streamprocessor/writers/TypedResponseWriter.java
@@ -17,6 +17,13 @@ public interface TypedResponseWriter {
 
   void writeRejectionOnCommand(TypedRecord<?> command, RejectionType type, String reason);
 
+  void writeRejection(
+      final TypedRecord<?> command,
+      final RejectionType type,
+      final String reason,
+      final long requestId,
+      final int requestStreamId);
+
   void writeEvent(TypedRecord<?> event);
 
   void writeEventOnCommand(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/client/MessageCorrelationClient.java
@@ -35,6 +35,14 @@ public final class MessageCorrelationClient {
               .withPartitionId(message.partitionId)
               .withCorrelationKey(message.correlationKey)
               .getFirst();
+  private static final Function<Message, Record<MessageCorrelationRecordValue>>
+      REJECTION_EXPECTATION =
+          (message) ->
+              RecordingExporter.messageCorrelationRecords(MessageCorrelationIntent.CORRELATE)
+                  .onlyCommandRejections()
+                  .withPartitionId(message.partitionId)
+                  .withCorrelationKey(message.correlationKey)
+                  .getFirst();
   private static final Function<Message, Record<MessageCorrelationRecordValue>> EXPECT_NOTHING =
       (message) ->
           RecordingExporter.messageCorrelationRecords(MessageCorrelationIntent.CORRELATE)
@@ -87,6 +95,11 @@ public final class MessageCorrelationClient {
 
   public MessageCorrelationClient onPartition(final int partitionId) {
     this.partitionId = partitionId;
+    return this;
+  }
+
+  public MessageCorrelationClient expectRejection() {
+    expectation = REJECTION_EXPECTATION;
     return this;
   }
 

--- a/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
+++ b/zeebe/gateway-protocol/src/main/proto/rest-api.yaml
@@ -1535,7 +1535,7 @@ components:
         correlationKey:
           description: The correlation key of the message
           type: string
-          nullable: true
+          default: ""
         variables:
           description: The message variables as JSON document
           additionalProperties: true

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CorrelateMessageTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/client/command/CorrelateMessageTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.it.client.command;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.api.command.ProblemException;
+import io.camunda.zeebe.it.util.ZeebeResourcesHelper;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.value.TenantOwned;
+import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration;
+import io.camunda.zeebe.qa.util.junit.ZeebeIntegration.TestZeebe;
+import java.time.Duration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+@ZeebeIntegration
+class CorrelateMessageTest {
+
+  ZeebeClient client;
+
+  @TestZeebe
+  final TestStandaloneBroker zeebe = new TestStandaloneBroker().withRecordingExporter(true);
+
+  ZeebeResourcesHelper resourcesHelper;
+
+  @BeforeEach
+  void initClientAndInstances() {
+    client = zeebe.newClientBuilder().defaultRequestTimeout(Duration.ofSeconds(15)).build();
+    resourcesHelper = new ZeebeResourcesHelper(client);
+  }
+
+  @Test
+  void shouldCorrelateToProcessInstanceStartEventWithCorrelationKey() {
+    // given
+    final var processId = "processId";
+    final var messageName = "messageName";
+    final var process =
+        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+    resourcesHelper.deployProcess(process);
+
+    // when
+    final var response =
+        client
+            .newCorrelateMessageCommand()
+            .messageName(messageName)
+            .correlationKey("test")
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getMessageKey()).isNotNull();
+    assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(response.getProcessInstanceKey()).isNotNull();
+  }
+
+  @Test
+  void shouldCorrelateToProcessInstanceStartEventWithoutCorrelationKey() {
+    // given
+    final var processId = "processId";
+    final var messageName = "messageName";
+    final var process =
+        Bpmn.createExecutableProcess(processId).startEvent().message(messageName).endEvent().done();
+    resourcesHelper.deployProcess(process);
+
+    // when
+    final var response =
+        client
+            .newCorrelateMessageCommand()
+            .messageName(messageName)
+            .withoutCorrelationKey()
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getMessageKey()).isNotNull();
+    assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(response.getProcessInstanceKey()).isNotNull();
+  }
+
+  @Test
+  void shouldCorrelateToMessageCatchEvent() {
+    // given
+    final var messageName = "messageName";
+    final var correlationKey = "correlationKey";
+    final var process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .intermediateCatchEvent()
+            .message(
+                m ->
+                    m.name(messageName)
+                        .zeebeCorrelationKeyExpression("= \"%s\"".formatted(correlationKey)))
+            .endEvent()
+            .done();
+    final var processDefinitionKey = resourcesHelper.deployProcess(process);
+    final var processInstanceKey = resourcesHelper.createProcessInstance(processDefinitionKey);
+
+    // when
+    final var response =
+        client
+            .newCorrelateMessageCommand()
+            .messageName(messageName)
+            .correlationKey(correlationKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getMessageKey()).isNotNull();
+    assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(response.getProcessInstanceKey()).isEqualTo(processInstanceKey);
+  }
+
+  @Test
+  void shouldCorrelateToProcessStartEventOverMessageCatchEvent() {
+    // given
+    final var processMessageStart = "processMessageStart";
+    final var processMessageCatch = "processMessageCatch";
+    final var messageName = "messageName";
+    final var correlationKey = "correlationKey";
+    final var messageStartProcess =
+        Bpmn.createExecutableProcess(processMessageStart)
+            .startEvent()
+            .message(messageName)
+            .endEvent()
+            .done();
+    resourcesHelper.deployProcess(messageStartProcess);
+    final var messageCatchProcess =
+        Bpmn.createExecutableProcess(processMessageCatch)
+            .startEvent()
+            .intermediateCatchEvent()
+            .message(
+                m ->
+                    m.name(messageName)
+                        .zeebeCorrelationKeyExpression("= \"%s\"".formatted(correlationKey)))
+            .endEvent()
+            .done();
+    final var processDefinitionKey = resourcesHelper.deployProcess(messageCatchProcess);
+    final var messageCatchProcessInstanceKey =
+        resourcesHelper.createProcessInstance(processDefinitionKey);
+
+    // when
+    final var response =
+        client
+            .newCorrelateMessageCommand()
+            .messageName(messageName)
+            .correlationKey(correlationKey)
+            .send()
+            .join();
+
+    // then
+    assertThat(response.getMessageKey()).isNotNull();
+    assertThat(response.getTenantId()).isEqualTo(TenantOwned.DEFAULT_TENANT_IDENTIFIER);
+    assertThat(response.getProcessInstanceKey()).isNotNull();
+    assertThat(response.getProcessInstanceKey()).isNotEqualTo(messageCatchProcessInstanceKey);
+  }
+
+  @Test
+  void shouldNotCorrelateWhenNoExistingSubscription() {
+    // given
+    final var messageName = "messageName";
+    final var correlationKey = "correlationKey";
+
+    // when
+    final var responseFuture =
+        client
+            .newCorrelateMessageCommand()
+            .messageName(messageName)
+            .correlationKey(correlationKey)
+            .send();
+
+    //     then
+    assertThatThrownBy(responseFuture::join)
+        .hasCauseInstanceOf(ProblemException.class)
+        .hasMessageContaining("title: NOT_FOUND")
+        .hasMessageContaining("status: 404")
+        .hasMessageContaining(
+            "Expected to find subscription for message with name '%s' and correlation key '%s', but none was found."
+                .formatted(messageName, correlationKey));
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Adds support for the message correlation REST andpoint to the Java client. Message correlation is not support in gPRC. The PR also adds integration tests, and some bugfixes I discovered whilst writing these tests.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #20478 
closes #20190 
