### PR TITLE
fix: add identity to the list of healthchecks in the initializer

### DIFF
--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -66,7 +66,9 @@ public class HealthConfigurationInitializer
 
   protected boolean shouldEnableProbes(final List<String> activeProfiles) {
     return activeProfiles.stream()
-        .anyMatch(Set.of(Profile.OPERATE.getId(), Profile.TASKLIST.getId())::contains);
+        .anyMatch(
+            Set.of(Profile.OPERATE.getId(), Profile.TASKLIST.getId(), Profile.IDENTITY.getId())
+                ::contains);
   }
 
   protected boolean shouldReadinessState(final List<String> activeProfiles) {

--- a/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
+++ b/dist/src/main/java/io/camunda/application/initializers/HealthConfigurationInitializer.java
@@ -72,7 +72,12 @@ public class HealthConfigurationInitializer
   protected boolean shouldReadinessState(final List<String> activeProfiles) {
     return activeProfiles.stream()
         .anyMatch(
-            Set.of(Profile.OPERATE.getId(), Profile.TASKLIST.getId(), Profile.BROKER)::contains);
+            Set.of(
+                    Profile.OPERATE.getId(),
+                    Profile.TASKLIST.getId(),
+                    Profile.BROKER,
+                    Profile.IDENTITY.getId())
+                ::contains);
   }
 
   /**
@@ -99,6 +104,10 @@ public class HealthConfigurationInitializer
 
     if (activeProfiles.contains(Profile.TASKLIST.getId())) {
       healthIndicators.add(INDICATOR_TASKLIST_SEARCH_ENGINE_CHECK);
+    }
+
+    if (activeProfiles.contains(Profile.IDENTITY.getId())) {
+      healthIndicators.add(INDICATOR_SPRING_READINESS_STATE);
     }
 
     return healthIndicators;


### PR DESCRIPTION
## Description

The controller team asked about health checks for the Identity component, after investigating this for them I noticed that Identity is not added to the health check initializer.
