### PR TITLE
feat: show license status in identity UI

### DIFF
--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -1,10 +1,20 @@
 import { C3Navigation } from "@camunda/camunda-composite-components";
 import { useGlobalRoutes } from "src/components/global/useGlobalRoutes";
 import { useNavigate } from "react-router";
+import { useApi } from "src/utility/api";
+import { checkLicense } from "src/utility/api/headers";
 
 const AppHeader = () => {
   const routes = useGlobalRoutes();
   const navigate = useNavigate();
+  const { data: license } = useApi(checkLicense);
+  const showLicense: boolean =
+    license == null
+      ? false
+      : license.licenseType !== undefined &&
+        license.licenseType == "self-managed";
+  const isProductionLicense: boolean =
+    license == null ? false : license.validLicense;
 
   return (
     <C3Navigation
@@ -26,6 +36,10 @@ const AppHeader = () => {
             onClick: () => navigate(route.key),
           },
         })),
+        licenseTag: {
+          show: showLicense,
+          isProductionLicense: isProductionLicense,
+        },
       }}
     />
   );

--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -11,7 +11,7 @@ const AppHeader = () => {
   const showLicense: boolean =
     license == null
       ? true
-      : license.licenseType === undefined && license.licenseType != "saas";
+      : license.licenseType === undefined || license.licenseType != "saas";
   const isProductionLicense: boolean =
     license == null ? false : license.validLicense;
 

--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -10,8 +10,8 @@ const AppHeader = () => {
   const { data: license } = useApi(checkLicense);
   const showLicense: boolean =
     license == null
-      ? false
-      : license.licenseType !== undefined && license.licenseType != "saas";
+      ? true
+      : license.licenseType === undefined && license.licenseType != "saas";
   const isProductionLicense: boolean =
     license == null ? false : license.validLicense;
 

--- a/identity/client/src/components/layout/AppHeader.tsx
+++ b/identity/client/src/components/layout/AppHeader.tsx
@@ -11,8 +11,7 @@ const AppHeader = () => {
   const showLicense: boolean =
     license == null
       ? false
-      : license.licenseType !== undefined &&
-        license.licenseType == "self-managed";
+      : license.licenseType !== undefined && license.licenseType != "saas";
   const isProductionLicense: boolean =
     license == null ? false : license.validLicense;
 

--- a/identity/client/src/pages/users/List.tsx
+++ b/identity/client/src/pages/users/List.tsx
@@ -71,7 +71,7 @@ const List: FC = () => {
     <Page>
       <EntityList
         title={t("Users")}
-        data={userSearchResults!.items}
+        data={userSearchResults == null ? [] : userSearchResults.items}
         headers={[
           { header: t("Username"), key: "username" },
           { header: t("Name"), key: "name" },

--- a/identity/client/src/utility/api/headers/index.ts
+++ b/identity/client/src/utility/api/headers/index.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+import { ApiDefinition, apiGet } from "../request";
+export const LICENSE_ENDPOINT = "/license";
+
+export type License = {
+  validLicense: boolean;
+  licenseType: string;
+};
+
+export const checkLicense: ApiDefinition<License> = () =>
+  apiGet(`${LICENSE_ENDPOINT}`);


### PR DESCRIPTION
## Description
Once the License endpoint in the monorepo is available, the front end needs to consume data from the endpoint and display it to the user. Use the `C3Navigation` component to display the status. The label will only show in Self Managed, it will not show in SaaS

The endpoint: 
```
GET /license
{
   "validLicense": true,
   "licenseType": "self-managed"
}
```
`validLicense` will be `true` or `false`. The value is determined whether the Camunda license is valid or not
`licenseType` will return one of three strings, `saas`, `self-managed`, or `unknown`. The value reflects the current running mode Camunda is in. `unknown` is returned when a license is invalid or missing.

## Related issues

closes #20739 
