### PR TITLE
bugfix: set a limit to evaluationFailureMessage size

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -61,7 +61,8 @@
               "type": "long"
             },
             "evaluationFailureMessage": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "failedDecisionId": {
               "type": "keyword"

--- a/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
+++ b/zeebe/exporters/opensearch-exporter/src/main/resources/zeebe-record-decision-evaluation-template.json
@@ -61,7 +61,8 @@
               "type": "long"
             },
             "evaluationFailureMessage": {
-              "type": "keyword"
+              "type": "keyword",
+              "ignore_above": 1024
             },
             "failedDecisionId": {
               "type": "keyword"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

There was a bug where `evaluationFailureMessage` was failed to be indexed when it goes over `keyword` data type's size. A limit is set to the related field to ignore the remaining part of the keyword when it is above the size 1024. I chose number as 1024 because evaluation failure message typically contains an error from a FEEL expression which is not expected to be too long.

## Related issues

closes #20248 
