### PR TITLE
fix: adjust config popover label styling to fix e2e tests

### DIFF
--- a/optimize/client/src/components/Reports/controlPanels/Configuration/Configuration.scss
+++ b/optimize/client/src/components/Reports/controlPanels/Configuration/Configuration.scss
@@ -25,8 +25,8 @@
     }
 
     .cds--toggle__appearance {
-      // This is to make the ellipsis text wrap
-      display: flex;
+      // We need text labels to wrap
+      grid-template-columns: max-content 1fr;
     }
   }
 


### PR DESCRIPTION
## Description
The e2e tests are failing due to a recent renovate update.
It seems that the selectors for the config popover toggles were broken due to an issue in testcafe. 
I changed the way the toggles are styles and this seems to fix the issue.
<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
