### PR TITLE
ci: remove obsolete required Zeebe CI status check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,16 +441,6 @@ jobs:
           secret_vault_roleId: ${{ secrets.VAULT_ROLE_ID }}
       - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
 
-  test-summary:
-    # Used as migration path to support old Zeebe CI Test summary
-    # TODO: can be removed after 2024-08-16, remaining PRs need to be rebased
-    name: Test summary
-    runs-on: ubuntu-latest
-    needs:
-      - zeebe-ci
-    steps:
-      - run: exit ${{ ((contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'failure')) && 1) || 0 }}
-
   notify-if-failed:
     name: Send slack notification on build failure
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Remove code as required by #21142. To be able to merge this PR the GH branch protection rules have to be changed.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21142
