### PR TITLE
feat: resolve called decisions for binding type `versionTag`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnDecisionBehavior.java
@@ -78,7 +78,7 @@ public final class BpmnDecisionBehavior {
 
     final var decisionId = decisionIdOrFailure.get();
     final var decisionOrFailure =
-        findDecisionByIdAndBindingType(decisionId, element.getBindingType(), context);
+        findCalledDecision(decisionId, element.getBindingType(), element.getVersionTag(), context);
     final Either<Failure, ParsedDecisionRequirementsGraph> drgOrFailure =
         decisionOrFailure
             .flatMap(decisionBehavior::findParsedDrgByDecision)
@@ -124,15 +124,16 @@ public final class BpmnDecisionBehavior {
     return resultOrFailure;
   }
 
-  private Either<Failure, PersistedDecision> findDecisionByIdAndBindingType(
+  private Either<Failure, PersistedDecision> findCalledDecision(
       final String decisionId,
       final ZeebeBindingType bindingType,
+      final String versionTag,
       final BpmnElementContext context) {
     return switch (bindingType) {
       case deployment -> getDecisionVersionInSameDeployment(decisionId, context);
       case latest -> getLatestDecisionVersion(decisionId, context.getTenantId());
-      // will be implemented with https://github.com/camunda/camunda/issues/21040
-      case versionTag -> Either.left(new Failure("Binding type 'versionTag' not supported"));
+      case versionTag ->
+          getLatestDecisionVersionWithVersionTag(decisionId, versionTag, context.getTenantId());
     };
   }
 
@@ -149,6 +150,12 @@ public final class BpmnDecisionBehavior {
   private Either<Failure, PersistedDecision> getLatestDecisionVersion(
       final String decisionId, final String tenantId) {
     return decisionBehavior.findLatestDecisionByIdAndTenant(decisionId, tenantId);
+  }
+
+  private Either<Failure, PersistedDecision> getLatestDecisionVersionWithVersionTag(
+      final String decisionId, final String versionTag, final String tenantId) {
+    return decisionBehavior.findDecisionByIdAndVersionTagAndTenant(
+        decisionId, versionTag, tenantId);
   }
 
   private Either<Failure, String> evalDecisionIdExpression(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/common/DecisionBehavior.java
@@ -75,6 +75,20 @@ public class DecisionBehavior {
                     .formatted(decisionId, deploymentKey)));
   }
 
+  public Either<Failure, PersistedDecision> findDecisionByIdAndVersionTagAndTenant(
+      final String decisionId, final String versionTag, final String tenantId) {
+    return Either.ofOptional(
+            decisionState.findDecisionByIdAndVersionTag(
+                tenantId, BufferUtil.wrapString(decisionId), versionTag))
+        .orElse(
+            new Failure(
+                """
+                Expected to evaluate decision with id '%s' and version tag '%s', but no such decision found. \
+                To resolve this incident, deploy a decision with the given id and version tag.\
+                """
+                    .formatted(decisionId, versionTag)));
+  }
+
   public Either<Failure, PersistedDecision> findDecisionByKeyAndTenant(
       final long decisionKey, final String tenantId) {
     return Either.ofOptional(decisionState.findDecisionByTenantAndKey(tenantId, decisionKey))

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableBusinessRuleTask.java
@@ -16,6 +16,7 @@ public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
   private Expression decisionId;
   private String resultVariable;
   private ZeebeBindingType bindingType;
+  private String versionTag;
 
   public ExecutableBusinessRuleTask(final String id) {
     super(id);
@@ -49,5 +50,15 @@ public final class ExecutableBusinessRuleTask extends ExecutableJobWorkerTask
   @Override
   public void setBindingType(final ZeebeBindingType bindingType) {
     this.bindingType = bindingType;
+  }
+
+  @Override
+  public String getVersionTag() {
+    return versionTag;
+  }
+
+  @Override
+  public void setVersionTag(final String versionTag) {
+    this.versionTag = versionTag;
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/ExecutableCalledDecision.java
@@ -24,4 +24,8 @@ public interface ExecutableCalledDecision {
   ZeebeBindingType getBindingType();
 
   void setBindingType(ZeebeBindingType bindingType);
+
+  String getVersionTag();
+
+  void setVersionTag(String versionTag);
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/zeebe/CalledDecisionTransformer.java
@@ -33,5 +33,8 @@ public final class CalledDecisionTransformer {
 
     final var bindingType = calledDecision.getBindingType();
     executableElement.setBindingType(bindingType);
+
+    final var versionTag = calledDecision.getVersionTag();
+    executableElement.setVersionTag(versionTag);
   }
 }


### PR DESCRIPTION
## Description
Business rule tasks that use the new binding type `versionTag` now call the version of the target decision referenced by the specified version tag.

## Related issues
closes #21040