### PR TITLE
[CPT] I can modify the clock for process tests

### DIFF
--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/api/CamundaProcessTestContext.java
@@ -18,6 +18,8 @@ package io.camunda.process.test.api;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.function.Consumer;
 
 /** The injected context for a process test. */
@@ -48,4 +50,20 @@ public interface CamundaProcessTestContext {
    * @return the URI of Zeebe's REST API address
    */
   URI getZeebeRestAddress();
+
+  /**
+   * The current time may differ from the system time if the time was modified using {@link
+   * #increaseTime(Duration)}.
+   *
+   * @return the current time for the process tests
+   */
+  Instant getCurrentTime();
+
+  /**
+   * Modifies the current time for the process tests. It can be used to jump to the future to avoid
+   * waiting until a due date is reached, for example, of a BPMN timer event.
+   *
+   * @param timeToAdd the duration to add to the current time
+   */
+  void increaseTime(final Duration timeToAdd);
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/HttpClientUtil.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/HttpClientUtil.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+import java.util.Optional;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+
+public class HttpClientUtil {
+
+  public static String getReponseAsString(final ClassicHttpResponse response) {
+    return Optional.ofNullable(response.getEntity())
+        .map(
+            entity -> {
+              try {
+                return EntityUtils.toString(entity);
+              } catch (final Exception e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .orElse("<empty>");
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/OperateApiClient.java
@@ -18,7 +18,6 @@ package io.camunda.process.test.impl.client;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.util.Optional;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.cookie.BasicCookieStore;
@@ -26,7 +25,6 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
-import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.HttpEntities;
 
 public class OperateApiClient {
@@ -71,7 +69,7 @@ public class OperateApiClient {
             throw new IllegalStateException(
                 String.format(
                     "Failed to login. [code: %d, message: %s]",
-                    response.getCode(), getReponseAsString(response)));
+                    response.getCode(), HttpClientUtil.getReponseAsString(response)));
           }
           return null;
         });
@@ -82,13 +80,13 @@ public class OperateApiClient {
       throw new ZeebeClientNotFoundException(
           String.format(
               "Failed send request. Object not found. [code: %d, message: %s]",
-              response.getCode(), getReponseAsString(response)));
+              response.getCode(), HttpClientUtil.getReponseAsString(response)));
     }
     if (response.getCode() != 200) {
       throw new RuntimeException(
           String.format(
               "Failed send request. [code: %d, message: %s]",
-              response.getCode(), getReponseAsString(response)));
+              response.getCode(), HttpClientUtil.getReponseAsString(response)));
     }
   }
 
@@ -123,25 +121,12 @@ public class OperateApiClient {
     return objectMapper.readValue(responseBody, VariableResponseDto.class);
   }
 
-  private static String getReponseAsString(final ClassicHttpResponse response) {
-    return Optional.ofNullable(response.getEntity())
-        .map(
-            entity -> {
-              try {
-                return EntityUtils.toString(entity);
-              } catch (final Exception e) {
-                throw new RuntimeException(e);
-              }
-            })
-        .orElse("?");
-  }
-
   private String sendGetRequest(final String endpoint) throws IOException {
     return httpClient.execute(
         new HttpGet(operateRestApi + endpoint),
         response -> {
           verifyStatusCode(response);
-          return getReponseAsString(response);
+          return HttpClientUtil.getReponseAsString(response);
         });
   }
 
@@ -154,7 +139,7 @@ public class OperateApiClient {
         request,
         response -> {
           verifyStatusCode(response);
-          return getReponseAsString(response);
+          return HttpClientUtil.getReponseAsString(response);
         });
   }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ZeebeAddClockRequestDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ZeebeAddClockRequestDto.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public class ZeebeAddClockRequestDto {
+
+  private long offsetMilli;
+
+  public long getOffsetMilli() {
+    return offsetMilli;
+  }
+
+  public void setOffsetMilli(final long offsetMilli) {
+    this.offsetMilli = offsetMilli;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ZeebeClockResponseDto.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ZeebeClockResponseDto.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+public class ZeebeClockResponseDto {
+
+  private long epochMilli;
+  private String instant;
+
+  public long getEpochMilli() {
+    return epochMilli;
+  }
+
+  public void setEpochMilli(final long epochMilli) {
+    this.epochMilli = epochMilli;
+  }
+
+  public String getInstant() {
+    return instant;
+  }
+
+  public void setInstant(final String instant) {
+    this.instant = instant;
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ZeebeManagementClient.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/client/ZeebeManagementClient.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2017 camunda services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.camunda.process.test.impl.client;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
+import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.HttpEntities;
+
+public class ZeebeManagementClient {
+
+  private static final String CLOCK_ENDPOINT = "/actuator/clock";
+  private static final String CLOCK_ADD_ENDPOINT = "/actuator/clock/add";
+
+  private final ObjectMapper objectMapper =
+      new ObjectMapper().disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+
+  private final CloseableHttpClient httpClient = HttpClients.createDefault();
+
+  private final URI zeebeManagementApi;
+
+  public ZeebeManagementClient(final URI zeebeManagementApi) {
+    this.zeebeManagementApi = zeebeManagementApi;
+  }
+
+  public Instant getCurrentTime() {
+
+    try {
+      final HttpGet request = new HttpGet(zeebeManagementApi + CLOCK_ENDPOINT);
+      final String responseBody = sendRequest(request);
+
+      final ZeebeClockResponseDto clockResponseDto =
+          objectMapper.readValue(responseBody, ZeebeClockResponseDto.class);
+      return Instant.parse(clockResponseDto.getInstant());
+
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to resolve the current time", e);
+    }
+  }
+
+  public void increaseTime(final Duration timeToAdd) {
+
+    final HttpPost request = new HttpPost(zeebeManagementApi + CLOCK_ADD_ENDPOINT);
+
+    final ZeebeAddClockRequestDto requestDto = new ZeebeAddClockRequestDto();
+    requestDto.setOffsetMilli(timeToAdd.toMillis());
+
+    try {
+      final String requestBody = objectMapper.writeValueAsString(requestDto);
+      request.setEntity(HttpEntities.create(requestBody, ContentType.APPLICATION_JSON));
+
+      sendRequest(request);
+
+    } catch (final Exception e) {
+      throw new RuntimeException("Failed to increase the time", e);
+    }
+  }
+
+  private String sendRequest(final ClassicHttpRequest request) throws IOException {
+    return httpClient.execute(
+        request,
+        response -> {
+          if (response.getCode() != 200) {
+            throw new RuntimeException(
+                String.format(
+                    "Request failed. [code: %d, message: %s]",
+                    response.getCode(), HttpClientUtil.getReponseAsString(response)));
+          }
+          return HttpClientUtil.getReponseAsString(response);
+        });
+  }
+}

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ZeebeContainer.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/containers/ZeebeContainer.java
@@ -95,4 +95,12 @@ public class ZeebeContainer extends GenericContainer<ZeebeContainer> {
   private URI toUriWithPort(final int port) {
     return URI.create("http://" + getHost() + ":" + port);
   }
+
+  public URI getMonitoringApiAddress() {
+    return toUriWithPort(getMonitoringApiPort());
+  }
+
+  public int getMonitoringApiPort() {
+    return getMappedPort(ContainerRuntimePorts.ZEEBE_MONITORING_API);
+  }
 }

--- a/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
+++ b/testing/camunda-process-test-java/src/main/java/io/camunda/process/test/impl/extension/CamundaProcessTestContextImpl.java
@@ -16,21 +16,27 @@
 package io.camunda.process.test.impl.extension;
 
 import io.camunda.process.test.api.CamundaProcessTestContext;
+import io.camunda.process.test.impl.client.ZeebeManagementClient;
 import io.camunda.process.test.impl.containers.ZeebeContainer;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.ZeebeClientBuilder;
 import java.net.URI;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.function.Consumer;
 
 public class CamundaProcessTestContextImpl implements CamundaProcessTestContext {
 
   private final ZeebeContainer zeebeContainer;
   private final Consumer<ZeebeClient> clientCreationCallback;
+  private final ZeebeManagementClient zeebeManagementClient;
 
   public CamundaProcessTestContextImpl(
       final ZeebeContainer zeebeContainer, final Consumer<ZeebeClient> clientCreationCallback) {
     this.zeebeContainer = zeebeContainer;
     this.clientCreationCallback = clientCreationCallback;
+
+    zeebeManagementClient = new ZeebeManagementClient(zeebeContainer.getMonitoringApiAddress());
   }
 
   @Override
@@ -62,5 +68,15 @@ public class CamundaProcessTestContextImpl implements CamundaProcessTestContext 
   @Override
   public URI getZeebeRestAddress() {
     return zeebeContainer.getRestApiAddress();
+  }
+
+  @Override
+  public Instant getCurrentTime() {
+    return zeebeManagementClient.getCurrentTime();
+  }
+
+  @Override
+  public void increaseTime(final Duration timeToAdd) {
+    zeebeManagementClient.increaseTime(timeToAdd);
   }
 }

--- a/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
+++ b/testing/camunda-process-test-java/src/test/java/io/camunda/process/test/api/CamundaProcessTestExtensionIT.java
@@ -15,10 +15,14 @@
  */
 package io.camunda.process.test.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 
 @CamundaProcessTest
@@ -26,6 +30,7 @@ public class CamundaProcessTestExtensionIT {
 
   // to be injected
   private ZeebeClient client;
+  private CamundaProcessTestContext processTestContext;
 
   @Test
   void shouldCreateProcessInstance() {
@@ -54,5 +59,47 @@ public class CamundaProcessTestExtensionIT {
         .hasCompletedElements("start")
         .hasActiveElements("task")
         .hasVariable("status", "active");
+  }
+
+  @Test
+  void shouldTriggerTimerEvent() {
+    // given
+    final Duration timerDuration = Duration.ofHours(1);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .name("start")
+            .userTask("A")
+            .name("A")
+            .endEvent()
+            // attach boundary timer event
+            .moveToActivity("A")
+            .boundaryEvent()
+            .timerWithDuration(timerDuration.toString())
+            .userTask()
+            .name("B")
+            .endEvent()
+            .done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    final ProcessInstanceEvent processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
+
+    // when
+    CamundaAssert.assertThat(processInstance).hasActiveElements("A");
+
+    final Instant timeBefore = processTestContext.getCurrentTime();
+
+    processTestContext.increaseTime(timerDuration);
+
+    final Instant timeAfter = processTestContext.getCurrentTime();
+
+    // then
+    CamundaAssert.assertThat(processInstance).hasTerminatedElements("A").hasActiveElements("B");
+
+    assertThat(Duration.between(timeBefore, timeAfter))
+        .isCloseTo(timerDuration, Duration.ofSeconds(10));
   }
 }

--- a/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
+++ b/testing/camunda-process-test-spring/src/test/java/io/camunda/process/test/api/CamundaSpringProcessTestListenerIT.java
@@ -15,10 +15,14 @@
  */
 package io.camunda.process.test.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.response.ProcessInstanceEvent;
 import io.camunda.zeebe.model.bpmn.Bpmn;
 import io.camunda.zeebe.model.bpmn.BpmnModelInstance;
+import java.time.Duration;
+import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,6 +32,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 public class CamundaSpringProcessTestListenerIT {
 
   @Autowired private ZeebeClient client;
+  @Autowired private CamundaProcessTestContext processTestContext;
 
   @Test
   void shouldCreateProcessInstance() {
@@ -56,5 +61,47 @@ public class CamundaSpringProcessTestListenerIT {
         .hasCompletedElements("start")
         .hasActiveElements("task")
         .hasVariable("status", "active");
+  }
+
+  @Test
+  void shouldTriggerTimerEvent() {
+    // given
+    final Duration timerDuration = Duration.ofHours(1);
+
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .name("start")
+            .userTask("A")
+            .name("A")
+            .endEvent()
+            // attach boundary timer event
+            .moveToActivity("A")
+            .boundaryEvent()
+            .timerWithDuration(timerDuration.toString())
+            .userTask()
+            .name("B")
+            .endEvent()
+            .done();
+
+    client.newDeployResourceCommand().addProcessModel(process, "process.bpmn").send().join();
+
+    final ProcessInstanceEvent processInstance =
+        client.newCreateInstanceCommand().bpmnProcessId("process").latestVersion().send().join();
+
+    // when
+    CamundaAssert.assertThat(processInstance).hasActiveElements("A");
+
+    final Instant timeBefore = processTestContext.getCurrentTime();
+
+    processTestContext.increaseTime(timerDuration);
+
+    final Instant timeAfter = processTestContext.getCurrentTime();
+
+    // then
+    CamundaAssert.assertThat(processInstance).hasTerminatedElements("A").hasActiveElements("B");
+
+    assertThat(Duration.between(timeBefore, timeAfter))
+        .isCloseTo(timerDuration, Duration.ofSeconds(10));
   }
 }


### PR DESCRIPTION
## Description

Allows modifying the clock for process tests. This enables the common use case to trigger a BPMN timer event without waiting until its due date is reached. 

The changes don't fulfill #19176 completely because it doesn't trigger a single BPMN timer event explicitly (and isolated). However, it's a common feature that could be used also for other purposes, for example, job backoff timeout and message TTL. 

Verify the behavior in integration tests only. The implementation is simple and I don't expect changes in the clock API. 

## Checklist

## Related issues

related to #19176 
