### PR TITLE
Don't merge boundary event subscriptions on instance migration

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationMigrateProcessor.java
@@ -239,6 +239,8 @@ public class ProcessInstanceMigrationMigrateProcessor
         elementId,
         targetElementId,
         sourceElementIdToTargetElementId);
+    requireNoDuplicateTargetsInBoundaryEventMappings(
+        processInstanceKey, sourceProcessDefinition, elementId, sourceElementIdToTargetElementId);
     requireNoConcurrentCommand(eventScopeInstanceState, elementInstance, processInstanceKey);
 
     stateWriter.appendFollowUpEvent(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateActivityTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateActivityTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceMigrationIntent;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateActivityTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldMigrateTwoElementInstancesToTheSameElement() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .parallelGateway()
+                    .serviceTask("A", a -> a.zeebeJobType("A"))
+                    .endEvent()
+                    .moveToLastGateway()
+                    .serviceTask("B", a -> a.zeebeJobType("B"))
+                    .endEvent()
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .serviceTask("C", a -> a.zeebeJobType("C"))
+                    .endEvent()
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("A")
+        .await();
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("B")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("A", "C")
+        .addMappingInstruction("B", "C")
+        .migrate();
+
+    // then
+    assertThat(
+            RecordingExporter.records()
+                .limit(r -> r.getIntent() == ProcessInstanceMigrationIntent.MIGRATED)
+                .processInstanceRecords()
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementId("C"))
+        .hasSize(2);
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBoundaryEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBoundaryEventTest.java
@@ -534,7 +534,7 @@ public class MigrateBoundaryEventTest {
         .hasRejectionType(RejectionType.INVALID_STATE)
         .extracting(Record::getRejectionReason)
         .asString()
-        .contains("Expected to migrate process instance '2251799813685252'")
+        .contains("Expected to migrate process instance '" + processInstanceKey + "'")
         .contains("active element with id 'A' is mapped to an element with id 'A'")
         .contains(
             "and has a boundary event with id 'boundary' that is mapped to an element with id 'boundary'")
@@ -609,7 +609,7 @@ public class MigrateBoundaryEventTest {
         .hasRejectionType(RejectionType.INVALID_STATE)
         .extracting(Record::getRejectionReason)
         .asString()
-        .contains("Expected to migrate process instance '2251799813685252'")
+        .contains("Expected to migrate process instance '" + processInstanceKey + "'")
         .contains("active element with id 'A' has a boundary event attached")
         .contains("boundary event attached that is mapped to a boundary event with id 'boundary3'")
         .contains(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBoundaryEventTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateBoundaryEventTest.java
@@ -541,4 +541,80 @@ public class MigrateBoundaryEventTest {
         .contains("These mappings detach the boundary event from the element in the target process")
         .contains("Boundary events must stay attached to the same element instance");
   }
+
+  @Test
+  public void shouldRejectCommandWhenMappedBoundaryEventsAreMerged() {
+    final String processId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(processId)
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundary1",
+                        b ->
+                            b.message(m -> m.name("msg1").zeebeCorrelationKeyExpression("key"))
+                                .endEvent())
+                    .moveToActivity("A")
+                    .boundaryEvent(
+                        "boundary2",
+                        b ->
+                            b.message(m -> m.name("msg2").zeebeCorrelationKeyExpression("key"))
+                                .endEvent())
+                    .moveToActivity("A")
+                    .endEvent("end")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent("start")
+                    .serviceTask("A", t -> t.zeebeJobType("A"))
+                    .boundaryEvent(
+                        "boundary3",
+                        b ->
+                            b.message(m -> m.name("msg3").zeebeCorrelationKeyExpression("key"))
+                                .endEvent())
+                    .moveToActivity("A")
+                    .endEvent()
+                    .done())
+            .deploy();
+
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+    final var processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(processId).withVariable("key", "key").create();
+
+    RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+        .withElementId("A")
+        .await();
+
+    // when
+    final var rejection =
+        ENGINE
+            .processInstance()
+            .withInstanceKey(processInstanceKey)
+            .migration()
+            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+            .addMappingInstruction("A", "A")
+            .addMappingInstruction("boundary1", "boundary3")
+            .addMappingInstruction("boundary2", "boundary3")
+            .expectRejection()
+            .migrate();
+
+    // then
+    Assertions.assertThat(rejection)
+        .hasRejectionType(RejectionType.INVALID_STATE)
+        .extracting(Record::getRejectionReason)
+        .asString()
+        .contains("Expected to migrate process instance '2251799813685252'")
+        .contains("active element with id 'A' has a boundary event attached")
+        .contains("boundary event attached that is mapped to a boundary event with id 'boundary3'")
+        .contains(
+            "There are multiple mapping instructions that target this boundary event: 'boundary1', 'boundary2'")
+        .contains("Boundary events cannot be merged by process instance migration")
+        .contains("Please ensure the mapping instructions target a boundary event only once");
+  }
 }

--- a/zeebe/gateway-protocol/src/main/proto/gateway.proto
+++ b/zeebe/gateway-protocol/src/main/proto/gateway.proto
@@ -958,6 +958,7 @@ service Gateway {
         - a mapping instruction refers to an unsupported element (i.e. some elements will be supported later on)
         - a mapping instruction refers to element in unsupported scenarios.
           (i.e. migration is not supported when process instance or target process elements contains event subscriptions)
+        - multiple mapping instructions target the same boundary event
 
       INVALID_ARGUMENT:
         - A `sourceElementId` does not refer to an element in the process instance's process definition


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

When [migrating a process instance](https://docs.camunda.io/docs/components/concepts/process-instance-migration/), the user provides mapping instructions to clarify how the migration should be executed. This includes the ability to map boundary events. The subscription of an active element to a boundary event is migrated over if a mapping is provided for it (see [Dealing with attached boundary events](https://docs.camunda.io/docs/components/concepts/process-instance-migration/#dealing-with-attached-boundary-events)).

It should not be possible for a mapped element's boundary events to be merged into a single boundary event. This would mean an element instance is subscribed multiple times to the same boundary event. 

To avoid this, we check each boundary event attached to an active element and ensure that
they are the target of a mapping instruction only once.

This rejects process instance migration commands when a boundary event is the target of multiple mapping instructions.

## Related issues

closes #19960 
