### PR TITLE
fix: Tasklist - OpenSearch AWS config can't be disabled 

### DIFF
--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -480,7 +480,7 @@ public class OpenSearchConnector {
   }
 
   public boolean hasAwsCredentials() {
-    if (tasklistProperties.getOpenSearch().isAwsEnabled()) {
+    if (!tasklistProperties.getOpenSearch().isAwsEnabled()) {
       return false;
     }
     final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();

--- a/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/os/OpenSearchConnector.java
@@ -151,7 +151,7 @@ public class OpenSearchConnector {
   private OpenSearchAsyncClient createAsyncOsClient(final OpenSearchProperties osConfig) {
     LOGGER.debug("Creating Async OpenSearch connection...");
     LOGGER.debug("Creating OpenSearch connection...");
-    if (isAws()) {
+    if (hasAwsCredentials()) {
       return getAwsAsyncClient(osConfig);
     }
     final HttpHost host = getHttpHostForClient5(osConfig);
@@ -205,7 +205,7 @@ public class OpenSearchConnector {
 
   private OpenSearchClient createOsClient(final OpenSearchProperties osConfig) {
     LOGGER.debug("Creating OpenSearch connection...");
-    if (isAws()) {
+    if (hasAwsCredentials()) {
       return getAwsClient(osConfig);
     }
     final HttpHost host = getHttpHostForClient5(osConfig);
@@ -479,7 +479,10 @@ public class OpenSearchConnector {
             e -> LOGGER.error("Retries {} exceeded for {}", e.getAttemptCount(), logMessage));
   }
 
-  private boolean isAws() {
+  public boolean hasAwsCredentials() {
+    if (tasklistProperties.getOpenSearch().isAwsEnabled()) {
+      return false;
+    }
     final AwsCredentialsProvider credentialsProvider = DefaultCredentialsProvider.create();
     try {
       credentialsProvider.resolveCredentials();
@@ -523,7 +526,7 @@ public class OpenSearchConnector {
       final org.apache.http.impl.nio.client.HttpAsyncClientBuilder builder,
       final OpenSearchProperties osConfig) {
 
-    if (isAws()) {
+    if (hasAwsCredentials()) {
       configureAwsSigningForApacheHttpClient(builder);
     } else if (useBasicAuthentication(osConfig)) {
       configureBasicAuthenticationForApacheHttpClient(osConfig, builder);

--- a/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
+++ b/tasklist/common/src/main/java/io/camunda/tasklist/property/OpenSearchProperties.java
@@ -42,6 +42,8 @@ public class OpenSearchProperties {
   private String username;
   private String password;
 
+  private boolean awsEnabled = false;
+
   @NestedConfigurationProperty private SslProperties ssl;
 
   @NestedConfigurationProperty private Map<String, InterceptorPluginProperties> interceptorPlugins;
@@ -175,5 +177,13 @@ public class OpenSearchProperties {
   public void setInterceptorPlugins(
       final Map<String, InterceptorPluginProperties> interceptorPlugins) {
     this.interceptorPlugins = interceptorPlugins;
+  }
+
+  public boolean isAwsEnabled() {
+    return awsEnabled;
+  }
+
+  public void setAwsEnabled(boolean awsEnabled) {
+    this.awsEnabled = awsEnabled;
   }
 }


### PR DESCRIPTION
## Description

Introduced the property camunda.operate.opensearch.awsEnabled which is now checked for before using AWS credentials to allow for using basic auth even when AWS credentials are set.

Related to the tests:
- There is no unit tests for OpenSearchConnector, I would separate this in another Scope

The distribution issue to add this property:
- https://github.com/camunda/camunda-platform-helm/issues/2215 



## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #https://github.com/camunda/camunda/issues/21070
