### PR TITLE
ci: revert matchers in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -75,13 +75,13 @@
     {
       "description": "Exclude SNAPSHOT versions, renovate may suggest them for pre-release values.",
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": [".*"],
+      "matchPackagePatterns": [".*"],
       "allowedVersions": "!/-SNAPSHOT$/"
     },
     {
       "description": "Exclude internal Maven modules and Maven dependencies lacking metadata.",
       "matchManagers": ["maven"],
-      "matchPackagePrefixes": [
+      "matchPackagePatterns": [
         "io.camunda:operate-parent",
         "io.camunda:operate-qa",
         "io.camunda:operate-qa-migration-tests-parent",
@@ -95,7 +95,7 @@
       "description": "Exclude frontend deps until migration is done in Operate (see issues #17736, #17844, #18851)",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["operate/**"],
-      "matchPackagePrefixes": [
+      "matchPackagePatterns": [
         "react-router-dom",
         "msw",
         "@carbon/react"
@@ -111,7 +111,7 @@
       "description": "Exclude frontend deps until Optimize migrates to react-router v6 and react v18",
       "matchManagers": ["npm", "nvm"],
       "matchFileNames": ["optimize/**"],
-      "matchPackagePrefixes": [
+      "matchPackagePatterns": [
         "@carbon/react",
         "old-bpmn-js",
         "react",
@@ -138,7 +138,7 @@
       "description": "Exclude Optimize backend dependencies",
       "matchManagers": ["maven"],
       "matchFileNames": ["optimize/**"],
-      "matchPackagePrefixes": [
+      "matchPackagePatterns": [
         "io.camunda.optimize:optimize-data-generator",
         "io.camunda.optimize:camunda-optimize",
         "io.camunda.optimize:util",
@@ -151,7 +151,7 @@
       "enabled": false
     },
     {
-      "matchPackagePrefixes": ["mcr.microsoft.com/playwright"],
+      "matchPackageNames": ["mcr.microsoft.com/playwright"],
       "additionalBranchPrefix": "fe-"
     },
     {
@@ -168,7 +168,7 @@
     },
     {
       "matchManagers": ["npm", "nvm"],
-      "matchPackagePrefixes": ["*"],
+      "matchPackagePatterns": ["*"],
       "matchUpdateTypes": ["patch"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-minor-patch"
@@ -178,19 +178,19 @@
       "matchFileNames": [
         ".github/workflows/*.yml"
       ],
-      "matchPackagePrefixes": [
+      "matchPackageNames": [
         "rhysd/actionlint"
       ],
       "extractVersion": "^v(?<version>.*)$"
     },
     {
       "description": "Both dependencies need to be updated at once for green CI.",
-      "matchPackagePrefixes": ["@playwright/test", "mcr.microsoft.com/playwright"],
+      "matchPackageNames": ["@playwright/test", "mcr.microsoft.com/playwright"],
       "groupName": "playwright"
     },
     {
       "description": "Automerge all updates with green CI.",
-      "matchPackagePrefixes": ["*"],
+      "matchPackagePatterns": ["*"],
       "automerge": true,
       "addLabels": ["automerge"]
     }


### PR DESCRIPTION
## Description

<!-- Describe the goal and purpose of this PR. -->

After the migration done to the renovate config, some settings are broken so we need to revert the changes to the olg config structure

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [ ] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

closes #
