### PR TITLE
deps: update jetty version to remedy spring boot update causing IT issues

### DIFF
--- a/optimize/backend/pom.xml
+++ b/optimize/backend/pom.xml
@@ -12,7 +12,7 @@
   <name>Optimize Backend</name>
 
   <properties>
-    <jetty.version>12.0.9</jetty.version>
+    <jetty.version>12.0.12</jetty.version>
     <jersey.version>3.1.3</jersey.version>
     <spring.security.version>6.3.3</spring.security.version>
     <nimbus.jose.jwt.version>9.40</nimbus.jose.jwt.version>


### PR DESCRIPTION
## Description
We previously reverted the automatic jetty update because it was causing issues preventing us from running IT. Now that renovate updated spring boot, this introduced a very similar looking [error](https://github.com/camunda/camunda/actions/runs/10514546020) when trying to start IT. Updating jetty again resolves the issue.

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
