### PR TITLE
feat: add aggregation framework to search api

### DIFF
--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformer.java
@@ -9,7 +9,11 @@ package io.camunda.search.es.transformers;
 
 import co.elastic.clients.elasticsearch._types.FieldValue;
 import co.elastic.clients.elasticsearch._types.SortOptions;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
 import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import io.camunda.search.clients.aggregation.SearchAggregate;
+import io.camunda.search.clients.aggregation.SearchAggregation;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.sort.SearchSortOptions;
 import io.camunda.search.clients.types.TypedValue;
@@ -37,5 +41,13 @@ public abstract class ElasticsearchTransformer<T, R> implements SearchTransfomer
 
   protected SearchTransfomer<SearchSortOptions, SortOptions> getSortOptionsTransformer() {
     return getTransformer(SearchSortOptions.class);
+  }
+
+  protected SearchTransfomer<SearchAggregation, Aggregation> getAggregationTransformer() {
+    return getTransformer(SearchAggregation.class);
+  }
+
+  protected SearchTransfomer<Aggregate, SearchAggregate> getAggregateTransformer() {
+    return getTransformer(SearchAggregate.class);
   }
 }

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformer.java
@@ -48,6 +48,6 @@ public abstract class ElasticsearchTransformer<T, R> implements SearchTransfomer
   }
 
   protected SearchTransfomer<Aggregate, SearchAggregate> getAggregateTransformer() {
-    return getTransformer(SearchAggregate.class);
+    return getTransformer(Aggregate.class);
   }
 }

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
@@ -7,6 +7,8 @@
  */
 package io.camunda.search.es.transformers;
 
+import io.camunda.search.clients.aggregation.SearchCardinalityAggregate;
+import io.camunda.search.clients.aggregation.SearchCardinalityAggregation;
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.clients.core.SearchQueryResponse;
@@ -27,6 +29,8 @@ import io.camunda.search.clients.query.SearchWildcardQuery;
 import io.camunda.search.clients.sort.SearchFieldSort;
 import io.camunda.search.clients.sort.SearchSortOptions;
 import io.camunda.search.clients.types.TypedValue;
+import io.camunda.search.es.transformers.aggregation.CardinalityAggregateTransformer;
+import io.camunda.search.es.transformers.aggregation.CardinalityAggregationTransformer;
 import io.camunda.search.es.transformers.query.BoolQueryTransformer;
 import io.camunda.search.es.transformers.query.ConstantScoreQueryTransformer;
 import io.camunda.search.es.transformers.query.ExistsQueryTransformer;
@@ -95,5 +99,11 @@ public final class ElasticsearchTransformers {
 
     // types
     mappers.put(TypedValue.class, new TypedValueTransformer(mappers));
+
+    // aggregations
+    mappers.put(SearchCardinalityAggregation.class, new CardinalityAggregationTransformer(mappers));
+
+    // aggregates
+    mappers.put(SearchCardinalityAggregate.class, new CardinalityAggregateTransformer(mappers));
   }
 }

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/ElasticsearchTransformers.java
@@ -7,7 +7,9 @@
  */
 package io.camunda.search.es.transformers;
 
-import io.camunda.search.clients.aggregation.SearchCardinalityAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregate;
+import io.camunda.search.clients.aggregation.SearchAggregation;
 import io.camunda.search.clients.aggregation.SearchCardinalityAggregation;
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryRequest;
@@ -31,6 +33,8 @@ import io.camunda.search.clients.sort.SearchSortOptions;
 import io.camunda.search.clients.types.TypedValue;
 import io.camunda.search.es.transformers.aggregation.CardinalityAggregateTransformer;
 import io.camunda.search.es.transformers.aggregation.CardinalityAggregationTransformer;
+import io.camunda.search.es.transformers.aggregation.SearchAggregateTransformer;
+import io.camunda.search.es.transformers.aggregation.SearchAggregationTransformer;
 import io.camunda.search.es.transformers.query.BoolQueryTransformer;
 import io.camunda.search.es.transformers.query.ConstantScoreQueryTransformer;
 import io.camunda.search.es.transformers.query.ExistsQueryTransformer;
@@ -101,9 +105,11 @@ public final class ElasticsearchTransformers {
     mappers.put(TypedValue.class, new TypedValueTransformer(mappers));
 
     // aggregations
+    mappers.put(SearchAggregation.class, new SearchAggregationTransformer(mappers));
     mappers.put(SearchCardinalityAggregation.class, new CardinalityAggregationTransformer(mappers));
 
     // aggregates
-    mappers.put(SearchCardinalityAggregate.class, new CardinalityAggregateTransformer(mappers));
+    mappers.put(Aggregate.class, new SearchAggregateTransformer(mappers));
+    mappers.put(CardinalityAggregate.class, new CardinalityAggregateTransformer(mappers));
   }
 }

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/AggregateOptionTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/AggregateOptionTransformer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import co.elastic.clients.elasticsearch._types.aggregations.AggregateVariant;
+import io.camunda.search.clients.aggregation.SearchAggregateOption;
+import io.camunda.search.es.transformers.ElasticsearchTransformer;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+
+public abstract class AggregateOptionTransformer<
+        T extends AggregateVariant, R extends SearchAggregateOption>
+    extends ElasticsearchTransformer<T, R> implements SearchTransfomer<T, R> {
+
+  public AggregateOptionTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/AggregationOptionTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/AggregationOptionTransformer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationVariant;
+import io.camunda.search.clients.aggregation.SearchAggregationOption;
+import io.camunda.search.es.transformers.ElasticsearchTransformer;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+
+public abstract class AggregationOptionTransformer<
+        T extends SearchAggregationOption, R extends AggregationVariant>
+    extends ElasticsearchTransformer<T, R> implements SearchTransfomer<T, R> {
+
+  public AggregationOptionTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregateTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregateTransformer.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregate;
+import io.camunda.search.clients.aggregation.SearchAggregateBuilders;
+import io.camunda.search.clients.aggregation.SearchCardinalityAggregate;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+
+public class CardinalityAggregateTransformer
+    extends AggregateOptionTransformer<CardinalityAggregate, SearchCardinalityAggregate> {
+
+  public CardinalityAggregateTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public SearchCardinalityAggregate apply(final CardinalityAggregate value) {
+    return SearchAggregateBuilders.cardinality().value(value.value()).build();
+  }
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregationTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregationTransformer.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationBuilders;
+import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregation;
+import io.camunda.search.clients.aggregation.SearchCardinalityAggregation;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+
+public final class CardinalityAggregationTransformer
+    extends AggregationOptionTransformer<SearchCardinalityAggregation, CardinalityAggregation> {
+
+  public CardinalityAggregationTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public CardinalityAggregation apply(final SearchCardinalityAggregation value) {
+    return AggregationBuilders.cardinality()
+        .field(value.field())
+        .precisionThreshold(value.precisionThreshold())
+        .build();
+  }
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/SearchAggregateTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/SearchAggregateTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregateVariant;
+import io.camunda.search.clients.aggregation.SearchAggregate;
+import io.camunda.search.clients.aggregation.SearchAggregateOption;
+import io.camunda.search.es.transformers.ElasticsearchTransformer;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+
+public class SearchAggregateTransformer
+    extends ElasticsearchTransformer<Aggregate, SearchAggregate> {
+
+  public SearchAggregateTransformer(final ElasticsearchTransformers mappers) {
+    super(mappers);
+  }
+
+  @Override
+  public SearchAggregate apply(final Aggregate aggregate) {
+    final var aggregateOption = (AggregateVariant) aggregate._get();
+
+    if (aggregateOption == null) {
+      return null;
+    }
+
+    final var aggregateVariantCls = aggregateOption.getClass();
+    final var transformer = getAggregateOptionTransformer(aggregateVariantCls);
+    final var transformedAggregationOption = transformer.apply(aggregateOption);
+    return transformedAggregationOption.toSearchAggregate();
+  }
+
+  public <T extends AggregateVariant, R extends SearchAggregateOption>
+      SearchTransfomer<T, R> getAggregateOptionTransformer(final Class<?> cls) {
+    return getTransformer(cls);
+  }
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/SearchAggregationTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/aggregation/SearchAggregationTransformer.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregationVariant;
+import io.camunda.search.clients.aggregation.SearchAggregation;
+import io.camunda.search.clients.aggregation.SearchAggregationOption;
+import io.camunda.search.es.transformers.ElasticsearchTransformer;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+
+public class SearchAggregationTransformer
+    extends ElasticsearchTransformer<SearchAggregation, Aggregation> {
+
+  public SearchAggregationTransformer(final ElasticsearchTransformers transformers) {
+    super(transformers);
+  }
+
+  @Override
+  public Aggregation apply(final SearchAggregation searchAggregation) {
+    final var aggregationOption = searchAggregation.aggregationOption();
+
+    if (aggregationOption == null) {
+      return null;
+    }
+
+    final var aggregationOptionCls = aggregationOption.getClass();
+    final var transformer = getAggregationOptionTransformer(aggregationOptionCls);
+    final var transformedAggregationOption = transformer.apply(aggregationOption);
+    return transformedAggregationOption._toAggregation();
+  }
+
+  public <T extends SearchAggregationOption, R extends AggregationVariant>
+      SearchTransfomer<T, R> getAggregationOptionTransformer(final Class<?> cls) {
+    return getTransformer(cls);
+  }
+}

--- a/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
+++ b/search/search-client-elasticsearch/src/main/java/io/camunda/search/es/transformers/search/SearchResponseTransformer.java
@@ -10,12 +10,15 @@ package io.camunda.search.es.transformers.search;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import co.elastic.clients.elasticsearch.core.search.TotalHits;
+import io.camunda.search.clients.aggregation.SearchAggregate;
 import io.camunda.search.clients.core.SearchQueryHit;
 import io.camunda.search.clients.core.SearchQueryResponse;
 import io.camunda.search.es.transformers.ElasticsearchTransformer;
 import io.camunda.search.es.transformers.ElasticsearchTransformers;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 public final class SearchResponseTransformer<T>
@@ -35,11 +38,13 @@ public final class SearchResponseTransformer<T>
 
     final var sourceHits = hits.hits();
     final var transformedHits = of(sourceHits);
+    final var transformedAggregates = of(value.aggregations());
 
     return new SearchQueryResponse.Builder<T>()
         .totalHits(totalHits)
         .scrollId(scrollId)
         .hits(transformedHits)
+        .aggregations(transformedAggregates)
         .build();
   }
 
@@ -56,5 +61,13 @@ public final class SearchResponseTransformer<T>
       return totalHits.value();
     }
     return 0;
+  }
+
+  private Map<String, SearchAggregate> of(
+      final Map<String, co.elastic.clients.elasticsearch._types.aggregations.Aggregate> values) {
+    final var aggregateTransformer = getAggregateTransformer();
+    return values.entrySet().stream()
+        .collect(
+            Collectors.toMap(Entry::getKey, entry -> aggregateTransformer.apply(entry.getValue())));
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/clients/ElasticsearchDataStoreClientTest.java
@@ -7,14 +7,21 @@
  */
 package io.camunda.search.es.clients;
 
+import static io.camunda.search.clients.aggregation.SearchAggregationBuilders.cardinality;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.CardinalityAggregation;
 import co.elastic.clients.elasticsearch.core.SearchResponse;
 import co.elastic.clients.elasticsearch.core.search.HitsMetadata;
 import co.elastic.clients.elasticsearch.core.search.TotalHitsRelation;
+import io.camunda.search.clients.aggregation.SearchAggregate;
+import io.camunda.search.clients.aggregation.SearchCardinalityAggregate;
 import io.camunda.search.clients.core.SearchQueryRequest;
 import io.camunda.search.es.util.StubbedElasticsearchClient;
 import java.util.ArrayList;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -36,6 +43,8 @@ public class ElasticsearchDataStoreClientTest {
                               (m) ->
                                   m.hits(new ArrayList<>())
                                       .total((t) -> t.value(789).relation(TotalHitsRelation.Eq))))
+                      .aggregations(
+                          "test-aggregate", Aggregate.of(a -> a.cardinality(c -> c.value(23))))
                       .shards((s) -> s.failed(0).successful(100).total(100))
                       .timedOut(false));
         });
@@ -47,7 +56,14 @@ public class ElasticsearchDataStoreClientTest {
   public void shouldTransformSearchRequest() {
     // given
     final SearchQueryRequest request =
-        SearchQueryRequest.of(b -> b.index("operate-list-view-8.3.0_").size(1));
+        SearchQueryRequest.of(
+            b ->
+                b.index("operate-list-view-8.3.0_")
+                    .size(1)
+                    .aggregations(
+                        Map.of(
+                            "test-aggregate",
+                            cardinality(c -> c.field("count")).toSearchAggregation())));
 
     // when
     client.search(request, Object.class);
@@ -55,6 +71,9 @@ public class ElasticsearchDataStoreClientTest {
     // then
     final var searchRequest = stubbedElasticsearchClient.getSingleSearchRequest();
     assertThat(searchRequest.index()).hasSize(1).contains("operate-list-view-8.3.0_");
+    assertThat(searchRequest.aggregations()).hasSize(1);
+    assertIsAggregation(
+        searchRequest.aggregations().get("test-aggregate"), CardinalityAggregation.class);
   }
 
   @Test
@@ -69,5 +88,20 @@ public class ElasticsearchDataStoreClientTest {
     // then
     assertThat(response).isNotNull();
     assertThat(response.get().totalHits()).isEqualTo(789);
+    assertThat(response.get().aggregations()).hasSize(1);
+    assertIsAggregate(
+        response.get().aggregations().get("test-aggregate"), SearchCardinalityAggregate.class);
+  }
+
+  private void assertIsAggregation(
+      final Aggregation aggregation, final Class<?> expectedAggregationVariantClass) {
+    assertThat(aggregation).isInstanceOf(Aggregation.class);
+    assertThat(aggregation._get()).isInstanceOf(expectedAggregationVariantClass);
+  }
+
+  private void assertIsAggregate(
+      final SearchAggregate searchAggregate, final Class<?> expectedAggregateOptionClass) {
+    assertThat(searchAggregate).isInstanceOf(SearchAggregate.class);
+    assertThat(searchAggregate.aggregateOption()).isInstanceOf(expectedAggregateOptionClass);
   }
 }

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregateTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregateTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.AggregateBuilders;
+import io.camunda.search.clients.aggregation.SearchAggregate;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CardinalityAggregateTest {
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<Aggregate, SearchAggregate> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(Aggregate.class);
+  }
+
+  private static Stream<Arguments> provideAggregates() {
+    return Stream.of(
+        Arguments.arguments(
+            AggregateBuilders.cardinality(c -> c.value(23)),
+            "SearchAggregate[aggregateOption=SearchCardinalityAggregate[value=23]]"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAggregates")
+  public void shouldApplyTransformer(
+      final Aggregate aggregate, final String expectedResultAggregate) {
+    // given
+    final var expectedAggregate = expectedResultAggregate.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(aggregate);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.toString()).isEqualTo(expectedAggregate);
+  }
+}

--- a/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregationTest.java
+++ b/search/search-client-elasticsearch/src/test/java/io/camunda/search/es/transformers/aggregation/CardinalityAggregationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.es.transformers.aggregation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import io.camunda.search.clients.aggregation.SearchAggregation;
+import io.camunda.search.clients.aggregation.SearchAggregationBuilders;
+import io.camunda.search.es.transformers.ElasticsearchTransformers;
+import io.camunda.search.transformers.SearchTransfomer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class CardinalityAggregationTest {
+
+  private final ElasticsearchTransformers transformers = new ElasticsearchTransformers();
+  private SearchTransfomer<SearchAggregation, Aggregation> transformer;
+
+  @BeforeEach
+  public void before() {
+    transformer = transformers.getTransformer(SearchAggregation.class);
+  }
+
+  private static Stream<Arguments> provideAggregations() {
+    return Stream.of(
+        Arguments.arguments(
+            SearchAggregationBuilders.cardinality(c -> c.field("name")).toSearchAggregation(),
+            "Aggregation: {'cardinality':{'field':'name'}}"),
+        Arguments.arguments(
+            SearchAggregationBuilders.cardinality(c -> c.field("name").precisionThreshold(100))
+                .toSearchAggregation(),
+            "Aggregation: {'cardinality':{'field':'name','precision_threshold':100}}"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideAggregations")
+  public void shouldApplyTransformer(
+      final SearchAggregation aggregation, final String expectedResultAggregation) {
+    // given
+    final var expectedAggregation = expectedResultAggregation.replace("'", "\"");
+
+    // when
+    final var result = transformer.apply(aggregation);
+
+    // then
+    assertThat(result).isNotNull();
+    assertThat(result.toString()).isEqualTo(expectedAggregation);
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregate.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregate.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+import static io.camunda.search.clients.aggregation.SearchAggregateBuilders.aggregate;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public record SearchAggregate(SearchAggregateOption aggregateOption) {
+
+  public static SearchAggregate of(final Function<Builder, ObjectBuilder<SearchAggregate>> fn) {
+    return aggregate(fn);
+  }
+
+  public static final class Builder implements ObjectBuilder<SearchAggregate> {
+
+    private SearchAggregateOption aggregateOption;
+
+    public Builder cardinality(final SearchCardinalityAggregate cardinality) {
+      aggregateOption = cardinality;
+      return this;
+    }
+
+    public Builder cardinality(
+        final Function<
+                SearchCardinalityAggregate.Builder, ObjectBuilder<SearchCardinalityAggregate>>
+            fn) {
+      return cardinality(SearchAggregateBuilders.cardinality(fn));
+    }
+
+    @Override
+    public SearchAggregate build() {
+      return new SearchAggregate(aggregateOption);
+    }
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregateBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregateBuilders.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+import io.camunda.search.clients.aggregation.SearchAggregate.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public class SearchAggregateBuilders {
+
+  public static SearchAggregate aggregate(
+      final Function<Builder, ObjectBuilder<SearchAggregate>> fn) {
+    return fn.apply(aggregate()).build();
+  }
+
+  public static SearchAggregate.Builder aggregate() {
+    return new SearchAggregate.Builder();
+  }
+
+  public static SearchCardinalityAggregate.Builder cardinality() {
+    return new SearchCardinalityAggregate.Builder();
+  }
+
+  public static SearchCardinalityAggregate cardinality(
+      final Function<SearchCardinalityAggregate.Builder, ObjectBuilder<SearchCardinalityAggregate>>
+          fn) {
+    return fn.apply(cardinality()).build();
+  }
+
+  public static SearchCardinalityAggregate cardinality(final Long value) {
+    return cardinality(c -> c.value(value));
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregateOption.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregateOption.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+public interface SearchAggregateOption {
+
+  default SearchAggregate toSearchAggregate() {
+    return new SearchAggregate(this);
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregation.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregation.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+import static io.camunda.search.clients.aggregation.SearchAggregationBuilders.aggregation;
+
+import io.camunda.search.clients.query.SearchQuery.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public record SearchAggregation(SearchAggregationOption aggregationOption) {
+
+  public static SearchAggregation of(final Function<Builder, ObjectBuilder<SearchAggregation>> fn) {
+    return aggregation(fn);
+  }
+
+  public static final class Builder implements ObjectBuilder<SearchAggregation> {
+
+    private SearchAggregationOption aggregationOption;
+
+    public Builder cardinality(final SearchCardinalityAggregation cardinality) {
+      aggregationOption = cardinality;
+      return this;
+    }
+
+    public Builder cardinality(
+        final Function<
+                SearchCardinalityAggregation.Builder, ObjectBuilder<SearchCardinalityAggregation>>
+            fn) {
+      return cardinality(SearchAggregationBuilders.cardinality(fn));
+    }
+
+    @Override
+    public SearchAggregation build() {
+      return new SearchAggregation(aggregationOption);
+    }
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregationBuilders.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregationBuilders.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+import io.camunda.search.clients.aggregation.SearchAggregation.Builder;
+import io.camunda.util.ObjectBuilder;
+import java.util.function.Function;
+
+public class SearchAggregationBuilders {
+
+  public static SearchAggregation aggregation(
+      final Function<Builder, ObjectBuilder<SearchAggregation>> fn) {
+    return fn.apply(aggregation()).build();
+  }
+
+  public static SearchAggregation.Builder aggregation() {
+    return new SearchAggregation.Builder();
+  }
+
+  public static SearchCardinalityAggregation.Builder cardinality() {
+    return new SearchCardinalityAggregation.Builder();
+  }
+
+  public static SearchCardinalityAggregation cardinality(
+      final Function<
+              SearchCardinalityAggregation.Builder, ObjectBuilder<SearchCardinalityAggregation>>
+          fn) {
+    return fn.apply(cardinality()).build();
+  }
+
+  public static SearchCardinalityAggregation cardinality(
+      final String field, final Integer precisionThreshold) {
+    return cardinality(c -> c.field(field).precisionThreshold(precisionThreshold));
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregationOption.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchAggregationOption.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+public interface SearchAggregationOption {
+
+  default SearchAggregation toSearchAggregation() {
+    return new SearchAggregation(this);
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchCardinalityAggregate.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchCardinalityAggregate.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+
+public record SearchCardinalityAggregate(Long value) implements SearchAggregateOption {
+
+  public static final class Builder implements ObjectBuilder<SearchCardinalityAggregate> {
+
+    private Long value;
+
+    public Builder value(final Long value) {
+      this.value = value;
+      return this;
+    }
+
+    @Override
+    public SearchCardinalityAggregate build() {
+      return new SearchCardinalityAggregate(
+          Objects.requireNonNull(value, "Expected non-null field for cardinality aggregate value"));
+    }
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchCardinalityAggregation.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/aggregation/SearchCardinalityAggregation.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.search.clients.aggregation;
+
+import io.camunda.util.ObjectBuilder;
+import java.util.Objects;
+
+public record SearchCardinalityAggregation(String field, Integer precisionThreshold)
+    implements SearchAggregationOption {
+
+  public static final class Builder implements ObjectBuilder<SearchCardinalityAggregation> {
+
+    private String field;
+    private Integer precisionThreshold;
+
+    public Builder field(final String field) {
+      this.field = field;
+      return this;
+    }
+
+    public Builder precisionThreshold(final Integer precisionThreshold) {
+      this.precisionThreshold = precisionThreshold;
+      return this;
+    }
+
+    @Override
+    public SearchCardinalityAggregation build() {
+      return new SearchCardinalityAggregation(
+          Objects.requireNonNull(field, "Expected non-null field for cardinality aggregation"),
+          precisionThreshold);
+    }
+  }
+}

--- a/search/search-client/src/main/java/io/camunda/search/clients/core/SearchQueryRequest.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/core/SearchQueryRequest.java
@@ -11,18 +11,21 @@ import static io.camunda.search.clients.core.RequestBuilders.searchRequest;
 import static io.camunda.util.CollectionUtil.addValuesToList;
 import static io.camunda.util.CollectionUtil.collectValues;
 
+import io.camunda.search.clients.aggregation.SearchAggregation;
 import io.camunda.search.clients.query.SearchQuery;
 import io.camunda.search.clients.query.SearchQueryBuilders;
 import io.camunda.search.clients.sort.SearchSortOptions;
 import io.camunda.search.clients.sort.SortOptionsBuilders;
 import io.camunda.util.ObjectBuilder;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
 public final record SearchQueryRequest(
     List<String> index,
     SearchQuery query,
+    Map<String, SearchAggregation> aggregations,
     List<SearchSortOptions> sort,
     Object[] searchAfter,
     Integer from,
@@ -37,6 +40,7 @@ public final record SearchQueryRequest(
 
     private List<String> index;
     private SearchQuery query;
+    private Map<String, SearchAggregation> aggregations;
     private List<SearchSortOptions> sort;
     private Object[] searchAfter;
     private Integer from;
@@ -53,6 +57,11 @@ public final record SearchQueryRequest(
 
     public Builder query(final SearchQuery value) {
       query = value;
+      return this;
+    }
+
+    public Builder aggregations(final Map<String, SearchAggregation> value) {
+      aggregations = value;
       return this;
     }
 
@@ -95,6 +104,7 @@ public final record SearchQueryRequest(
           Objects.requireNonNull(
               index, "Expected to create request for index, but given index was null."),
           query,
+          aggregations,
           sort,
           searchAfter,
           from,

--- a/search/search-client/src/main/java/io/camunda/search/clients/core/SearchQueryResponse.java
+++ b/search/search-client/src/main/java/io/camunda/search/clients/core/SearchQueryResponse.java
@@ -7,14 +7,19 @@
  */
 package io.camunda.search.clients.core;
 
+import io.camunda.search.clients.aggregation.SearchAggregate;
 import io.camunda.util.ObjectBuilder;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
 
-public final record SearchQueryResponse<T>(
-    long totalHits, String scrollId, List<SearchQueryHit<T>> hits) {
+public record SearchQueryResponse<T>(
+    long totalHits,
+    String scrollId,
+    List<SearchQueryHit<T>> hits,
+    Map<String, SearchAggregate> aggregations) {
 
   public static <T> SearchQueryResponse<T> of(
       final Function<Builder<T>, ObjectBuilder<SearchQueryResponse<T>>> fn) {
@@ -26,6 +31,7 @@ public final record SearchQueryResponse<T>(
     private long totalHits;
     private String scrollId;
     private List<SearchQueryHit<T>> hits;
+    private Map<String, SearchAggregate> aggregations;
 
     public Builder<T> totalHits(final long value) {
       totalHits = value;
@@ -42,10 +48,18 @@ public final record SearchQueryResponse<T>(
       return this;
     }
 
+    public Builder<T> aggregations(final Map<String, SearchAggregate> value) {
+      aggregations = value;
+      return this;
+    }
+
     @Override
     public SearchQueryResponse<T> build() {
       return new SearchQueryResponse<T>(
-          totalHits, scrollId, Objects.requireNonNullElse(hits, Collections.emptyList()));
+          totalHits,
+          scrollId,
+          Objects.requireNonNullElse(hits, Collections.emptyList()),
+          aggregations);
     }
   }
 }


### PR DESCRIPTION
## Description

* Add Aggregation framework for Search API
  * Different types of Aggregation and Aggregate are defined in the same manner as `SearchQueryOption`. It is called `SearchAggregationOption` and `SearchAggregateOption`
* Implemented Elasticsearch parts
* Based on Cardinality aggregation
* Not included:
  * tests
  * OpenSearch implementation
* In this [PR](https://github.com/camunda/camunda/pull/21585) (based on this branch) subaggregations are addressed

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
