### PR TITLE
feat: use dynamic routing info for round robin request dispatch

### DIFF
--- a/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
+++ b/zeebe/broker-client/src/main/java/io/camunda/zeebe/broker/client/impl/RoundRobinDispatchStrategy.java
@@ -10,7 +10,10 @@ package io.camunda.zeebe.broker.client.impl;
 import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Return the next partition using a round-robin strategy, but skips the partitions where there is
@@ -18,22 +21,87 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public final class RoundRobinDispatchStrategy implements RequestDispatchStrategy {
 
-  private final AtomicInteger partitions = new AtomicInteger(0);
+  /** Holds the current partition ring. Starts off uninitialized and is updated on every request. */
+  private final AtomicReference<VersionedPartitionRing> partitionRing =
+      new AtomicReference<>(VersionedPartitionRing.uninitialized());
+
+  private final AtomicInteger offset = new AtomicInteger(0);
 
   @Override
   public int determinePartition(final BrokerTopologyManager topologyManager) {
     final BrokerClusterState topology = topologyManager.getTopology();
 
-    if (topology != null) {
-      for (int i = 0; i < topology.getPartitionsCount(); i++) {
-        final int offset = partitions.getAndIncrement();
-        final int partition = topology.getPartition(offset);
-        if (topology.getLeaderForPartition(partition) != BrokerClusterState.NODE_ID_NULL) {
-          return partition;
-        }
+    if (topology == null) {
+      return BrokerClusterState.PARTITION_ID_NULL;
+    }
+
+    final var partitions = updatePartitionRing(topologyManager);
+
+    for (int i = 0; i < topology.getPartitionsCount(); i++) {
+      final int partition = partitions.partitionAtOffset(offset.getAndIncrement());
+      if (topology.getLeaderForPartition(partition) != BrokerClusterState.NODE_ID_NULL) {
+        return partition;
       }
     }
 
     return BrokerClusterState.PARTITION_ID_NULL;
+  }
+
+  /**
+   * Updates the partition ring. This either initializes the partition ring to span over all
+   * statically configured partitions when routing state is not available (i.e. partition scaling is
+   * not enabled) or creates a new partition ring to span over the active partitions from the latest
+   * routing state.
+   */
+  private PartitionRing updatePartitionRing(final BrokerTopologyManager topologyManager) {
+    final var routingState = topologyManager.getClusterConfiguration().routingState();
+    final long expectedVersion =
+        routingState.map(RoutingState::version).orElse(VersionedPartitionRing.NO_ROUTING_STATE);
+
+    var currentValue = partitionRing.get();
+    if (currentValue.version() >= expectedVersion) {
+      return currentValue.partitions();
+    }
+
+    final var newPartitionRing =
+        routingState
+            .map(RoutingState::activePartitions)
+            .map(PartitionRing::of)
+            .orElseGet(() -> PartitionRing.all(topologyManager.getTopology().getPartitionsCount()));
+    final var newValue = new VersionedPartitionRing(expectedVersion, newPartitionRing);
+
+    while (currentValue.version() < expectedVersion) {
+      currentValue = partitionRing.compareAndExchange(currentValue, newValue);
+    }
+
+    return newPartitionRing;
+  }
+
+  record VersionedPartitionRing(long version, PartitionRing partitions) {
+    static final long NOT_INITIALIZED = -2;
+    static final long NO_ROUTING_STATE = -1;
+
+    private static VersionedPartitionRing uninitialized() {
+      return new VersionedPartitionRing(NOT_INITIALIZED, null);
+    }
+  }
+
+  private record PartitionRing(int[] partitions) {
+    static PartitionRing all(final int partitionCount) {
+      final var partitions = new int[partitionCount];
+      for (int i = 0; i < partitionCount; i++) {
+        partitions[i] = i + 1;
+      }
+      return new PartitionRing(partitions);
+    }
+
+    static PartitionRing of(final Set<Integer> partitions) {
+      final var sorted = partitions.stream().sorted().mapToInt(Integer::intValue).toArray();
+      return new PartitionRing(sorted);
+    }
+
+    public int partitionAtOffset(final int offset) {
+      return partitions[offset % partitions.length];
+    }
   }
 }

--- a/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
+++ b/zeebe/broker-client/src/test/java/io/camunda/zeebe/broker/client/impl/TestTopologyManager.java
@@ -14,6 +14,7 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 
 final class TestTopologyManager implements BrokerTopologyManager {
   private final BrokerClusterStateImpl topology;
+  private ClusterConfiguration clusterConfiguration = ClusterConfiguration.uninitialized();
 
   TestTopologyManager() {
     this(new BrokerClusterStateImpl());
@@ -34,6 +35,11 @@ final class TestTopologyManager implements BrokerTopologyManager {
     return this;
   }
 
+  TestTopologyManager withClusterConfiguration(final ClusterConfiguration clusterConfiguration) {
+    this.clusterConfiguration = clusterConfiguration;
+    return this;
+  }
+
   @Override
   public BrokerClusterState getTopology() {
     return topology;
@@ -41,7 +47,7 @@ final class TestTopologyManager implements BrokerTopologyManager {
 
   @Override
   public ClusterConfiguration getClusterConfiguration() {
-    throw new UnsupportedOperationException("not implemented");
+    return clusterConfiguration;
   }
 
   @Override

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/api/util/StubbedTopologyManager.java
@@ -18,12 +18,14 @@ import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
 public final class StubbedTopologyManager implements BrokerTopologyManager {
 
   private final BrokerClusterStateImpl clusterState;
+  private final ClusterConfiguration clusterConfiguration;
 
   StubbedTopologyManager() {
     this(8);
   }
 
   StubbedTopologyManager(final int partitionsCount) {
+    clusterConfiguration = ClusterConfiguration.uninitialized();
     clusterState = new BrokerClusterStateImpl();
     clusterState.addBrokerIfAbsent(0);
     clusterState.setBrokerAddressIfPresent(0, "localhost:26501");
@@ -41,7 +43,7 @@ public final class StubbedTopologyManager implements BrokerTopologyManager {
 
   @Override
   public ClusterConfiguration getClusterConfiguration() {
-    throw new UnsupportedOperationException("Not yet implemented");
+    return clusterConfiguration;
   }
 
   @Override


### PR DESCRIPTION
This extends the `RoundRobinDispatchStrategy` to not just iterate over partitions with leaders in `BrokerClusterState` but to also respect the routing state in the `ClusterConfiguration` if it is available.

With partition scaling, the set of active partitions might update from say `1, 2, 3` to `1, 2, 3, 5` because we scaled up from 3 to 5 partitions but partition 4 is slow to initialize and not yet ready to receive requests. This PR ensures that we dispatch to partitions 1, 2, 3, and 5 but not 4.

To achieve this, I've introduced a type called `PartitionRing` that can give a partition id for a given offset that is incremented on every request. Whenever routing state updates (i.e. gets a new version) we regenerate the `PartitionRing`. When routing state is not available (i.e. the partition scaling feature is disabled), the `PartitionRing` is generated over the full list of available partitions from the current `BrokerClusterState`, essentially falling back to the same behavior we had before.

closes #21466