### PR TITLE
CI: fix zeebe compatibility CI

### DIFF
--- a/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
+++ b/optimize/backend/src/it/java/io/camunda/optimize/service/importing/ZeebeUserTaskImportIT.java
@@ -37,7 +37,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledIf;
 
-@DisabledIf("isZeebeVersionPre85")
+@DisabledIf("isZeebeVersionPre86")
 public class ZeebeUserTaskImportIT extends AbstractCCSMIT {
 
   private static final String TEST_PROCESS = "aProcess";


### PR DESCRIPTION
## Description

The latest zeebe client version is not compatible with 8.5.0 anymore so we have to disable the userTask IT for those versions. This is to fix [Optimize zeebe IT](https://github.com/camunda/camunda/actions/runs/10480473027/job/29042738538)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
