### PR TITLE
ci: ensure independent workflows on main don't cancel each other

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 # Exception for deploy jobs that have to wait for each other to avoid overwriting
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 defaults:
   run:

--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -17,7 +17,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   test:

--- a/.github/workflows/operate-ci.yml
+++ b/.github/workflows/operate-ci.yml
@@ -35,7 +35,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   run-build:

--- a/.github/workflows/operate-docker-tests.yml
+++ b/.github/workflows/operate-docker-tests.yml
@@ -32,7 +32,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   integration-tests:

--- a/.github/workflows/operate-e2e-tests.yml
+++ b/.github/workflows/operate-e2e-tests.yml
@@ -32,7 +32,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   test:

--- a/.github/workflows/operate-frontend.yml
+++ b/.github/workflows/operate-frontend.yml
@@ -17,7 +17,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   linting-and-testing:

--- a/.github/workflows/operate-merge-ci.yaml
+++ b/.github/workflows/operate-merge-ci.yaml
@@ -9,7 +9,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   run-build:

--- a/.github/workflows/operate-playwright.yml
+++ b/.github/workflows/operate-playwright.yml
@@ -18,7 +18,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   test:

--- a/.github/workflows/renovatelint.yml
+++ b/.github/workflows/renovatelint.yml
@@ -10,7 +10,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   renovate-config-validator:

--- a/.github/workflows/tasklist-ci.yml
+++ b/.github/workflows/tasklist-ci.yml
@@ -30,7 +30,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   check_changes:

--- a/.github/workflows/tasklist-docker-tests.yml
+++ b/.github/workflows/tasklist-docker-tests.yml
@@ -29,7 +29,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   integration-tests:

--- a/.github/workflows/tasklist-e2e-tests.yml
+++ b/.github/workflows/tasklist-e2e-tests.yml
@@ -29,7 +29,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   test:

--- a/.github/workflows/tasklist-merge-ci.yml
+++ b/.github/workflows/tasklist-merge-ci.yml
@@ -9,7 +9,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   run-build:

--- a/.github/workflows/tasklist-update_visual_snapshots.yml
+++ b/.github/workflows/tasklist-update_visual_snapshots.yml
@@ -8,7 +8,7 @@ on:
 # Exception for main branch: complete builds for every commit needed for confidenence
 concurrency:
   cancel-in-progress: true
-  group: ${{ github.ref == 'refs/heads/main' && github.sha || format('{0}-{1}', github.workflow, github.ref) }}
+  group: ${{ format('{0}-{1}', github.workflow, github.ref == 'refs/heads/main' && github.sha || github.ref) }}
 
 jobs:
   update-snapshots:


### PR DESCRIPTION
## Description

This is a fixup to https://github.com/camunda/camunda/pull/20483 which was reported in https://camunda.slack.com/archives/C071KP5BTHB/p1723798638842329 to have unintended side-effects due to a faulty new `concurrency` configuration for `main` branch. The missing piece here was that the new `concurrency` configuration works only if used by only one workflow at a time since it doesn't discriminate between workflow names.

Example for this is https://github.com/camunda/camunda/actions/runs/10450995603 which says `Canceling since a higher priority waiting request for '53d5cfaf9b1473bb3c300d150fae1260222944f2' exists` so no workflow name was involved that would allow distinction.

This PR adds that distinction to make sure that on `main` the concurrency group will always be `workflow_name-github_sha` which should be unique and still (as intended with #20483) allow all workflows to run til their end.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
