### PR TITLE
refactor: remove CDN font-path

### DIFF
--- a/operate/client/src/index.scss
+++ b/operate/client/src/index.scss
@@ -5,10 +5,7 @@
  * except in compliance with the proprietary license.
  */
 
-@use '@carbon/react' as * with (
-  $font-path: 'https://fonts.camunda.io'
-);
-
+@use '@carbon/react' as *;
 @use '@carbon/react/scss/themes';
 @use '@carbon/react/scss/theme';
 


### PR DESCRIPTION
## Description

This PR removes `fonts.camunda.io` as font resolver for `carbon/react`. Instead fonts like IBM Plex will now be resolved with a bundled version of the font. This ensures that the correct font is loaded even if Operate runs in self managed setups without internet access.

This also fixes an issue with resolving the IBM Plex font correctly after a [dependency update](https://github.com/camunda/camunda/pull/21287/files#diff-ab72112d545f504654de5bfd7703fdb6ea4528138712f46c0f22b554026ace97R1334) of `carbon/styles` to version 1.63.0. In this version Carbon changed the way how the IBM Plex font is imported (see https://github.com/carbon-design-system/carbon/pull/17025), which broke the font resolution to `fonts.camunda.io`. This caused rendering a fallback font which then caused all visual regression fonts to fail. 

~~In this PR there are still some visual regression snapshots updated. These are related to minor changes like:~~

- ~~updated background color of date picker input fields~~
- ~~minor change to the IBM Plex font itself~~

After rebasing on `stable/operate-8.5` these problems resolved itself.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
