### PR TITLE
Make customHeaders dynamic for Opensearch task index

### DIFF
--- a/tasklist/els-schema/src/main/resources/schema/os/create/template/tasklist-task.json
+++ b/tasklist/els-schema/src/main/resources/schema/os/create/template/tasklist-task.json
@@ -81,7 +81,8 @@
       "type": "integer"
     },
     "customHeaders": {
-      "type": "object"
+      "type": "object",
+      "dynamic": true
     },
     "priority": {
       "type": "integer"


### PR DESCRIPTION
## Description

- Fix Opensearch user task import template for _customHeaders_ field to be _dynamic_. 
- Add test scenario to cover the case.
## Related issues

closes #21296 
