### PR TITLE
[Backport stable/8.3] feat: allow dns resolution to fall back to TCP

### DIFF
--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
@@ -109,7 +109,13 @@ public final class NettyMessagingService implements ManagedMessagingService {
   private EventLoopGroup serverGroup;
   private EventLoopGroup clientGroup;
   private Class<? extends ServerChannel> serverChannelClass;
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
   private Class<? extends Channel> clientChannelClass;
+=======
+  private Class<? extends SocketChannel> clientChannelClass;
+  private Class<? extends DatagramChannel> clientDataGramChannelClass;
+
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
   private Channel serverChannel;
 
   // a single thread executor which silently rejects tasks being submitted when it's shutdown
@@ -367,6 +373,19 @@ public final class NettyMessagingService implements ManagedMessagingService {
         .thenCompose(ok -> bootstrapServer())
         .thenRun(
             () -> {
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
+=======
+              final var metrics = new NettyDnsMetrics();
+              dnsResolverGroup =
+                  new DnsAddressResolverGroup(
+                      new DnsNameResolverBuilder(clientGroup.next())
+                          .dnsQueryLifecycleObserverFactory(
+                              new BiDnsQueryLifecycleObserverFactory(
+                                  ignored -> metrics,
+                                  new LoggingDnsQueryLifeCycleObserverFactory()))
+                          .socketChannelType(clientChannelClass)
+                          .channelType(clientDataGramChannelClass));
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyMessagingService.java
               timeoutExecutor =
                   Executors.newSingleThreadScheduledExecutor(
                       new DefaultThreadFactory("netty-messaging-timeout-"));

--- a/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+++ b/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
@@ -39,6 +39,14 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.DatagramChannel;
 import io.netty.channel.socket.DatagramPacket;
 import io.netty.channel.socket.nio.NioDatagramChannel;
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
+=======
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.resolver.dns.BiDnsQueryLifecycleObserverFactory;
+import io.netty.resolver.dns.DnsAddressResolverGroup;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.LoggingDnsQueryLifeCycleObserverFactory;
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
 import io.netty.util.concurrent.Future;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -193,7 +201,24 @@ public class NettyUnicastService implements ManagedUnicastService {
   public CompletableFuture<UnicastService> start() {
     group = new NioEventLoopGroup(0, namedThreads("netty-unicast-event-nio-client-%d", log));
     return bootstrap()
+<<<<<<< HEAD:atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
         .thenRun(() -> started.set(true))
+=======
+        .thenRun(
+            () -> {
+              final var metrics = new NettyDnsMetrics();
+              started.set(true);
+              dnsAddressResolverGroup =
+                  new DnsAddressResolverGroup(
+                      new DnsNameResolverBuilder(group.next())
+                          .dnsQueryLifecycleObserverFactory(
+                              new BiDnsQueryLifecycleObserverFactory(
+                                  ignored -> metrics,
+                                  new LoggingDnsQueryLifeCycleObserverFactory()))
+                          .socketChannelType(NioSocketChannel.class)
+                          .channelType(NioDatagramChannel.class));
+            })
+>>>>>>> c8ee3eab (feat: allow dns resolution to fall back to TCP):zeebe/atomix/cluster/src/main/java/io/atomix/cluster/messaging/impl/NettyUnicastService.java
         .thenApply(
             v -> {
               log.info(


### PR DESCRIPTION
# Description
Backport of #21066 to `stable/8.3`.

relates to 
original author: @lenaschoenburg