### PR TITLE
feat: support user record in exporter

### DIFF
--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/entities/UserEntity.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/entities/UserEntity.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.entities;
+
+public class UserEntity implements ExporterEntity<UserEntity> {
+  private String id;
+  private String username;
+  private String name;
+  private String email;
+  private String password;
+
+  @Override
+  public String getId() {
+    return id;
+  }
+
+  @Override
+  public UserEntity setId(final String id) {
+    this.id = id;
+    return this;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public UserEntity setUsername(final String username) {
+    this.username = username;
+    return this;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public UserEntity setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public String getEmail() {
+    return email;
+  }
+
+  public UserEntity setEmail(final String email) {
+    this.email = email;
+    return this;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public UserEntity setPassword(final String password) {
+    this.password = password;
+    return this;
+  }
+}

--- a/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserRecordValueExportHandler.java
+++ b/zeebe/exporters/camunda-exporter/src/main/java/io/camunda/exporter/handlers/UserRecordValueExportHandler.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.exporter.handlers;
+
+import io.camunda.exporter.entities.UserEntity;
+import io.camunda.exporter.exceptions.PersistenceException;
+import io.camunda.exporter.store.BatchRequest;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.value.UserRecordValue;
+import java.util.List;
+
+public class UserRecordValueExportHandler implements ExportHandler<UserEntity, UserRecordValue> {
+  @Override
+  public ValueType getHandledValueType() {
+    return ValueType.USER;
+  }
+
+  @Override
+  public Class<UserEntity> getEntityType() {
+    return UserEntity.class;
+  }
+
+  @Override
+  public boolean handlesRecord(final Record<UserRecordValue> record) {
+    return getHandledValueType().equals(record.getValueType());
+  }
+
+  @Override
+  public List<String> generateIds(final Record<UserRecordValue> record) {
+    return List.of(String.valueOf(record.getKey()));
+  }
+
+  @Override
+  public UserEntity createNewEntity(final String id) {
+    return new UserEntity().setId(id);
+  }
+
+  @Override
+  public void updateEntity(final Record<UserRecordValue> record, final UserEntity entity) {
+    final UserRecordValue value = record.getValue();
+    entity
+        .setUsername(value.getUsername())
+        .setName(value.getName())
+        .setEmail(value.getEmail())
+        .setPassword(value.getPassword());
+  }
+
+  @Override
+  public void flush(final UserEntity entity, final BatchRequest batchRequest)
+      throws PersistenceException {
+    batchRequest.add(getIndexName(), entity);
+  }
+
+  private String getIndexName() {
+    return "users";
+  }
+}


### PR DESCRIPTION
## Description

This PR adds in the two implementations required to handle user records within the new camunda-exporter. 

Things to think about:

1. I have used the record key as the ID, I'm not sure if this is the correct approach but it felt like the best option for now
2. I've set the index at the moment to `users`, do we have any preferences here? For example should our indexes be prefixes with something that avoids clashes with potentially other indexes in ES?
3. Tests do not exist yet so I haven't added anything there yet

## Related issues

closes #21230 
