### PR TITLE
ci: use `runner.environment` variable instead of custom script

### DIFF
--- a/.github/actions/setup-zeebe/action.yml
+++ b/.github/actions/setup-zeebe/action.yml
@@ -144,18 +144,6 @@ runs:
         -D aether.syncContext.named.time=120
         -D maven.artifact.threads=32
         EOF
-    - name: Determine if running on GH infra or self-hosted
-      if: inputs.java == 'true'
-      id: runner-env
-      shell: bash
-      # it matters for caching as absolute paths on self-hosted and Github runners differ
-      # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
-      run: |
-        if [[ "${{ runner.name }}" =~ ^(actions-runner-|gcp-|aws-|n1-).*$ ]]; then
-          echo "result=self-hosted" >> $GITHUB_OUTPUT
-        else
-          echo "result=gh-hosted" >> $GITHUB_OUTPUT
-        fi
     - name: Cache local Maven repository
       # Only use the full cache action if we're on main or stable/* branches
       if: inputs.java == 'true' && (startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
@@ -165,9 +153,11 @@ runs:
         # `aether.enhancedLocalRepository.remotePrefix` defaults to 'cached'
         # `aether.enhancedLocalRepository.releasesPrefix` defaults to 'releases'
         path: ~/.m2/repository/cached/releases/
-        key: ${{ steps.runner-env.outputs.result }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        # it matters for caching as absolute paths on self-hosted and Github runners differ
+        # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ steps.runner-env.outputs.result }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
     - name: Restore maven cache
       # Restore cache (but don't save it) if we're not on main or stable/* branches
       if: inputs.java == 'true' && !(startsWith(github.ref_name, 'stable/') || github.ref_name == 'main')
@@ -175,9 +165,9 @@ runs:
       with:
         # This has to match the 'Cache local Maven repository' step above
         path: ~/.m2/repository/cached/releases/
-        key: ${{ steps.runner-env.outputs.result }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ steps.runner-env.outputs.result }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
+          ${{ runner.environment }}-${{ runner.os }}-mvn-${{ inputs.maven-cache-key-modifier }}
     - if: ${{ inputs.go == 'true' }}
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
## Description

Relying on `runner.name` prefix is fragile and the list is outdated currently anyways (Infra runners currently have the prefix `camunda-`). This PR removes an impediment for #18212.

⚠️ Merging this PR will lead to one-time Maven cache recreation on `main`.

See also [docs 1](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context) or [docs 2](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#runner-context)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

None
