### PR TITLE
feat: add exporting metrics

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -28,11 +28,11 @@ public final class ExporterMetrics {
           .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_VALUE_TYPE)
           .register();
 
-  private static final Histogram EXPORTER_LATENCY =
+  private static final Histogram EXPORTER_EXPORTING_DURATION =
       Histogram.build()
           .namespace(NAMESPACE_ZEEBE)
-          .name("exporter_latency")
-          .help("Time exporter needs to export certain record (in seconds)")
+          .name("exporter_exporting_duration")
+          .help("The time an exporter needs to export certain record (duration in seconds)")
           .labelNames(LABEL_NAME_PARTITION, LABEL_NAME_EXPORTER, LABEL_NAME_VALUE_TYPE)
           .register();
 
@@ -116,8 +116,11 @@ public final class ExporterMetrics {
         .observe((exporting - written) / 1000f);
   }
 
-  public Histogram.Timer startExportLatencyTimer(final ValueType valueType, final String exporter) {
-    return EXPORTER_LATENCY.labels(partitionIdLabel, exporter, valueType.name()).startTimer();
+  public Histogram.Timer startExporterExportingTimer(
+      final ValueType valueType, final String exporter) {
+    return EXPORTER_EXPORTING_DURATION
+        .labels(partitionIdLabel, exporter, valueType.name())
+        .startTimer();
   }
 
   public void initializeExporterState(final ExporterPhase state) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/ExporterMetrics.java
@@ -117,7 +117,7 @@ public final class ExporterMetrics {
   }
 
   public Histogram.Timer startExportLatencyTimer(final ValueType valueType, final String exporter) {
-    return EXPORTING_LATENCY.labels(partitionIdLabel, valueType.name(), exporter).startTimer();
+    return EXPORTER_LATENCY.labels(partitionIdLabel, exporter, valueType.name()).startTimer();
   }
 
   public void initializeExporterState(final ExporterPhase state) {

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/exporter/stream/RecordExporter.java
@@ -74,7 +74,7 @@ final class RecordExporter {
       final ExporterContainer container = containers.get(exporterIndex);
 
       try (final var timer =
-          exporterMetrics.startExportLatencyTimer(valueType, container.getId())) {
+          exporterMetrics.startExporterExportingTimer(valueType, container.getId())) {
         if (container.exportRecord(rawMetadata, typedEvent)) {
           exporterIndex++;
           exporterMetrics.setLastExportedPosition(container.getId(), typedEvent.getPosition());

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/exporter/stream/ExporterRule.java
@@ -24,6 +24,7 @@ import io.camunda.zeebe.protocol.record.intent.Intent;
 import io.camunda.zeebe.scheduler.clock.ControlledActorClock;
 import io.camunda.zeebe.scheduler.testing.ActorSchedulerRule;
 import io.camunda.zeebe.stream.api.EventFilter;
+import io.camunda.zeebe.stream.api.StreamClock;
 import io.camunda.zeebe.stream.impl.SkipPositionsFilter;
 import io.camunda.zeebe.test.util.AutoCloseableRule;
 import java.time.Duration;
@@ -121,6 +122,7 @@ public final class ExporterRule implements TestRule {
             .id(EXPORTER_PROCESSOR_ID)
             .name(PROCESSOR_NAME)
             .logStream(stream.getAsyncLogStream())
+            .clock(StreamClock.system())
             .zeebeDb(capturedZeebeDb)
             .exporterMode(exporterMode)
             .distributionInterval(distributionInterval)


### PR DESCRIPTION
## Description

To get a better understanding where time is spent, adding new metrics for the exporting.

 * new metric for exporting, time from record written to exporting
 * new metric for exporter latency, time how long it takes for each exporter to accept an record

This allows us to already visualize latency like this:

![2024-08-20_10-54](https://github.com/user-attachments/assets/25f65365-7360-46d8-b9d7-e05dcafc1944)


Missing:

 * elasticsearch exporter - exporting latency
 * importer latency
 * ...
 
## Related issues

related to https://github.com/camunda/camunda/issues/16912
