### PR TITLE
Expose stream clock via partitions actuator to ease debugging

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/management/PartitionStatus.java
@@ -9,7 +9,9 @@ package io.camunda.zeebe.broker.system.management;
 
 import io.atomix.raft.RaftServer.Role;
 import io.camunda.zeebe.broker.exporter.stream.ExporterPhase;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
 import io.camunda.zeebe.stream.impl.StreamProcessor.Phase;
+import java.time.Instant;
 
 public record PartitionStatus(
     Role role,
@@ -18,4 +20,9 @@ public record PartitionStatus(
     Long processedPositionInSnapshot,
     Phase streamProcessorPhase,
     ExporterPhase exporterPhase,
-    Long exportedPosition) {}
+    Long exportedPosition,
+    ClockStatus clock) {
+  // without the modificationType, you need to interpret the modification based on its fields, which
+  // may not always be obvious
+  public record ClockStatus(Instant instant, String modificationType, Modification modification) {}
+}

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/transport/commandapi/CommandApiRequestReader.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.broker.transport.RequestReaderException;
 import io.camunda.zeebe.protocol.impl.encoding.AuthInfo;
 import io.camunda.zeebe.protocol.impl.record.RecordMetadata;
 import io.camunda.zeebe.protocol.impl.record.UnifiedRecordValue;
+import io.camunda.zeebe.protocol.impl.record.value.clock.ClockRecord;
 import io.camunda.zeebe.protocol.impl.record.value.compensation.CompensationSubscriptionRecord;
 import io.camunda.zeebe.protocol.impl.record.value.decision.DecisionEvaluationRecord;
 import io.camunda.zeebe.protocol.impl.record.value.deployment.DeploymentRecord;
@@ -68,6 +69,7 @@ public class CommandApiRequestReader implements RequestReader<ExecuteCommandRequ
     RECORDS_BY_TYPE.put(ValueType.COMPENSATION_SUBSCRIPTION, CompensationSubscriptionRecord::new);
     RECORDS_BY_TYPE.put(ValueType.MESSAGE_CORRELATION, MessageCorrelationRecord::new);
     RECORDS_BY_TYPE.put(ValueType.USER, UserRecord::new);
+    RECORDS_BY_TYPE.put(ValueType.CLOCK, ClockRecord::new);
   }
 
   private UnifiedRecordValue value;

--- a/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
+++ b/zeebe/protocol-impl/src/main/java/io/camunda/zeebe/protocol/impl/record/value/clock/ClockRecord.java
@@ -17,7 +17,7 @@ public final class ClockRecord extends UnifiedRecordValue implements ClockRecord
   private final LongProperty timeProperty = new LongProperty("time", 0);
 
   public ClockRecord() {
-    super(2);
+    super(1);
     declareProperty(timeProperty);
   }
 

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/system/BrokerAdminServiceTest.java
@@ -280,7 +280,7 @@ public class BrokerAdminServiceTest {
     final var clock = status.get(1).clock();
     assertThat(clock.instant()).isEqualTo(expectedInstant);
     assertThat(clock.modificationType()).isEqualTo("Pin");
-    assertThat(clock.modification().get("at")).isEqualTo(expectedInstant.toString());
+    assertThat(clock.modification()).containsEntry("at", expectedInstant.toString());
   }
 
   private void waitForSnapshotAtBroker() {

--- a/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeResourcesHelper.java
+++ b/zeebe/qa/integration-tests/src/test/java/io/camunda/zeebe/it/util/ZeebeResourcesHelper.java
@@ -22,6 +22,7 @@ import io.camunda.zeebe.protocol.record.intent.DeploymentIntent;
 import io.camunda.zeebe.protocol.record.intent.JobIntent;
 import io.camunda.zeebe.protocol.record.intent.UserTaskIntent;
 import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.util.CloseableSilently;
 import java.time.Duration;
 import java.util.List;
 import java.util.function.Consumer;
@@ -29,12 +30,17 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.awaitility.Awaitility;
 
-public class ZeebeResourcesHelper {
+public class ZeebeResourcesHelper implements CloseableSilently {
 
   private final ZeebeClient client;
 
   public ZeebeResourcesHelper(final ZeebeClient client) {
     this.client = client;
+  }
+
+  @Override
+  public void close() {
+    client.close();
   }
 
   public void waitUntilDeploymentIsDone(final long key) {

--- a/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
+++ b/zeebe/qa/util/src/main/java/io/camunda/zeebe/qa/util/actuator/PartitionsActuator.java
@@ -8,6 +8,8 @@
 package io.camunda.zeebe.qa.util.actuator;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import feign.Feign;
 import feign.Headers;
 import feign.RequestLine;
@@ -15,8 +17,11 @@ import feign.Retryer;
 import feign.Target.HardCodedTarget;
 import feign.jackson.JacksonDecoder;
 import feign.jackson.JacksonEncoder;
+import io.camunda.zeebe.broker.system.management.PartitionStatus.ClockStatus;
 import io.camunda.zeebe.qa.util.cluster.TestStandaloneBroker;
 import io.zeebe.containers.ZeebeBrokerNode;
+import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -72,9 +77,10 @@ public interface PartitionsActuator {
   @SuppressWarnings("JavadocLinkAsPlainText")
   static PartitionsActuator of(final String endpoint) {
     final var target = new HardCodedTarget<>(PartitionsActuator.class, endpoint);
+    final var decoder = new JacksonDecoder(List.of(new Jdk8Module(), new JavaTimeModule()));
     return Feign.builder()
         .encoder(new JacksonEncoder())
-        .decoder(new JacksonDecoder())
+        .decoder(decoder)
         .retryer(Retryer.NEVER_RETRY)
         .target(target);
   }
@@ -119,5 +125,9 @@ public interface PartitionsActuator {
       Long processedPositionInSnapshot,
       String streamProcessorPhase,
       Long exportedPosition,
-      String exporterPhase) {}
+      String exporterPhase,
+      ClockStatus clock) {}
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  record ClockStatus(Instant instant, String modificationType, Map<String, Object> modification) {}
 }

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/api/StreamClock.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.zeebe.stream.api;
 
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
 import io.camunda.zeebe.stream.impl.ControllableStreamClockImpl;
 import io.camunda.zeebe.stream.impl.UncontrolledStreamClock;
 import java.time.Duration;
@@ -24,12 +25,18 @@ public interface StreamClock extends InstantSource {
   }
 
   static StreamClock system() {
-    return new UncontrolledStreamClock(InstantSource.system());
+    return uncontrolled(InstantSource.system());
   }
 
   static ControllableStreamClock controllable(final InstantSource source) {
     return new ControllableStreamClockImpl(source);
   }
+
+  /**
+   * Returns the current modification applied to the clock. If no modification is applied, {@link
+   * Modification.None} is returned.
+   */
+  Modification currentModification();
 
   /**
    * A controllable {@link StreamClock} that allows to pin the time to a specific instant or to
@@ -45,12 +52,6 @@ public interface StreamClock extends InstantSource {
      *     clock to current system time.
      */
     void applyModification(Modification modification);
-
-    /**
-     * Returns the current modification applied to the clock. If no modification is applied, {@link
-     * Modification.None} is returned.
-     */
-    Modification currentModification();
 
     /**
      * Shortcut to pin the clock to a specific instant.

--- a/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncontrolledStreamClock.java
+++ b/zeebe/stream-platform/src/main/java/io/camunda/zeebe/stream/impl/UncontrolledStreamClock.java
@@ -8,6 +8,7 @@
 package io.camunda.zeebe.stream.impl;
 
 import io.camunda.zeebe.stream.api.StreamClock;
+import io.camunda.zeebe.stream.api.StreamClock.ControllableStreamClock.Modification;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.InstantSource;
@@ -19,6 +20,11 @@ public final class UncontrolledStreamClock implements StreamClock {
 
   public UncontrolledStreamClock(final InstantSource source) {
     this.source = Objects.requireNonNull(source);
+  }
+
+  @Override
+  public Modification currentModification() {
+    return Modification.none();
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR exposes the stream clock (immutably, aka in a thread safe manner) via the partitions actuator. This then allows anyone to quickly debug if everything is working as expected when they make clock modifications.

As part of it, I migrated the old broker admin service integration test to use our new testing infrastructure, which is closer to "production" usage.

I also fixed one issue where I forgot to allow the clock commands to be accepted by the command API.

## Related issues

related to #21068 
