### PR TITLE
feat: initialize routing state when partition scaling feature is enabled

### DIFF
--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -40,6 +40,8 @@ public final class StaticConfigurationGenerator {
   public static StaticConfiguration getStaticConfiguration(
       final BrokerCfg brokerCfg, final MemberId localMemberId) {
     final var clusterCfg = brokerCfg.getCluster();
+    final var enablePartitionScaling =
+        brokerCfg.getExperimental().getFeatures().isEnablePartitionScaling();
     final var partitioningCfg = brokerCfg.getExperimental().getPartitioning();
     final var partitionCount = clusterCfg.getPartitionsCount();
     final var replicationFactor = clusterCfg.getReplicationFactor();
@@ -50,6 +52,7 @@ public final class StaticConfigurationGenerator {
     final var partitionConfig = generatePartitionConfig(brokerCfg);
 
     return new StaticConfiguration(
+        enablePartitionScaling,
         partitionDistributor,
         clusterMembers,
         localMemberId,

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/topology/StaticConfigurationGenerator.java
@@ -41,30 +41,24 @@ public final class StaticConfigurationGenerator {
       final BrokerCfg brokerCfg, final MemberId localMemberId) {
     final var clusterCfg = brokerCfg.getCluster();
     final var partitioningCfg = brokerCfg.getExperimental().getPartitioning();
-    final var allMembers = StaticConfigurationGenerator.getRaftGroupMembers(clusterCfg);
+    final var partitionCount = clusterCfg.getPartitionsCount();
+    final var replicationFactor = clusterCfg.getReplicationFactor();
 
-    final var commonConfig = generateConfig(brokerCfg);
+    final var partitionDistributor = getPartitionDistributor(partitioningCfg);
+    final var clusterMembers = getRaftGroupMembers(clusterCfg);
+    final var partitionIds = getSortedPartitionIds(partitionCount);
+    final var partitionConfig = generatePartitionConfig(brokerCfg);
 
     return new StaticConfiguration(
-        StaticConfigurationGenerator.getPartitionDistributor(partitioningCfg),
-        allMembers,
+        partitionDistributor,
+        clusterMembers,
         localMemberId,
-        StaticConfigurationGenerator.getSortedPartitionIds(clusterCfg.getPartitionsCount()),
-        clusterCfg.getReplicationFactor(),
-        commonConfig);
+        partitionIds,
+        replicationFactor,
+        partitionConfig);
   }
 
-  private static DynamicPartitionConfig generateConfig(final BrokerCfg brokerCfg) {
-    final Map<String, ExporterState> exporters = new HashMap<>();
-    brokerCfg
-        .getExporters()
-        .forEach(
-            (exporterId, ignore) ->
-                exporters.put(exporterId, new ExporterState(0, State.ENABLED, Optional.empty())));
-    return new DynamicPartitionConfig(new ExportersConfig(Map.copyOf(exporters)));
-  }
-
-  static PartitionDistributor getPartitionDistributor(final PartitioningCfg partitionCfg) {
+  private static PartitionDistributor getPartitionDistributor(final PartitioningCfg partitionCfg) {
     return buildPartitionDistributor(partitionCfg);
   }
 
@@ -97,11 +91,21 @@ public final class StaticConfigurationGenerator {
         .collect(Collectors.toSet());
   }
 
-  static List<PartitionId> getSortedPartitionIds(final int partitionCount) {
+  private static List<PartitionId> getSortedPartitionIds(final int partitionCount) {
     // partition ids start from 1
     return IntStream.rangeClosed(1, partitionCount)
         .mapToObj(p -> PartitionId.from(PartitionManagerImpl.GROUP_NAME, p))
         .sorted()
         .toList();
+  }
+
+  private static DynamicPartitionConfig generatePartitionConfig(final BrokerCfg brokerCfg) {
+    final Map<String, ExporterState> exporters = new HashMap<>();
+    brokerCfg
+        .getExporters()
+        .forEach(
+            (exporterId, ignore) ->
+                exporters.put(exporterId, new ExporterState(0, State.ENABLED, Optional.empty())));
+    return new DynamicPartitionConfig(new ExportersConfig(Map.copyOf(exporters)));
   }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -42,10 +42,9 @@ import org.slf4j.LoggerFactory;
  * <li>When the local configuration is empty, a non-coordinating member waits until it receives a
  *     valid configuration from the coordinator via gossip. See {@link GossipInitializer}.
  * <li>After initialization, the configuration can be modified using {@link
- *     ClusterConfigurationModifier}. Currently only {@link
- *     io.camunda.zeebe.dynamic.config.ClusterConfigurationModifier.ExporterStateInitializer} is
- *     available. It overwrites the local member's state to keep it in sync with the statically
- *     configured exporters.
+ *     ClusterConfigurationModifier}. Currently only {@link ExporterStateInitializer} is available.
+ *     It overwrites the local member's state to keep it in sync with the statically configured
+ *     exporters.
  */
 public interface ClusterConfigurationInitializer {
   Logger LOG = LoggerFactory.getLogger(ClusterConfigurationInitializer.class);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializer.java
@@ -42,9 +42,8 @@ import org.slf4j.LoggerFactory;
  * <li>When the local configuration is empty, a non-coordinating member waits until it receives a
  *     valid configuration from the coordinator via gossip. See {@link GossipInitializer}.
  * <li>After initialization, the configuration can be modified using {@link
- *     ClusterConfigurationModifier}. Currently only {@link ExporterStateInitializer} is available.
- *     It overwrites the local member's state to keep it in sync with the statically configured
- *     exporters.
+ *     ClusterConfigurationModifier}. For example, {@link ExporterStateInitializer} overwrites the
+ *     local member's state to keep it in sync with the statically configured exporters.
  */
 public interface ClusterConfigurationInitializer {
   Logger LOG = LoggerFactory.getLogger(ClusterConfigurationInitializer.class);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -16,7 +16,6 @@ import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.Initializ
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.StaticInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationInitializer.SyncInitializer;
 import io.camunda.zeebe.dynamic.config.ClusterConfigurationManager.InconsistentConfigurationListener;
-import io.camunda.zeebe.dynamic.config.ClusterConfigurationModifier.ExporterStateInitializer;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationManagementRequestsHandler;
 import io.camunda.zeebe.dynamic.config.api.ClusterConfigurationRequestServer;
 import io.camunda.zeebe.dynamic.config.changes.ConfigurationChangeAppliersImpl;

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagerService.java
@@ -128,7 +128,11 @@ public final class ClusterConfigurationManagerService
             new ExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
                 staticConfiguration.localMemberId(),
-                managerActor));
+                managerActor))
+        .andThen(
+            new RoutingStateInitializer(
+                staticConfiguration.enablePartitionScaling(),
+                staticConfiguration.partitionCount()));
   }
 
   private ClusterConfigurationInitializer getCoordinatorInitializer(
@@ -149,7 +153,11 @@ public final class ClusterConfigurationManagerService
             new ExporterStateInitializer(
                 staticConfiguration.partitionConfig().exporting().exporters().keySet(),
                 staticConfiguration.localMemberId(),
-                managerActor));
+                managerActor))
+        .andThen(
+            new RoutingStateInitializer(
+                staticConfiguration.enablePartitionScaling(),
+                staticConfiguration.partitionCount()));
   }
 
   /** Starts ClusterConfigurationManager which initializes ClusterConfiguration */

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifier.java
@@ -7,14 +7,8 @@
  */
 package io.camunda.zeebe.dynamic.config;
 
-import io.atomix.cluster.MemberId;
 import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
-import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
-import io.camunda.zeebe.dynamic.config.state.MemberState;
-import io.camunda.zeebe.dynamic.config.state.PartitionState;
-import io.camunda.zeebe.scheduler.ConcurrencyControl;
 import io.camunda.zeebe.scheduler.future.ActorFuture;
-import java.util.Set;
 
 /**
  * After the configuration is initialized, we can use a {@link ClusterConfigurationModifier} to
@@ -35,76 +29,4 @@ public interface ClusterConfigurationModifier {
    * @return modified configuration
    */
   ActorFuture<ClusterConfiguration> modify(ClusterConfiguration configuration);
-
-  /**
-   * Updates the exporter state of the local member in the configuration. If a broker restarts with
-   * a changes of exporters in the static configuration, this modifier updates the dynamic config to
-   * reflect that. If new exporter are added to the static configuration, they are added to the
-   * dynamic config with state ENABLED. If existing exporters are removed, they are marked as
-   * disabled. Note that the exporters are not removed from the dynamic config.
-   */
-  class ExporterStateInitializer implements ClusterConfigurationModifier {
-
-    private final Set<String> configuredExporters;
-    private final MemberId localMemberId;
-    private final ConcurrencyControl executor;
-
-    public ExporterStateInitializer(
-        final Set<String> configuredExporters,
-        final MemberId localMemberId,
-        final ConcurrencyControl executor) {
-      this.configuredExporters = configuredExporters;
-      this.localMemberId = localMemberId;
-      this.executor = executor;
-    }
-
-    @Override
-    public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
-      final ActorFuture<ClusterConfiguration> result = executor.createFuture();
-      if (!configuration.hasMember(localMemberId)) {
-        result.complete(configuration);
-      } else {
-        result.complete(
-            configuration.updateMember(
-                localMemberId, memberState -> updateExporterState(memberState)));
-      }
-      return result;
-    }
-
-    private MemberState updateExporterState(final MemberState memberState) {
-      MemberState updatedMemberState = memberState;
-      for (final var p : memberState.partitions().keySet()) {
-        final PartitionState currentPartitionState = memberState.partitions().get(p);
-        final var updatedPartitionState = updateExporterStateInPartition(currentPartitionState);
-        // Do not update the member state if the partition state is not changed, otherwise the
-        // version will be updated during every restart and this could interfere with other
-        // concurrent configuration changes.
-        if (!updatedPartitionState.equals(currentPartitionState)) {
-          updatedMemberState =
-              updatedMemberState.updatePartition(p, partitionState -> updatedPartitionState);
-        }
-      }
-      return updatedMemberState;
-    }
-
-    private PartitionState updateExporterStateInPartition(final PartitionState partitionState) {
-      final var initializedPartitionState =
-          partitionState.config().isInitialized()
-              ? partitionState
-              : new PartitionState(
-                  partitionState.state(), partitionState.priority(), DynamicPartitionConfig.init());
-      final var exportersInConfig = initializedPartitionState.config().exporting().exporters();
-
-      final var newlyAddedExporters =
-          configuredExporters.stream().filter(id -> !exportersInConfig.containsKey(id)).toList();
-      final var removedExporters =
-          exportersInConfig.keySet().stream()
-              .filter(id -> !configuredExporters.contains(id))
-              .toList();
-
-      return initializedPartitionState
-          .updateConfig(c -> c.updateExporting(e -> e.disableExporters(removedExporters)))
-          .updateConfig(c -> c.updateExporting(e -> e.addExporters(newlyAddedExporters)));
-    }
-  }
 }

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/ExporterStateInitializer.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.atomix.cluster.MemberId;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
+import io.camunda.zeebe.dynamic.config.state.MemberState;
+import io.camunda.zeebe.dynamic.config.state.PartitionState;
+import io.camunda.zeebe.scheduler.ConcurrencyControl;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import java.util.Set;
+
+/**
+ * Updates the exporter state of the local member in the configuration. If a broker restarts with a
+ * changes of exporters in the static configuration, this modifier updates the dynamic config to
+ * reflect that. If new exporter are added to the static configuration, they are added to the
+ * dynamic config with state ENABLED. If existing exporters are removed, they are marked as
+ * disabled. Note that the exporters are not removed from the dynamic config.
+ */
+public class ExporterStateInitializer implements ClusterConfigurationModifier {
+
+  private final Set<String> configuredExporters;
+  private final MemberId localMemberId;
+  private final ConcurrencyControl executor;
+
+  public ExporterStateInitializer(
+      final Set<String> configuredExporters,
+      final MemberId localMemberId,
+      final ConcurrencyControl executor) {
+    this.configuredExporters = configuredExporters;
+    this.localMemberId = localMemberId;
+    this.executor = executor;
+  }
+
+  @Override
+  public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
+    final ActorFuture<ClusterConfiguration> result = executor.createFuture();
+    if (!configuration.hasMember(localMemberId)) {
+      result.complete(configuration);
+    } else {
+      result.complete(configuration.updateMember(localMemberId, this::updateExporterState));
+    }
+    return result;
+  }
+
+  private MemberState updateExporterState(final MemberState memberState) {
+    MemberState updatedMemberState = memberState;
+    for (final var p : memberState.partitions().keySet()) {
+      final PartitionState currentPartitionState = memberState.partitions().get(p);
+      final var updatedPartitionState = updateExporterStateInPartition(currentPartitionState);
+      // Do not update the member state if the partition state is not changed, otherwise the
+      // version will be updated during every restart and this could interfere with other
+      // concurrent configuration changes.
+      if (!updatedPartitionState.equals(currentPartitionState)) {
+        updatedMemberState =
+            updatedMemberState.updatePartition(p, partitionState -> updatedPartitionState);
+      }
+    }
+    return updatedMemberState;
+  }
+
+  private PartitionState updateExporterStateInPartition(final PartitionState partitionState) {
+    final var initializedPartitionState =
+        partitionState.config().isInitialized()
+            ? partitionState
+            : new PartitionState(
+                partitionState.state(), partitionState.priority(), DynamicPartitionConfig.init());
+    final var exportersInConfig = initializedPartitionState.config().exporting().exporters();
+
+    final var newlyAddedExporters =
+        configuredExporters.stream().filter(id -> !exportersInConfig.containsKey(id)).toList();
+    final var removedExporters =
+        exportersInConfig.keySet().stream()
+            .filter(id -> !configuredExporters.contains(id))
+            .toList();
+
+    return initializedPartitionState
+        .updateConfig(c -> c.updateExporting(e -> e.disableExporters(removedExporters)))
+        .updateConfig(c -> c.updateExporting(e -> e.addExporters(newlyAddedExporters)));
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/RoutingStateInitializer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.scheduler.future.ActorFuture;
+import io.camunda.zeebe.scheduler.future.CompletableActorFuture;
+import java.util.Optional;
+
+/**
+ * Initializes the routing state of the cluster configuration if the partition scaling feature is
+ * enabled. All members will initialize the same routing state (as long as their statically
+ * configured partition counts match).
+ */
+public class RoutingStateInitializer implements ClusterConfigurationModifier {
+
+  private final boolean enablePartitionScaling;
+  private final int staticPartitionCount;
+
+  public RoutingStateInitializer(
+      final boolean enablePartitionScaling, final int staticPartitionCount) {
+    this.enablePartitionScaling = enablePartitionScaling;
+    this.staticPartitionCount = staticPartitionCount;
+  }
+
+  @Override
+  public ActorFuture<ClusterConfiguration> modify(final ClusterConfiguration configuration) {
+    if (configuration.routingState().isPresent() || !enablePartitionScaling) {
+      return CompletableActorFuture.completed(configuration);
+    }
+
+    final var routingState = RoutingState.initializeWithPartitionCount(staticPartitionCount);
+    final var withRoutingState =
+        new ClusterConfiguration(
+            configuration.version(),
+            configuration.members(),
+            configuration.lastChange(),
+            configuration.pendingChanges(),
+            Optional.of(routingState));
+    return CompletableActorFuture.completed(withRoutingState);
+  }
+}

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Set;
 
 public record StaticConfiguration(
+    boolean enablePartitionScaling,
     PartitionDistributor partitionDistributor,
     Set<MemberId> clusterMembers,
     MemberId localMemberId,

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -31,7 +31,8 @@ public record StaticConfiguration(
 
   public ClusterConfiguration generateTopology() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
-    return ConfigurationUtil.getClusterConfigFrom(partitionDistribution, partitionConfig);
+    return ConfigurationUtil.getClusterConfigFrom(
+        enablePartitionScaling, partitionDistribution, partitionConfig);
   }
 
   public Set<PartitionMetadata> generatePartitionDistribution() {

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/StaticConfiguration.java
@@ -24,6 +24,10 @@ public record StaticConfiguration(
     int replicationFactor,
     DynamicPartitionConfig partitionConfig) {
 
+  public int partitionCount() {
+    return partitionIds.size();
+  }
+
   public ClusterConfiguration generateTopology() {
     final Set<PartitionMetadata> partitionDistribution = generatePartitionDistribution();
     return ConfigurationUtil.getClusterConfigFrom(partitionDistribution, partitionConfig);

--- a/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
+++ b/zeebe/dynamic-config/src/main/java/io/camunda/zeebe/dynamic/config/util/ConfigurationUtil.java
@@ -15,6 +15,7 @@ import io.camunda.zeebe.dynamic.config.state.DynamicPartitionConfig;
 import io.camunda.zeebe.dynamic.config.state.MemberState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState;
 import io.camunda.zeebe.dynamic.config.state.PartitionState.State;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -27,6 +28,7 @@ public final class ConfigurationUtil {
   private ConfigurationUtil() {}
 
   public static ClusterConfiguration getClusterConfigFrom(
+      final boolean enablePartitionScaling,
       final Set<PartitionMetadata> partitionDistribution,
       final DynamicPartitionConfig partitionConfig) {
     final var partitionStatesByMember = new HashMap<MemberId, Map<Integer, PartitionState>>();
@@ -44,12 +46,17 @@ public final class ConfigurationUtil {
       memberStates.put(e.getKey(), MemberState.initializeAsActive(e.getValue()));
     }
 
+    final var routingState =
+        enablePartitionScaling
+            ? Optional.of(RoutingState.initializeWithPartitionCount(partitionDistribution.size()))
+            : Optional.<RoutingState>empty();
+
     return new ClusterConfiguration(
         ClusterConfiguration.INITIAL_VERSION,
         Map.copyOf(memberStates),
         Optional.empty(),
         Optional.empty(),
-        Optional.empty());
+        routingState);
   }
 
   public static Set<PartitionMetadata> getPartitionDistributionFrom(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationAssert.java
@@ -95,6 +95,21 @@ public final class ClusterConfigurationAssert
     return this;
   }
 
+  public ClusterConfigurationAssert hasRoutingState() {
+    assertThat(actual.routingState()).isPresent();
+    return this;
+  }
+
+  public ClusterConfigurationAssert hasNoRoutingState() {
+    assertThat(actual.routingState()).isEmpty();
+    return this;
+  }
+
+  public RoutingStateAssert routingState() {
+    assertThat(actual.routingState()).isPresent();
+    return RoutingStateAssert.assertThat(actual.routingState().orElseThrow());
+  }
+
   /**
    * Asserts that the actual topology has the same topology as the expected topology ignoring
    * timestamps and versions.

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationAssert.java
@@ -124,6 +124,13 @@ public final class ClusterConfigurationAssert
         .usingRecursiveComparison()
         .ignoringFieldsMatchingRegexes(".*startedAt", ".*version")
         .isEqualTo(optionalExpectedOngoingChange);
+
+    // compare routing state without version
+    assertThat(actual.routingState())
+        .usingRecursiveComparison()
+        .ignoringFieldsOfTypesMatchingRegexes(".*version")
+        .isEqualTo(expected.routingState());
+
     return this;
   }
 }

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationInitializerTest.java
@@ -206,6 +206,7 @@ final class ClusterConfigurationInitializerTest {
                 PartitionId.from("test", 1), Set.of(member), Map.of(member, 1), 1, member));
     return new StaticInitializer(
         new StaticConfiguration(
+            false,
             new ControllablePartitionDistributor().withPartitions(partitions),
             Set.of(member),
             member,

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationManagementIntegrationTest.java
@@ -298,6 +298,7 @@ class ClusterConfigurationManagementIntegrationTest {
           service.start(
               actorScheduler,
               new StaticConfiguration(
+                  false,
                   new ControllablePartitionDistributor().withPartitions(partitions),
                   clusterMembers,
                   cluster.getMembershipService().getLocalMember().id(),

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -59,8 +59,7 @@ final class ClusterConfigurationModifierTest {
     void shouldUpdateExporterConfig(final ExporterConfigParameter parameter) {
       // given
       final var exporterStateInitializer =
-          new ClusterConfigurationModifier.ExporterStateInitializer(
-              parameter.configuredExporters(), localMemberId, executor);
+          new ExporterStateInitializer(parameter.configuredExporters(), localMemberId, executor);
 
       // when
       final var newConfiguration = exporterStateInitializer.modify(currentConfiguration).join();
@@ -103,8 +102,7 @@ final class ClusterConfigurationModifierTest {
 
       // when
       final var newConfiguration =
-          new ClusterConfigurationModifier.ExporterStateInitializer(
-                  Set.of("expA", "expB"), localMemberId, executor)
+          new ExporterStateInitializer(Set.of("expA", "expB"), localMemberId, executor)
               .modify(currentConfiguration)
               .join();
 
@@ -121,8 +119,7 @@ final class ClusterConfigurationModifierTest {
     void shouldNotUpdateMemberStateIfNoExporterChanges() {
       // when
       final var newConfiguration =
-          new ClusterConfigurationModifier.ExporterStateInitializer(
-                  Set.of("expA", "expB"), localMemberId, executor)
+          new ExporterStateInitializer(Set.of("expA", "expB"), localMemberId, executor)
               .modify(currentConfiguration)
               .join();
 

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/ClusterConfigurationModifierTest.java
@@ -52,6 +52,38 @@ final class ClusterConfigurationModifierTest {
                       1, PartitionState.active(1, config), 2, PartitionState.active(2, config))));
 
   @Nested
+  final class RoutingStateInitializerTest {
+    @Test
+    void shouldNotInitializeRoutingStateIfPartitionScalingIsDisabled() {
+      // given
+      final var routingStateInitializer = new RoutingStateInitializer(false, 3);
+
+      // when
+      final var newConfiguration = routingStateInitializer.modify(currentConfiguration).join();
+
+      // then
+      ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration).hasNoRoutingState();
+    }
+
+    @Test
+    void shouldInitializeRoutingStateIfPartitionScalingIsEnabled() {
+      // given
+      final var routingStateInitializer = new RoutingStateInitializer(true, 5);
+
+      // when
+      final var newConfiguration = routingStateInitializer.modify(currentConfiguration).join();
+
+      // then
+      ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration).hasRoutingState();
+      ClusterConfigurationAssert.assertThatClusterTopology(newConfiguration)
+          .routingState()
+          .hasVersion(1)
+          .hasActivatedPartitions(5)
+          .correlatesMessagesToPartitions(5);
+    }
+  }
+
+  @Nested
   class ExporterStateInitializerTest {
 
     @ParameterizedTest

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/RoutingStateAssert.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/RoutingStateAssert.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.dynamic.config;
+
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import java.util.stream.IntStream;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
+
+public class RoutingStateAssert extends AbstractAssert<RoutingStateAssert, RoutingState> {
+
+  protected RoutingStateAssert(final RoutingState routingState, final Class<?> selfType) {
+    super(routingState, selfType);
+  }
+
+  public static RoutingStateAssert assertThat(final RoutingState routingState) {
+    return new RoutingStateAssert(routingState, RoutingStateAssert.class);
+  }
+
+  public RoutingStateAssert hasVersion(final int version) {
+    Assertions.assertThat(actual.version()).isEqualTo(version);
+    return this;
+  }
+
+  public RoutingStateAssert hasActivatedPartitions(final int partitionCount) {
+    Assertions.assertThat(actual.activePartitions())
+        .containsExactlyElementsOf(IntStream.rangeClosed(1, partitionCount).boxed().toList());
+    return this;
+  }
+
+  public RoutingStateAssert correlatesMessagesToPartitions(final int partitionCount) {
+    Assertions.assertThat(actual.messageCorrelation()).isNotNull();
+    Assertions.assertThat(actual.messageCorrelation()).isInstanceOf(HashMod.class);
+    final var actualPartitionCount = ((HashMod) actual.messageCorrelation()).partitionCount();
+    Assertions.assertThat(actualPartitionCount).isEqualTo(partitionCount);
+    return this;
+  }
+}

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/PartitionReassignRequestTransformerTest.java
@@ -103,7 +103,7 @@ class PartitionReassignRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(
@@ -155,7 +155,7 @@ class PartitionReassignRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 oldReplicationFactor);
     var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
     for (int i = 0; i < max(oldClusterSize, newClusterSize); i++) {
       oldClusterTopology =
           oldClusterTopology.updateMember(

--- a/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
+++ b/zeebe/dynamic-config/src/test/java/io/camunda/zeebe/dynamic/config/api/ScaleRequestTransformerTest.java
@@ -87,7 +87,7 @@ class ScaleRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     final var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
 
     //  when
     final var operationsEither =
@@ -121,7 +121,7 @@ class ScaleRequestTransformerTest {
                 getSortedPartitionIds(partitionCount),
                 replicationFactor);
     final var oldClusterTopology =
-        ConfigurationUtil.getClusterConfigFrom(oldDistribution, partitionConfig);
+        ConfigurationUtil.getClusterConfigFrom(true, oldDistribution, partitionConfig);
 
     // when
     final var operations =


### PR DESCRIPTION
:warning: Depends on https://github.com/camunda/camunda/pull/21529

This adds a new `ClusterConfigurationModifier` to initialize the routing state once on startup if the feature flag is enabled.
If it is enabled, all members will initialize the routing state the same way (assuming that they are all configured with the same partition count, otherwise all bets are off). Because all members will initialize it the same way, there will be no merge conflicts as long as the routing state is not further modified.

closes #21465