### PR TITLE
[Backport release-8.6.0-alpha5] ci: skip optimize from platform release

### DIFF
--- a/.github/workflows/camunda-platform-release.yml
+++ b/.github/workflows/camunda-platform-release.yml
@@ -155,6 +155,7 @@ jobs:
             -DpushChanges=${PUSH_CHANGES} \
             -DremoteTagging=${PUSH_CHANGES} \
             -DcompletionGoals="spotless:apply" \
+            -D skipOptimize \
             -P-autoFormat \
             -DpreparationGoals="" \
             -Darguments=''
@@ -180,6 +181,7 @@ jobs:
             -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}" \
             -DlocalCheckout=${{ inputs.dryRun }} \
             -DskipQaBuild=true \
+            -DskipOptimize \
             -P-autoFormat \
             -Darguments='-P-autoFormat -DskipQaBuild=true -DskipChecks=true -DskipTests=true -Dskip.fe.build=false -Dspotless.apply.skip=false -Dskip.central.release=${SKIP_REPO_DEPLOY} -Dskip.camunda.release=${SKIP_REPO_DEPLOY} -Dzbctl.force -Dzbctl.rootDir=${ZBCTL_ROOT_DIR} -Dgpg.passphrase="${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}"'
 


### PR DESCRIPTION
# Description
Backport of #21613 to `release-8.6.0-alpha5`.

relates to 
original author: @OmranAbazid