### PR TITLE
feat: scheduling service is configurable and observable

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -968,6 +968,11 @@
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SKIPPOSITIONS
       # skipPositions: ""
 
+      # Configures the rate at which a partition leader checks for expired scheduled tasks such as the due date checker.
+      # The default value is 1 second. Use a lower interval to potentially decrease delays between requested and actual execution of scheduled tasks.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SCHEDULEDTASKCHECKINTERVAL
+      # scheduledTaskCheckInterval: 1s
+
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -970,6 +970,7 @@
 
       # Configures the rate at which a partition leader checks for expired scheduled tasks such as the due date checker.
       # The default value is 1 second. Use a lower interval to potentially decrease delays between requested and actual execution of scheduled tasks.
+      # Using a low interval will result in unnecessary load while idle. We recommend to benchmark any changes to this setting.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SCHEDULEDTASKCHECKINTERVAL
       # scheduledTaskCheckInterval: 1s
 

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -861,6 +861,7 @@
 
       # Configures the rate at which a partition leader checks for expired scheduled tasks such as the due date checker.
       # The default value is 1 second. Use a lower interval to potentially decrease delays between requested and actual execution of scheduled tasks.
+      # Using a low interval will result in unnecessary load while idle. We recommend to benchmark any changes to this setting.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SCHEDULEDTASKCHECKINTERVAL
       # scheduledTaskCheckInterval: 1s
     # experimental

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -858,6 +858,11 @@
       # The value is a comma-separated list of positions to skip. Whitespace is ignored.
       # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SKIPPOSITIONS
       # skipPositions: ""
+
+      # Configures the rate at which a partition leader checks for expired scheduled tasks such as the due date checker.
+      # The default value is 1 second. Use a lower interval to potentially decrease delays between requested and actual execution of scheduled tasks.
+      # This setting can also be overridden using the environment variable ZEEBE_BROKER_PROCESSING_SCHEDULEDTASKCHECKINTERVAL
+      # scheduledTaskCheckInterval: 1s
     # experimental
       # Be aware that all configuration's which are part of the experimental section
       # are subject to change and can be dropped at any time.

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/ProcessingCfg.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.broker.system.configuration;
 
+import java.time.Duration;
 import java.util.Set;
 
 public final class ProcessingCfg implements ConfigurationEntry {
@@ -14,6 +15,7 @@ public final class ProcessingCfg implements ConfigurationEntry {
   private static final int DEFAULT_PROCESSING_BATCH_LIMIT = 100;
   private Integer maxCommandsInBatch = DEFAULT_PROCESSING_BATCH_LIMIT;
   private boolean enableAsyncScheduledTasks = true;
+  private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
   private Set<Long> skipPositions;
 
   @Override
@@ -21,6 +23,11 @@ public final class ProcessingCfg implements ConfigurationEntry {
     if (maxCommandsInBatch < 1) {
       throw new IllegalArgumentException(
           "maxCommandsInBatch must be >= 1 but was %s".formatted(maxCommandsInBatch));
+    }
+    if (!scheduledTaskCheckInterval.isPositive()) {
+      throw new IllegalArgumentException(
+          "scheduledTaskCheckInterval must be positive but was %s"
+              .formatted(scheduledTaskCheckInterval));
     }
   }
 
@@ -55,6 +62,16 @@ public final class ProcessingCfg implements ConfigurationEntry {
         + maxCommandsInBatch
         + ", enableAsyncScheduledTasks="
         + enableAsyncScheduledTasks
+        + ", scheduledTaskCheckInterval="
+        + scheduledTaskCheckInterval
         + '}';
+  }
+
+  public Duration getScheduledTaskCheckInterval() {
+    return scheduledTaskCheckInterval;
+  }
+
+  public void setScheduledTaskCheckInterval(final Duration scheduledTaskCheckInterval) {
+    this.scheduledTaskCheckInterval = scheduledTaskCheckInterval;
   }
 }

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -151,6 +151,7 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         SkipPositionsFilter.of(context.getBrokerCfg().getProcessing().skipPositions());
 
     return StreamProcessor.builder()
+        .meterRegistry(context.getMeterRegistry())
         .logStream(context.getLogStream())
         .actorSchedulingService(context.getActorSchedulingService())
         .zeebeDb(context.getZeebeDb())

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/partitions/impl/steps/StreamProcessorTransitionStep.java
@@ -161,6 +161,8 @@ public final class StreamProcessorTransitionStep implements PartitionTransitionS
         .maxCommandsInBatch(context.getBrokerCfg().getProcessing().getMaxCommandsInBatch())
         .setEnableAsyncScheduledTasks(
             context.getBrokerCfg().getProcessing().isEnableAsyncScheduledTasks())
+        .setScheduledTaskCheckInterval(
+            context.getBrokerCfg().getProcessing().getScheduledTaskCheckInterval())
         .processingFilter(processingFilter)
         .listener(
             processedCommand ->

--- a/zeebe/engine/pom.xml
+++ b/zeebe/engine/pom.xml
@@ -254,6 +254,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/util/TestStreams.java
@@ -51,6 +51,7 @@ import io.camunda.zeebe.stream.impl.TypedEventRegistry;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import io.camunda.zeebe.util.Either;
 import io.camunda.zeebe.util.FileUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
@@ -285,6 +286,7 @@ public final class TestStreams {
             .streamProcessorMode(streamProcessorMode)
             .maxCommandsInBatch(maxCommandsInBatch)
             .partitionCommandSender(mock(InterPartitionCommandSender.class))
+            .meterRegistry(new SimpleMeterRegistry())
             .clock(StreamClock.controllable(clock));
 
     processorConfiguration.accept(builder);

--- a/zeebe/stream-platform/pom.xml
+++ b/zeebe/stream-platform/pom.xml
@@ -85,6 +85,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceImpl.java
@@ -17,6 +17,7 @@ import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableSch
 import io.camunda.zeebe.stream.api.scheduling.SimpleProcessingScheduleService;
 import io.camunda.zeebe.stream.api.scheduling.Task;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
+import io.camunda.zeebe.stream.impl.metrics.ScheduledTaskMetrics;
 import java.time.Duration;
 import java.time.InstantSource;
 import java.util.PriorityQueue;
@@ -40,6 +41,7 @@ public class ProcessingScheduleServiceImpl
   private final Supplier<LogStreamWriter> writerSupplier;
   private final StageableScheduledCommandCache commandCache;
   private final InstantSource clock;
+  private final ScheduledTaskMetrics metrics;
   private final PriorityQueue<ScheduledTaskImpl> scheduledTasks = new PriorityQueue<>();
   private LogStreamWriter logStreamWriter;
   private ActorControl actorControl;
@@ -51,12 +53,14 @@ public class ProcessingScheduleServiceImpl
       final BooleanSupplier abortCondition,
       final Supplier<LogStreamWriter> writerSupplier,
       final StageableScheduledCommandCache commandCache,
-      final InstantSource clock) {
+      final InstantSource clock,
+      final ScheduledTaskMetrics metrics) {
     this.streamProcessorPhaseSupplier = streamProcessorPhaseSupplier;
     this.abortCondition = abortCondition;
     this.writerSupplier = writerSupplier;
     this.commandCache = commandCache;
     this.clock = clock;
+    this.metrics = metrics;
   }
 
   @Override
@@ -128,8 +132,9 @@ public class ProcessingScheduleServiceImpl
   private void processScheduledTasks() {
     final var now = clock.millis();
     while (scheduledTasks.peek() != null && scheduledTasks.peek().scheduledTime <= now) {
+      metrics.decrementScheduledTasks();
       final var expiredTask = scheduledTasks.poll();
-      actorControl.submit(expiredTask.runnable);
+      actorControl.submit(expiredTask);
     }
   }
 
@@ -137,6 +142,7 @@ public class ProcessingScheduleServiceImpl
     final var scheduledTask = new ScheduledTaskImpl(timestamp, task);
     actorControl.run(
         () -> {
+          metrics.incrementScheduledTasks();
           final var delay = timestamp - clock.millis();
           scheduledTasks.add(scheduledTask);
           if (delay < PERIODIC_CHECK_INTERVAL_MS / 2) {
@@ -211,7 +217,8 @@ public class ProcessingScheduleServiceImpl
   }
 
   /** Note: this class has a natural ordering that is inconsistent with equals. */
-  private final class ScheduledTaskImpl implements ScheduledTask, Comparable<ScheduledTaskImpl> {
+  private final class ScheduledTaskImpl
+      implements ScheduledTask, Comparable<ScheduledTaskImpl>, Runnable {
     private final long scheduledTime;
     private final Runnable runnable;
 
@@ -222,12 +229,23 @@ public class ProcessingScheduleServiceImpl
 
     @Override
     public void cancel() {
-      actorControl.run(() -> scheduledTasks.remove(this));
+      actorControl.run(
+          () -> {
+            if (scheduledTasks.remove(this)) {
+              metrics.decrementScheduledTasks();
+            }
+          });
     }
 
     @Override
     public int compareTo(final ProcessingScheduleServiceImpl.ScheduledTaskImpl o) {
       return Long.compare(scheduledTime, o.scheduledTime);
+    }
+
+    @Override
+    public void run() {
+      metrics.observeScheduledTaskExecution(clock.millis() - scheduledTime);
+      runnable.run();
     }
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -111,6 +111,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   private ProcessingScheduleServiceImpl processorActorService;
   private ProcessingScheduleServiceImpl asyncScheduleService;
   private AsyncProcessingScheduleServiceActor asyncActor;
+  private ScheduledTaskMetrics scheduledTaskMetrics;
 
   protected StreamProcessor(final StreamProcessorBuilder processorBuilder) {
     actorSchedulingService = processorBuilder.getActorSchedulingService();
@@ -162,7 +163,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
       final var startRecoveryTimer = metrics.startRecoveryTimer();
       final long snapshotPosition = recoverFromSnapshot();
 
-      final var scheduledTaskMetrics =
+      scheduledTaskMetrics =
           ScheduledTaskMetrics.of(
               streamProcessorContext.getMeterRegistry(), streamProcessorContext.getPartitionId());
       processorActorService =
@@ -281,6 +282,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
   }
 
   private void tearDown() {
+    scheduledTaskMetrics.close();
     processorActorService.close();
     asyncScheduleService.close();
     streamProcessorContext.getLogStreamReader().close();

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessor.java
@@ -173,6 +173,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               logStream::newLogStreamWriter,
               scheduledCommandCache,
               streamProcessorContext.getClock(),
+              streamProcessorContext.getScheduledTaskCheckInterval(),
               scheduledTaskMetrics);
       asyncScheduleService =
           new ProcessingScheduleServiceImpl(
@@ -181,6 +182,7 @@ public class StreamProcessor extends Actor implements HealthMonitorable, LogReco
               logStream::newLogStreamWriter,
               scheduledCommandCache,
               streamProcessorContext.getClock(),
+              streamProcessorContext.getScheduledTaskCheckInterval(),
               scheduledTaskMetrics);
       asyncActor = new AsyncProcessingScheduleServiceActor(asyncScheduleService, partitionId);
       final var extendedProcessingScheduleService =

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -18,6 +18,7 @@ import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock;
 import io.camunda.zeebe.stream.api.StreamProcessorLifecycleAware;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.NoopScheduledCommandCache;
 import io.camunda.zeebe.stream.api.scheduling.ScheduledCommandCache.StageableScheduledCommandCache;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -171,6 +172,12 @@ public final class StreamProcessorBuilder {
   public StreamProcessorBuilder meterRegistry(
       final io.micrometer.core.instrument.MeterRegistry meterRegistry) {
     streamProcessorContext.meterRegistry(meterRegistry);
+    return this;
+  }
+
+  public StreamProcessorBuilder setScheduledTaskCheckInterval(
+      final Duration scheduledTaskCheckInterval) {
+    streamProcessorContext.setScheduledTaskCheckInterval(scheduledTaskCheckInterval);
     return this;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorBuilder.java
@@ -167,4 +167,10 @@ public final class StreamProcessorBuilder {
     streamProcessorContext.clock(clock);
     return this;
   }
+
+  public StreamProcessorBuilder meterRegistry(
+      final io.micrometer.core.instrument.MeterRegistry meterRegistry) {
+    streamProcessorContext.meterRegistry(meterRegistry);
+    return this;
+  }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Duration;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
@@ -55,6 +56,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private EventFilter processingFilter = e -> true;
   private ControllableStreamClock clock;
   private MeterRegistry meterRegistry;
+  private Duration scheduledTaskCheckInterval = Duration.ofSeconds(1);
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -242,5 +244,15 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
 
   public MeterRegistry getMeterRegistry() {
     return meterRegistry;
+  }
+
+  public Duration getScheduledTaskCheckInterval() {
+    return scheduledTaskCheckInterval;
+  }
+
+  public StreamProcessorContext setScheduledTaskCheckInterval(
+      final Duration scheduledTaskCheckInterval) {
+    this.scheduledTaskCheckInterval = scheduledTaskCheckInterval;
+    return this;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/StreamProcessorContext.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.stream.api.state.KeyGeneratorControls;
 import io.camunda.zeebe.stream.api.state.MutableLastProcessedPositionState;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.records.RecordValues;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Objects;
 import java.util.function.BooleanSupplier;
 
@@ -53,6 +54,7 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   private boolean enableAsyncScheduledTasks = true;
   private EventFilter processingFilter = e -> true;
   private ControllableStreamClock clock;
+  private MeterRegistry meterRegistry;
 
   public StreamProcessorContext actor(final ActorControl actor) {
     this.actor = actor;
@@ -231,5 +233,14 @@ public final class StreamProcessorContext implements ReadonlyStreamProcessorCont
   public StreamProcessorContext processingFilter(final EventFilter processingFilter) {
     this.processingFilter = processingFilter;
     return this;
+  }
+
+  public StreamProcessorContext meterRegistry(final MeterRegistry meterRegistry) {
+    this.meterRegistry = meterRegistry;
+    return this;
+  }
+
+  public MeterRegistry getMeterRegistry() {
+    return meterRegistry;
   }
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ScheduledTaskMetrics.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/metrics/ScheduledTaskMetrics.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.stream.impl.metrics;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.LongAdder;
+
+public interface ScheduledTaskMetrics {
+  void incrementScheduledTasks();
+
+  void decrementScheduledTasks();
+
+  void observeScheduledTaskExecution(final long delay);
+
+  static ScheduledTaskMetrics noop() {
+    return new ScheduledTaskMetrics() {
+      @Override
+      public void incrementScheduledTasks() {}
+
+      @Override
+      public void decrementScheduledTasks() {}
+
+      @Override
+      public void observeScheduledTaskExecution(final long delay) {}
+    };
+  }
+
+  static ScheduledTaskMetrics of(final MeterRegistry registry, final int partition) {
+    return new ScheduledTaskMetricsImpl(registry, partition);
+  }
+
+  final class ScheduledTaskMetricsImpl implements ScheduledTaskMetrics {
+    private final LongAdder scheduledTasksCounter = new LongAdder();
+    private final Timer scheduledTaskDelay;
+
+    private ScheduledTaskMetricsImpl(final MeterRegistry registry, final int partition) {
+      final var tags = Tags.of("partition", String.valueOf(partition));
+      Gauge.builder("zeebe.processing.scheduling.tasks", scheduledTasksCounter, LongAdder::sum)
+          .tags(tags)
+          .description("The number of currently scheduled tasks")
+          .register(registry);
+      scheduledTaskDelay =
+          Timer.builder("zeebe.processing.scheduling.delay")
+              .description("The delay of scheduled tasks")
+              .tags(tags)
+              .publishPercentileHistogram()
+              .register(registry);
+    }
+
+    @Override
+    public void incrementScheduledTasks() {
+      scheduledTasksCounter.increment();
+    }
+
+    @Override
+    public void decrementScheduledTasks() {
+      scheduledTasksCounter.decrement();
+    }
+
+    @Override
+    public void observeScheduledTaskExecution(final long delay) {
+      scheduledTaskDelay.record(delay, TimeUnit.MILLISECONDS);
+    }
+  }
+}

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -69,6 +69,7 @@ class ProcessingScheduleServiceTest {
             () -> testWriter,
             commandCache,
             actorScheduler.getClock(),
+            Duration.ofSeconds(1),
             ScheduledTaskMetrics.noop());
 
     scheduleService = new TestScheduleServiceActorDecorator(processingScheduleService);
@@ -164,6 +165,7 @@ class ProcessingScheduleServiceTest {
             () -> testWriter,
             new NoopScheduledCommandCache(),
             InstantSource.system(),
+            Duration.ofSeconds(1),
             ScheduledTaskMetrics.noop());
     final var mockedTask = spy(new DummyTask());
 
@@ -188,6 +190,7 @@ class ProcessingScheduleServiceTest {
                 },
                 new NoopScheduledCommandCache(),
                 InstantSource.system(),
+                Duration.ofSeconds(1),
                 ScheduledTaskMetrics.noop()));
 
     // when
@@ -641,6 +644,7 @@ class ProcessingScheduleServiceTest {
               () -> testWriter,
               new NoopScheduledCommandCache(),
               InstantSource.system(),
+              Duration.ofSeconds(1),
               ScheduledTaskMetrics.noop());
       final var mockedTask = spy(new DummyTask());
 

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/ProcessingScheduleServiceTest.java
@@ -31,6 +31,7 @@ import io.camunda.zeebe.stream.api.scheduling.TaskResult;
 import io.camunda.zeebe.stream.api.scheduling.TaskResultBuilder;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
 import io.camunda.zeebe.stream.impl.TestScheduledCommandCache.TestCommandCache;
+import io.camunda.zeebe.stream.impl.metrics.ScheduledTaskMetrics;
 import io.camunda.zeebe.stream.impl.records.RecordBatch;
 import io.camunda.zeebe.stream.util.Records;
 import io.camunda.zeebe.test.util.junit.RegressionTest;
@@ -67,7 +68,8 @@ class ProcessingScheduleServiceTest {
             lifecycleSupplier,
             () -> testWriter,
             commandCache,
-            actorScheduler.getClock());
+            actorScheduler.getClock(),
+            ScheduledTaskMetrics.noop());
 
     scheduleService = new TestScheduleServiceActorDecorator(processingScheduleService);
     actorScheduler.submitActor(scheduleService);
@@ -161,7 +163,8 @@ class ProcessingScheduleServiceTest {
             lifecycleSupplier,
             () -> testWriter,
             new NoopScheduledCommandCache(),
-            InstantSource.system());
+            InstantSource.system(),
+            ScheduledTaskMetrics.noop());
     final var mockedTask = spy(new DummyTask());
 
     // when
@@ -184,7 +187,8 @@ class ProcessingScheduleServiceTest {
                   throw new RuntimeException("expected");
                 },
                 new NoopScheduledCommandCache(),
-                InstantSource.system()));
+                InstantSource.system(),
+                ScheduledTaskMetrics.noop()));
 
     // when
     final var actorFuture = actorScheduler.submitActor(notOpenScheduleService);
@@ -636,7 +640,8 @@ class ProcessingScheduleServiceTest {
               lifecycleSupplier,
               () -> testWriter,
               new NoopScheduledCommandCache(),
-              InstantSource.system());
+              InstantSource.system(),
+              ScheduledTaskMetrics.noop());
       final var mockedTask = spy(new DummyTask());
 
       // when

--- a/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
+++ b/zeebe/stream-platform/src/test/java/io/camunda/zeebe/stream/impl/StreamPlatform.java
@@ -38,6 +38,7 @@ import io.camunda.zeebe.stream.impl.state.DbLastProcessedPositionState;
 import io.camunda.zeebe.stream.util.RecordToWrite;
 import io.camunda.zeebe.util.FileUtil;
 import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
@@ -289,6 +290,7 @@ public final class StreamPlatform {
 
     final var builder =
         StreamProcessor.builder()
+            .meterRegistry(new SimpleMeterRegistry())
             .clock(StreamClock.controllable(clock))
             .logStream(stream.getAsyncLogStream())
             .zeebeDb(zeebeDb)


### PR DESCRIPTION
Follow up after https://github.com/camunda/camunda/issues/21051.

Makes the micrometer registry available to the stream processor and uses it to publish new metrics for the scheduling service:

- Number of scheduled tasks
- Delay between actual task execution and the requested time

These metrics are not visualized because they are usually not relevant. The number of scheduled tasks is usually 6 because all of the scheduled tasks try hard to only schedule their next execution and nothing more.
The delay might be slightly more interesting but we don't often investigate support cases where this information is needed.

I've also added a configuration option for the interval at which we check for expired scheduled tasks: `zeebe.broker.processing.scheduledTaskCheckInterval`. By default it's still 1 second.