### PR TITLE
ci: use bigger runner for release workflow

### DIFF
--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -35,7 +35,7 @@ defaults:
 jobs:
   build:
     name: Execute Release
-    runs-on: gcp-core-2-release
+    runs-on: gcp-core-4-release
     env:
       DOCKER_IMAGE_TEAM: registry.camunda.cloud/team-optimize/optimize
       DOCKER_IMAGE_DOCKER_HUB: camunda/optimize


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

As per [this PR](https://github.com/camunda/camunda/pull/21464), also the main release workflow should use more powerful runner, to handle self-managed services from `docker-compose.smoketest.yml` 

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
