### PR TITLE
operate: include priority field for user tasks

### DIFF
--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/UserTaskZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/UserTaskZeebeRecordProcessor.java
@@ -97,7 +97,9 @@ public class UserTaskZeebeRecordProcessor {
             "dueDate",
             new Tuple<>(UserTaskTemplate.DUE_DATE, userTaskEntity::getDueDate),
             "followUpDate",
-            new Tuple<>(UserTaskTemplate.FOLLOW_UP_DATE, userTaskEntity::getFollowUpDate));
+            new Tuple<>(UserTaskTemplate.FOLLOW_UP_DATE, userTaskEntity::getFollowUpDate),
+            "priority",
+            new Tuple<>(UserTaskTemplate.PRIORITY, userTaskEntity::getPriority));
 
     final var changedAttributes = userTaskEntity.getChangedAttributes();
     final var map = new HashMap<String, Object>();
@@ -198,7 +200,8 @@ public class UserTaskZeebeRecordProcessor {
         .setVariables(objectMapper.writeValueAsString(userTaskRecordValue.getVariables()))
         .setFormKey(userTaskRecordValue.getFormKey())
         .setChangedAttributes(userTaskRecordValue.getChangedAttributes())
-        .setAction(userTaskRecordValue.getAction());
+        .setAction(userTaskRecordValue.getAction())
+        .setPriority(userTaskRecordValue.getPriority());
   }
 
   private OffsetDateTime toDateOrNull(final String dateString) {

--- a/operate/importer-8_6/src/test/java/io/camunda/operate/zeebeimport/v8_6/processors/UserTaskZeebeRecordProcessorTest.java
+++ b/operate/importer-8_6/src/test/java/io/camunda/operate/zeebeimport/v8_6/processors/UserTaskZeebeRecordProcessorTest.java
@@ -54,6 +54,7 @@ class UserTaskZeebeRecordProcessorTest {
         ImmutableUserTaskRecordValue.builder()
             .withUserTaskKey(1L)
             .withTenantId(DEFAULT_TENANT_ID)
+            .withPriority(50)
             .build();
     when(userTaskTemplate.getFullQualifiedName()).thenReturn("user-task-index");
     when(userTaskRecord.getIntent()).thenReturn(UserTaskIntent.CREATED);
@@ -75,6 +76,7 @@ class UserTaskZeebeRecordProcessorTest {
             .setProcessDefinitionVersion(0)
             .setProcessInstanceKey(0L)
             .setTenantId(DEFAULT_TENANT_ID)
+            .setPriority(50)
             .setChangedAttributes(List.of());
     verify(batchRequest).addWithId("user-task-index", "1", expectedUserEntity);
   }

--- a/operate/schema/src/main/java/io/camunda/operate/entities/UserTaskEntity.java
+++ b/operate/schema/src/main/java/io/camunda/operate/entities/UserTaskEntity.java
@@ -33,12 +33,13 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
   private String action;
   private List<String> changedAttributes;
   private String tenantId = DEFAULT_TENANT_ID;
+  private Integer priority;
 
   public Long getUserTaskKey() {
     return userTaskKey;
   }
 
-  public UserTaskEntity setUserTaskKey(Long userTaskKey) {
+  public UserTaskEntity setUserTaskKey(final Long userTaskKey) {
     this.userTaskKey = userTaskKey;
     return this;
   }
@@ -47,7 +48,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return assignee;
   }
 
-  public UserTaskEntity setAssignee(String assignee) {
+  public UserTaskEntity setAssignee(final String assignee) {
     this.assignee = assignee;
     return this;
   }
@@ -56,7 +57,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return candidateGroups;
   }
 
-  public UserTaskEntity setCandidateGroups(List<String> candidateGroups) {
+  public UserTaskEntity setCandidateGroups(final List<String> candidateGroups) {
     this.candidateGroups = candidateGroups;
     return this;
   }
@@ -65,7 +66,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return candidateUsers;
   }
 
-  public UserTaskEntity setCandidateUsers(List<String> candidateUsers) {
+  public UserTaskEntity setCandidateUsers(final List<String> candidateUsers) {
     this.candidateUsers = candidateUsers;
     return this;
   }
@@ -74,7 +75,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return dueDate;
   }
 
-  public UserTaskEntity setDueDate(OffsetDateTime dueDate) {
+  public UserTaskEntity setDueDate(final OffsetDateTime dueDate) {
     this.dueDate = dueDate;
     return this;
   }
@@ -83,7 +84,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return followUpDate;
   }
 
-  public UserTaskEntity setFollowUpDate(OffsetDateTime followUpDate) {
+  public UserTaskEntity setFollowUpDate(final OffsetDateTime followUpDate) {
     this.followUpDate = followUpDate;
     return this;
   }
@@ -92,7 +93,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return formKey;
   }
 
-  public UserTaskEntity setFormKey(Long formKey) {
+  public UserTaskEntity setFormKey(final Long formKey) {
     this.formKey = formKey;
     return this;
   }
@@ -101,7 +102,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return elementId;
   }
 
-  public UserTaskEntity setElementId(String elementId) {
+  public UserTaskEntity setElementId(final String elementId) {
     this.elementId = elementId;
     return this;
   }
@@ -110,7 +111,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return elementInstanceKey;
   }
 
-  public UserTaskEntity setElementInstanceKey(Long elementInstanceKey) {
+  public UserTaskEntity setElementInstanceKey(final Long elementInstanceKey) {
     this.elementInstanceKey = elementInstanceKey;
     return this;
   }
@@ -119,7 +120,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return bpmnProcessId;
   }
 
-  public UserTaskEntity setBpmnProcessId(String bpmnProcessId) {
+  public UserTaskEntity setBpmnProcessId(final String bpmnProcessId) {
     this.bpmnProcessId = bpmnProcessId;
     return this;
   }
@@ -128,7 +129,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return processDefinitionKey;
   }
 
-  public UserTaskEntity setProcessDefinitionKey(Long processDefinitionKey) {
+  public UserTaskEntity setProcessDefinitionKey(final Long processDefinitionKey) {
     this.processDefinitionKey = processDefinitionKey;
     return this;
   }
@@ -137,7 +138,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return processDefinitionVersion;
   }
 
-  public UserTaskEntity setProcessDefinitionVersion(Integer processDefinitionVersion) {
+  public UserTaskEntity setProcessDefinitionVersion(final Integer processDefinitionVersion) {
     this.processDefinitionVersion = processDefinitionVersion;
     return this;
   }
@@ -146,7 +147,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return processInstanceKey;
   }
 
-  public UserTaskEntity setProcessInstanceKey(Long processInstanceKey) {
+  public UserTaskEntity setProcessInstanceKey(final Long processInstanceKey) {
     this.processInstanceKey = processInstanceKey;
     return this;
   }
@@ -155,7 +156,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return variables;
   }
 
-  public UserTaskEntity setVariables(String variables) {
+  public UserTaskEntity setVariables(final String variables) {
     this.variables = variables;
     return this;
   }
@@ -164,7 +165,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return tenantId;
   }
 
-  public UserTaskEntity setTenantId(String tenantId) {
+  public UserTaskEntity setTenantId(final String tenantId) {
     this.tenantId = tenantId;
     return this;
   }
@@ -173,7 +174,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return externalReference;
   }
 
-  public UserTaskEntity setExternalReference(String externalReference) {
+  public UserTaskEntity setExternalReference(final String externalReference) {
     this.externalReference = externalReference;
     return this;
   }
@@ -182,7 +183,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return action;
   }
 
-  public UserTaskEntity setAction(String action) {
+  public UserTaskEntity setAction(final String action) {
     this.action = action;
     return this;
   }
@@ -191,13 +192,47 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
     return changedAttributes;
   }
 
-  public UserTaskEntity setChangedAttributes(List<String> changedAttributes) {
+  public UserTaskEntity setChangedAttributes(final List<String> changedAttributes) {
     this.changedAttributes = changedAttributes;
     return this;
   }
 
+  public Integer getPriority() {
+    return priority;
+  }
+
+  public UserTaskEntity setPriority(final Integer priority) {
+    this.priority = priority;
+    return this;
+  }
+
   @Override
-  public boolean equals(Object o) {
+  public int hashCode() {
+    return Objects.hash(
+        super.hashCode(),
+        userTaskKey,
+        assignee,
+        candidateGroups,
+        candidateUsers,
+        dueDate,
+        followUpDate,
+        formKey,
+        elementId,
+        elementInstanceKey,
+        bpmnProcessId,
+        processDefinitionKey,
+        processDefinitionVersion,
+        processInstanceKey,
+        variables,
+        externalReference,
+        action,
+        changedAttributes,
+        tenantId,
+        priority);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
@@ -225,30 +260,7 @@ public class UserTaskEntity extends OperateZeebeEntity<UserTaskEntity> {
         && Objects.equals(externalReference, that.externalReference)
         && Objects.equals(action, that.action)
         && Objects.equals(changedAttributes, that.changedAttributes)
-        && Objects.equals(tenantId, that.tenantId);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(
-        super.hashCode(),
-        userTaskKey,
-        assignee,
-        candidateGroups,
-        candidateUsers,
-        dueDate,
-        followUpDate,
-        formKey,
-        elementId,
-        elementInstanceKey,
-        bpmnProcessId,
-        processDefinitionKey,
-        processDefinitionVersion,
-        processInstanceKey,
-        variables,
-        externalReference,
-        action,
-        changedAttributes,
-        tenantId);
+        && Objects.equals(tenantId, that.tenantId)
+        && Objects.equals(priority, that.priority);
   }
 }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/templates/UserTaskTemplate.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/templates/UserTaskTemplate.java
@@ -35,6 +35,7 @@ public class UserTaskTemplate extends AbstractTemplateDescriptor
   public static final String EXTERNAL_REFERENCE = "externalReference";
   public static final String ACTION = "action";
   public static final String CHANGED_ATTRIBUTES = "changedAttributes";
+  public static final String PRIORITY = "priority";
 
   @Override
   public String getIndexName() {

--- a/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-user-task.json
+++ b/operate/schema/src/main/resources/schema/elasticsearch/create/template/operate-user-task.json
@@ -69,6 +69,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "priority": {
+        "type": "integer"
       }
     }
   }

--- a/operate/schema/src/main/resources/schema/opensearch/create/template/operate-user-task.json
+++ b/operate/schema/src/main/resources/schema/opensearch/create/template/operate-user-task.json
@@ -69,6 +69,9 @@
       },
       "position": {
         "type": "long"
+      },
+      "priority": {
+        "type": "integer"
       }
     }
   }


### PR DESCRIPTION
## Description

Include priority field in user-task index of Operate for future usage.

## Related issues
part of: https://github.com/camunda/product-hub/issues/217
closes #21293 
