### PR TITLE
fix: Job fields are not updating correctly

### DIFF
--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/JobZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/JobZeebeRecordProcessor.java
@@ -23,6 +23,7 @@ import io.camunda.zeebe.protocol.record.value.*;
 import java.time.Instant;
 import java.util.*;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,7 +36,6 @@ public class JobZeebeRecordProcessor {
 
   private static final Set<String> JOB_EVENTS = new HashSet<>();
   private static final Set<String> FAILED_JOB_EVENTS = new HashSet<>();
-  private static final String ID_PATTERN = "%s_%s";
 
   static {
     JOB_EVENTS.add(JobIntent.CREATED.name());
@@ -59,26 +59,34 @@ public class JobZeebeRecordProcessor {
       final boolean concurrencyMode)
       throws PersistenceException {
     LOGGER.debug("Importing Job records.");
-    for (final List<Record<JobRecordValue>> jobRecords : records.values()) {
-      processLastRecord(
-          jobRecords,
-          JOB_EVENTS,
-          rethrowConsumer(
-              record -> {
-                final JobRecordValue recordValue = (JobRecordValue) record.getValue();
-                processJob(record, recordValue, batchRequest, concurrencyMode);
-              }));
+    for (final List<Record<JobRecordValue>> flowNodeJobRecords : records.values()) {
+      final Map<Long, List<Record<JobRecordValue>>> groupedByJobKey =
+          flowNodeJobRecords.stream()
+              .collect(Collectors.groupingBy(jobRecord -> jobRecord.getKey()));
+      for (final List<Record<JobRecordValue>> jobRecords : groupedByJobKey.values()) {
+        processLastRecord(
+            jobRecords,
+            JOB_EVENTS,
+            rethrowConsumer(
+                record -> {
+                  final JobRecordValue recordValue = (JobRecordValue) record.getValue();
+                  processJob(record, recordValue, batchRequest, concurrencyMode);
+                }));
+      }
     }
   }
 
   private <T extends RecordValue> void processLastRecord(
-      final List<Record<T>> records,
+      final List<Record<JobRecordValue>> records,
       final Set<String> events,
       final Consumer<Record<? extends RecordValue>> recordProcessor) {
     if (records.size() >= 1) {
       for (int i = records.size() - 1; i >= 0; i--) {
         final String intentStr = records.get(i).getIntent().name();
         if (events.contains(intentStr)) {
+          if (i > 0 && FAILED_JOB_EVENTS.contains(intentStr)) {
+            recordProcessor.accept(records.get(i - 1));
+          }
           recordProcessor.accept(records.get(i));
           break;
         }
@@ -108,7 +116,8 @@ public class JobZeebeRecordProcessor {
             .setErrorCode(recordValue.getErrorCode())
             .setEndTime(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(record.getTimestamp())))
             .setCustomHeaders(recordValue.getCustomHeaders())
-            .setJobKind(recordValue.getJobKind().name());
+            .setJobKind(recordValue.getJobKind().name())
+            .setFlowNodeId(recordValue.getElementId());
 
     if (recordValue.getJobListenerEventType() != null) {
       jobEntity.setListenerEventType(recordValue.getJobListenerEventType().name());
@@ -117,14 +126,15 @@ public class JobZeebeRecordProcessor {
     if (jobDeadline >= 0) {
       jobEntity.setDeadline(DateUtil.toOffsetDateTime(Instant.ofEpochMilli(jobDeadline)));
     }
-    // only set flowNodeId for CREATED because incidents can overwrite it
-    if (record.getIntent().name().equals(JobIntent.CREATED.name())) {
-      jobEntity.setFlowNodeId(recordValue.getElementId());
-    }
-    if (FAILED_JOB_EVENTS.contains(record.getIntent().name()) && recordValue.getRetries() > 0) {
-      jobEntity.setJobFailedWithRetriesLeft(true);
-    } else {
-      jobEntity.setJobFailedWithRetriesLeft(false);
+
+    if (FAILED_JOB_EVENTS.contains(record.getIntent().name())) {
+      // set flowNodeId to null to not overwrite it (because zeebe puts an error message there)
+      jobEntity.setFlowNodeId(null);
+      if (recordValue.getRetries() > 0) {
+        jobEntity.setJobFailedWithRetriesLeft(true);
+      } else {
+        jobEntity.setJobFailedWithRetriesLeft(false);
+      }
     }
     final Map<String, Object> updateFields = new HashMap<>();
     updateFields.put(FLOW_NODE_ID, jobEntity.getFlowNodeId());

--- a/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/JobZeebeRecordProcessor.java
+++ b/operate/importer-8_6/src/main/java/io/camunda/operate/zeebeimport/processors/JobZeebeRecordProcessor.java
@@ -48,7 +48,7 @@ public class JobZeebeRecordProcessor {
     JOB_EVENTS.add(JobIntent.MIGRATED.name());
 
     FAILED_JOB_EVENTS.add(JobIntent.FAILED.name());
-    JOB_EVENTS.add(JobIntent.ERROR_THROWN.name());
+    FAILED_JOB_EVENTS.add(JobIntent.ERROR_THROWN.name());
   }
 
   @Autowired private JobTemplate jobTemplate;

--- a/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/JobZeebeRecordProcessorIT.java
+++ b/operate/qa/integration-tests/src/test/java/io/camunda/operate/zeebeimport/processors/JobZeebeRecordProcessorIT.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.operate.zeebeimport.processors;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.camunda.operate.entities.ListenerState;
+import io.camunda.operate.exceptions.PersistenceException;
+import io.camunda.operate.schema.indices.IndexDescriptor;
+import io.camunda.operate.schema.templates.JobTemplate;
+import io.camunda.operate.store.BatchRequest;
+import io.camunda.operate.util.j5templates.OperateSearchAbstractIT;
+import io.camunda.operate.webapp.reader.ListenerReader;
+import io.camunda.operate.webapp.rest.dto.ListenerDto;
+import io.camunda.operate.webapp.rest.dto.ListenerRequestDto;
+import io.camunda.operate.webapp.rest.dto.ListenerResponseDto;
+import io.camunda.operate.webapp.rest.dto.SortingDto;
+import io.camunda.zeebe.protocol.record.ImmutableRecord;
+import io.camunda.zeebe.protocol.record.Record;
+import io.camunda.zeebe.protocol.record.RecordType;
+import io.camunda.zeebe.protocol.record.RecordValue;
+import io.camunda.zeebe.protocol.record.RejectionType;
+import io.camunda.zeebe.protocol.record.ValueType;
+import io.camunda.zeebe.protocol.record.intent.Intent;
+import io.camunda.zeebe.protocol.record.intent.JobIntent;
+import io.camunda.zeebe.protocol.record.value.ImmutableJobRecordValue;
+import io.camunda.zeebe.protocol.record.value.JobKind;
+import io.camunda.zeebe.protocol.record.value.JobListenerEventType;
+import io.camunda.zeebe.protocol.record.value.JobRecordValue;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class JobZeebeRecordProcessorIT extends OperateSearchAbstractIT {
+
+  @Autowired ListenerReader listenerReader;
+  @Autowired private JobZeebeRecordProcessor underTest;
+  @Autowired private JobTemplate jobTemplate;
+  @Autowired private BeanFactory beanFactory;
+
+  @Test
+  public void shouldUpdateRecordsCorrectly() throws PersistenceException {
+    final String elementId = "ExampleJobActivity";
+    final long processInstanceId = 11113L;
+
+    final long taskStartDate = 1724755457190L;
+    final long taskCompletedDate = taskStartDate + 50;
+    final Record<JobRecordValue> originalRecord =
+        (Record<JobRecordValue>)
+            createSimpleZeebeJobRecord(
+                11111L,
+                taskStartDate,
+                JobIntent.CREATED,
+                "job-processor-it",
+                elementId,
+                11112,
+                JobKind.BPMN_ELEMENT,
+                null,
+                processInstanceId,
+                "JobActivity");
+    importJobZeebeRecords(List.of(originalRecord));
+
+    final ListenerRequestDto listenerRequestDto =
+        new ListenerRequestDto()
+            .setPageSize(10)
+            .setFlowNodeId(elementId)
+            .setSorting(new SortingDto().setSortBy(JobTemplate.TIME).setSortOrder("desc"));
+    final ListenerResponseDto response =
+        listenerReader.getListenerExecutions(String.valueOf(processInstanceId), listenerRequestDto);
+
+    // there is no general job reader at the moment so we can only check for listeners
+    assertTrue(response.getTotalCount() == 0);
+
+    final Record<JobRecordValue> updateRecord =
+        createUpdatedZeebeJobRecordFrom(
+            originalRecord,
+            taskCompletedDate,
+            JobIntent.COMPLETED,
+            originalRecord.getValue().getElementId());
+    final long listenerStartTime = taskStartDate + 60;
+    final long listenerFailedTime = taskStartDate + 80;
+    final Record<JobRecordValue> listenerRecord =
+        createRecordForSameFlowNodeFrom(
+            originalRecord,
+            22222L,
+            listenerStartTime,
+            JobIntent.CREATED,
+            elementId,
+            JobKind.EXECUTION_LISTENER,
+            JobListenerEventType.END,
+            "ExampleListener");
+    // different element ID to check if it does not get overwritten
+    final Record<JobRecordValue> listenerErrorRecord =
+        createUpdatedZeebeJobRecordFrom(
+            listenerRecord, listenerFailedTime, JobIntent.ERROR_THROWN, "NO_CATCH_EVENT_FOUND");
+
+    importJobZeebeRecords(List.of(updateRecord, listenerRecord, listenerErrorRecord));
+    final ListenerResponseDto updateResponse =
+        listenerReader.getListenerExecutions(String.valueOf(processInstanceId), listenerRequestDto);
+    assertTrue(updateResponse.getTotalCount() == 1);
+    final ListenerDto actualListenerRecord = updateResponse.getListeners().getFirst();
+    assertTrue(actualListenerRecord.getJobType().equals("ExampleListener"));
+    assertTrue(actualListenerRecord.getState().equals(ListenerState.FAILED));
+  }
+
+  private void importJobZeebeRecords(final List<Record<JobRecordValue>> zeebeRecords)
+      throws PersistenceException {
+    final BatchRequest batchRequest = beanFactory.getBean(BatchRequest.class);
+    underTest.processJobRecords(
+        zeebeRecords.stream()
+            .collect(Collectors.groupingBy(obj -> obj.getValue().getElementInstanceKey())),
+        batchRequest,
+        false);
+    batchRequest.execute();
+    searchContainerManager.refreshIndices(jobTemplate.getFullQualifiedName());
+  }
+
+  private Record<JobRecordValue> createUpdatedZeebeJobRecordFrom(
+      final Record<JobRecordValue> record,
+      final long updateTime,
+      final Intent updateIntent,
+      final String updateElementId) {
+    return createSimpleZeebeJobRecord(
+        record.getKey(),
+        updateTime,
+        updateIntent,
+        record.getValue().getBpmnProcessId(),
+        updateElementId,
+        record.getValue().getElementInstanceKey(),
+        record.getValue().getJobKind(),
+        record.getValue().getJobListenerEventType(),
+        record.getValue().getProcessInstanceKey(),
+        record.getValue().getType());
+  }
+
+  private Record<JobRecordValue> createRecordForSameFlowNodeFrom(
+      final Record<JobRecordValue> record,
+      final long key,
+      final long time,
+      final Intent intent,
+      final String elementId,
+      final JobKind jobKind,
+      final JobListenerEventType listenerEventType,
+      final String jobType) {
+    return createSimpleZeebeJobRecord(
+        key,
+        time,
+        intent,
+        record.getValue().getBpmnProcessId(),
+        elementId,
+        record.getValue().getElementInstanceKey(),
+        jobKind,
+        listenerEventType,
+        record.getValue().getProcessInstanceKey(),
+        jobType);
+  }
+
+  private Record createSimpleZeebeJobRecord(
+      final long key,
+      final long time,
+      final Intent intent,
+      final String bpmnProcessId,
+      final String elementId,
+      final long elementInstanceKey,
+      final JobKind jobKind,
+      final JobListenerEventType listenerEventType,
+      final long processInstanceKey,
+      final String type) {
+    final Map<String, Object> authorization =
+        Map.of("authorized_tenants", List.of(IndexDescriptor.DEFAULT_TENANT_ID));
+    final JobRecordValue value =
+        ImmutableJobRecordValue.builder()
+            .withBpmnProcessId(bpmnProcessId)
+            .withElementId(elementId)
+            .withElementInstanceKey(elementInstanceKey)
+            .withJobKind(jobKind)
+            .withJobListenerEventType(listenerEventType)
+            .withProcessDefinitionKey(1L)
+            .withProcessDefinitionVersion(1)
+            .withProcessInstanceKey(processInstanceKey)
+            .withRetries(2)
+            .withTenantId(IndexDescriptor.DEFAULT_TENANT_ID)
+            .withType(type)
+            .withDeadline(-1)
+            .build();
+    final Record<RecordValue> record =
+        ImmutableRecord.builder()
+            .withPosition(1)
+            .withSourceRecordPosition(1L)
+            .withKey(key)
+            .withTimestamp(time)
+            .withIntent(intent)
+            .withPartitionId(1)
+            .withRecordType(RecordType.EVENT)
+            .withRejectionType(RejectionType.NULL_VAL)
+            .withBrokerVersion("8.6.0")
+            .withAuthorizations(authorization)
+            .withRecordVersion(1)
+            .withValueType(ValueType.JOB)
+            .withValue(value)
+            .withOperationReference(-1)
+            .build();
+    return record;
+  }
+}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->
Fixed jobs not being updated correctly because only the most recent record for each flow-node was processed in one batch. They are now grouped by job keys and the most recent record for the job key is used.
If there was an exception in the job, a previous record for the node is processed first, to ensure the `flowNodeId `is already persisted for the job, since zeebe overwrites them in the case of an error (workaround for https://github.com/camunda/camunda/issues/21567).


## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes https://github.com/camunda/camunda/issues/21530
