### PR TITLE
[Backport stable/8.2] feat: allow dns resolution to fall back to TCP

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -108,7 +108,13 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private EventLoopGroup serverGroup;
   private EventLoopGroup clientGroup;
   private Class<? extends ServerChannel> serverChannelClass;
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
   private Class<? extends Channel> clientChannelClass;
+=======
+  private Class<? extends SocketChannel> clientChannelClass;
+  private Class<? extends DatagramChannel> clientDataGramChannelClass;
+
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
   private Channel serverChannel;
 
   // a single thread executor which silently rejects tasks being submitted when it's shutdown
@@ -368,6 +374,19 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .thenCompose(ok -> bootstrapServer())
         .thenRun(
             () -> {
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+=======
+              final var metrics = new NettyDnsMetrics();
+              dnsResolverGroup =
+                  new DnsAddressResolverGroup(
+                      new DnsNameResolverBuilder(clientGroup.next())
+                          .dnsQueryLifecycleObserverFactory(
+                              new BiDnsQueryLifecycleObserverFactory(
+                                  ignored -> metrics,
+                                  new LoggingDnsQueryLifeCycleObserverFactory()))
+                          .socketChannelType(clientChannelClass)
+                          .channelType(clientDataGramChannelClass));
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
               timeoutExecutor =
                   Executors.newSingleThreadScheduledExecutor(
                       new DefaultThreadFactory("netty-messaging-timeout-"));

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -40,7 +40,16 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
 import java.net.InetAddress;
+=======
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.resolver.dns.BiDnsQueryLifecycleObserverFactory;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
+import io.netty.util.concurrent.Future;
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
 import java.net.InetSocketAddress;
 import java.util.Iterator;
 import java.util.Map;
@@ -222,7 +231,33 @@ public class NettyUnicastService implements ManagedUnicastService {
   @Override
   public CompletableFuture<UnicastService> start() {
     group = new NioEventLoopGroup(0, namedThreads("netty-unicast-event-nio-client-%d", log));
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
     return bootstrap().thenRun(() -> started.set(true)).thenApply(v -> this);
+=======
+    return bootstrap()
+        .thenRun(
+            () -> {
+              final var metrics = new NettyDnsMetrics();
+              started.set(true);
+              dnsAddressResolverGroup =
+                  new DnsAddressResolverGroup(
+                      new DnsNameResolverBuilder(group.next())
+                          .dnsQueryLifecycleObserverFactory(
+                              new BiDnsQueryLifecycleObserverFactory(
+                                  ignored -> metrics,
+                                  new LoggingDnsQueryLifeCycleObserverFactory()))
+                          .socketChannelType(NioSocketChannel.class)
+                          .channelType(NioDatagramChannel.class));
+            })
+        .thenApply(
+            v -> {
+              log.info(
+                  "Started plaintext unicast service bound to {}, advertising {}",
+                  bindAddress,
+                  advertisedAddress);
+              return this;
+            });
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
   }
 
   @Override


### PR DESCRIPTION
# Description
Backport of #21066 to `stable/8.2`.

relates to 
original author: @lenaschoenburg