### PR TITLE
ci: remove too short timeout and use default

### DIFF
--- a/.github/actions/compose/action.yml
+++ b/.github/actions/compose/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: "Additional flags to pass to the compose command"
     required: false
   timeout:
-    description: "Timeout for the healthcheck"
+    description: "Timeout for the healthcheck (in seconds)"
     required: false
     default: "300"
 runs:

--- a/.github/workflows/optimize-release-optimize-c8-only.yml
+++ b/.github/workflows/optimize-release-optimize-c8-only.yml
@@ -288,7 +288,6 @@ jobs:
         with:
           compose_file: .github/actions/compose/docker-compose.smoketest.yml
           project_name: smoketest
-          timeout: 15
         env:
           OPTIMIZE_IMAGE_TAG: ${{ env.RELEASE_VERSION }}
           ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

The timeout set for the release smoketest docker file to be up and running was set to only 15 seconds by accident, in this time it is not possible to start all the services.
In the deployment workflow (part of our main CI) we are relying on the default timeout of the `compose` action which is 300 seconds and it works so we try to do the same here as well

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
