### PR TITLE
feat: show version tag in process instances table

### DIFF
--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -16,24 +16,28 @@ import {Paths} from 'modules/Routes';
 import {tracking} from 'modules/tracking';
 import {Link} from 'modules/components/Link';
 import {useFilters} from 'modules/hooks/useFilters';
+
+/** Stores */
 import {
   MAX_PROCESS_INSTANCES_STORED,
   processInstancesStore,
 } from 'modules/stores/processInstances';
-import {getProcessName} from 'modules/utils/instance';
 import {processInstancesSelectionStore} from 'modules/stores/processInstancesSelection';
 import {authenticationStore} from 'modules/stores/authentication';
+import {processesStore} from 'modules/stores/processes/processes.list';
+import {notificationsStore} from 'modules/stores/notifications';
+import {batchModificationStore} from 'modules/stores/batchModification';
+import {processStatisticsBatchModificationStore} from 'modules/stores/processStatistics/processStatistics.batchModification';
+
+import {getProcessName} from 'modules/utils/instance';
 import {Toolbar} from './Toolbar';
 import {getProcessInstanceFilters} from 'modules/utils/filter/getProcessInstanceFilters';
 import {useLocation} from 'react-router-dom';
-import {processesStore} from 'modules/stores/processes/processes.list';
 import {Operations} from 'modules/components/Operations';
-import {notificationsStore} from 'modules/stores/notifications';
-import {batchModificationStore} from 'modules/stores/batchModification';
 import {BatchModificationFooter} from './BatchModificationFooter';
 import {useEffect} from 'react';
-import {processStatisticsBatchModificationStore} from 'modules/stores/processStatistics/processStatistics.batchModification';
 import {getProcessInstancesRequestFilters} from 'modules/utils/filter';
+import {IS_VERSION_TAG_ENABLED} from 'modules/feature-flags';
 
 const ROW_HEIGHT = 34;
 
@@ -196,6 +200,8 @@ const InstancesTable: React.FC = observer(() => {
           processInstancesStore.fetchNextInstances();
         }}
         rows={processInstances.map((instance) => {
+          const versionTag = processesStore.getVersionTag(instance.processId);
+
           return {
             id: instance.id,
             processName: (
@@ -231,6 +237,7 @@ const InstancesTable: React.FC = observer(() => {
               </Link>
             ),
             processVersion: instance.processVersion,
+            versionTag: versionTag ?? '--',
             tenant: isTenantColumnVisible ? instance.tenantId : undefined,
             startDate: formatDate(instance.startDate),
             endDate: formatDate(instance.endDate),
@@ -320,6 +327,15 @@ const InstancesTable: React.FC = observer(() => {
             header: 'Version',
             key: 'processVersion',
           },
+          ...(IS_VERSION_TAG_ENABLED && processesStore.hasVersionTags
+            ? [
+                {
+                  header: 'Version Tag',
+                  key: 'versionTag',
+                  isDisabled: true,
+                },
+              ]
+            : []),
           ...(isTenantColumnVisible
             ? [
                 {

--- a/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/index.tsx
@@ -47,6 +47,13 @@ const InstancesTable: React.FC = observer(() => {
     state: {status, filteredProcessInstancesCount, processInstances},
   } = processInstancesStore;
 
+  /**
+   * Is true if at least one process instances from the store has a version tag.
+   */
+  const hasVersionTags = processInstances.some(({processId}) => {
+    return processesStore.getVersionTag(processId);
+  });
+
   const filters = useFilters();
   const location = useLocation();
 
@@ -327,7 +334,7 @@ const InstancesTable: React.FC = observer(() => {
             header: 'Version',
             key: 'processVersion',
           },
-          ...(IS_VERSION_TAG_ENABLED && processesStore.hasVersionTags
+          ...(IS_VERSION_TAG_ENABLED && hasVersionTags
             ? [
                 {
                   header: 'Version Tag',

--- a/operate/client/src/App/Processes/ListView/InstancesTable/versionTag.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/versionTag.test.tsx
@@ -17,6 +17,8 @@ import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupe
 import {createInstance, groupedProcessesMock} from 'modules/testUtils';
 import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
 
+jest.mock('modules/feature-flags', () => ({IS_VERSION_TAG_ENABLED: true}));
+
 const createProcessInstance = ({
   bpmnProcessId,
   version,

--- a/operate/client/src/App/Processes/ListView/InstancesTable/versionTag.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/versionTag.test.tsx
@@ -94,15 +94,19 @@ describe('<InstancesTable /> - version tag', () => {
   });
 
   it('should show version tag column (only header)', async () => {
-    const processInstance = createProcessInstance({
+    const demoProcessInstance = createProcessInstance({
       bpmnProcessId: 'demoProcess',
+      version: 1,
+    });
+    const bigVarProcessInstance = createProcessInstance({
+      bpmnProcessId: 'bigVarProcess',
       version: 1,
     });
 
     mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
     mockFetchProcessInstances().withSuccess({
-      totalCount: 1,
-      processInstances: [processInstance],
+      totalCount: 2,
+      processInstances: [demoProcessInstance, bigVarProcessInstance],
     });
 
     render(<InstancesTable />, {
@@ -110,15 +114,19 @@ describe('<InstancesTable /> - version tag', () => {
     });
 
     // wait for process instance to be rendered
-    expect(await screen.findByTestId('cell-processName')).toHaveTextContent(
-      processInstance.processName,
-    );
+    expect(await screen.findAllByTestId('cell-processName')).toHaveLength(2);
+
+    const versionTagCells = screen.getAllByTestId('cell-versionTag');
 
     /**
-     * Expect that no version tag is rendered, because demoProcess version 1
-     * has no related version tag.
+     * Expect that no version tag is rendered for demoProcess version 1
      */
-    expect(screen.getByTestId('cell-versionTag')).toHaveTextContent('--');
+    expect(versionTagCells[0]).toHaveTextContent('--');
+
+    /**
+     * Expect that version tag is rendered for bigVarProcess version 1
+     */
+    expect(versionTagCells[1]).toHaveTextContent('MyVersionTag');
 
     /**
      * Expect that the version tag column header is rendered, because there is at least
@@ -135,7 +143,7 @@ describe('<InstancesTable /> - version tag', () => {
       version: 1,
     });
 
-    mockFetchGroupedProcesses().withSuccess([groupedProcessesMock[0]!]);
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
     mockFetchProcessInstances().withSuccess({
       totalCount: 1,
       processInstances: [processInstance],

--- a/operate/client/src/App/Processes/ListView/InstancesTable/versionTag.test.tsx
+++ b/operate/client/src/App/Processes/ListView/InstancesTable/versionTag.test.tsx
@@ -1,0 +1,167 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+
+import {render, screen} from 'modules/testing-library';
+import {InstancesTable} from '.';
+import {unstable_HistoryRouter as HistoryRouter} from 'react-router-dom';
+import {useEffect} from 'react';
+import {createMemoryHistory} from 'history';
+import {processInstancesStore} from 'modules/stores/processInstances';
+import {processesStore} from 'modules/stores/processes/processes.list';
+import {mockFetchGroupedProcesses} from 'modules/mocks/api/processes/fetchGroupedProcesses';
+import {createInstance, groupedProcessesMock} from 'modules/testUtils';
+import {mockFetchProcessInstances} from 'modules/mocks/api/processInstances/fetchProcessInstances';
+
+const createProcessInstance = ({
+  bpmnProcessId,
+  version,
+}: {
+  bpmnProcessId: string;
+  version: number;
+}) => {
+  const processDefinitions = groupedProcessesMock.find((process) => {
+    return process.bpmnProcessId === bpmnProcessId;
+  })?.processes;
+
+  const processDefinition = processDefinitions?.find((processDefinition) => {
+    return processDefinition.version === version;
+  });
+
+  return createInstance({
+    bpmnProcessId: processDefinition?.bpmnProcessId,
+    processVersion: processDefinition?.version,
+    processId: processDefinition?.id,
+  });
+};
+
+function getWrapper() {
+  const Wrapper: React.FC<{children?: React.ReactNode}> = ({children}) => {
+    useEffect(() => {
+      processesStore.fetchProcesses();
+      processInstancesStore.fetchProcessInstancesFromFilters();
+
+      return () => {
+        processesStore.reset();
+        processInstancesStore.reset();
+      };
+    });
+
+    return (
+      <HistoryRouter history={createMemoryHistory()}>{children}</HistoryRouter>
+    );
+  };
+
+  return Wrapper;
+}
+
+describe('<InstancesTable /> - version tag', () => {
+  it('should show version tag column (header + content)', async () => {
+    const processInstance = createProcessInstance({
+      bpmnProcessId: 'bigVarProcess',
+      version: 1,
+    });
+
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessInstances().withSuccess({
+      totalCount: 1,
+      processInstances: [processInstance],
+    });
+
+    render(<InstancesTable />, {
+      wrapper: getWrapper(),
+    });
+
+    // wait for process instance to be rendered
+    expect(await screen.findByTestId('cell-processName')).toHaveTextContent(
+      processInstance.processName,
+    );
+
+    /**
+     * Expect that the version tag is rendered, because bigVarProcess version 1
+     * has a related version tag.
+     */
+    expect(screen.getByTestId('cell-versionTag')).toHaveTextContent(
+      'MyVersionTag',
+    );
+    expect(
+      screen.getByRole('columnheader', {name: /Version Tag/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should show version tag column (only header)', async () => {
+    const processInstance = createProcessInstance({
+      bpmnProcessId: 'demoProcess',
+      version: 1,
+    });
+
+    mockFetchGroupedProcesses().withSuccess(groupedProcessesMock);
+    mockFetchProcessInstances().withSuccess({
+      totalCount: 1,
+      processInstances: [processInstance],
+    });
+
+    render(<InstancesTable />, {
+      wrapper: getWrapper(),
+    });
+
+    // wait for process instance to be rendered
+    expect(await screen.findByTestId('cell-processName')).toHaveTextContent(
+      processInstance.processName,
+    );
+
+    /**
+     * Expect that no version tag is rendered, because demoProcess version 1
+     * has no related version tag.
+     */
+    expect(screen.getByTestId('cell-versionTag')).toHaveTextContent('--');
+
+    /**
+     * Expect that the version tag column header is rendered, because there is at least
+     * one process definition with a version tag (bigVarProcess, version 1).
+     */
+    expect(
+      screen.getByRole('columnheader', {name: /Version Tag/i}),
+    ).toBeInTheDocument();
+  });
+
+  it('should not show version tag column when there is no process with a version tag', async () => {
+    const processInstance = createProcessInstance({
+      bpmnProcessId: 'demoProcess',
+      version: 1,
+    });
+
+    mockFetchGroupedProcesses().withSuccess([groupedProcessesMock[0]!]);
+    mockFetchProcessInstances().withSuccess({
+      totalCount: 1,
+      processInstances: [processInstance],
+    });
+
+    render(<InstancesTable />, {
+      wrapper: getWrapper(),
+    });
+
+    // wait for process instance to be rendered
+    expect(await screen.findByTestId('cell-processName')).toHaveTextContent(
+      processInstance.processName,
+    );
+
+    /**
+     * Expect that no version tag is rendered, because demoProcess version 1
+     * has no related version tag.
+     */
+    expect(screen.queryByTestId('cell-versionTag')).not.toBeInTheDocument();
+
+    /**
+     * Expect that no version tag column header is rendered, because there no
+     * other process definition with a version tag.
+     */
+    expect(
+      screen.queryByRole('columnheader', {name: /Version Tag/i}),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/operate/client/src/modules/mock-server/handlers.ts
+++ b/operate/client/src/modules/mock-server/handlers.ts
@@ -32,7 +32,11 @@ const processInstancesVersionTagHandler = [
       (processDefinition: any) => {
         const processesWithVersionTag = processDefinition.processes.map(
           (process: any) => {
-            return {...process, versionTag: 'myVersionTag'};
+            if (process.bpmnProcessId === 'complexProcess') {
+              return {...process, versionTag: 'myVersionTag'};
+            } else {
+              return {...process, versionTag: null};
+            }
           },
         );
         return {...processDefinition, processes: processesWithVersionTag};

--- a/operate/client/src/modules/stores/processes/processes.list.ts
+++ b/operate/client/src/modules/stores/processes/processes.list.ts
@@ -6,9 +6,47 @@
  * except in compliance with the Camunda License 1.0.
  */
 
+import {computed, makeObservable} from 'mobx';
 import {ProcessesBase} from './processes.base';
+import {ProcessVersionDto} from 'modules/api/processes/fetchGroupedProcesses';
 
-class Processes extends ProcessesBase {}
+class Processes extends ProcessesBase {
+  constructor() {
+    super();
+    makeObservable(this, {
+      processVersions: computed,
+      hasVersionTags: computed,
+    });
+  }
+
+  /**
+   * flat list of all process versions
+   */
+  get processVersions() {
+    return this.filteredProcesses.reduce<ProcessVersionDto[]>(
+      (processVersions, process) => {
+        return [
+          ...processVersions,
+          ...process.processes.map((processDefinition) => processDefinition),
+        ];
+      },
+      [],
+    );
+  }
+
+  /**
+   * Returns true if there are is at least one process version with a version tag.
+   */
+  get hasVersionTags() {
+    return this.processVersions.some(({versionTag}) => versionTag !== null);
+  }
+
+  getVersionTag(processId: string) {
+    return this.processVersions.find(({id}) => {
+      return id === processId;
+    })?.versionTag;
+  }
+}
 
 const processesStore = new Processes();
 

--- a/operate/client/src/modules/stores/processes/processes.list.ts
+++ b/operate/client/src/modules/stores/processes/processes.list.ts
@@ -15,7 +15,6 @@ class Processes extends ProcessesBase {
     super();
     makeObservable(this, {
       processVersions: computed,
-      hasVersionTags: computed,
     });
   }
 
@@ -32,13 +31,6 @@ class Processes extends ProcessesBase {
       },
       [],
     );
-  }
-
-  /**
-   * Returns true if there are is at least one process version with a version tag.
-   */
-  get hasVersionTags() {
-    return this.processVersions.some(({versionTag}) => versionTag !== null);
   }
 
   getVersionTag(processId: string) {


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

- extend processes store with computed values for a flat list of process versions and for an indicator if there are any version tags.
- add a method to the processes store which returns the version tag for a specific process id
- add version tag column to instances list, if there are any
- show version tag for each process instance (if any)

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #21327 
