### PR TITLE
ci: disable Docker to GHA cache for Zeebe Benchmark

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -218,8 +218,6 @@ jobs:
           context: .
           push: true
           tags: gcr.io/zeebe-io/operate:${{ inputs.operate-tag }}
-          cache-from: type=gha,ignore-error=true
-          cache-to: type=gha,mode=max,ignore-error=true
           file: operate.Dockerfile
 
   build-benchmark-images:


### PR DESCRIPTION
## Description

Produces large cache which is probably not useful. See #18750 for motivation to get GHA cache size down to less dangerous levels. Looking at the history of https://github.com/camunda/camunda/actions/workflows/zeebe-benchmark.yml it is usually invoked only a couple of times per week so user impact should be small.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #18750
