### PR TITLE
Reject decimal from task priority and throw incidents

### DIFF
--- a/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebePriorityDefinitionValidator.java
+++ b/zeebe/bpmn-model/src/main/java/io/camunda/zeebe/model/bpmn/validation/zeebe/ZeebePriorityDefinitionValidator.java
@@ -22,8 +22,8 @@ import org.camunda.bpm.model.xml.validation.ValidationResultCollector;
 public class ZeebePriorityDefinitionValidator
     implements ModelElementValidator<ZeebePriorityDefinition> {
 
-  private static final Long PRIORITY_LOWER_BOUND = 0L;
-  private static final Long PRIORITY_UPPER_BOUND = 100L;
+  public static final Integer PRIORITY_LOWER_BOUND = 0;
+  public static final Integer PRIORITY_UPPER_BOUND = 100;
 
   @Override
   public Class<ZeebePriorityDefinition> getElementType() {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnUserTaskBehavior.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.zeebe.engine.processing.bpmn.behavior;
 
+import static io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebePriorityDefinitionValidator.PRIORITY_LOWER_BOUND;
+import static io.camunda.zeebe.model.bpmn.validation.zeebe.ZeebePriorityDefinitionValidator.PRIORITY_UPPER_BOUND;
 import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
 
 import io.camunda.zeebe.el.Expression;
@@ -264,7 +266,20 @@ public final class BpmnUserTaskBehavior {
     if (priorityExpression == null) {
       return Either.right(ZeebePriorityDefinition.DEFAULT_NUMBER_PRIORITY);
     }
-    return expressionBehavior.evaluateIntegerExpression(priorityExpression, scopeKey);
+    return expressionBehavior
+        .evaluateIntegerExpression(priorityExpression, scopeKey)
+        .flatMap(
+            priority -> {
+              if (priority < PRIORITY_LOWER_BOUND || priority > PRIORITY_UPPER_BOUND) {
+                return Either.left(
+                    new Failure(
+                        String.format(
+                            "Expected priority to be in the range [0,100] but was '%s'.", priority),
+                        ErrorType.EXTRACT_VALUE_ERROR,
+                        scopeKey));
+              }
+              return Either.right(priority);
+            });
   }
 
   public void cancelUserTask(final BpmnElementContext context) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/ExpressionProcessor.java
@@ -315,8 +315,20 @@ public final class ExpressionProcessor {
       final Expression expression, final long scopeKey) {
     return evaluateExpressionAsEither(expression, scopeKey)
         .flatMap(result -> typeCheck(result, ResultType.NUMBER, scopeKey))
-        .map(EvaluationResult::getNumber)
-        .map(Number::intValue);
+        .flatMap(
+            result -> {
+              if (result.getNumber().doubleValue() % 1 == 0) {
+                return Either.right(result.getNumber().intValue());
+              } else {
+                return Either.left(
+                    createFailureMessage(
+                        result,
+                        String.format(
+                            "Expected result of the expression '%s' to be an integer, but was a decimal.",
+                            expression.getExpression()),
+                        scopeKey));
+              }
+            });
   }
 
   private Either<Failure, EvaluationResult> typeCheckCorrelationKey(

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/ZeebeRuntimeValidationTest.java
@@ -497,6 +497,17 @@ public final class ZeebeRuntimeValidationTest {
                 ZeebePriorityDefinition.class,
                 "Priority must be a number between 0 and 100, but was '120'"))
       },
+      {
+        /*decimal priority static value */
+        Bpmn.createExecutableProcess("process")
+            .startEvent()
+            .userTask("task", b -> b.zeebeTaskPriority("33.3"))
+            .done(),
+        List.of(
+            expect(
+                ZeebePriorityDefinition.class,
+                "Expected static value to be a valid Number between 0 and 100, but found '33.3'"))
+      },
     };
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/incident/UserTaskIncidentTest.java
@@ -782,4 +782,114 @@ public class UserTaskIncidentTest {
 
     assertThat(incidentResolved.getKey()).isEqualTo(incidentCreated.getKey());
   }
+
+  @Test
+  public void shouldCreateIncidentIfPriorityExpressionIsDecimal() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithUserTask(u -> u.zeebeUserTask().zeebeTaskPriority("=priority")))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("priority", 33.3)
+            .create();
+
+    final var userTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.USER_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, userTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected result of the expression 'priority' to be an integer, but was a decimal.");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfPriorityExpressionIsNotANumber() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithUserTask(u -> u.zeebeUserTask().zeebeTaskPriority("=priority")))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE
+            .processInstance()
+            .ofBpmnProcessId(PROCESS_ID)
+            .withVariable("priority", "definitely not a number")
+            .create();
+
+    final var userTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.USER_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, userTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage(
+            "Expected result of the expression 'priority' to be 'NUMBER', but was 'STRING'.");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfPriorityExpressionIsNotInRangeHigher() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithUserTask(u -> u.zeebeUserTask().zeebeTaskPriority("=priority")))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("priority", 120).create();
+
+    final var userTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.USER_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, userTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage("Expected priority to be in the range [0,100] but was '120'.");
+  }
+
+  @Test
+  public void shouldCreateIncidentIfPriorityExpressionIsNotInRangeLower() {
+    // given
+    ENGINE
+        .deployment()
+        .withXmlResource(processWithUserTask(u -> u.zeebeUserTask().zeebeTaskPriority("=priority")))
+        .deploy();
+
+    // when
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).withVariable("priority", -10).create();
+
+    final var userTaskActivating =
+        RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATING)
+            .withProcessInstanceKey(processInstanceKey)
+            .withElementId(TASK_ELEMENT_ID)
+            .withElementType(BpmnElementType.USER_TASK)
+            .getFirst();
+
+    // then
+    assertIncidentCreated(processInstanceKey, userTaskActivating.getKey())
+        .hasErrorType(ErrorType.EXTRACT_VALUE_ERROR)
+        .hasErrorMessage("Expected priority to be in the range [0,100] but was '-10'.");
+  }
 }


### PR DESCRIPTION
## Description

Validator was mapping doubles as integers. Provide a fix to only accept integers and not decimal numbers.

Adjust expression evaluation to throw incidents when priority expression is not in the [0,100] range.

Add test cases for the above two scenarios

## Related issues

closes #21434 
