### PR TITLE
fix: Operate OpenSearch AWS config can't be disabled [Backport stable/operate-8.5]

### DIFF
--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -138,7 +138,7 @@ public class OpensearchConnector {
   public OpenSearchAsyncClient createAsyncOsClient(OpensearchProperties osConfig) {
     LOGGER.debug("Creating Async OpenSearch connection...");
     LOGGER.debug("Creating OpenSearch connection...");
-    if (isAws()) {
+    if (hasAwsCredentials()) {
       return getAwsAsyncClient(osConfig);
     }
     final HttpHost host = getHttpHost(osConfig);
@@ -187,7 +187,11 @@ public class OpensearchConnector {
     return openSearchAsyncClient;
   }
 
-  private boolean isAws() {
+  private boolean hasAwsCredentials() {
+    if (!operateProperties.getOpensearch().isAwsEnabled()) {
+      LOGGER.info("AWS Credentials are disabled. Using basic auth.");
+      return false;
+    }
     final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
     try {
       credentialsProvider.resolveCredentials();
@@ -201,7 +205,7 @@ public class OpensearchConnector {
 
   public OpenSearchClient createOsClient(OpensearchProperties osConfig) {
     LOGGER.debug("Creating OpenSearch connection...");
-    if (isAws()) {
+    if (hasAwsCredentials()) {
       return getAwsClient(osConfig);
     }
     final HttpHost host = getHttpHost(osConfig);

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -102,7 +102,7 @@ public class OpensearchConnector {
     try {
       final HealthResponse response = openSearchClient.cluster().health();
       LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
     }
     return openSearchClient;
@@ -123,7 +123,7 @@ public class OpensearchConnector {
               LOGGER.info("OpenSearch cluster health: {}", response.status());
             }
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new RuntimeException(e);
     }
     return openSearchClient;
@@ -135,7 +135,7 @@ public class OpensearchConnector {
     return createOsClient(operateProperties.getZeebeOpensearch());
   }
 
-  public OpenSearchAsyncClient createAsyncOsClient(OpensearchProperties osConfig) {
+  public OpenSearchAsyncClient createAsyncOsClient(final OpensearchProperties osConfig) {
     LOGGER.debug("Creating Async OpenSearch connection...");
     LOGGER.debug("Creating OpenSearch connection...");
     if (hasAwsCredentials()) {
@@ -175,7 +175,7 @@ public class OpensearchConnector {
               LOGGER.info("OpenSearch cluster health: {}", response.status());
             }
           });
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new OperateRuntimeException(e);
     }
 
@@ -197,13 +197,13 @@ public class OpensearchConnector {
       credentialsProvider.resolveCredentials();
       LOGGER.info("AWS Credentials can be resolved. Use AWS Opensearch");
       return true;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.warn("AWS not configured due to: {} ", e.getMessage());
       return false;
     }
   }
 
-  public OpenSearchClient createOsClient(OpensearchProperties osConfig) {
+  public OpenSearchClient createOsClient(final OpensearchProperties osConfig) {
     LOGGER.debug("Creating OpenSearch connection...");
     if (hasAwsCredentials()) {
       return getAwsClient(osConfig);
@@ -232,7 +232,7 @@ public class OpensearchConnector {
     try {
       final HealthResponse response = openSearchClient.cluster().health();
       LOGGER.info("OpenSearch cluster health: {}", response.status());
-    } catch (IOException e) {
+    } catch (final IOException e) {
       LOGGER.error("Error in getting health status from {}", "localhost:9205", e);
     }
 
@@ -244,7 +244,7 @@ public class OpensearchConnector {
     return openSearchClient;
   }
 
-  private OpenSearchClient getAwsClient(OpensearchProperties osConfig) {
+  private OpenSearchClient getAwsClient(final OpensearchProperties osConfig) {
     final String region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     final AwsSdk2Transport transport =
@@ -258,7 +258,7 @@ public class OpensearchConnector {
     return new ExtendedOpenSearchClient(transport);
   }
 
-  private OpenSearchAsyncClient getAwsAsyncClient(OpensearchProperties osConfig) {
+  private OpenSearchAsyncClient getAwsAsyncClient(final OpensearchProperties osConfig) {
     final String region = new DefaultAwsRegionProviderChain().getRegion();
     final SdkAsyncHttpClient httpClient = NettyNioAsyncHttpClient.builder().build();
     final AwsSdk2Transport transport =
@@ -272,17 +272,17 @@ public class OpensearchConnector {
     return new OpenSearchAsyncClient(transport);
   }
 
-  private HttpHost getHttpHost(OpensearchProperties osConfig) {
+  private HttpHost getHttpHost(final OpensearchProperties osConfig) {
     try {
       final URI uri = new URI(osConfig.getUrl());
       return new HttpHost(uri.getScheme(), uri.getHost(), uri.getPort());
-    } catch (URISyntaxException e) {
+    } catch (final URISyntaxException e) {
       throw new OperateRuntimeException("Error in url: " + osConfig.getUrl(), e);
     }
   }
 
   private HttpAsyncClientBuilder setupAuthentication(
-      final HttpAsyncClientBuilder builder, OpensearchProperties osConfig) {
+      final HttpAsyncClientBuilder builder, final OpensearchProperties osConfig) {
     if (!StringUtils.hasText(osConfig.getUsername())
         || !StringUtils.hasText(osConfig.getPassword())) {
       LOGGER.warn(
@@ -301,7 +301,7 @@ public class OpensearchConnector {
   }
 
   private void setupSSLContext(
-      HttpAsyncClientBuilder httpAsyncClientBuilder, SslProperties sslConfig) {
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final SslProperties sslConfig) {
     try {
       final ClientTlsStrategyBuilder tlsStrategyBuilder = ClientTlsStrategyBuilder.create();
       tlsStrategyBuilder.setSslContext(getSSLContext(sslConfig));
@@ -315,12 +315,12 @@ public class OpensearchConnector {
 
       httpAsyncClientBuilder.setConnectionManager(connectionManager);
 
-    } catch (Exception e) {
+    } catch (final Exception e) {
       LOGGER.error("Error in setting up SSLContext", e);
     }
   }
 
-  private SSLContext getSSLContext(SslProperties sslConfig)
+  private SSLContext getSSLContext(final SslProperties sslConfig)
       throws KeyStoreException, NoSuchAlgorithmException, KeyManagementException {
     final KeyStore truststore = loadCustomTrustStore(sslConfig);
     final TrustStrategy trustStrategy =
@@ -333,7 +333,7 @@ public class OpensearchConnector {
     }
   }
 
-  private KeyStore loadCustomTrustStore(SslProperties sslConfig) {
+  private KeyStore loadCustomTrustStore(final SslProperties sslConfig) {
     try {
       final KeyStore trustStore = KeyStore.getInstance(KeyStore.getDefaultType());
       trustStore.load(null);
@@ -343,7 +343,7 @@ public class OpensearchConnector {
         setCertificateInTrustStore(trustStore, serverCertificate);
       }
       return trustStore;
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final String message =
           "Could not create certificate trustStore for the secured OpenSearch Connection!";
       throw new OperateRuntimeException(message, e);
@@ -355,7 +355,7 @@ public class OpensearchConnector {
     try {
       final Certificate cert = loadCertificateFromPath(serverCertificate);
       trustStore.setCertificateEntry("opensearch-host", cert);
-    } catch (Exception e) {
+    } catch (final Exception e) {
       final String message =
           "Could not load configured server certificate for the secured OpenSearch Connection!";
       throw new OperateRuntimeException(message, e);
@@ -365,7 +365,8 @@ public class OpensearchConnector {
   private Certificate loadCertificateFromPath(final String certificatePath)
       throws IOException, CertificateException {
     final Certificate cert;
-    try (BufferedInputStream bis = new BufferedInputStream(new FileInputStream(certificatePath))) {
+    try (final BufferedInputStream bis =
+        new BufferedInputStream(new FileInputStream(certificatePath))) {
       final CertificateFactory cf = CertificateFactory.getInstance("X.509");
 
       if (bis.available() > 0) {
@@ -380,7 +381,7 @@ public class OpensearchConnector {
   }
 
   protected HttpAsyncClientBuilder configureHttpClient(
-      HttpAsyncClientBuilder httpAsyncClientBuilder, OpensearchProperties osConfig) {
+      final HttpAsyncClientBuilder httpAsyncClientBuilder, final OpensearchProperties osConfig) {
     setupAuthentication(httpAsyncClientBuilder, osConfig);
     if (osConfig.getSsl() != null) {
       setupSSLContext(httpAsyncClientBuilder, osConfig.getSsl());
@@ -400,7 +401,7 @@ public class OpensearchConnector {
     return builder;
   }
 
-  public boolean checkHealth(OpenSearchClient osClient) {
+  public boolean checkHealth(final OpenSearchClient osClient) {
     final OpensearchProperties osConfig = operateProperties.getOpensearch();
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)
@@ -412,7 +413,7 @@ public class OpensearchConnector {
             });
   }
 
-  public boolean checkHealth(OpenSearchAsyncClient osAsyncClient) {
+  public boolean checkHealth(final OpenSearchAsyncClient osAsyncClient) {
     final OpensearchProperties osConfig = operateProperties.getOpensearch();
     final RetryPolicy<Boolean> retryPolicy = getConnectionRetryPolicy(osConfig);
     return Failsafe.with(retryPolicy)

--- a/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
+++ b/operate/common/src/main/java/io/camunda/operate/connect/OpensearchConnector.java
@@ -239,7 +239,7 @@ public class OpensearchConnector {
     if (!checkHealth(openSearchClient)) {
       LOGGER.warn("OpenSearch cluster is not accessible");
     } else {
-      LOGGER.debug("Elasticsearch connection was successfully created.");
+      LOGGER.debug("OpenSearch connection was successfully created.");
     }
     return openSearchClient;
   }

--- a/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
+++ b/operate/common/src/main/java/io/camunda/operate/property/OpensearchProperties.java
@@ -52,6 +52,8 @@ public class OpensearchProperties {
 
   private int bulkRequestMaxSizeInBytes = BULK_REQUEST_MAX_SIZE_IN_BYTES_DEFAULT;
 
+  private boolean awsEnabled = false;
+
   @NestedConfigurationProperty private SslProperties ssl;
 
   public String getClusterName() {
@@ -166,6 +168,15 @@ public class OpensearchProperties {
 
   public void setConnectTimeout(final Integer connectTimeout) {
     this.connectTimeout = connectTimeout;
+  }
+
+  public boolean isAwsEnabled() {
+    return awsEnabled;
+  }
+
+  public OpensearchProperties setAwsEnabled(final boolean awsEnabled) {
+    this.awsEnabled = awsEnabled;
+    return this;
   }
 
   public SslProperties getSsl() {

--- a/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
+++ b/operate/common/src/test/java/io/camunda/operate/connect/OpensearchConnectorTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Camunda Services GmbH
+ *
+ * BY INSTALLING, DOWNLOADING, ACCESSING, USING, OR DISTRIBUTING THE SOFTWARE (“USE”), YOU INDICATE YOUR ACCEPTANCE TO AND ARE ENTERING INTO A CONTRACT WITH, THE LICENSOR ON THE TERMS SET OUT IN THIS AGREEMENT. IF YOU DO NOT AGREE TO THESE TERMS, YOU MUST NOT USE THE SOFTWARE. IF YOU ARE RECEIVING THE SOFTWARE ON BEHALF OF A LEGAL ENTITY, YOU REPRESENT AND WARRANT THAT YOU HAVE THE ACTUAL AUTHORITY TO AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT ON BEHALF OF SUCH ENTITY.
+ * “Licensee” means you, an individual, or the entity on whose behalf you receive the Software.
+ *
+ * Permission is hereby granted, free of charge, to the Licensee obtaining a copy of this Software and associated documentation files to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject in each case to the following conditions:
+ * Condition 1: If the Licensee distributes the Software or any derivative works of the Software, the Licensee must attach this Agreement.
+ * Condition 2: Without limiting other conditions in this Agreement, the grant of rights is solely for non-production use as defined below.
+ * "Non-production use" means any use of the Software that is not directly related to creating products, services, or systems that generate revenue or other direct or indirect economic benefits.  Examples of permitted non-production use include personal use, educational use, research, and development. Examples of prohibited production use include, without limitation, use for commercial, for-profit, or publicly accessible systems or use for commercial or revenue-generating purposes.
+ *
+ * If the Licensee is in breach of the Conditions, this Agreement, including the rights granted under it, will automatically terminate with immediate effect.
+ *
+ * SUBJECT AS SET OUT BELOW, THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ * NOTHING IN THIS AGREEMENT EXCLUDES OR RESTRICTS A PARTY’S LIABILITY FOR (A) DEATH OR PERSONAL INJURY CAUSED BY THAT PARTY’S NEGLIGENCE, (B) FRAUD, OR (C) ANY OTHER LIABILITY TO THE EXTENT THAT IT CANNOT BE LAWFULLY EXCLUDED OR RESTRICTED.
+ */
+package io.camunda.operate.connect;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.camunda.operate.property.OperateOpensearchProperties;
+import io.camunda.operate.property.OperateProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchAsyncClient;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.aws.AwsSdk2Transport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5Transport;
+
+@ExtendWith(MockitoExtension.class)
+public class OpensearchConnectorTest {
+
+  private static final String AWS_REGION = "eu-west-1";
+  private static final String AWS_SECRET_ACCESS_KEY = "awsSecretAcessKey";
+  private static final String AWS_ACCESS_KEY_ID = "awsAccessKeyId";
+
+  ObjectMapper objectMapper = new ObjectMapper();
+
+  private final OperateOpensearchProperties opensearchProperties =
+      new OperateOpensearchProperties();
+
+  private final OperateProperties operateProperties = new OperateProperties();
+
+  private OpensearchConnector opensearchConnector;
+
+  @BeforeEach
+  public void setup() {
+    operateProperties.setOpensearch(opensearchProperties);
+    opensearchConnector = new OpensearchConnector(operateProperties, objectMapper);
+  }
+
+  @Test
+  public void asyncHasAwsEnabledAndAwsCredentialsSetAndShouldUseAwsCredentials() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    opensearchProperties.setAwsEnabled(true);
+
+    final OpenSearchAsyncClient client =
+        opensearchConnector.createAsyncOsClient(opensearchProperties);
+
+    assertEquals(AwsSdk2Transport.class, client._transport().getClass());
+  }
+
+  @Test
+  public void asyncHasAwsCredentialsButShouldUseBasicAuth() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    // awsEnabled not set -> should default to false
+    final OpensearchConnector spyConnector = spy(opensearchConnector);
+    doReturn(true).when(spyConnector).checkHealth(any(OpenSearchAsyncClient.class));
+
+    final OpenSearchAsyncClient client = spyConnector.createAsyncOsClient(opensearchProperties);
+
+    assertEquals(ApacheHttpClient5Transport.class, client._transport().getClass());
+  }
+
+  @Test
+  public void syncHasAwsEnabledAndAwsCredentialsSetAndShouldUseAwsCredentials() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    opensearchProperties.setAwsEnabled(true);
+
+    final OpenSearchClient client = opensearchConnector.createOsClient(opensearchProperties);
+
+    assertEquals(AwsSdk2Transport.class, client._transport().getClass());
+  }
+
+  @Test
+  public void syncHasAwsCredentialsButShouldUseBasicAuth() {
+    System.setProperty("aws.accessKeyId", AWS_ACCESS_KEY_ID);
+    System.setProperty("aws.secretAccessKey", AWS_SECRET_ACCESS_KEY);
+    System.setProperty("aws.region", AWS_REGION);
+    opensearchProperties.setUsername("demo");
+    opensearchProperties.setPassword("demo");
+    // awsEnabled not set -> should default to false
+    final OpensearchConnector spyConnector = spy(opensearchConnector);
+    doReturn(true).when(spyConnector).checkHealth(any(OpenSearchClient.class));
+
+    final OpenSearchClient client = spyConnector.createOsClient(opensearchProperties);
+
+    assertEquals(ApacheHttpClient5Transport.class, client._transport().getClass());
+  }
+}


### PR DESCRIPTION
## Description
Introduced the property `camunda.operate.opensearch.awsEnabled` which is now checked for before using AWS credentials to allow for using basic auth even when AWS credentials are set.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/20939
