### PR TITLE
[Backport stable/8.4] refactor: record value and metadata length is always non-zero

### DIFF
--- a/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
+++ b/logstreams/src/main/java/io/camunda/zeebe/logstreams/impl/log/Sequencer.java
@@ -136,9 +136,6 @@ final class Sequencer implements LogStreamWriter, Closeable {
   }
 
   private boolean isEntryValid(final LogAppendEntry entry) {
-    return entry.recordValue() != null
-        && entry.recordValue().getLength() > 0
-        && entry.recordMetadata() != null
-        && entry.recordMetadata().getLength() > 0;
+    return entry.recordValue() != null && entry.recordMetadata() != null;
   }
 }


### PR DESCRIPTION
# Description
Backport of #21311 to `stable/8.4`.

relates to #19225
original author: @lenaschoenburg