### PR TITLE
ci: use setup-yarn-cache everywhere

### DIFF
--- a/.github/actions/build-frontend/action.yml
+++ b/.github/actions/build-frontend/action.yml
@@ -15,7 +15,7 @@ runs:
     - name: Setup yarn
       run: npm install -g yarn
       shell: bash
-    - name: Setup yarn cache
+    - name: Setup NodeJS
       uses: actions/setup-node@v4
       with:
         node-version: "20"

--- a/.github/actions/build-operate-fe/action.yml
+++ b/.github/actions/build-operate-fe/action.yml
@@ -11,12 +11,13 @@ runs:
     - name: Setup yarn
       run: npm install -g yarn
       shell: bash
-    - name: Setup yarn cache
+    - name: Setup NodeJS
       uses: actions/setup-node@v4
       with:
         node-version: "20"
-        cache: "yarn"
-        cache-dependency-path: operate/client/yarn.lock
+    - uses: ./.github/actions/setup-yarn-cache
+      with:
+        directory: ${{ inputs.directory }}
     - name: Install node dependencies
       working-directory: ./operate/client
       shell: bash

--- a/.github/actions/build-tasklist-fe/action.yml
+++ b/.github/actions/build-tasklist-fe/action.yml
@@ -11,12 +11,13 @@ runs:
     - name: Setup yarn
       run: npm install -g yarn
       shell: bash
-    - name: Setup yarn cache
+    - name: Setup NodeJS
       uses: actions/setup-node@v4
       with:
         node-version: "20"
-        cache: "yarn"
-        cache-dependency-path: tasklist/client/yarn.lock
+    - uses: ./.github/actions/setup-yarn-cache
+      with:
+        directory: ${{ inputs.directory }}
     - name: Install node dependencies
       working-directory: ./tasklist/client
       shell: bash

--- a/.github/workflows/operate-a11y.yml
+++ b/.github/workflows/operate-a11y.yml
@@ -28,12 +28,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Setup yarn cache
+      - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: operate/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: operate/client
       - name: Install node dependencies
         working-directory: ./operate/client
         run: yarn

--- a/.github/workflows/operate-update-docs-screenshots.yml
+++ b/.github/workflows/operate-update-docs-screenshots.yml
@@ -10,12 +10,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Setup yarn cache
+      - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: operate/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: operate/client
       - name: Install node dependencies
         working-directory: ./operate/client
         run: yarn

--- a/.github/workflows/optimize-check-c4.yml
+++ b/.github/workflows/optimize-check-c4.yml
@@ -26,12 +26,14 @@ jobs:
         id: "pom_info"
         uses: YunaBraska/java-info-action@main
 
-      - name: Setup yarn cache
+      - name: Setup NodeJS
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:
           node-version: ${{ steps.pom_info.outputs.x_version_node }}
-          cache: "yarn"
-          cache-dependency-path: optimize/c4/yarn.lock
+
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: optimize/c4
 
       - name: Install dependencies
         working-directory: ./optimize/c4

--- a/.github/workflows/optimize-e2e-test-cloud.yml
+++ b/.github/workflows/optimize-e2e-test-cloud.yml
@@ -62,12 +62,13 @@ jobs:
         ELASTIC_VERSION: ${{ steps.pom-info.outputs.x_elasticsearch_test_version }}
         ELASTIC_JVM_MEMORY: 1
         ELASTIC_HTTP_PORT: ${{ steps.pom-info.outputs.x_new_elasticsearch_port }}
-    - name: Setup yarn cache
+    - name: Setup NodeJS
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
       with:
         node-version: ${{ steps.pom-info.outputs.x_version_node }}
-        cache: "yarn"
-        cache-dependency-path: optimize/client/yarn.lock
+    - uses: ./.github/actions/setup-yarn-cache
+      with:
+        directory: optimize/client
     - name: Install node dependencies
       working-directory: ./optimize/client
       run: yarn install

--- a/.github/workflows/optimize-e2e-tests-sm.yml
+++ b/.github/workflows/optimize-e2e-tests-sm.yml
@@ -75,12 +75,14 @@ jobs:
       - name: Setup yarn
         run: npm install -g yarn
 
-      - name: Setup yarn cache
+      - name: Setup NodeJS
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:
           node-version: ${{ steps.pom_info.outputs.x_version_node }}
-          cache: "yarn"
-          cache-dependency-path: optimize/client/yarn.lock
+
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: optimize/client
 
       - name: Build backend & frontend
         run: mvn clean install -DskipTests -Dskip.docker -pl optimize/backend -am

--- a/.github/workflows/optimize-publish-c4.yml
+++ b/.github/workflows/optimize-publish-c4.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./optimize/c4 
+        working-directory: ./optimize/c4
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -19,8 +19,9 @@ jobs:
         uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
         with:
           node-version: ${{ steps.pom_info.outputs.x_version_node }}
-          cache: "yarn"
-          cache-dependency-path: 'optimize/c4/yarn.lock'
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: optimize/c4
       - name: Install
         run: yarn install --frozen-lockfile
       - name: Build

--- a/.github/workflows/tasklist-ci-fe-reusable.yml
+++ b/.github/workflows/tasklist-ci-fe-reusable.yml
@@ -15,8 +15,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: tasklist/client
       - run: yarn install --frozen-lockfile
         name: Install dependencies
       - run: yarn ts-check
@@ -42,8 +43,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: tasklist/client
       - run: yarn install --frozen-lockfile
         name: Install dependencies
       - run: yarn eslint
@@ -69,8 +71,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: tasklist/client
       - run: yarn install --frozen-lockfile
         name: Install dependencies
       - run: yarn stylelint
@@ -96,8 +99,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: tasklist/client
       - run: yarn install --frozen-lockfile
         name: Install dependencies
       - run: yarn test:ci
@@ -124,12 +128,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Setup yarn cache
+      - name: SetSetup NodeJShe
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: tasklist/client
       - name: Install node dependencies
         run: yarn
       - name: Build frontend
@@ -166,12 +171,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v4
-      - name: Setup yarn cache
+      - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: tasklist/client
       - name: Install node dependencies
         run: yarn
       - name: Build frontend

--- a/.github/workflows/tasklist-update_visual_snapshots.yml
+++ b/.github/workflows/tasklist-update_visual_snapshots.yml
@@ -21,12 +21,13 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
-      - name: Setup yarn cache
+      - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "yarn"
-          cache-dependency-path: tasklist/client/yarn.lock
+      - uses: ./.github/actions/setup-yarn-cache
+        with:
+          directory: tasklist/client
       - name: Install node dependencies
         working-directory: ./tasklist/client
         run: yarn

--- a/.github/workflows/zeebe-ci.yml
+++ b/.github/workflows/zeebe-ci.yml
@@ -195,7 +195,7 @@ jobs:
   go-client:
     name: Go client tests
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-zeebe


### PR DESCRIPTION
## Description

Follow-up to https://github.com/camunda/camunda/pull/21475 + https://github.com/camunda/camunda/pull/21495 now using it for all frontend-related GHA jobs.

On this PR it can be checked that https://github.com/camunda/camunda/actions/caches?query=branch%3Arefs%2Fpull%2F21607%2Fmerge contains no frontend-related caches anymore (since the new action implements the [caching strategy](https://github.com/camunda/camunda/wiki/CI-&-Automation#caching-strategy))

## Checklist

<!--- Please delete options that are not relevant. Boxes should be checked by reviewer. -->
- [ ] for CI changes:
  - [x] structural/foundational changes signed off by [CI DRI](https://github.com/cmur2)
  - [ ] [ci.yml](https://github.com/camunda/camunda/blob/main/.github/workflows/ci.yml) modifications comply with ["Unified CI" requirements](https://github.com/camunda/camunda/wiki/CI-&-Automation#workflow-inclusion-criteria)

## Related issues

Related to #21427
