### PR TITLE
fix: include total count in the listener endpoint

### DIFF
--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/ListenerReader.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/reader/ListenerReader.java
@@ -7,12 +7,11 @@
  */
 package io.camunda.operate.webapp.reader;
 
-import io.camunda.operate.webapp.rest.dto.ListenerDto;
 import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
-import java.util.List;
+import io.camunda.operate.webapp.rest.dto.ListenerResponseDto;
 
 public interface ListenerReader {
 
-  public List<ListenerDto> getListenerExecutions(
+  public ListenerResponseDto getListenerExecutions(
       String processInstanceId, ListenerRequestDto request);
 }

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/ProcessInstanceRestService.java
@@ -205,7 +205,7 @@ public class ProcessInstanceRestService extends InternalAPIErrorController {
 
   @Operation(summary = "Get listeners by process instance id")
   @PostMapping("/{processInstanceId}/listeners")
-  public List<ListenerDto> getListeners(
+  public ListenerResponseDto getListeners(
       @PathVariable @ValidLongId final String processInstanceId,
       @RequestBody final ListenerRequestDto request) {
     checkIdentityReadPermission(Long.parseLong(processInstanceId));

--- a/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerResponseDto.java
+++ b/operate/webapp/src/main/java/io/camunda/operate/webapp/rest/dto/ListenerResponseDto.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.webapp.rest.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ListenerResponseDto {
+  private List<ListenerDto> listeners = new ArrayList<>();
+  private Long totalCount;
+
+  public ListenerResponseDto() {}
+
+  public ListenerResponseDto(final List listeners, final Long totalCount) {
+    this.totalCount = totalCount;
+    this.listeners = listeners;
+  }
+
+  public List<ListenerDto> getListeners() {
+    return listeners;
+  }
+
+  public ListenerResponseDto setListeners(final List<ListenerDto> listeners) {
+    this.listeners = listeners;
+    return this;
+  }
+
+  public Long getTotalCount() {
+    return totalCount;
+  }
+
+  public ListenerResponseDto setTotalCount(final Long totalCount) {
+    this.totalCount = totalCount;
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(listeners, totalCount);
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final ListenerResponseDto that = (ListenerResponseDto) o;
+    return Objects.equals(listeners, that.listeners) && Objects.equals(totalCount, that.totalCount);
+  }
+
+  @Override
+  public String toString() {
+    return "ListenerResponseDto{" + "listeners=" + listeners + ", totalCount=" + totalCount + '}';
+  }
+}


### PR DESCRIPTION
This is a fix for a requested API change by frontend to allow for pagination.
Added a DTO for listener responses that includes the total hit count on top of the listener hits.

## Description

<!-- Describe the goal and purpose of this PR. -->

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/21512
