### PR TITLE
feat: add optional routing state to cluster configuration

### DIFF
--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -49,9 +49,12 @@ import io.camunda.zeebe.dynamic.config.state.ExporterState;
 import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation;
 import io.camunda.zeebe.util.Either;
 import java.nio.ByteBuffer;
 import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
@@ -133,12 +136,13 @@ public class ProtoBufSerializer
             ? Optional.of(decodeChangePlan(encodedClusterTopology.getCurrentChange()))
             : Optional.empty();
 
+    final Optional<RoutingState> routingState =
+        encodedClusterTopology.hasRoutingState()
+            ? Optional.of(decodeRoutingState(encodedClusterTopology.getRoutingState()))
+            : Optional.empty();
+
     return new ClusterConfiguration(
-        encodedClusterTopology.getVersion(),
-        members,
-        completedChange,
-        currentChange,
-        Optional.empty());
+        encodedClusterTopology.getVersion(), members, completedChange, currentChange, routingState);
   }
 
   private Map<MemberId, io.camunda.zeebe.dynamic.config.state.MemberState> decodeMemberStateMap(
@@ -163,6 +167,9 @@ public class ProtoBufSerializer
     clusterConfiguration
         .pendingChanges()
         .ifPresent(changePlan -> builder.setCurrentChange(encodeChangePlan(changePlan)));
+    clusterConfiguration
+        .routingState()
+        .ifPresent(routingState -> builder.setRoutingState(encodeRoutingState(routingState)));
 
     return builder.build();
   }
@@ -453,6 +460,43 @@ public class ProtoBufSerializer
             clusterChangePlan.getStartedAt().getNanos()),
         completedOperations,
         pendingOperations);
+  }
+
+  private RoutingState decodeRoutingState(final Topology.RoutingState routingState) {
+    return new RoutingState(
+        routingState.getVersion(),
+        new HashSet<>(routingState.getActivePartitionsList()),
+        decodeMessageCorrelation(routingState.getMessageCorrelation()));
+  }
+
+  private MessageCorrelation decodeMessageCorrelation(
+      final Topology.MessageCorrelation messageCorrelation) {
+    return switch (messageCorrelation.getCorrelationCase()) {
+      case HASHMOD ->
+          new MessageCorrelation.HashMod(messageCorrelation.getHashMod().getPartitionCount());
+      case CORRELATION_NOT_SET ->
+          throw new IllegalArgumentException("Unknown message correlation type");
+    };
+  }
+
+  private Topology.RoutingState encodeRoutingState(final RoutingState routingState) {
+    return Topology.RoutingState.newBuilder()
+        .setVersion(routingState.version())
+        .addAllActivePartitions(routingState.activePartitions())
+        .setMessageCorrelation(encodeMessageCorrelation(routingState.messageCorrelation()))
+        .build();
+  }
+
+  private Topology.MessageCorrelation encodeMessageCorrelation(
+      final MessageCorrelation correlation) {
+    return switch (correlation) {
+      case MessageCorrelation.HashMod(final var partitionCount) ->
+          Topology.MessageCorrelation.newBuilder()
+              .setHashMod(
+                  Topology.MessageCorrelation.HashMod.newBuilder()
+                      .setPartitionCount(partitionCount))
+              .build();
+    };
   }
 
   private io.camunda.zeebe.dynamic.config.state.CompletedChange decodeCompletedChange(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializer.java
@@ -134,7 +134,11 @@ public class ProtoBufSerializer
             : Optional.empty();
 
     return new ClusterConfiguration(
-        encodedClusterTopology.getVersion(), members, completedChange, currentChange);
+        encodedClusterTopology.getVersion(),
+        members,
+        completedChange,
+        currentChange,
+        Optional.empty());
   }
 
   private Map<MemberId, io.camunda.zeebe.dynamic.config.state.MemberState> decodeMemberStateMap(

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -37,14 +37,15 @@ public record ClusterConfiguration(
     long version,
     Map<MemberId, MemberState> members,
     Optional<CompletedChange> lastChange,
-    Optional<ClusterChangePlan> pendingChanges) {
+    Optional<ClusterChangePlan> pendingChanges,
+    Optional<RoutingState> routingState) {
 
   public static final int INITIAL_VERSION = 1;
   private static final int UNINITIALIZED_VERSION = -1;
 
   public static ClusterConfiguration uninitialized() {
     return new ClusterConfiguration(
-        UNINITIALIZED_VERSION, Map.of(), Optional.empty(), Optional.empty());
+        UNINITIALIZED_VERSION, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   public boolean isUninitialized() {
@@ -52,7 +53,8 @@ public record ClusterConfiguration(
   }
 
   public static ClusterConfiguration init() {
-    return new ClusterConfiguration(INITIAL_VERSION, Map.of(), Optional.empty(), Optional.empty());
+    return new ClusterConfiguration(
+        INITIAL_VERSION, Map.of(), Optional.empty(), Optional.empty(), Optional.empty());
   }
 
   public ClusterConfiguration addMember(final MemberId memberId, final MemberState state) {
@@ -65,7 +67,7 @@ public record ClusterConfiguration(
 
     final var newMembers =
         ImmutableMap.<MemberId, MemberState>builder().putAll(members).put(memberId, state).build();
-    return new ClusterConfiguration(version, newMembers, lastChange, pendingChanges);
+    return new ClusterConfiguration(version, newMembers, lastChange, pendingChanges, routingState);
   }
 
   /**
@@ -103,7 +105,7 @@ public record ClusterConfiguration(
     }
 
     final var newMembers = mapBuilder.buildKeepingLast();
-    return new ClusterConfiguration(version, newMembers, lastChange, pendingChanges);
+    return new ClusterConfiguration(version, newMembers, lastChange, pendingChanges, routingState);
   }
 
   public ClusterConfiguration startConfigurationChange(
@@ -121,7 +123,8 @@ public record ClusterConfiguration(
           newVersion,
           members,
           lastChange,
-          Optional.of(ClusterChangePlan.init(newVersion, operations)));
+          Optional.of(ClusterChangePlan.init(newVersion, operations)),
+          routingState);
     }
   }
 
@@ -148,8 +151,15 @@ public record ClusterConfiguration(
               .flatMap(Optional::stream)
               .reduce(ClusterChangePlan::merge);
 
+      // TODO: Merge routing state
+      final var mergedRoutingState = routingState;
+
       return new ClusterConfiguration(
-          version, ImmutableMap.copyOf(mergedMembers), lastChange, mergedChanges);
+          version,
+          ImmutableMap.copyOf(mergedMembers),
+          lastChange,
+          mergedChanges,
+          mergedRoutingState);
     }
   }
 
@@ -199,7 +209,11 @@ public record ClusterConfiguration(
     }
     final ClusterConfiguration result =
         new ClusterConfiguration(
-            version, members, lastChange, Optional.of(pendingChanges.orElseThrow().advance()));
+            version,
+            members,
+            lastChange,
+            Optional.of(pendingChanges.orElseThrow().advance()),
+            routingState);
 
     if (!result.hasPendingChanges()) {
       // The last change has been applied. Clean up the members that are marked as LEFT in the
@@ -218,7 +232,11 @@ public record ClusterConfiguration(
       // configuration.
       final var completedChange = pendingChanges.orElseThrow().completed();
       return new ClusterConfiguration(
-          result.version() + 1, currentMembers, Optional.of(completedChange), Optional.empty());
+          result.version() + 1,
+          currentMembers,
+          Optional.of(completedChange),
+          Optional.empty(),
+          routingState);
     }
 
     return result;
@@ -283,7 +301,7 @@ public record ClusterConfiguration(
       // A conflict would not happen if the cancel is only called when the operation is truly stuck.
       final var newVersion = version + 2;
       return new ClusterConfiguration(
-          newVersion, members, Optional.of(cancelledChange), Optional.empty());
+          newVersion, members, Optional.of(cancelledChange), Optional.empty(), routingState);
     } else {
       return this;
     }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/ClusterConfiguration.java
@@ -151,8 +151,10 @@ public record ClusterConfiguration(
               .flatMap(Optional::stream)
               .reduce(ClusterChangePlan::merge);
 
-      // TODO: Merge routing state
-      final var mergedRoutingState = routingState;
+      final var mergedRoutingState =
+          Stream.of(routingState, other.routingState)
+              .flatMap(Optional::stream)
+              .reduce(RoutingState::merge);
 
       return new ClusterConfiguration(
           version,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/state/RoutingState.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config.state;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Holds information about the state of partitions that is necessary to decide where to route new
+ * requests.
+ */
+public record RoutingState(
+    long version, Set<Integer> activePartitions, MessageCorrelation messageCorrelation) {
+  public RoutingState {
+    Objects.requireNonNull(activePartitions);
+    Objects.requireNonNull(messageCorrelation);
+
+    if (version < 0) {
+      throw new IllegalArgumentException("Version must be positive");
+    }
+
+    for (final var partition : activePartitions) {
+      if (partition <= 0) {
+        throw new IllegalArgumentException("Partition id must be positive");
+      }
+    }
+  }
+
+  /**
+   * Returns the initial routing info for the given partition count when all partitions participate
+   * in message correlation.
+   */
+  public static RoutingState initializeWithPartitionCount(final int partitionCount) {
+    return new RoutingState(
+        1,
+        IntStream.rangeClosed(1, partitionCount).boxed().collect(Collectors.toSet()),
+        new MessageCorrelation.HashMod(partitionCount));
+  }
+
+  /** Strategy used to correlate messages via their correlation key to partitions. */
+  public sealed interface MessageCorrelation {
+    record HashMod(int partitionCount) implements MessageCorrelation {
+      public HashMod {
+        if (partitionCount <= 0) {
+          throw new IllegalArgumentException("Partition count must be positive");
+        }
+      }
+    }
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -48,6 +48,7 @@ public final class ConfigurationUtil {
         ClusterConfiguration.INITIAL_VERSION,
         Map.copyOf(memberStates),
         Optional.empty(),
+        Optional.empty(),
         Optional.empty());
   }
 

--- a/zeebe/dynamic-config/src/main/resources/proto/proto.lock
+++ b/zeebe/dynamic-config/src/main/resources/proto/proto.lock
@@ -368,6 +368,11 @@
                 "id": 4,
                 "name": "currentChange",
                 "type": "ClusterChangePlan"
+              },
+              {
+                "id": 5,
+                "name": "routingState",
+                "type": "RoutingState"
               }
             ],
             "maps": [
@@ -378,6 +383,49 @@
                   "name": "members",
                   "type": "MemberState"
                 }
+              }
+            ]
+          },
+          {
+            "name": "RoutingState",
+            "fields": [
+              {
+                "id": 1,
+                "name": "version",
+                "type": "int64"
+              },
+              {
+                "id": 2,
+                "name": "activePartitions",
+                "type": "sint32",
+                "is_repeated": true
+              },
+              {
+                "id": 3,
+                "name": "messageCorrelation",
+                "type": "MessageCorrelation"
+              }
+            ]
+          },
+          {
+            "name": "MessageCorrelation",
+            "fields": [
+              {
+                "id": 1,
+                "name": "hashMod",
+                "type": "HashMod"
+              }
+            ],
+            "messages": [
+              {
+                "name": "HashMod",
+                "fields": [
+                  {
+                    "id": 1,
+                    "name": "partitionCount",
+                    "type": "sint32"
+                  }
+                ]
               }
             ]
           },

--- a/zeebe/dynamic-config/src/main/resources/proto/topology.proto
+++ b/zeebe/dynamic-config/src/main/resources/proto/topology.proto
@@ -14,6 +14,23 @@ message ClusterTopology {
   map<string, MemberState> members = 2;
   CompletedChange lastChange = 3;
   ClusterChangePlan currentChange = 4;
+  RoutingState routingState = 5;
+}
+
+message RoutingState {
+  int64  version = 1;
+  repeated sint32 activePartitions = 2;
+  MessageCorrelation messageCorrelation = 3;
+}
+
+message MessageCorrelation {
+  oneof correlation {
+    HashMod hashMod = 1;
+  }
+
+  message HashMod {
+    sint32 partitionCount = 1;
+  }
 }
 
 message MemberState {

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerTest.java
@@ -312,7 +312,8 @@ final class ClusterConfigurationManagerTest {
             topologyWithoutMember.version() + 1,
             topologyWithoutMember.members(),
             topologyWithoutMember.lastChange(),
-            topologyWithoutMember.pendingChanges());
+            topologyWithoutMember.pendingChanges(),
+            topologyWithoutMember.routingState());
     clusterTopologyManager.onGossipReceived(notConflictingTopology);
 
     // then

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -76,7 +76,8 @@ final class PersistedClusterConfigurationRandomizedPropertyTest {
       // `ClusterTopology#isUninitialized` to return false.
       final var arbitraryVersion = Arbitraries.integers().greaterOrEqual(0);
       final var arbitraryMembers =
-          Arbitraries.maps(memberIds(), Arbitraries.forType(MemberState.class).enableRecursion());
+          Arbitraries.maps(memberIds(), Arbitraries.forType(MemberState.class).enableRecursion())
+              .ofMaxSize(10);
       final var arbitraryCompletedChange =
           Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
       final var arbitraryChangePlan =

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/PersistedClusterConfigurationRandomizedPropertyTest.java
@@ -16,9 +16,11 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation;
 import io.camunda.zeebe.dynamic.config.state.CompletedChange;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import io.camunda.zeebe.util.ReflectUtil;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Optional;
 import net.jqwik.api.Arbitraries;
 import net.jqwik.api.Arbitrary;
 import net.jqwik.api.Combinators;
@@ -75,8 +77,14 @@ final class PersistedClusterConfigurationRandomizedPropertyTest {
           Arbitraries.forType(CompletedChange.class).enableRecursion().optional();
       final var arbitraryChangePlan =
           Arbitraries.forType(ClusterChangePlan.class).enableRecursion().optional();
+      // TODO: Generate random routing state
+      final var arbitraryRoutingState = Arbitraries.<Optional<RoutingState>>of(Optional.empty());
       return Combinators.combine(
-              arbitraryVersion, arbitraryMembers, arbitraryCompletedChange, arbitraryChangePlan)
+              arbitraryVersion,
+              arbitraryMembers,
+              arbitraryCompletedChange,
+              arbitraryChangePlan,
+              arbitraryRoutingState)
           .as(ClusterConfiguration::new);
     }
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/serializer/ProtoBufSerializerTest.java
@@ -36,6 +36,7 @@ import io.camunda.zeebe.dynamic.config.state.ExporterState.State;
 import io.camunda.zeebe.dynamic.config.state.ExportersConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -222,7 +223,8 @@ final class ProtoBufSerializerTest {
         topologyWithExporterState(),
         topologyWithExporterDisableOperation(),
         topologyWithExporterEnableOperation(),
-        topologyWithUninitializedPartitionConfig());
+        topologyWithUninitializedPartitionConfig(),
+        topologyWithRoutingState());
   }
 
   private static ClusterConfiguration topologyWithOneMemberNoPartitions() {
@@ -369,5 +371,15 @@ final class ProtoBufSerializerTest {
             MemberId.from("0"),
             MemberState.initializeAsActive(
                 Map.of(1, PartitionState.active(1, DynamicPartitionConfig.uninitialized()))));
+  }
+
+  private static ClusterConfiguration topologyWithRoutingState() {
+    return new ClusterConfiguration(
+        ClusterConfiguration.INITIAL_VERSION,
+        Map.of(),
+        Optional.empty(),
+        Optional.empty(),
+        Optional.of(
+            new RoutingState(1, Set.of(1, 2, 3), new RoutingState.MessageCorrelation.HashMod(2))));
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -252,6 +252,7 @@ class ClusterConfigurationTest {
                     Map.of(1, PartitionState.active(1, emptyPartitionConfig)))),
             Optional.of(
                 new CompletedChange(changeId, Status.COMPLETED, Instant.now(), Instant.now())),
+            Optional.empty(),
             Optional.empty());
 
     ClusterConfigurationAssert.assertThatClusterTopology(finalTopology).hasSameTopologyAs(expected);
@@ -302,6 +303,7 @@ class ClusterConfigurationTest {
                 MemberState.initializeAsActive(
                     Map.of(1, PartitionState.active(1, DynamicPartitionConfig.uninitialized())))),
             Optional.empty(),
+            Optional.empty(),
             Optional.empty());
 
     final DynamicPartitionConfig validConfig =
@@ -313,6 +315,7 @@ class ClusterConfigurationTest {
             Map.of(
                 member(1),
                 MemberState.initializeAsActive(Map.of(1, PartitionState.active(1, validConfig)))),
+            Optional.empty(),
             Optional.empty(),
             Optional.empty());
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/state/ClusterConfigurationTest.java
@@ -17,10 +17,12 @@ import io.camunda.zeebe.dynamic.config.state.ClusterChangePlan.Status;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionJoinOperation;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfigurationChangeOperation.PartitionChangeOperation.PartitionLeaveOperation;
 import io.camunda.zeebe.dynamic.config.state.MemberState.State;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class ClusterConfigurationTest {
@@ -330,6 +332,25 @@ class ClusterConfigurationTest {
     ClusterConfigurationAssert.assertThatClusterTopology(mergeUninitializedToValid)
         .member(1)
         .hasPartitionSatisfying(1, p -> PartitionStateAssert.assertThat(p).hasConfig(validConfig));
+  }
+
+  @Test
+  void shouldMergeRoutingState() {
+    // given
+    final var oldRoutingState = Optional.of(new RoutingState(1, Set.of(1, 2, 3), new HashMod(3)));
+    final var oldConfig =
+        new ClusterConfiguration(1, Map.of(), Optional.empty(), Optional.empty(), oldRoutingState);
+
+    final var newRoutingState =
+        Optional.of(new RoutingState(2, Set.of(1, 2, 3, 4), new HashMod(4)));
+    final var newConfig =
+        new ClusterConfiguration(1, Map.of(), Optional.empty(), Optional.empty(), newRoutingState);
+
+    // when
+    final var merged = oldConfig.merge(newConfig);
+
+    // then
+    assertThat(merged.routingState()).isEqualTo(newRoutingState);
   }
 
   private MemberId member(final int id) {


### PR DESCRIPTION
This PR adds a new optional field `routingState` to the dynamic cluster configuration.
This field is not yet initialized in any way, this will be done as a follow-up.

Routing state is versioned. We expect that it will be the coordinators responsibility to update it as new partitions are added and become ready. The version is useful for other members to merge updates received out of order.

The routing state itself consists of two fields, `activePartitions` and `messageCorrelation`.

`activePartitions` is a set of partition ids. This will be used later on by the gateway to route requests such as creating new process instances, activating jobs etc.

`messageCorrelation` describes the current strategy for routing messages. The only supported strategy right now is our default "hash then mod over partition count".

The routing state is pure data, it does not implement any interfaces that would help the gateway or engine to actually make use of that data yet.

Relates to https://github.com/camunda/camunda/issues/21465