### PR TITLE
Migrate process instance with an active exclusive gateway

### DIFF
--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -98,9 +98,12 @@ public final class ExclusiveGatewayProcessor
     }
 
     final var outgoingSequenceFlows = element.getOutgoing();
-    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.getFirst().getCondition() == null) {
-      // only one flow without a condition, can just be taken
-      return Either.right(Optional.of(element.getOutgoing().getFirst()));
+    if (outgoingSequenceFlows.size() == 1) {
+      final var singleOutgoingSequenceFlow = outgoingSequenceFlows.getFirst();
+      if (singleOutgoingSequenceFlow.getCondition() == null) {
+        // only one flow without a condition, can just be taken
+        return Either.right(Optional.of(singleOutgoingSequenceFlow));
+      }
     }
 
     for (final ExecutableSequenceFlow sequenceFlow : element.getOutgoingWithCondition()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/bpmn/gateway/ExclusiveGatewayProcessor.java
@@ -98,9 +98,9 @@ public final class ExclusiveGatewayProcessor
     }
 
     final var outgoingSequenceFlows = element.getOutgoing();
-    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.get(0).getCondition() == null) {
+    if (outgoingSequenceFlows.size() == 1 && outgoingSequenceFlows.getFirst().getCondition() == null) {
       // only one flow without a condition, can just be taken
-      return Either.right(Optional.of(element.getOutgoing().get(0)));
+      return Either.right(Optional.of(element.getOutgoing().getFirst()));
     }
 
     for (final ExecutableSequenceFlow sequenceFlow : element.getOutgoingWithCondition()) {

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -637,11 +637,12 @@ public final class ProcessInstanceMigrationPreconditions {
       final String sourceElementId,
       final String targetElementId,
       final Map<String, String> sourceElementIdToTargetElementId) {
-    final var sourceElement =
-        sourceProcessDefinition
-            .getProcess()
-            .getElementById(sourceElementId, ExecutableCatchEventSupplier.class);
-    for (final var boundaryIdBuffer : sourceElement.getBoundaryElementIds()) {
+    final var sourceElement = sourceProcessDefinition.getProcess().getElementById(sourceElementId);
+    if (!(sourceElement instanceof final ExecutableCatchEventSupplier sourceElementWithEvents)) {
+      return;
+    }
+
+    for (final var boundaryIdBuffer : sourceElementWithEvents.getBoundaryElementIds()) {
       final String sourceBoundaryEventId = BufferUtil.bufferAsString(boundaryIdBuffer);
       if (!sourceElementIdToTargetElementId.containsKey(sourceBoundaryEventId)) {
         // only check mapped boundary events
@@ -689,13 +690,13 @@ public final class ProcessInstanceMigrationPreconditions {
       final DeployedProcess sourceProcessDefinition,
       final String sourceElementId,
       final Map<String, String> mappingInstructions) {
-    final var sourceElement =
-        sourceProcessDefinition
-            .getProcess()
-            .getElementById(sourceElementId, ExecutableCatchEventSupplier.class);
+    final var sourceElement = sourceProcessDefinition.getProcess().getElementById(sourceElementId);
+    if (!(sourceElement instanceof final ExecutableCatchEventSupplier sourceElementWithEvents)) {
+      return;
+    }
 
     final var sourceBoundaryEventIdsByTargetBoundaryEventId = new HashMap<String, List<String>>();
-    sourceElement.getBoundaryElementIds().stream()
+    sourceElementWithEvents.getBoundaryElementIds().stream()
         .map(BufferUtil::bufferAsString)
         .filter(mappingInstructions::containsKey)
         .forEach(

--- a/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
+++ b/zeebe/engine/src/main/java/io/camunda/zeebe/engine/processing/processinstance/ProcessInstanceMigrationPreconditions.java
@@ -48,7 +48,8 @@ public final class ProcessInstanceMigrationPreconditions {
           BpmnElementType.CALL_ACTIVITY,
           BpmnElementType.INTERMEDIATE_CATCH_EVENT,
           BpmnElementType.RECEIVE_TASK,
-          BpmnElementType.EVENT_SUB_PROCESS);
+          BpmnElementType.EVENT_SUB_PROCESS,
+          BpmnElementType.EXCLUSIVE_GATEWAY);
   private static final Set<BpmnElementType> UNSUPPORTED_ELEMENT_TYPES =
       EnumSet.complementOf(SUPPORTED_ELEMENT_TYPES);
   private static final Set<BpmnEventType> SUPPORTED_INTERMEDIATE_CATCH_EVENT_TYPES =

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateExclusiveGatewayTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateExclusiveGatewayTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.engine.processing.processinstance.migration;
+
+import static io.camunda.zeebe.engine.processing.processinstance.migration.MigrationTestUtil.extractProcessDefinitionKeyByProcessId;
+
+import io.camunda.zeebe.engine.util.EngineRule;
+import io.camunda.zeebe.model.bpmn.Bpmn;
+import io.camunda.zeebe.protocol.record.Assertions;
+import io.camunda.zeebe.protocol.record.intent.IncidentIntent;
+import io.camunda.zeebe.protocol.record.intent.ProcessInstanceIntent;
+import io.camunda.zeebe.protocol.record.value.BpmnElementType;
+import io.camunda.zeebe.test.util.BrokerClassRuleHelper;
+import io.camunda.zeebe.test.util.record.RecordingExporter;
+import io.camunda.zeebe.test.util.record.RecordingExporterTestWatcher;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+
+public class MigrateExclusiveGatewayTest {
+
+  @ClassRule public static final EngineRule ENGINE = EngineRule.singlePartition();
+  private static final String INVALID_EXPRESSION = "missing_var";
+
+  @Rule public final TestWatcher watcher = new RecordingExporterTestWatcher();
+  @Rule public final BrokerClassRuleHelper helper = new BrokerClassRuleHelper();
+
+  @Test
+  public void shouldResolveIncidentForInvalidCondition() {
+    final String sourceProcessId = helper.getBpmnProcessId();
+    final String targetProcessId = helper.getBpmnProcessId() + "_v2";
+
+    final var deployment =
+        ENGINE
+            .deployment()
+            .withXmlResource(
+                Bpmn.createExecutableProcess(sourceProcessId)
+                    .startEvent()
+                    .exclusiveGateway("xor")
+                    .conditionExpression(INVALID_EXPRESSION)
+                    .endEvent("A")
+                    .moveToLastGateway()
+                    .conditionExpression(INVALID_EXPRESSION)
+                    .endEvent("B")
+                    .done())
+            .withXmlResource(
+                Bpmn.createExecutableProcess(targetProcessId)
+                    .startEvent()
+                    .exclusiveGateway("xor2")
+                    .conditionExpression("true")
+                    .endEvent("A")
+                    .moveToLastGateway()
+                    .conditionExpression("false")
+                    .endEvent("B")
+                    .done())
+            .deploy();
+    final long targetProcessDefinitionKey =
+        extractProcessDefinitionKeyByProcessId(deployment, targetProcessId);
+
+    final long processInstanceKey =
+        ENGINE.processInstance().ofBpmnProcessId(sourceProcessId).create();
+
+    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
+        .withProcessInstanceKey(processInstanceKey)
+        .withElementId("xor")
+        .await();
+
+    // when
+    ENGINE
+        .processInstance()
+        .withInstanceKey(processInstanceKey)
+        .migration()
+        .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
+        .addMappingInstruction("xor", "xor2")
+        .migrate();
+
+    // then
+    ENGINE.incident().ofInstance(processInstanceKey).resolve();
+
+    Assertions.assertThat(
+            RecordingExporter.processInstanceRecords(ProcessInstanceIntent.ELEMENT_ACTIVATED)
+                .withProcessInstanceKey(processInstanceKey)
+                .withElementType(BpmnElementType.END_EVENT)
+                .getFirst()
+                .getValue())
+        .describedAs("Expected to successfully evaluate the condition to reach the end event")
+        .hasElementId("A");
+  }
+}

--- a/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceUnsupportedElementsTest.java
+++ b/zeebe/engine/src/test/java/io/camunda/zeebe/engine/processing/processinstance/migration/MigrateProcessInstanceUnsupportedElementsTest.java
@@ -87,66 +87,6 @@ public class MigrateProcessInstanceUnsupportedElementsTest {
   }
 
   @Test
-  public void shouldRejectMigrationForActiveExclusiveGateway() {
-    // given
-    final var deployment =
-        ENGINE
-            .deployment()
-            .withXmlResource(
-                Bpmn.createExecutableProcess(SOURCE_PROCESS)
-                    .startEvent()
-                    .exclusiveGateway("A")
-                    .conditionExpression("missing_function_causing_incident()")
-                    .endEvent()
-                    .moveToLastExclusiveGateway()
-                    .defaultFlow()
-                    .endEvent()
-                    .done())
-            .withXmlResource(
-                Bpmn.createExecutableProcess(TARGET_PROCESS)
-                    .startEvent()
-                    .exclusiveGateway("A")
-                    .conditionExpression("missing_function_causing_incident()")
-                    .endEvent()
-                    .moveToLastExclusiveGateway()
-                    .defaultFlow()
-                    .userTask("B")
-                    .endEvent()
-                    .done())
-            .deploy();
-    final long targetProcessDefinitionKey = extractTargetProcessDefinitionKey(deployment);
-
-    final var processInstanceKey =
-        ENGINE.processInstance().ofBpmnProcessId(SOURCE_PROCESS).create();
-
-    RecordingExporter.incidentRecords(IncidentIntent.CREATED)
-        .withProcessInstanceKey(processInstanceKey)
-        .withElementId("A")
-        .await();
-
-    // when
-    final var rejection =
-        ENGINE
-            .processInstance()
-            .withInstanceKey(processInstanceKey)
-            .migration()
-            .withTargetProcessDefinitionKey(targetProcessDefinitionKey)
-            .addMappingInstruction("A", "A")
-            .expectRejection()
-            .migrate();
-
-    // then
-    assertThat(rejection).hasRejectionType(RejectionType.INVALID_STATE);
-    Assertions.assertThat(rejection.getRejectionReason())
-        .contains(
-            String.format(
-                """
-                Expected to migrate process instance '%s' but active element with id '%s' \
-                has an unsupported type. The migration of a %s is not supported""",
-                processInstanceKey, "A", "EXCLUSIVE_GATEWAY"));
-  }
-
-  @Test
   public void shouldRejectMigrationForActiveInclusiveGateway() {
     // given
     final var deployment =


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

This pull request makes it possible to fix mistakes in the Condition expression of sequence flows outgoing from an Exclusive Gateway.

- When the Exclusive Gateway activates, the Conditions of the outgoing Sequence Flows are evaluated. If the evaluation fails, an Incident is raised on the Exclusive Gateway. If the evaluation fails because of a mistake in the Condition expression itself, this could not be resolved previously.

- Users can now fix the mistake in the model, redeploy it, and migrate the process instance to this model. After migrating the process instance, the incident can be resolved.

> [!NOTE]
> Exclusive Gateways are activated and completed atomically (when there are no incidents). So, there is no other case to test or migrate.

> [!NOTE]
> I've taken the liberty to refactor some Exclusive Gateway Processor code 

## Related issues

closes #21580
