### PR TITLE
Manage dependency versions for spring-boot-starter-camunda-sdk

### DIFF
--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -22,7 +22,6 @@
   <properties>
     <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <spring-boot-test.version>3.2.5</spring-boot-test.version>
     <wiremock-standalone.version>3.9.1</wiremock-standalone.version>
   </properties>
 

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -21,7 +21,6 @@
 
   <properties>
     <version.java>17</version.java>
-    <commons-beanutils.version>1.9.4</commons-beanutils.version>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
     <java-jwt.version>4.4.0</java-jwt.version>
     <spring-boot-test.version>3.2.5</spring-boot-test.version>
@@ -182,14 +181,8 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>${commons-beanutils.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-collections</groupId>
-          <artifactId>commons-collections</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -158,7 +158,6 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-aop</artifactId>
-      <version>${version.spring}</version>
       <scope>provided</scope>
     </dependency>
 

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -22,7 +22,6 @@
   <properties>
     <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <java-jwt.version>4.4.0</java-jwt.version>
     <spring-boot-test.version>3.2.5</spring-boot-test.version>
     <wiremock-standalone.version>3.9.1</wiremock-standalone.version>
   </properties>
@@ -168,7 +167,6 @@
     <dependency>
       <groupId>com.auth0</groupId>
       <artifactId>java-jwt</artifactId>
-      <version>${java-jwt.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/clients/spring-boot-starter-camunda-sdk/pom.xml
+++ b/clients/spring-boot-starter-camunda-sdk/pom.xml
@@ -22,7 +22,6 @@
   <properties>
     <version.java>17</version.java>
     <license.header>com/mycila/maven/plugin/license/templates/APACHE-2.txt</license.header>
-    <wiremock-standalone.version>3.9.1</wiremock-standalone.version>
   </properties>
 
   <dependencies>
@@ -189,7 +188,6 @@
     <dependency>
       <groupId>org.wiremock</groupId>
       <artifactId>wiremock-standalone</artifactId>
-      <version>${wiremock-standalone.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -1438,6 +1438,12 @@
         <version>${version.wiremock}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.wiremock</groupId>
+        <artifactId>wiremock-standalone</artifactId>
+        <version>${version.wiremock}</version>
+      </dependency>
+
       <!-- Testcontainers & Docker for container based integration tests -->
       <dependency>
         <groupId>org.testcontainers</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -42,6 +42,7 @@
     <version.camunda>7.22.0-SNAPSHOT</version.camunda>
     <version.camunda-license-check>2.9.0</version.camunda-license-check>
     <version.checkstyle>10.17.0</version.checkstyle>
+    <version.commons-beanutils>1.9.4</version.commons-beanutils>
     <version.commons-lang>3.16.0</version.commons-lang>
     <version.commons-logging>1.3.4</version.commons-logging>
     <version.commons-math>3.6.1</version.commons-math>
@@ -1324,6 +1325,18 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-text</artifactId>
         <version>${version.commons-text}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>${version.commons-beanutils}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

Dependencies should generally be managed by the dependencyManagement section of the parent pom. This helps avoid running into diamond dependency conflicts where two modules depend on different versions of the same dependency.

## Related issues

First seen causing issues in #21137 
