### PR TITLE
feat: feature flag to disable partition scaling by default

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1288,3 +1288,7 @@
         # We recommend testing this feature in a non-production environment before enabling it in production.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLETIMERDUEDATECHECKERASYNC
         # enableTimerDueDateCheckerAsync: false
+
+        # Disables the experimental partition scaling feature by default until it is stable: https://github.com/camunda/camunda/issues/21439
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEPARTITIONSCALING
+        # enablePartitionScaling: false

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1178,3 +1178,7 @@
         # We recommend testing this feature in a non-production environment before enabling it in production.
         # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLETIMERDUEDATECHECKERASYNC
         # enableTimerDueDateCheckerAsync: false
+
+        # Disables the experimental partition scaling feature by default until it is stable: https://github.com/camunda/camunda/issues/21439
+        # This setting can also be overridden using the environment variable ZEEBE_BROKER_EXPERIMENTAL_FEATURES_ENABLEPARTITIONSCALING
+        # enablePartitionScaling: false

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfg.java
@@ -37,6 +37,7 @@ public final class FeatureFlagsCfg {
       DEFAULT_SETTINGS.enableTimerDueDateCheckerAsync();
   private boolean enableStraightThroughProcessingLoopDetector =
       DEFAULT_SETTINGS.enableStraightThroughProcessingLoopDetector();
+  private boolean enablePartitionScaling = DEFAULT_SETTINGS.enablePartitionScaling();
 
   public boolean isEnableYieldingDueDateChecker() {
     return enableYieldingDueDateChecker;
@@ -79,13 +80,22 @@ public final class FeatureFlagsCfg {
     this.enableStraightThroughProcessingLoopDetector = enableStraightThroughProcessingLoopDetector;
   }
 
+  public boolean isEnablePartitionScaling() {
+    return enablePartitionScaling;
+  }
+
+  public void setEnablePartitionScaling(final boolean enablePartitionScaling) {
+    this.enablePartitionScaling = enablePartitionScaling;
+  }
+
   public FeatureFlags toFeatureFlags() {
     return new FeatureFlags(
         enableYieldingDueDateChecker,
         enableActorMetrics,
         enableMessageTtlCheckerAsync,
         enableTimerDueDateCheckerAsync,
-        enableStraightThroughProcessingLoopDetector
+        enableStraightThroughProcessingLoopDetector,
+        enablePartitionScaling
         /*, enableFoo*/ );
   }
 

--- a/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
+++ b/zeebe/broker/src/test/java/io/camunda/zeebe/broker/system/configuration/FeatureFlagsCfgTest.java
@@ -162,4 +162,37 @@ final class FeatureFlagsCfgTest {
     // then
     assertThat(featureFlagsCfg.isEnableStraightThroughProcessingLoopDetector()).isTrue();
   }
+
+  @Test
+  void shouldDisablePartitionScalingByDefault() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("empty", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnablePartitionScaling()).isFalse();
+  }
+
+  @Test
+  void shouldSetEnablePartitionScalingFromConfig() {
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnablePartitionScaling()).isTrue();
+  }
+
+  @Test
+  void shouldSetEnablePartitionScalingFromEnv() {
+    // given
+    environment.put("zeebe.broker.experimental.features.enablePartitionScaling", "false");
+
+    // when
+    final BrokerCfg cfg = TestConfigReader.readConfig("feature-flags-cfg", environment);
+    final var featureFlagsCfg = cfg.getExperimental().getFeatures();
+
+    // then
+    assertThat(featureFlagsCfg.isEnablePartitionScaling()).isFalse();
+  }
 }

--- a/zeebe/broker/src/test/resources/system/feature-flags-cfg.yaml
+++ b/zeebe/broker/src/test/resources/system/feature-flags-cfg.yaml
@@ -7,3 +7,4 @@ zeebe:
         enableMessageTTLCheckerAsync: true
         enableTimerDueDateCheckerAsync: true
         enableStraightThroughProcessingLoopDetector: false
+        enablePartitionScaling: true

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationDisabledTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/deployment/model/validation/StraightThroughProcessingLoopValidationDisabledTest.java
@@ -23,7 +23,7 @@ public class StraightThroughProcessingLoopValidationDisabledTest {
   public static final EngineRule ENGINE =
       EngineRule.singlePartition()
           // Disable loop detector feature flag
-          .withFeatureFlags(new FeatureFlags(true, false, true, true, false));
+          .withFeatureFlags(new FeatureFlags(true, false, true, true, false, true));
 
   @Rule
   public final RecordingExporterTestWatcher recordingExporter = new RecordingExporterTestWatcher();

--- a/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
+++ b/zeebe/util/src/main/java/io/camunda/zeebe/util/FeatureFlags.java
@@ -15,7 +15,8 @@ public record FeatureFlags(
     boolean enableActorMetrics,
     boolean enableMessageTTLCheckerAsync,
     boolean enableTimerDueDateCheckerAsync,
-    boolean enableStraightThroughProcessingLoopDetector
+    boolean enableStraightThroughProcessingLoopDetector,
+    boolean enablePartitionScaling
     /*, boolean foo*/ ) {
 
   /* To add a new feature toggle, please follow these steps:
@@ -51,6 +52,7 @@ public record FeatureFlags(
   private static final boolean ENABLE_MSG_TTL_CHECKER_ASYNC = false;
   private static final boolean ENABLE_DUE_DATE_CHECKER_ASYNC = false;
   private static final boolean ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR = true;
+  private static final boolean ENABLE_PARTITION_SCALING = false;
 
   public static FeatureFlags createDefault() {
     return new FeatureFlags(
@@ -58,7 +60,8 @@ public record FeatureFlags(
         ENABLE_ACTOR_METRICS,
         ENABLE_MSG_TTL_CHECKER_ASYNC,
         ENABLE_DUE_DATE_CHECKER_ASYNC,
-        ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR
+        ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR,
+        ENABLE_PARTITION_SCALING
         /*, FOO_DEFAULT*/ );
   }
 
@@ -73,7 +76,8 @@ public record FeatureFlags(
         false, /* ENABLE_ACTOR_METRICS */
         true, /* ENABLE_MSG_TTL_CHECKER_ASYNC */
         true, /* ENABLE_DUE_DATE_CHECKER_ASYNC */
-        true /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
+        true, /* ENABLE_STRAIGHT_THOUGH_PROCESSING_LOOP_DETECTOR */
+        true /* ENABLE_PARTITION_SCALING */
         /*, FOO_DEFAULT*/ );
   }
 

--- a/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
+++ b/zeebe/util/src/test/java/io/camunda/zeebe/util/FeatureFlagsTest.java
@@ -22,6 +22,7 @@ class FeatureFlagsTest {
     assertThat(sut.yieldingDueDateChecker()).isTrue();
     assertThat(sut.enableActorMetrics()).isFalse();
     assertThat(sut.enableMessageTTLCheckerAsync()).isFalse();
+    assertThat(sut.enablePartitionScaling()).isFalse();
   }
 
   @Test
@@ -32,5 +33,6 @@ class FeatureFlagsTest {
     // then
     assertThat(sut.yieldingDueDateChecker()).isTrue();
     assertThat(sut.enableMessageTTLCheckerAsync()).isTrue();
+    assertThat(sut.enablePartitionScaling()).isTrue();
   }
 }


### PR DESCRIPTION
Very boring PR but the first one for partition scaling :tada: 

Adds a new experimental feature under `zeebe.broker.experimental.features.enablePartitionScaling` that is disabled by default. It's currently not used at all but will be soon.

Closes https://github.com/camunda/camunda/issues/21463