### PR TITLE
Check if partitions root directory remains empty after restore.

### DIFF
--- a/dist/src/main/config/broker.standalone.yaml.template
+++ b/dist/src/main/config/broker.standalone.yaml.template
@@ -1191,7 +1191,7 @@
       # to see how to use this in practise.
       # queryApi:
         # Enables the query api in the broker.
-        # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
         # enabled: false
 
       # engine:

--- a/dist/src/main/config/broker.yaml.template
+++ b/dist/src/main/config/broker.yaml.template
@@ -1081,7 +1081,7 @@
       # to see how to use this in practise.
       # queryApi:
         # Enables the query api in the broker.
-        # This setting can also be set using the environmentvariable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
+        # This setting can also be set using the environment variable ZEEBE_BROKER_EXPERIMENTAL_QUERYAPI_ENABLED
         # enabled: false
 
       # engine:

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -24,10 +24,12 @@ import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class RaftPartitionFactory {
   public static final String GROUP_NAME = "raft-partition";
-
+  private static final Logger LOG = LoggerFactory.getLogger(RaftPartitionFactory.class);
   private final BrokerCfg brokerCfg;
 
   public RaftPartitionFactory(final BrokerCfg brokerCfg) {
@@ -41,6 +43,11 @@ public final class RaftPartitionFactory {
             .resolve("partitions")
             .resolve(partitionMetadata.id().id().toString());
     try {
+      if (FileUtil.isEmpty(partitionDirectory)) {
+        LOG.info(
+            "Root directory for partition {} is empty or does not exist, creating it if does not exist.",
+            partitionDirectory);
+      }
       FileUtil.ensureDirectoryExists(partitionDirectory);
     } catch (final IOException e) {
       throw new UncheckedIOException(e);

--- a/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
+++ b/zeebe/broker/src/main/java/io/camunda/zeebe/broker/partitioning/startup/RaftPartitionFactory.java
@@ -25,11 +25,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public final class RaftPartitionFactory {
   public static final String GROUP_NAME = "raft-partition";
-  private static final Logger LOG = LoggerFactory.getLogger(RaftPartitionFactory.class);
+  private static final Logger LOG = Loggers.SYSTEM_LOGGER;
   private final BrokerCfg brokerCfg;
 
   public RaftPartitionFactory(final BrokerCfg brokerCfg) {
@@ -45,8 +44,10 @@ public final class RaftPartitionFactory {
     try {
       if (FileUtil.isEmpty(partitionDirectory)) {
         LOG.info(
-            "Root directory for partition {} is empty or does not exist, creating it if does not exist.",
-            partitionDirectory);
+            "Root directory {} for partition {} is empty or does not exist. The partition {} is starting with no pre-existing data.",
+            partitionDirectory,
+            partitionMetadata.id(),
+            partitionMetadata.id());
       }
       FileUtil.ensureDirectoryExists(partitionDirectory);
     } catch (final IOException e) {


### PR DESCRIPTION
## Description

This PR adds a warning if data directory remains empty after restore.

The request for this warning came from a support case where the customer failed to recognize that restoring from backup was not successful. This was due to a mistake in our internal documentation which we shared with the customer. As a result, their restore wasn't effective because it didn't restore data to the Zeebe disks but to temporary disks.

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #https://github.com/camunda/camunda/issues/16181
