### PR TITLE
chore: error on eslint warnings in dev environment

### DIFF
--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -62,8 +62,8 @@
     "src/**/*.scss": [
       "prettier --write"
     ],
-    "src/**/*.js": [
-      "eslint --fix",
+    "src/**/*.{js,jsx}": [
+      "eslint --fix --max-warnings=0",
       "prettier --write"
     ]
   },


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
The eslint commit hook does not fire in local development for warnings. However,  eslint by default is stricter on the CI. So the warnings appear there which make the build fail. To make things consistent, i made the commit hook fail on warnings to avoid such issues.



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
