### PR TITLE
Qualify operateObjectMapper injections

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -60,6 +60,7 @@ import org.opensearch.client.transport.aws.AwsSdk2TransportOptions;
 import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
@@ -78,10 +79,12 @@ public class OpensearchConnector {
   private static final Logger LOGGER = LoggerFactory.getLogger(OpensearchConnector.class);
 
   private final OperateProperties operateProperties;
+
   private final ObjectMapper objectMapper;
 
   public OpensearchConnector(
-      final OperateProperties operateProperties, final ObjectMapper objectMapper) {
+      final OperateProperties operateProperties,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.operateProperties = operateProperties;
     this.objectMapper = objectMapper;
   }
@@ -93,7 +96,7 @@ public class OpensearchConnector {
     try {
       final HealthResponse response = openSearchClient.cluster().health();
       LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
     }
     return openSearchClient;
@@ -114,7 +117,7 @@ public class OpensearchConnector {
               LOGGER.info("OpenSearch cluster health: {}", response.status());
             }
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
     return openSearchClient;
@@ -126,7 +129,7 @@ public class OpensearchConnector {
     return createOsClient(operateProperties.getZeebeOpensearch());
   }
 
-  public OpenSearchAsyncClient createAsyncOsClient(OpensearchProperties osConfig) {
+  public OpenSearchAsyncClient createAsyncOsClient(final OpensearchProperties osConfig) {
     LOGGER.debug("Creating Async OpenSearch connection...");
     LOGGER.debug("Creating OpenSearch connection...");
     if (isAws()) {
@@ -166,7 +169,7 @@ public class OpensearchConnector {
               LOGGER.info("OpenSearch cluster health: {}", response.status());
             }
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(e);
     }
 
@@ -184,13 +187,13 @@ public class OpensearchConnector {
       credentialsProvider.resolveCredentials();
       LOGGER.info("AWS Credentials can be resolved. Use AWS Opensearch");
       return true;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.warn("AWS not configured due to: {} ", e.getMessage());
       return false;
     }
   }
 
-  public OpenSearchClient createOsClient(OpensearchProperties osConfig) {
+  public OpenSearchClient createOsClient(final OpensearchProperties osConfig) {
     LOGGER.debug("Creating OpenSearch connection...");
     if (isAws()) {
       return getAwsClient(osConfig);
@@ -219,7 +222,7 @@ public class OpensearchConnector {
     try {
       final HealthResponse response = openSearchClient.cluster().health();
       LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
     }
 
@@ -231,7 +234,7 @@ public class OpensearchConnector {
     return openSearchClient;
   }
 
-  private OpenSearchClient getAwsClient(OpensearchProperties osConfig) {
+  private OpenSearchClient getAwsClient(final OpensearchProperties osConfig) {
     final String region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     final AwsSdk2Transport transport =
@@ -245,7 +248,7 @@ public class OpensearchConnector {
     return new ExtendedOpenSearchClient(transport);
   }
 
-  private OpenSearchAsyncClient getAwsAsyncClient(OpensearchProperties osConfig) {
+  private OpenSearchAsyncClient getAwsAsyncClient(final OpensearchProperties osConfig) {
     final String region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     final AwsSdk2Transport transport =
@@ -259,17 +262,17 @@ public class OpensearchConnector {
     return new OpenSearchAsyncClient(transport);
   }
 
-  private HttpHost getHttpHost(OpensearchProperties osConfig) {
+  private HttpHost getHttpHost(final OpensearchProperties osConfig) {
     try {
       final URI uri = new URI(osConfig.getUrl());
       return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
-    } catch (URISyntaxException e) {
+    } catch (final URISyntaxException e) {
       throw new OperateRuntimeException("Error in url: " + osConfig.getUrl(), e);
     }
   }
 
   private HttpAsyncClientBuilder setupAuthentication(
-      final HttpAsyncClientBuilder builder, OpensearchProperties osConfig) {
+      final HttpAsyncClientBuilder builder, final OpensearchProperties osConfig) {
     if (!StringUtils.hasText(osConfig.getUsername())
         || !StringUtils.hasText(osConfig.getPassword())) {
       LOGGER.warn(
@@ -288,7 +291,7 @@ public class OpensearchConnector {
   }
 
   private void setupSSLContext(
-      HttpAsyncClientBuilder httpAsyncClientBuilder, SslProperties sslConfig) {
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final SslProperties sslConfig) {
     try {
       final ClientTlsStrategyBuilder tlsStrategyBuilder = ClientTlsStrategyBuilder.create();
       tlsStrategyBuilder.setSslContext(getSSLContext(sslConfig));
@@ -302,12 +305,12 @@ public class OpensearchConnector {
 
       httpAsyncClientBuilder.setConnectionManager(connectionManager);
 
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error("Error in setting up SSLContext", e);
     }
   }
 
-  private SSLContext getSSLContext(SslProperties sslConfig)
+  private SSLContext getSSLContext(final SslProperties sslConfig)
       throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
     final KeyStore truststore = loadCustomTrustStore(sslConfig);
     final TrustStrategy trustStrategy =
@@ -320,7 +323,7 @@ public class OpensearchConnector {
     }
   }
 
-  private KeyStore loadCustomTrustStore(SslProperties sslConfig) {
+  private KeyStore loadCustomTrustStore(final SslProperties sslConfig) {
     try {
       final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
       trustStore.load(null);
@@ -330,7 +333,7 @@ public class OpensearchConnector {
         setCertificateInTrustStore(trustStore, serverCertificate);
       }
       return trustStore;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final String message =
           "Could not create certificate trustStore for the secured OpenSearch Connection!";
       throw new OperateRuntimeException(message, e);
@@ -342,7 +345,7 @@ public class OpensearchConnector {
     try {
       final Certificate cert = loadCertificateFromPath(serverCertificate);
       trustStore.setCertificateEntry("opensearch-host", cert);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final String message =
           "Could not load configured server certificate for the secured OpenSearch Connection!";
       throw new OperateRuntimeException(message, e);
@@ -352,7 +355,8 @@ public class OpensearchConnector {
   private Certificate loadCertificateFromPath(final String certificatePath)
       throws IOException, CertificateException {
     final Certificate cert;
-    try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(certificatePath))) {
+    try (final BufferedInputStream bis =
+        new BufferedInputStream(new FileInputStream(certificatePath))) {
       final CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
       if (bis.available() > 0) {
@@ -367,7 +371,7 @@ public class OpensearchConnector {
   }
 
   protected HttpAsyncClientBuilder configureHttpClient(
-      HttpAsyncClientBuilder httpAsyncClientBuilder, OpensearchProperties osConfig) {
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final OpensearchProperties osConfig) {
     setupAuthentication(httpAsyncClientBuilder, osConfig);
     if (osConfig.getSsl() != null) {
       setupSSLContext(httpAsyncClientBuilder, osConfig.getSsl());
@@ -387,7 +391,7 @@ public class OpensearchConnector {
     return builder;
   }
 
-  public boolean checkHealth(OpenSearchClient osClient) {
+  public boolean checkHealth(final OpenSearchClient osClient) {
     final OpensearchProperties osConfig = operateProperties.getOpensearch();
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)
@@ -399,7 +403,7 @@ public class OpensearchConnector {
             });
   }
 
-  public boolean checkHealth(OpenSearchAsyncClient osAsyncClient) {
+  public boolean checkHealth(final OpenSearchAsyncClient osAsyncClient) {
     final OpensearchProperties osConfig = operateProperties.getOpensearch();
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)

--- a/operate/qa/util/pom.xml
+++ b/operate/qa/util/pom.xml
@@ -125,6 +125,11 @@
       <groupId>com.github.docker-java</groupId>
       <artifactId>docker-java-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestOpensearchSchemaManager.java
+++ b/operate/qa/util/src/main/java/io/camunda/operate/qa/util/TestOpensearchSchemaManager.java
@@ -7,6 +7,7 @@
  */
 package io.camunda.operate.qa.util;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.camunda.operate.conditions.OpensearchCondition;
 import io.camunda.operate.property.OperateProperties;
 import io.camunda.operate.schema.indices.IndexDescriptor;
@@ -17,6 +18,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -34,13 +36,19 @@ public class TestOpensearchSchemaManager extends OpensearchSchemaManager
       final OperateProperties operateProperties,
       final RichOpenSearchClient richOpenSearchClient,
       final List<TemplateDescriptor> templateDescriptors,
-      final List<IndexDescriptor> indexDescriptors) {
-    super(operateProperties, richOpenSearchClient, templateDescriptors, indexDescriptors);
+      final List<IndexDescriptor> indexDescriptors,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
+    super(
+        operateProperties,
+        richOpenSearchClient,
+        templateDescriptors,
+        indexDescriptors,
+        objectMapper);
   }
 
   @Override
   public void deleteSchema() {
-    final String prefix = this.operateProperties.getOpensearch().getIndexPrefix();
+    final String prefix = operateProperties.getOpensearch().getIndexPrefix();
     LOGGER.info("Removing indices {}*", prefix);
     richOpenSearchClient.index().deleteIndicesWithRetries(prefix + "*");
     richOpenSearchClient.template().deleteTemplatesWithRetries(prefix + "*");
@@ -50,18 +58,18 @@ public class TestOpensearchSchemaManager extends OpensearchSchemaManager
   public void deleteSchemaQuietly() {
     try {
       deleteSchema();
-    } catch (Exception t) {
+    } catch (final Exception t) {
       LOGGER.debug(t.getMessage());
     }
   }
 
   @Override
-  public void setCreateSchema(boolean createSchema) {
+  public void setCreateSchema(final boolean createSchema) {
     operateProperties.getOpensearch().setCreateSchema(createSchema);
   }
 
   @Override
-  public void setIndexPrefix(String indexPrefix) {
+  public void setIndexPrefix(final String indexPrefix) {
     operateProperties.getOpensearch().setIndexPrefix(indexPrefix);
   }
 

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchFillPostImporterQueuePlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchFillPostImporterQueuePlan.java
@@ -44,6 +44,7 @@ import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public class ElasticsearchFillPostImporterQueuePlan implements FillPostImporterQueuePlan {
 
@@ -65,7 +66,7 @@ public class ElasticsearchFillPostImporterQueuePlan implements FillPostImporterQ
   public ElasticsearchFillPostImporterQueuePlan(
       final OperateProperties operateProperties,
       final MigrationProperties migrationProperties,
-      final ObjectMapper objectMapper,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
       final RestHighLevelClient esClient) {
     this.operateProperties = operateProperties;
     this.migrationProperties = migrationProperties;

--- a/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchReindexWithQueryAndScriptPlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/migration/elasticsearch/ElasticsearchReindexWithQueryAndScriptPlan.java
@@ -35,6 +35,7 @@ import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 /**
  * This migration plan scrolls the srcIndex, get additional data from list-view index and reindex
@@ -59,8 +60,8 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
 
   public ElasticsearchReindexWithQueryAndScriptPlan(
       final MigrationProperties migrationProperties,
-      final ObjectMapper objectMapper,
-      RestHighLevelClient esClient,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
+      final RestHighLevelClient esClient,
       final RetryElasticsearchClient retryElasticsearchClient) {
     this.migrationProperties = migrationProperties;
     this.objectMapper = objectMapper;
@@ -69,25 +70,25 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
   }
 
   @Override
-  public ReindexWithQueryAndScriptPlan setSrcIndex(String srcIndex) {
+  public ReindexWithQueryAndScriptPlan setSrcIndex(final String srcIndex) {
     this.srcIndex = srcIndex;
     return this;
   }
 
   @Override
-  public ReindexWithQueryAndScriptPlan setDstIndex(String dstIndex) {
+  public ReindexWithQueryAndScriptPlan setDstIndex(final String dstIndex) {
     this.dstIndex = dstIndex;
     return this;
   }
 
   @Override
-  public ReindexWithQueryAndScriptPlan setSteps(List<Step> steps) {
+  public ReindexWithQueryAndScriptPlan setSteps(final List<Step> steps) {
     this.steps = steps;
     return this;
   }
 
   @Override
-  public ReindexWithQueryAndScriptPlan setListViewIndexName(String listViewIndexName) {
+  public ReindexWithQueryAndScriptPlan setListViewIndexName(final String listViewIndexName) {
     this.listViewIndexName = listViewIndexName;
     return this;
   }
@@ -153,7 +154,7 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
       if (processInstanceKeys.size() > 0) {
         reindexPart(esClient, processInstanceKeys);
       }
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new MigrationException(e.getMessage(), e);
     }
   }
@@ -171,7 +172,7 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
     }
   }
 
-  private void reindexPart(RestHighLevelClient esClient, Set<Long> processInstanceKeys)
+  private void reindexPart(final RestHighLevelClient esClient, final Set<Long> processInstanceKeys)
       throws MigrationException, JsonProcessingException {
     final Map<String, Tuple<String, String>> bpmnProcessIdsMap =
         getBpmnProcessIds(processInstanceKeys, esClient);
@@ -200,7 +201,8 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
   }
 
   private Map<String, Tuple<String, String>> getBpmnProcessIds(
-      Set<Long> processInstanceKeys, RestHighLevelClient esClient) throws MigrationException {
+      final Set<Long> processInstanceKeys, final RestHighLevelClient esClient)
+      throws MigrationException {
     final SearchRequest searchRequest =
         new SearchRequest(listViewIndexName + "*")
             .source(
@@ -227,7 +229,7 @@ public class ElasticsearchReindexWithQueryAndScriptPlan implements ReindexWithQu
           esClient,
           migrationProperties.getScrollKeepAlive());
       return result;
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new MigrationException(e.getMessage(), e);
     }
   }

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchFillPostImporterQueuePlan.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchFillPostImporterQueuePlan.java
@@ -31,6 +31,7 @@ import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueuePlan {
 
@@ -54,7 +55,7 @@ public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueu
 
   public OpensearchFillPostImporterQueuePlan(
       final RichOpenSearchClient richOpenSearchClient,
-      final ObjectMapper objectMapper,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper,
       final OperateProperties operateProperties,
       final MigrationProperties migrationProperties) {
     this.richOpenSearchClient = richOpenSearchClient;
@@ -64,26 +65,26 @@ public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueu
   }
 
   @Override
-  public FillPostImporterQueuePlan setListViewIndexName(String listViewIndexName) {
+  public FillPostImporterQueuePlan setListViewIndexName(final String listViewIndexName) {
     this.listViewIndexName = listViewIndexName;
     return this;
   }
 
   @Override
-  public FillPostImporterQueuePlan setIncidentsIndexName(String incidentsIndexName) {
+  public FillPostImporterQueuePlan setIncidentsIndexName(final String incidentsIndexName) {
     this.incidentsIndexName = incidentsIndexName;
     return this;
   }
 
   @Override
   public FillPostImporterQueuePlan setPostImporterQueueIndexName(
-      String postImporterQueueIndexName) {
+      final String postImporterQueueIndexName) {
     this.postImporterQueueIndexName = postImporterQueueIndexName;
     return this;
   }
 
   @Override
-  public FillPostImporterQueuePlan setSteps(List<Step> steps) {
+  public FillPostImporterQueuePlan setSteps(final List<Step> steps) {
     this.steps = steps;
     return this;
   }
@@ -121,7 +122,7 @@ public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueu
                         getIncidentEntities(incidentKeysFieldName, hits);
                     final var batchRequest = richOpenSearchClient.batch().newBatchRequest();
                     int index = 0;
-                    for (IncidentEntity incident : incidents) {
+                    for (final IncidentEntity incident : incidents) {
                       index++;
                       final PostImporterQueueEntity entity =
                           createPostImporterQueueEntity(incident, index);
@@ -134,7 +135,7 @@ public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueu
                   flowNodesWithIncidentsCount = hitsMetadata.total().value();
                 }
               });
-    } catch (Exception e) {
+    } catch (final Exception e) {
       throw new MigrationException(e.getMessage(), e);
     }
   }
@@ -152,7 +153,7 @@ public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueu
   }
 
   private List<IncidentEntity> getIncidentEntities(
-      String incidentKeysFieldName, List<Hit<Long>> hits) {
+      final String incidentKeysFieldName, final List<Hit<Long>> hits) {
     final var incidentKeys = hits.stream().map(Hit::source).toList();
     final var request =
         searchRequestBuilder(incidentKeysFieldName + "*")
@@ -163,7 +164,7 @@ public class OpensearchFillPostImporterQueuePlan implements FillPostImporterQueu
   }
 
   private PostImporterQueueEntity createPostImporterQueueEntity(
-      IncidentEntity incident, long index) {
+      final IncidentEntity incident, final long index) {
     return new PostImporterQueueEntity()
         .setId(String.format("%s-%s", incident.getId(), incident.getState().getZeebeIntent()))
         .setCreationTime(OffsetDateTime.now())

--- a/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
+++ b/operate/schema/src/main/java/io/camunda/operate/schema/opensearch/OpensearchSchemaManager.java
@@ -48,6 +48,7 @@ import org.opensearch.client.opensearch.indices.put_index_template.IndexTemplate
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
@@ -66,7 +67,7 @@ public class OpensearchSchemaManager implements SchemaManager {
 
   protected final RichOpenSearchClient richOpenSearchClient;
 
-  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final ObjectMapper objectMapper;
   private final JsonbJsonpMapper jsonpMapper = new JsonbJsonpMapper();
 
   private final List<TemplateDescriptor> templateDescriptors;
@@ -78,11 +79,13 @@ public class OpensearchSchemaManager implements SchemaManager {
       final OperateProperties operateProperties,
       final RichOpenSearchClient richOpenSearchClient,
       final List<TemplateDescriptor> templateDescriptors,
-      final List<IndexDescriptor> indexDescriptors) {
+      final List<IndexDescriptor> indexDescriptors,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     super();
     this.operateProperties = operateProperties;
     this.richOpenSearchClient = richOpenSearchClient;
     this.templateDescriptors = templateDescriptors;
+    this.objectMapper = objectMapper;
     this.indexDescriptors =
         indexDescriptors.stream()
             .filter(indexDescriptor -> !(indexDescriptor instanceof TemplateDescriptor))

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchUserStore.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/OpensearchUserStore.java
@@ -22,6 +22,7 @@ import org.opensearch.client.opensearch._types.FieldValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.DependsOn;
 import org.springframework.context.annotation.Profile;
@@ -43,16 +44,18 @@ public class OpensearchUserStore implements UserStore {
 
   @Autowired protected OpenSearchClient openSearchClient;
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("operateObjectMapper")
+  protected ObjectMapper objectMapper;
 
   @Autowired private UserIndex userIndex;
 
-  protected String userEntityToJSONString(UserEntity aUser) throws JsonProcessingException {
+  protected String userEntityToJSONString(final UserEntity aUser) throws JsonProcessingException {
     return objectMapper.writeValueAsString(aUser);
   }
 
   @Override
-  public UserEntity getById(String id) {
+  public UserEntity getById(final String id) {
     try {
       final var response =
           openSearchClient.search(
@@ -69,7 +72,7 @@ public class OpensearchUserStore implements UserStore {
       } else {
         throw new NotFoundException(String.format("Could not find user with userId '%s'.", id));
       }
-    } catch (IOException e) {
+    } catch (final IOException e) {
       final String message =
           String.format("Exception occurred, while obtaining the user: %s", e.getMessage());
       throw new OperateRuntimeException(message, e);
@@ -77,13 +80,13 @@ public class OpensearchUserStore implements UserStore {
   }
 
   @Override
-  public void save(UserEntity user) {
+  public void save(final UserEntity user) {
     try {
       final var response =
           openSearchClient.index(
               r -> r.index(userIndex.getFullQualifiedName()).id(user.getId()).document(user));
       LOGGER.info("User {} {}", user.getUserId(), response.result());
-    } catch (Exception t) {
+    } catch (final Exception t) {
       LOGGER.error("Could not create user with userId {}", user.getUserId(), t);
     }
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/OpenSearchIndexOperations.java
@@ -31,6 +31,7 @@ import org.opensearch.client.opensearch.indices.update_aliases.Action;
 import org.opensearch.client.opensearch.indices.update_aliases.AddAction;
 import org.opensearch.client.opensearch.tasks.GetTasksResponse;
 import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public class OpenSearchIndexOperations extends OpenSearchRetryOperation {
   public static final String NUMBERS_OF_REPLICA = "index.number_of_replicas";
@@ -43,7 +44,7 @@ public class OpenSearchIndexOperations extends OpenSearchRetryOperation {
   public OpenSearchIndexOperations(
       final Logger logger,
       final OpenSearchClient openSearchClient,
-      final ObjectMapper objectMapper) {
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     super(logger, openSearchClient);
     this.objectMapper = objectMapper;
   }

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/RichOpenSearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/RichOpenSearchClient.java
@@ -18,6 +18,7 @@ import org.opensearch.client.opensearch.OpenSearchClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.stereotype.Component;
 
@@ -39,10 +40,10 @@ public class RichOpenSearchClient {
   OpenSearchClient openSearchClient;
 
   public RichOpenSearchClient(
-      BeanFactory beanFactory,
-      OpenSearchClient openSearchClient,
-      OpenSearchAsyncClient openSearchAsyncClient,
-      ObjectMapper objectMapper) {
+      final BeanFactory beanFactory,
+      final OpenSearchClient openSearchClient,
+      final OpenSearchAsyncClient openSearchAsyncClient,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.beanFactory = beanFactory;
     this.openSearchClient = openSearchClient;
     async = new Async(openSearchAsyncClient);
@@ -107,14 +108,14 @@ public class RichOpenSearchClient {
     final OpenSearchAsyncSnapshotOperations openSearchAsyncSnapshotOperations;
     final OpenSearchAsyncTaskOperations openSearchAsyncTaskOperations;
 
-    public Async(OpenSearchAsyncClient openSearchAsyncClient) {
-      this.openSearchAsyncDocumentOperations =
+    public Async(final OpenSearchAsyncClient openSearchAsyncClient) {
+      openSearchAsyncDocumentOperations =
           new OpenSearchAsyncDocumentOperations(LOGGER, openSearchAsyncClient);
-      this.openSearchAsyncIndexOperations =
+      openSearchAsyncIndexOperations =
           new OpenSearchAsyncIndexOperations(LOGGER, openSearchAsyncClient);
-      this.openSearchAsyncSnapshotOperations =
+      openSearchAsyncSnapshotOperations =
           new OpenSearchAsyncSnapshotOperations(LOGGER, openSearchAsyncClient);
-      this.openSearchAsyncTaskOperations =
+      openSearchAsyncTaskOperations =
           new OpenSearchAsyncTaskOperations(LOGGER, openSearchAsyncClient);
     }
 

--- a/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/ZeebeRichOpenSearchClient.java
+++ b/operate/schema/src/main/java/io/camunda/operate/store/opensearch/client/sync/ZeebeRichOpenSearchClient.java
@@ -28,9 +28,9 @@ public class ZeebeRichOpenSearchClient {
   private final OpenSearchTemplateOperations openSearchTemplateOperations;
 
   public ZeebeRichOpenSearchClient(
-      BeanFactory beanFactory,
-      @Qualifier("zeebeOpensearchClient") OpenSearchClient openSearchClient,
-      ObjectMapper objectMapper) {
+      final BeanFactory beanFactory,
+      @Qualifier("zeebeOpensearchClient") final OpenSearchClient openSearchClient,
+      @Qualifier("operateObjectMapper") final ObjectMapper objectMapper) {
     this.beanFactory = beanFactory;
     this.openSearchClient = openSearchClient;
     openSearchDocumentOperations = new OpenSearchDocumentOperations(LOGGER, openSearchClient);

--- a/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
+++ b/tasklist/els-schema/src/main/java/io/camunda/tasklist/schema/manager/OpenSearchSchemaManager.java
@@ -88,7 +88,9 @@ public class OpenSearchSchemaManager implements SchemaManager {
   @Qualifier("tasklistOsClient")
   private OpenSearchClient openSearchClient;
 
-  @Autowired private ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  private ObjectMapper objectMapper;
 
   @Override
   public void createSchema() {

--- a/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
+++ b/tasklist/importer/src/main/java/io/camunda/tasklist/zeebeimport/ImportJobAbstract.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 public abstract class ImportJobAbstract implements ImportJob {
 
@@ -36,7 +37,9 @@ public abstract class ImportJobAbstract implements ImportJob {
 
   @Autowired protected RecordsReaderHolder recordsReaderHolder;
 
-  @Autowired protected ObjectMapper objectMapper;
+  @Autowired
+  @Qualifier("tasklistObjectMapper")
+  protected ObjectMapper objectMapper;
 
   @Autowired protected TasklistProperties tasklistProperties;
 


### PR DESCRIPTION
## Description
Qualify Jackson ObjectMapper with _operateObjectMapper_ in Operate due to conflicts in _StandaloneCamunda_ runner and the _camunda/camunda_ docker image conflicting with other modules such as Tasklsit.
