### PR TITLE
Unlearn spotless to ratchet from main

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -290,9 +290,6 @@
           <plugin>
             <groupId>com.diffplug.spotless</groupId>
             <artifactId>spotless-maven-plugin</artifactId>
-            <configuration>
-              <ratchetFrom>origin/main</ratchetFrom>
-            </configuration>
             <executions>
               <execution>
                 <id>spotless-format</id>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

[Ratcheting can be used to introduce spotless formatting gradually](https://github.com/diffplug/spotless/tree/main/plugin-maven#how-can-i-enforce-formatting-gradually-aka-ratchet) to a project. However, our project already applies (and checks) the formatting of all supported files (`java`, `pom`, `markdown`).

Locally, my machine is able to run `spotless:check` and `spotless:apply` much faster (~4x faster) when `ratchetFrom` is disabled.

Possibly this is because of the size of our git repo. Note that spotless itself is fast and uses [incremental up to date checking and formatting](https://github.com/diffplug/spotless/tree/main/plugin-maven#incremental-up-to-date-checking-and-formatting) to avoid doing unnecessary work.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21191 
