### PR TITLE
feat: use new license properties to display license tag

### DIFF
--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -43,11 +43,6 @@
     "rightsReserved": "Alle Rechte vorbehalten",
     "timezone": "Datum und Uhrzeit werden in der lokalen Zeitzone angezeigt:"
   },
-  "license": {
-    "referTo": "Für mehr Informationen zum Produktivbetrieb lesen Sie bitte unsere",
-    "terms": "Allgemeinen Geschäftsbedingungen (AGB)",
-    "contactSales": "wenden Sie sich an den Vertrieb"
-  },
   "saveGuard": {
     "header": "Ungespeicherte Änderungen",
     "text": "{label} hat ungespeicherte Änderungen. Wollen Sie speichern?",

--- a/optimize/backend/src/main/resources/localization/de.json
+++ b/optimize/backend/src/main/resources/localization/de.json
@@ -44,7 +44,6 @@
     "timezone": "Datum und Uhrzeit werden in der lokalen Zeitzone angezeigt:"
   },
   "license": {
-    "nonProduction": "Lizenz: Kein Produktivbetrieb",
     "referTo": "Für mehr Informationen zum Produktivbetrieb lesen Sie bitte unsere",
     "terms": "Allgemeinen Geschäftsbedingungen (AGB)",
     "contactSales": "wenden Sie sich an den Vertrieb"

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -43,11 +43,6 @@
     "rightsReserved": "All Rights Reserved",
     "timezone": "Date and time displayed in local timezone:"
   },
-  "license": {
-    "referTo": "If you would like information on production usage, please refer to our",
-    "terms": "terms & conditions",
-    "contactSales": "contact sales"
-  },
   "saveGuard": {
     "header": "Unsaved changes",
     "text": "The {label} has unsaved changes. Save before continuing?",

--- a/optimize/backend/src/main/resources/localization/en.json
+++ b/optimize/backend/src/main/resources/localization/en.json
@@ -44,7 +44,6 @@
     "timezone": "Date and time displayed in local timezone:"
   },
   "license": {
-    "nonProduction": "Non-Production License",
     "referTo": "If you would like information on production usage, please refer to our",
     "terms": "terms & conditions",
     "contactSales": "contact sales"

--- a/optimize/client/package.json
+++ b/optimize/client/package.json
@@ -5,7 +5,7 @@
   "homepage": ".",
   "dependencies": {
     "@bpmn-io/element-templates-icons-renderer": "^0.3.0",
-    "@camunda/camunda-composite-components": "^0.6.2",
+    "@camunda/camunda-composite-components": "^0.8.1",
     "@camunda/camunda-optimize-composite-components": "^0.0.16",
     "@carbon/icons-react": "^11.41.0",
     "@carbon/react": "^1.55.0",

--- a/optimize/client/src/components/Header/Header.test.tsx
+++ b/optimize/client/src/components/Header/Header.test.tsx
@@ -26,7 +26,7 @@ const defaultUiConfig = {
   onboarding: {orgId: 'orgId'},
   notificationsUrl: 'notificationsUrl',
   validLicense: true,
-  licenseType: 'self-managed',
+  licenseType: 'production',
 };
 
 jest.mock('hooks', () => ({

--- a/optimize/client/src/components/Header/Header.test.tsx
+++ b/optimize/client/src/components/Header/Header.test.tsx
@@ -25,6 +25,8 @@ const defaultUiConfig = {
   },
   onboarding: {orgId: 'orgId'},
   notificationsUrl: 'notificationsUrl',
+  validLicense: true,
+  licenseType: 'self-managed',
 };
 
 jest.mock('hooks', () => ({
@@ -62,15 +64,33 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-it('should show license warning if enterpriseMode is not set', async () => {
-  (useUiConfig as jest.Mock).mockReturnValue({...defaultUiConfig, enterpriseMode: false});
+it('should show license tag if not in saas', async () => {
   const node = shallow(<Header />);
 
   await runLastEffect();
   await node.update();
 
-  const tags = node.find(C3Navigation).prop<C3NavigationProps['navbar']>('navbar').tags;
-  expect(tags?.find((tag) => tag.key === 'licenseWarning')).toBeDefined();
+  expect(
+    node.find(C3Navigation).prop<C3NavigationProps['navbar']>('navbar').licenseTag
+  ).toMatchObject({
+    isProductionLicense: true,
+    show: true,
+  });
+});
+
+it('should hide license tag in saas', async () => {
+  (useUiConfig as jest.Mock).mockReturnValue({...defaultUiConfig, licenseType: 'saas'});
+  const node = shallow(<Header />);
+
+  await runLastEffect();
+  await node.update();
+
+  expect(
+    node.find(C3Navigation).prop<C3NavigationProps['navbar']>('navbar').licenseTag
+  ).toMatchObject({
+    isProductionLicense: true,
+    show: false,
+  });
 });
 
 it('should not display navbar and sidebar if noAction prop is specified', () => {

--- a/optimize/client/src/components/Header/Header.tsx
+++ b/optimize/client/src/components/Header/Header.tsx
@@ -13,8 +13,8 @@ import {
   C3UserConfigurationProvider,
   C3NavigationProps,
   C3NavigationElementProps,
+  C3NavigationNavBarProps,
 } from '@camunda/camunda-composite-components';
-import {Link as CarbonLink} from '@carbon/react';
 
 // @ts-ignore
 import {NavItem} from 'components';
@@ -129,8 +129,8 @@ function createNavBarProps(
   enterpriseMode: boolean,
   pathname: string,
   optimizeDatabase?: string
-): C3NavigationProps['navbar'] {
-  const elements: C3NavigationProps['navbar']['elements'] = [
+): C3NavigationNavBarProps {
+  const elements: C3NavigationNavBarProps['elements'] = [
     {
       key: 'dashboards',
       label: t('navigation.dashboards').toString(),
@@ -171,39 +171,7 @@ function createNavBarProps(
     },
   ];
 
-  const tags: C3NavigationProps['navbar']['tags'] = [];
-  if (!enterpriseMode) {
-    tags.push({
-      key: 'licenseWarning',
-      label: t('license.nonProduction').toString(),
-      tooltip: {
-        content: (
-          <span>
-            {t('license.referTo')}{' '}
-            <CarbonLink
-              inline
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://camunda.com/legal/terms/cloud-terms-and-conditions/camunda-cloud-self-managed-free-edition-terms/"
-            >
-              {t('license.terms')}
-            </CarbonLink>{' '}
-            {t('common.or')}{' '}
-            <CarbonLink
-              href="https://camunda.com/contact/"
-              target="_blank"
-              rel="noopener noreferrer"
-              inline
-            >
-              {t('license.contactSales')}
-            </CarbonLink>
-          </span>
-        ),
-        buttonLabel: t('license.nonProduction').toString(),
-      },
-      color: 'red',
-    });
-  }
+  const tags: C3NavigationNavBarProps['tags'] = [];
 
   if (optimizeDatabase === 'opensearch') {
     tags.push({
@@ -217,9 +185,15 @@ function createNavBarProps(
     });
   }
 
+  const licenseTag: C3NavigationNavBarProps['licenseTag'] = {
+    show: false,
+    isProductionLicense: false,
+  };
+
   return {
     elements,
     tags,
+    licenseTag,
   };
 }
 

--- a/optimize/client/src/components/Header/Header.tsx
+++ b/optimize/client/src/components/Header/Header.tsx
@@ -134,7 +134,7 @@ function createWebappLinks(webappLinks: Record<string, string> | null): C3Naviga
 
 function createNavBarProps(
   validLicense: boolean,
-  licenseType: 'self-managed' | 'saas' | 'unknown',
+  licenseType: 'production' | 'saas' | 'unknown',
   pathname: string,
   optimizeDatabase?: string
 ): C3NavigationNavBarProps {

--- a/optimize/client/src/components/Header/Header.tsx
+++ b/optimize/client/src/components/Header/Header.tsx
@@ -43,6 +43,8 @@ export default function Header({noActions}: {noActions?: boolean}) {
     optimizeDatabase,
     onboarding,
     notificationsUrl,
+    validLicense,
+    licenseType,
   } = useUiConfig();
 
   useEffect(() => {
@@ -56,7 +58,12 @@ export default function Header({noActions}: {noActions?: boolean}) {
   };
 
   if (!noActions) {
-    props.navbar = createNavBarProps(enterpriseMode, location.pathname, optimizeDatabase);
+    props.navbar = createNavBarProps(
+      validLicense,
+      licenseType,
+      location.pathname,
+      optimizeDatabase
+    );
     props.infoSideBar = createInfoSideBarProps(getBaseDocsUrl(), enterpriseMode);
     props.userSideBar = userSideBar;
   }
@@ -126,7 +133,8 @@ function createWebappLinks(webappLinks: Record<string, string> | null): C3Naviga
 }
 
 function createNavBarProps(
-  enterpriseMode: boolean,
+  validLicense: boolean,
+  licenseType: 'self-managed' | 'saas' | 'unknown',
   pathname: string,
   optimizeDatabase?: string
 ): C3NavigationNavBarProps {
@@ -186,8 +194,8 @@ function createNavBarProps(
   }
 
   const licenseTag: C3NavigationNavBarProps['licenseTag'] = {
-    show: false,
-    isProductionLicense: false,
+    show: licenseType !== 'saas',
+    isProductionLicense: validLicense,
   };
 
   return {

--- a/optimize/client/src/modules/config.tsx
+++ b/optimize/client/src/modules/config.tsx
@@ -61,6 +61,8 @@ export type UiConfig = {
   userSearchAvailable: boolean;
   optimizeDatabase: 'opensearch' | 'elasticsearch';
   userTaskAssigneeAnalyticsEnabled: boolean;
+  licenseType: 'self-managed' | 'saas' | 'unknown';
+  validLicense: boolean;
 };
 
 let globalConfig: UiConfig;

--- a/optimize/client/src/modules/config.tsx
+++ b/optimize/client/src/modules/config.tsx
@@ -61,7 +61,7 @@ export type UiConfig = {
   userSearchAvailable: boolean;
   optimizeDatabase: 'opensearch' | 'elasticsearch';
   userTaskAssigneeAnalyticsEnabled: boolean;
-  licenseType: 'self-managed' | 'saas' | 'unknown';
+  licenseType: 'production' | 'saas' | 'unknown';
   validLicense: boolean;
 };
 

--- a/optimize/client/yarn.lock
+++ b/optimize/client/yarn.lock
@@ -2175,12 +2175,13 @@
     inherits "^2.0.4"
     tiny-svg "^3.0.0"
 
-"@camunda/camunda-composite-components@^0.6.2":
-  version "0.6.4"
-  resolved "https://registry.yarnpkg.com/@camunda/camunda-composite-components/-/camunda-composite-components-0.6.4.tgz#4804a24dff5ae32f2b4cf8add4a2622fa84a78b3"
-  integrity sha512-xyDUoz4R8DvI95q/HsTLfeCurhYzD98wk3LUKnEvvBHRBCpi4UqmVmCasHKDqJfu5LUSLhBuL+4kyOJYNP3a9A==
+"@camunda/camunda-composite-components@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@camunda/camunda-composite-components/-/camunda-composite-components-0.8.1.tgz#f6d308030172dd9761827b0ea50ec28e96c6e3f8"
+  integrity sha512-q2rGOahml4cbruU4yqX+RcTyNoR9GbLRcQBWLeAX9LrI7y+Y9gciWNZz96oJCNjroj78iCjQTgE/0QthZJoIXw==
   dependencies:
     jwt-decode "4.0.0"
+    react-error-boundary "4.0.13"
     react-markdown "8.0.7"
 
 "@camunda/camunda-optimize-composite-components@^0.0.16":
@@ -13265,6 +13266,13 @@ react-draggable@^4.0.3, react-draggable@^4.4.5:
   dependencies:
     clsx "^1.1.1"
     prop-types "^15.8.1"
+
+react-error-boundary@4.0.13:
+  version "4.0.13"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.13.tgz#80386b7b27b1131c5fbb7368b8c0d983354c7947"
+  integrity sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-error-boundary@^3.1.4:
   version "3.1.4"


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This PR updates the C# library, and uses new license properties in the `ui-configuration` API to show the license tag in the page header

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

related to https://github.com/camunda/camunda/issues/20639