### PR TITLE
fix: adjust security SpEL expression context for authorization

### DIFF
--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -194,6 +194,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+    </dependency>
+
+
+    <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
     </dependency>

--- a/operate/webapp/pom.xml
+++ b/operate/webapp/pom.xml
@@ -198,7 +198,6 @@
       <artifactId>spring-expression</artifactId>
     </dependency>
 
-
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/security/CustomMethodSecurityExpressionHandler.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/security/CustomMethodSecurityExpressionHandler.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.operate.webapp.security;
 
+import java.util.function.Supplier;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
 import org.springframework.security.core.Authentication;
@@ -22,8 +25,17 @@ public class CustomMethodSecurityExpressionHandler extends DefaultMethodSecurity
   @Autowired BeanFactory beanFactory;
 
   @Override
+  public EvaluationContext createEvaluationContext(
+      final Supplier<Authentication> authentication, final MethodInvocation mi) {
+    final StandardEvaluationContext context =
+        (StandardEvaluationContext) super.createEvaluationContext(authentication, mi);
+    context.setRootObject(createSecurityExpressionRoot(authentication.get(), mi));
+    return context;
+  }
+
+  @Override
   protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
-      Authentication authentication, MethodInvocation invocation) {
+      final Authentication authentication, final MethodInvocation invocation) {
     final CustomSecurityExpressionRoot root = new CustomSecurityExpressionRoot(authentication);
     root.setUserService(getUserService());
     root.setThis(invocation.getThis());

--- a/tasklist/webapp/pom.xml
+++ b/tasklist/webapp/pom.xml
@@ -459,6 +459,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-expression</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-config</artifactId>
     </dependency>

--- a/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/CustomMethodSecurityExpressionHandler.java
+++ b/tasklist/webapp/src/main/java/io/camunda/tasklist/webapp/security/CustomMethodSecurityExpressionHandler.java
@@ -7,9 +7,12 @@
  */
 package io.camunda.tasklist.webapp.security;
 
+import java.util.function.Supplier;
 import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
 import org.springframework.security.access.expression.method.MethodSecurityExpressionOperations;
 import org.springframework.security.core.Authentication;
@@ -22,8 +25,17 @@ public class CustomMethodSecurityExpressionHandler extends DefaultMethodSecurity
   @Autowired BeanFactory beanFactory;
 
   @Override
+  public EvaluationContext createEvaluationContext(
+      final Supplier<Authentication> authentication, final MethodInvocation mi) {
+    final StandardEvaluationContext context =
+        (StandardEvaluationContext) super.createEvaluationContext(authentication, mi);
+    context.setRootObject(createSecurityExpressionRoot(authentication.get(), mi));
+    return context;
+  }
+
+  @Override
   protected MethodSecurityExpressionOperations createSecurityExpressionRoot(
-      Authentication authentication, MethodInvocation invocation) {
+      final Authentication authentication, final MethodInvocation invocation) {
     final CustomSecurityExpressionRoot root = new CustomSecurityExpressionRoot(authentication);
     root.setUserReader(getUserReader());
     root.setThis(invocation.getThis());


### PR DESCRIPTION
## Description

Patch authorization evaluation context creation for Identity permissions.

With the renovate bump of spring-security to 6.3.2 , the previous setup for the SpEL evaluation on authorized only methods stopped working [ref](https://docs.spring.io/spring-security/reference/servlet/authorization/method-security.html#_use_a_custom_bean_instead_of_subclassing_defaultmethodsecurityexpressionhandler). 
