### PR TITLE
Avoid concurrent database writes in `MigrateProcessInstanceConcurrentNoBatchingTest`

### DIFF
--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceConcurrentNoBatchingTest.java
@@ -977,6 +977,8 @@ public class MigrateProcessInstanceConcurrentNoBatchingTest {
         .await();
 
     // we generate a key for the intermediate catch event so we can activate it using events
+    // this requires us to pause processing to avoid concurrent database transaction modification
+    ENGINE.pauseProcessing(1);
     final var keyGenerator =
         ((MutableProcessingState) ENGINE.getProcessingState()).getKeyGenerator();
     final var intermediateCatchEventKey = keyGenerator.nextKey();


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This unflakes `MigrateProcessInstanceConcurrentNoBatchingTest` by pausing the processing before generating a record key.

This test needs to generate a record key for use in some events that it appends to the log as part of the set up of this test case.

Generating a next key with `DbKeyGenerator` is not a safe operation for use in tests. It reads and changes a value in the state. The state is also accessed concurrently by the stream processor. This can lead to errors in committing the database transaction when both are trying to do so simultaneously.

We can avoid this by pausing processing before generating the key.

An alternative approach would be to stop the engine first (which we do after generating the key so we can write events that are applied during replay), but this is not possible. If the engine is stopped, the state is inaccessible.

## Related issues

closes #21196
