### PR TITLE
refactor: record value and metadata length is always non-zero

### DIFF
--- a/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/zeebe/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -136,9 +136,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
   }
 
   private static boolean isEntryValid(final LogAppendEntry entry) {
-    return entry.recordValue() != null
-        && entry.recordValue().getLength() > 0
-        && entry.recordMetadata() != null
-        && entry.recordMetadata().getLength() > 0;
+    return entry.recordValue() != null && entry.recordMetadata() != null;
   }
 }


### PR DESCRIPTION
This is a performance improvement to avoid calculating the length of record value and metadata for every entry that's being appended.

Record values inherit from `ObjectValue` which always has non-zero length due to the map header.
Record metadata is serialized via SBE which also requires a header and thus always has non-zero length.

closes #19225