### PR TITLE
ci(preview-env): add workflow to check on merge conflicts

### DIFF
--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -1,0 +1,16 @@
+---
+name: Check for PR conflicts
+
+on:
+  schedule:
+  - cron: 23 1 * * 1-5
+  workflow_dispatch:
+  pull_request: 
+
+jobs:
+  check-pr-conflicts:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - name: Check all PRs for conflict
+      uses: camunda/infra-global-github-actions/preview-env/conflicts@main

--- a/.github/workflows/check-pr-conflicts.yml
+++ b/.github/workflows/check-pr-conflicts.yml
@@ -5,12 +5,23 @@ on:
   schedule:
   - cron: 23 1 * * 1-5
   workflow_dispatch:
-  pull_request: 
+  pull_request:
 
 jobs:
-  check-pr-conflicts:
+  check-all-pr-conflicts:
+    if: ${{ github.event_name == 'schedule' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
     - name: Check all PRs for conflict
       uses: camunda/infra-global-github-actions/preview-env/conflicts@main
+  check-single-pr-conflict:
+    # No check on label `deploy-preview` here, because it wouldn't run
+    # if there's a remaining merge conflict. Thus, only a cleanup can happen here.
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check PR for merge conflicts
+      uses: camunda/infra-global-github-actions/preview-env/conflicts@main
+      with:
+        pull-request-id: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Description

This simple PR adds a cron-workflow which checks PRs (labeled with `deploy-preview`) for merge conflicts and upserts a sticky comment on the PR which highlights the conflict!

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)

## Related issues

https://github.com/camunda/team-infrastructure/issues/566
