### PR TITLE
ci: improve benchmark workflow

### DIFF
--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -129,24 +129,22 @@ jobs:
           token_format: 'access_token'
           workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
           service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
-      - name: Setup BuildKit
-        uses: docker/setup-buildx-action@v3
-      - name: Login to GCR
-        uses: docker/login-action@v3
+      - uses: ./.github/actions/setup-zeebe
         with:
-          registry: gcr.io
-          username: oauth2accesstoken
-          password: ${{ steps.auth.outputs.access_token }}
-      - uses: docker/build-push-action@v6
+          secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
+          secret_vault_address: ${{ secrets.VAULT_ADDR }}
+          secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+      - uses: ./.github/actions/build-zeebe
+        id: build-zeebe
         with:
-          context: .
-          tags: gcr.io/zeebe-io/zeebe:${{ needs.calculate-image-tag.outputs.image-tag }}
+          maven-extra-args: -PskipFrontendBuild
+      - uses: ./.github/actions/build-platform-docker
+        with:
+          repository: 'gcr.io/zeebe-io/zeebe'
+          revision: ${{ inputs.ref }}
           push: true
-          cache-from: type=gha,ignore-error=true
-          cache-to: type=gha,mode=max,ignore-error=true
-          build-args: DIST=build
-          provenance: false
-          target: app
+          version: ${{ needs.calculate-image-tag.outputs.image-tag }}
+          distball: ${{ steps.build-zeebe.outputs.distball }}
 
   build-operate-image:
     name: Build + Push Operate Docker image

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -PskipFrontendBuild
+          maven-extra-args: -PskipFrontendBuild -Dmaven.test.skip=true
           go: false
       - uses: ./.github/actions/build-platform-docker
         with:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -123,12 +123,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref }}
-      - uses: google-github-actions/auth@v2
-        id: auth
-        with:
-          token_format: 'access_token'
-          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
-          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
       - uses: ./.github/actions/setup-zeebe
         with:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
@@ -140,6 +134,18 @@ jobs:
         with:
           maven-extra-args: -PskipFrontendBuild -Dmaven.test.skip=true -am -pl :camunda-zeebe
           go: false
+      - uses: google-github-actions/auth@v2
+        id: auth
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: 'projects/628707732411/locations/global/workloadIdentityPools/zeebe-gh-actions/providers/gha-provider'
+          service_account: 'zeebe-gh-actions@zeebe-io.iam.gserviceaccount.com'
+      - name: Login to GCR
+        uses: docker/login-action@v3
+        with:
+          registry: gcr.io
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
       - uses: ./.github/actions/build-platform-docker
         with:
           repository: 'gcr.io/zeebe-io/zeebe'

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -138,7 +138,7 @@ jobs:
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
-          maven-extra-args: -PskipFrontendBuild -Dmaven.test.skip=true
+          maven-extra-args: -PskipFrontendBuild -Dmaven.test.skip=true -am -pl :camunda-zeebe
           go: false
       - uses: ./.github/actions/build-platform-docker
         with:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -34,7 +34,7 @@ on:
         description: 'Measure impact of network latency'
         type: boolean
         required: false
-        default: true
+        default: false
       stable-vms:
         description: 'Deploy to non-spot VMs'
         type: boolean
@@ -275,7 +275,7 @@ jobs:
         --set camunda-platform.zeebeGateway.image.repository=gcr.io/zeebe-io/zeebe
         --set camunda-platform.zeebeGateway.image.tag=${{ needs.calculate-image-tag.outputs.image-tag }}
         ${{ inputs.benchmark-load }}
-        
+
   deploy-benchmark-cluster:
     name: Deploy
     needs:

--- a/.github/workflows/zeebe-benchmark.yml
+++ b/.github/workflows/zeebe-benchmark.yml
@@ -134,10 +134,12 @@ jobs:
           secret_vault_secretId: ${{ secrets.VAULT_SECRET_ID }}
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
+          go: false
       - uses: ./.github/actions/build-zeebe
         id: build-zeebe
         with:
           maven-extra-args: -PskipFrontendBuild
+          go: false
       - uses: ./.github/actions/build-platform-docker
         with:
           repository: 'gcr.io/zeebe-io/zeebe'

--- a/.github/workflows/zeebe-medic-benchmarks.yml
+++ b/.github/workflows/zeebe-medic-benchmarks.yml
@@ -59,6 +59,7 @@ jobs:
       cluster: zeebe-cluster
       cluster-region: europe-west1-b
       ref: ${{ needs.benchmark-data.outputs.full-ref }}
+      measure: true
       publish: "slack"
   setup-mixed-benchmark:
     name: Mixed Benchmark


### PR DESCRIPTION
- Don't measure network latency by default, no one wants that
- Use the shared maven cache
- Only build the dist module and its dependencies
- Skip building test sources, the frontend and anything needing Go

Reduces the time it takes to run this workflow from ~10 minutes to ~ 4 minutes: https://github.com/camunda/camunda/actions/runs/10404685239

Also removes a lot of flakiness by not building the frontend.