### PR TITLE
feat: resolve linked forms for binding type `versionTag`

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/behavior/BpmnJobBehavior.java
@@ -123,9 +123,10 @@ public final class BpmnJobBehavior {
                 userTaskBehavior
                     .evaluateFormIdExpressionToFormKey(
                         jobWorkerProps.getFormId(),
-                        scopeKey,
-                        jobWorkerProps.getBindingType(),
-                        context)
+                        jobWorkerProps.getFormBindingType(),
+                        jobWorkerProps.getFormVersionTag(),
+                        context,
+                        scopeKey)
                     .map(key -> Objects.toString(key, null))
                     .map(p::formKey));
   }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/UserTaskProperties.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/element/UserTaskProperties.java
@@ -23,7 +23,8 @@ public class UserTaskProperties {
   private Expression formId;
   private Expression priority;
   private Map<String, String> taskHeaders = Map.of();
-  private ZeebeBindingType bindingType;
+  private ZeebeBindingType formBindingType;
+  private String formVersionTag;
 
   public Expression getAssignee() {
     return assignee;
@@ -89,12 +90,12 @@ public class UserTaskProperties {
     this.taskHeaders = taskHeaders;
   }
 
-  public ZeebeBindingType getBindingType() {
-    return bindingType;
+  public ZeebeBindingType getFormBindingType() {
+    return formBindingType;
   }
 
-  public void setBindingType(final ZeebeBindingType bindingType) {
-    this.bindingType = bindingType;
+  public void setFormBindingType(final ZeebeBindingType bindingType) {
+    formBindingType = bindingType;
   }
 
   public Expression getPriority() {
@@ -103,6 +104,14 @@ public class UserTaskProperties {
 
   public void setPriority(final Expression priority) {
     this.priority = priority;
+  }
+
+  public String getFormVersionTag() {
+    return formVersionTag;
+  }
+
+  public void setFormVersionTag(final String versionTag) {
+    formVersionTag = versionTag;
   }
 
   public void wrap(final UserTaskProperties userTaskProperties) {
@@ -114,7 +123,8 @@ public class UserTaskProperties {
     setFollowUpDate(userTaskProperties.getFollowUpDate());
     setFormId(userTaskProperties.getFormId());
     setTaskHeaders(userTaskProperties.getTaskHeaders());
-    setBindingType(userTaskProperties.getBindingType());
+    setFormBindingType(userTaskProperties.getFormBindingType());
     setPriority(userTaskProperties.getPriority());
+    setFormVersionTag(userTaskProperties.getFormVersionTag());
   }
 }

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/deployment/model/transformer/UserTaskTransformer.java
@@ -61,6 +61,7 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
     transformTaskFormId(element, userTaskProperties);
     transformModelTaskHeaders(element, userTaskProperties);
     transformBindingType(element, userTaskProperties);
+    transformVersionTag(element, userTaskProperties);
 
     if (isZeebeUserTask) {
       transformExternalReference(element, userTaskProperties);
@@ -254,7 +255,17 @@ public final class UserTaskTransformer implements ModelElementTransformer<UserTa
         element.getSingleExtensionElement(ZeebeFormDefinition.class);
 
     if (formDefinition != null) {
-      userTaskProperties.setBindingType(formDefinition.getBindingType());
+      userTaskProperties.setFormBindingType(formDefinition.getBindingType());
+    }
+  }
+
+  private void transformVersionTag(
+      final UserTask element, final UserTaskProperties userTaskProperties) {
+    final ZeebeFormDefinition formDefinition =
+        element.getSingleExtensionElement(ZeebeFormDefinition.class);
+
+    if (formDefinition != null) {
+      userTaskProperties.setFormVersionTag(formDefinition.getVersionTag());
     }
   }
 

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/bpmn/activity/JobBasedUserTaskFormTest.java
@@ -38,6 +38,12 @@ public class JobBasedUserTaskFormTest {
   private static final String PROCESS_ID = "process";
   private static final String TEST_FORM_1 = "/form/test-form-1.form";
   private static final String TEST_FORM_1_V2 = "/form/test-form-1_v2.form";
+  private static final String TEST_FORM_1_WITH_VERSION_TAG_V1 =
+      "/form/test-form-1-with-version-tag-v1.form";
+  private static final String TEST_FORM_1_WITH_VERSION_TAG_V1_NEW =
+      "/form/test-form-1-with-version-tag-v1-new.form";
+  private static final String TEST_FORM_1_WITH_VERSION_TAG_V2 =
+      "/form/test-form-1-with-version-tag-v2.form";
   private static final String TEST_FORM_2 = "/form/test-form-2.form";
   private static final String FORM_ID_1 = "Form_0w7r08e";
   private static final String FORM_ID_2 = "Form_6s1b76p";
@@ -124,6 +130,34 @@ public class JobBasedUserTaskFormTest {
   }
 
   @Test
+  public void shouldActivateUserTaskWithLatestFormVersionWithVersionTagForBindingTypeVersionTag() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.versionTag)
+            .zeebeFormVersionTag("v1.0")
+            .endEvent()
+            .done();
+    ENGINE
+        .deployment()
+        .withXmlResource(process)
+        .withXmlClasspathResource(TEST_FORM_1_WITH_VERSION_TAG_V1)
+        .deploy();
+    final var deployedFormV1New = deployForm(TEST_FORM_1_WITH_VERSION_TAG_V1_NEW);
+    deployForm(TEST_FORM_1_WITH_VERSION_TAG_V2);
+    deployForm(TEST_FORM_1);
+
+    // when
+    final long processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertUserTaskActivation(processInstanceKey, deployedFormV1New.getFormKey());
+  }
+
+  @Test
   public void shouldRaiseAnIncidentIfFormIsNotDeployed() {
     // given
     final var formId = "non-existent-form-id";
@@ -199,6 +233,33 @@ public class JobBasedUserTaskFormTest {
         that is deployed together with the intended form to use.\
         """
             .formatted(FORM_ID_1, deployment.getKey()));
+  }
+
+  @Test
+  public void shouldRaiseAnIncidentIfFormWithVersionTagIsNotDeployedForBindingTypeVersionTag() {
+    // given
+    final BpmnModelInstance process =
+        Bpmn.createExecutableProcess(PROCESS_ID)
+            .startEvent()
+            .userTask("task")
+            .zeebeFormId(FORM_ID_1)
+            .zeebeFormBindingType(ZeebeBindingType.versionTag)
+            .zeebeFormVersionTag("v1.0")
+            .endEvent()
+            .done();
+    ENGINE.deployment().withXmlResource(process).deploy();
+
+    // when
+    final var processInstanceKey = ENGINE.processInstance().ofBpmnProcessId(PROCESS_ID).create();
+
+    // then
+    assertFormIncident(
+        processInstanceKey,
+        """
+        Expected to use a form with id '%s' and version tag '%s', but no such form found. \
+        To resolve the incident, deploy a form with the given id and version tag.
+        """
+            .formatted(FORM_ID_1, "v1.0"));
   }
 
   private void deployProcess(final String formId) {

--- a/zeebe/engine/src/test/resources/form/test-form-1-with-version-tag-v2.form
+++ b/zeebe/engine/src/test/resources/form/test-form-1-with-version-tag-v2.form
@@ -1,0 +1,20 @@
+{
+  "components": [
+    {
+      "label": "Number",
+      "type": "number",
+      "id": "Field_1ojq0w2",
+      "key": "field_16vwphu"
+    }
+  ],
+  "type": "default",
+  "id": "Form_0w7r08e",
+  "executionPlatform": "Camunda Cloud",
+  "executionPlatformVersion": "8.1.0",
+  "exporter": {
+    "name": "Camunda Modeler",
+    "version": "5.9.0"
+  },
+  "schemaVersion": 7,
+  "versionTag": "v2.0"
+}


### PR DESCRIPTION
## Description
User tasks that use the new binding type `versionTag` now use the version of the linked form referenced by the specified version tag.

## Related issues
closes #21041