### PR TITLE
Add ES exporter metrics

### DIFF
--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -24,7 +24,7 @@ public class ElasticsearchMetrics {
   private final Timer flushDuration;
   private final DistributionSummary bulkSize;
   private final Counter failedFlush;
-  private final Timer recordBufferLifetime;
+  private final Timer flushLatency;
 
   public ElasticsearchMetrics(final int partitionId, final MeterRegistry registry) {
     partitionIdLabel = String.valueOf(partitionId);
@@ -55,10 +55,10 @@ public class ElasticsearchMetrics {
             .tags(PARTITION_LABEL, partitionIdLabel)
             .register(meterRegistry);
 
-    recordBufferLifetime =
-        Timer.builder(meterName("record.buffer.lifetime"))
+    flushLatency =
+        Timer.builder(meterName("flush.latency"))
             .description(
-                "Approximation of how long a record (the first) has to spent in the exporter buffer, before flushing.")
+                "Time of how long a export buffer is open and collects new records before flushing, meaning latency until the next flush is done.")
             .tags(PARTITION_LABEL, partitionIdLabel)
             .publishPercentileHistogram()
             .register(meterRegistry);
@@ -84,13 +84,13 @@ public class ElasticsearchMetrics {
     return NAMESPACE + "." + name;
   }
 
-  public Timer.Sample startRecordBufferLifetimeMeasurement() {
+  public Timer.Sample startFlushLatencyMeasurement() {
     return Timer.start(meterRegistry);
   }
 
-  public void stopRecordBufferLifetimeMeasurement(final Timer.Sample sample) {
-    if (sample != null) {
-      sample.stop(recordBufferLifetime);
+  public void stopFlushLatencyMeasurement(final Timer.Sample flushLatencySample) {
+    if (flushLatencySample != null) {
+      flushLatencySample.stop(flushLatency);
     }
   }
 }

--- a/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
+++ b/zeebe/exporters/elasticsearch-exporter/src/main/java/io/camunda/zeebe/exporter/ElasticsearchMetrics.java
@@ -89,6 +89,8 @@ public class ElasticsearchMetrics {
   }
 
   public void stopRecordBufferLifetimeMeasurement(final Timer.Sample sample) {
-    sample.stop(recordBufferLifetime);
+    if (sample != null) {
+      sample.stop(recordBufferLifetime);
+    }
   }
 }


### PR DESCRIPTION

## Description
Add an approximation of how long a record has to spent in the exporter buffer, before flushing. It is an approximation or a max calculation as the first record in the buffer is only considered, but it still already shows some interesting insights.

You could also name it as how long the buffer is open (alive) and collects new records before it gets flushed. 

<!-- Describe the goal and purpose of this PR. -->

Allows to build the following panel:


![2024-08-21_17-30](https://github.com/user-attachments/assets/694005e8-9081-42d1-a254-a3c43db9345f)




## Related issues

related to https://github.com/camunda/camunda/issues/16912
