### PR TITLE
feat: use dynamic routing info for message request dispatch

### DIFF
--- a/zeebe/gateway/pom.xml
+++ b/zeebe/gateway/pom.xml
@@ -110,6 +110,18 @@
     </dependency>
 
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>

--- a/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategy.java
+++ b/zeebe/gateway/src/main/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategy.java
@@ -7,11 +7,16 @@
  */
 package io.camunda.zeebe.gateway.impl.broker;
 
+import static io.camunda.zeebe.protocol.impl.SubscriptionUtil.getSubscriptionPartitionId;
+import static io.camunda.zeebe.util.buffer.BufferUtil.wrapString;
+
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
 import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
 import io.camunda.zeebe.broker.client.api.NoTopologyAvailableException;
 import io.camunda.zeebe.broker.client.api.RequestDispatchStrategy;
-import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
-import io.camunda.zeebe.util.buffer.BufferUtil;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import java.util.Optional;
 
 public final class PublishMessageDispatchStrategy implements RequestDispatchStrategy {
 
@@ -23,16 +28,32 @@ public final class PublishMessageDispatchStrategy implements RequestDispatchStra
 
   @Override
   public int determinePartition(final BrokerTopologyManager topologyManager) {
-    final var topology = topologyManager.getTopology();
-    if (topology == null || topology.getPartitionsCount() == 0) {
-      throw new NoTopologyAvailableException(
-          String.format(
-              "Expected to pick partition for message with correlation key '%s', but no topology is available",
-              correlationKey));
-    }
+    return topologyManager
+        .getClusterConfiguration()
+        .routingState()
+        .map(this::fromRoutingState)
+        .or(() -> Optional.ofNullable(topologyManager.getTopology()).map(this::fromTopology))
+        .orElseThrow(
+            () ->
+                new NoTopologyAvailableException(
+                    "Expected to pick partition for message with correlation key '%s', but no topology is available"
+                        .formatted(correlationKey)));
+  }
 
-    final int partitionsCount = topology.getPartitionsCount();
-    return SubscriptionUtil.getSubscriptionPartitionId(
-        BufferUtil.wrapString(correlationKey), partitionsCount);
+  public int fromRoutingState(final RoutingState routingState) {
+    return switch (routingState.messageCorrelation()) {
+      case HashMod(final int partitionCount) ->
+          getSubscriptionPartitionId(wrapString(correlationKey), partitionCount);
+    };
+  }
+
+  public int fromTopology(final BrokerClusterState topology) {
+    final var partitionCount = topology.getPartitionsCount();
+    if (partitionCount == 0) {
+      throw new NoTopologyAvailableException(
+          "Expected to pick partition for message with correlation key '%s', but topology contains no partitions"
+              .formatted(correlationKey));
+    }
+    return getSubscriptionPartitionId(wrapString(correlationKey), partitionCount);
   }
 }

--- a/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
+++ b/zeebe/gateway/src/test/java/io/camunda/zeebe/gateway/impl/broker/PublishMessageDispatchStrategyTest.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright Camunda Services GmbH and/or licensed to Camunda Services GmbH under
+ * one or more contributor license agreements. See the NOTICE file distributed
+ * with this work for additional information regarding copyright ownership.
+ * Licensed under the Camunda License 1.0. You may not use this file
+ * except in compliance with the Camunda License 1.0.
+ */
+package io.camunda.zeebe.gateway.impl.broker;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.camunda.zeebe.broker.client.api.BrokerClusterState;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyListener;
+import io.camunda.zeebe.broker.client.api.BrokerTopologyManager;
+import io.camunda.zeebe.dynamic.config.state.ClusterConfiguration;
+import io.camunda.zeebe.dynamic.config.state.RoutingState;
+import io.camunda.zeebe.dynamic.config.state.RoutingState.MessageCorrelation.HashMod;
+import io.camunda.zeebe.protocol.impl.SubscriptionUtil;
+import io.camunda.zeebe.protocol.record.PartitionHealthStatus;
+import io.camunda.zeebe.util.buffer.BufferUtil;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+final class PublishMessageDispatchStrategyTest {
+
+  @Test
+  void shouldDispatchViaTopology() {
+    // given
+    final var correlationKey = "correlationKey";
+    final var dispatchStrategy = new PublishMessageDispatchStrategy(correlationKey);
+    final var partitionCount = 3;
+
+    // when -- No routing state in cluster configuration
+    final var topologyManager =
+        new TestTopologyManager(
+            new TestBrokerClusterState(partitionCount), ClusterConfiguration.uninitialized());
+
+    // then - the request is dispatched based on the partition count from the topology
+    assertEquals(
+        SubscriptionUtil.getSubscriptionPartitionId(
+            BufferUtil.wrapString(correlationKey), partitionCount),
+        dispatchStrategy.determinePartition(topologyManager));
+  }
+
+  @Test
+  void shouldDispatchViaRoutingState() {
+    // given
+    final var correlationKey = "correlationKey";
+    final var dispatchStrategy = new PublishMessageDispatchStrategy(correlationKey);
+    final var partitionCount = 3;
+    final var messagePartitionCount = 2;
+
+    // when -- Routing state is available in cluster configuration
+    final var routingState =
+        new RoutingState(1, Set.of(1, 2, 3), new HashMod(messagePartitionCount));
+    final var clusterConfiguration =
+        new ClusterConfiguration(
+            1, Map.of(), Optional.empty(), Optional.empty(), Optional.of(routingState));
+    final var topologyManager =
+        new TestTopologyManager(new TestBrokerClusterState(partitionCount), clusterConfiguration);
+
+    // then - the request is dispatched based on the routing state
+    assertEquals(
+        SubscriptionUtil.getSubscriptionPartitionId(
+            BufferUtil.wrapString(correlationKey), messagePartitionCount),
+        dispatchStrategy.determinePartition(topologyManager));
+  }
+
+  private record TestBrokerClusterState(int partitionCount) implements BrokerClusterState {
+
+    @Override
+    public int getClusterSize() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPartitionsCount() {
+      return partitionCount;
+    }
+
+    @Override
+    public int getReplicationFactor() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLeaderForPartition(final int partition) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Integer> getFollowersForPartition(final int partition) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Set<Integer> getInactiveNodesForPartition(final int partition) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getRandomBroker() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Integer> getPartitions() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<Integer> getBrokers() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getBrokerAddress(final int brokerId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getPartition(final int index) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getBrokerVersion(final int brokerId) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public PartitionHealthStatus getPartitionHealth(final int brokerId, final int partition) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private record TestTopologyManager(
+      BrokerClusterState topology, ClusterConfiguration clusterConfiguration)
+      implements BrokerTopologyManager {
+
+    @Override
+    public BrokerClusterState getTopology() {
+      return topology;
+    }
+
+    @Override
+    public ClusterConfiguration getClusterConfiguration() {
+      return clusterConfiguration;
+    }
+
+    @Override
+    public void addTopologyListener(final BrokerTopologyListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeTopologyListener(final BrokerTopologyListener listener) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onClusterConfigurationUpdated(final ClusterConfiguration clusterConfiguration) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
:warning:  Depends on https://github.com/camunda/camunda/pull/21590

Updates the `PublishMessageDispatchStrategy` to prefer the message correlation strategy of the current routing state. This ensures that after partition scaling, messages will be routed to the old partitions until we support message relocation.

closes #21468
