### PR TITLE
Migrate intermediate timer catch events

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -48,7 +48,7 @@ public final class ProcessInstanceMigrationPreconditions {
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
   private static final Set<BpmnEventType> SUPPORTED_INTERMEDIATE_CATCH_EVENT_TYPES =
-      EnumSet.of(BpmnEventType.MESSAGE);
+      EnumSet.of(BpmnEventType.MESSAGE, BpmnEventType.TIMER);
 
   private static final String ERROR_MESSAGE_PROCESS_INSTANCE_NOT_FOUND =
       "Expected to migrate process instance but no process instance found with key '%d'";


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

With this PR, migration of active timer catch events will be supported. Since we already support migrating timer events in the migration processor with `handleCatchEvents()` method, no additional change is needed in the processor.

## Related issues

closes #20911 
