### PR TITLE
ci: don't build frontend to test docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,18 +320,6 @@ jobs:
           secret_vault_address: ${{ secrets.VAULT_ADDR }}
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
           docker-secret-path: secret/data/products/camunda/ci/github-actions
-      - uses: ./.github/actions/build-frontend
-        id: build-operate-fe
-        with:
-          directory: ./operate/client
-      - uses: ./.github/actions/build-frontend
-        id: build-tasklist-fe
-        with:
-          directory: ./tasklist/client
-      - uses: ./.github/actions/build-frontend
-        id: build-identity-fe
-        with:
-          directory: ./identity/client
       - uses: ./.github/actions/build-zeebe
         id: build-camunda
         with:


### PR DESCRIPTION
These tests don't need a working frontend. Removing these steps should make the workflow much faster.

Before it took 15 minutes: https://github.com/camunda/camunda/actions/runs/10405673664/job/28817024677
After it took 8 minutes: https://github.com/camunda/camunda/actions/runs/10405712323/job/28817102079