### PR TITLE
ci: add composite action to set up Yarn cache

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -19,8 +19,9 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: "20"
-        cache: "yarn"
-        cache-dependency-path: ${{ inputs.directory }}/yarn.lock
+    - uses: ./.github/actions/setup-yarn-cache
+      with:
+        directory: ${{ inputs.directory }}
     - name: Install node dependencies
       working-directory: ${{ inputs.directory }}
       shell: bash

--- a/.github/actions/setup-yarn-cache/action.yml
+++ b/.github/actions/setup-yarn-cache/action.yml
@@ -1,0 +1,47 @@
+---
+name: Setup Yarn Cache
+
+
+description: Configured GHA cache for Yarn global cache dir (no save on PRs), see https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy
+
+inputs:
+  directory:
+    description: Directory of the project for which Yarn to GHA cache should be configured
+    required: true
+
+runs:
+  using: composite
+  steps:
+  - name: Get Yarn global cache directory
+    id: get-yarn-global-cache-dir
+    shell: bash
+    working-directory: ${{ inputs.directory }}
+    run: |
+      yarn_version=$(yarn --version)
+
+      if [[ $yarn_version == 1* ]]; then
+        echo "result=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      else
+        echo "result=$(yarn config get cacheFolder)" >> $GITHUB_OUTPUT
+      fi
+
+  - name: Save global Yarn cache on non-PRs
+    if: startsWith(github.ref_name, 'stable') || github.ref_name == 'main'
+    uses: actions/cache@v4
+    with:
+      path: "${{ steps.get-yarn-global-cache-dir.outputs.result }}"
+      # it matters for caching as absolute paths on self-hosted and Github runners differ
+      # self-hosted: `/runner/` vs gh-hosted: `/home/runner`
+      key: ${{ runner.environment }}-${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.directory)) }}
+      restore-keys: |
+        ${{ runner.environment }}-${{ runner.os }}-yarn
+
+  - name: Restore global Yarn cache always
+    # Restore cache (but don't save it) if we're not on main or stable/* branches
+    if: ${{ !(startsWith(github.ref_name, 'stable') || github.ref_name == 'main') }}
+    uses: actions/cache/restore@v4
+    with:
+      path: "${{ steps.get-yarn-global-cache-dir.outputs.result }}"
+      key: ${{ runner.environment }}-${{ runner.os }}-yarn-${{ hashFiles(format('{0}/yarn.lock', inputs.directory)) }}
+      restore-keys: |
+        ${{ runner.environment }}-${{ runner.os }}-yarn


### PR DESCRIPTION
## Description

This PRs adds a custom action that uses similar logic like [Zeebe has for Maven](https://github.com/camunda/camunda/blob/fd2e86a59785408bd39daa1134aa1d292281c390/.github/actions/setup-zeebe/action.yml#L113-L180) combined with Yarn-specific paths from https://github.com/actions/setup-node/blob/26961cf329f22f6837d5f54c3efd76b480300ace/src/cache-utils.ts#L39-L66 ([setup-node cannot do it](https://github.com/actions/setup-node/issues/663)) to implement our [caching strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy).

To demonstrate that this causes no problems I changed only 1 job to use it, see https://github.com/camunda/camunda/actions/runs/10508214639/job/29111637484?pr=21475 -- remaining jobs will be refactored in https://github.com/camunda/camunda/issues/21427

Old usage:

```yaml
    - name: Setup yarn cache
      uses: actions/setup-node@v4
      with:
        node-version: "20"
        cache: "yarn"
        cache-dependency-path: project-path/yarn.lock
```

New usage after this PR:

```yaml
    - name: Setup yarn cache
      uses: actions/setup-node@v4
      with:
        node-version: "20"
    - uses: ./.github/actions/setup-yarn-cache
      with:
        directory: project-path
```

As a test in https://github.com/camunda/camunda/pull/21475/commits/d4324461c70c9b2086034d3442b3b395bb2c31b6 I replaced all usages like this and indeed no **node** caches were created on the PR:

![image](https://github.com/user-attachments/assets/4031032a-5f7a-43cd-88f4-d12950ef9c63)


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [x] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [x] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21424