### PR TITLE
feat: resolve called processes for binding type `versionTag`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnStateBehavior.java
@@ -149,6 +149,13 @@ public final class BpmnStateBehavior {
     return Optional.ofNullable(process);
   }
 
+  public Optional<DeployedProcess> getProcessByProcessIdAndVersionTag(
+      final DirectBuffer processId, final String versionTag, final String tenantId) {
+    final var process =
+        processState.getProcessByProcessIdAndVersionTag(processId, versionTag, tenantId);
+    return Optional.ofNullable(process);
+  }
+
   public Either<Failure, Long> getDeploymentKey(
       final long processDefinitionKey, final String tenantId) {
     return getProcess(processDefinitionKey, tenantId)

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCallActivity.java
@@ -24,6 +24,7 @@ public class ExecutableCallActivity extends ExecutableActivity {
   private int lexicographicIndex;
 
   private ZeebeBindingType bindingType;
+  private String versionTag;
 
   public ExecutableCallActivity(final String id) {
     super(id);
@@ -69,5 +70,13 @@ public class ExecutableCallActivity extends ExecutableActivity {
 
   public void setBindingType(final ZeebeBindingType bindingType) {
     this.bindingType = bindingType;
+  }
+
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  public void setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/CallActivityTransformer.java
@@ -59,6 +59,9 @@ public final class CallActivityTransformer implements ModelElementTransformer<Ca
 
     final var bindingType = calledElement.getBindingType();
     callActivity.setBindingType(bindingType);
+
+    final var versionTag = calledElement.getVersionTag();
+    callActivity.setVersionTag(versionTag);
   }
 
   private static void transformLexicographicIndex(


### PR DESCRIPTION
## Description
Call activities that use the new binding type `versionTag` now call the version of the target process referenced by the specified version tag.

## Related issues
closes #21038